### PR TITLE
feat: implement txxt binary tool for token inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +90,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.5.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
@@ -94,6 +190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "insta"
 version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +205,18 @@ dependencies = [
  "once_cell",
  "similar",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -156,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +289,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ppv-lite86"
@@ -299,10 +425,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -332,9 +513,12 @@ dependencies = [
 name = "txxt-nano"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "insta",
  "logos",
  "proptest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -348,6 +532,12 @@ name = "unicode-ident"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"
@@ -379,7 +569,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -397,14 +596,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -414,10 +630,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -426,10 +654,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -438,10 +678,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -450,10 +702,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/bin/txxt.rs"
 
 [dependencies]
 logos = "0.14"
+clap = { version = "4.4", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "1.4"

--- a/src/bin/txxt.rs
+++ b/src/bin/txxt.rs
@@ -1,11 +1,54 @@
 //! Command-line interface for txxt-nano
 
-use txxt_nano::txxt_nano::Parser;
+use clap::{Arg, Command};
+use txxt_nano::txxt_nano::processor::{available_formats, ProcessingError};
 
 fn main() {
-    println!("txxt-nano CLI tool");
-    println!("Version: {}", env!("CARGO_PKG_VERSION"));
+    let matches = Command::new("txxt")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("A tool for inspecting txxt files")
+        .arg(
+            Arg::new("path")
+                .help("Path to the txxt file to process")
+                .required_unless_present("list-formats")
+                .index(1),
+        )
+        .arg(
+            Arg::new("format")
+                .help("Output format (e.g., token-simple, token-json)")
+                .required_unless_present("list-formats")
+                .index(2),
+        )
+        .arg(
+            Arg::new("list-formats")
+                .long("list-formats")
+                .help("List all available formats")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .get_matches();
 
-    let _parser = Parser::new();
-    println!("Parser initialized successfully");
+    if matches.get_flag("list-formats") {
+        println!("Available formats:");
+        for format in available_formats() {
+            println!("  {}", format);
+        }
+        return;
+    }
+
+    let path = matches.get_one::<String>("path").unwrap();
+    let format_str = matches.get_one::<String>("format").unwrap();
+
+    match process_file_with_format(path, format_str) {
+        Ok(output) => print!("{}", output),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Process a file with the given format string
+fn process_file_with_format(path: &str, format_str: &str) -> Result<String, ProcessingError> {
+    let spec = txxt_nano::txxt_nano::processor::ProcessingSpec::from_string(format_str)?;
+    txxt_nano::txxt_nano::processor::process_file(path, &spec)
 }

--- a/src/txxt_nano.rs
+++ b/src/txxt_nano.rs
@@ -1,6 +1,7 @@
 //! Main module for txxt-nano library functionality
 
 pub mod lexer;
+pub mod processor;
 
 /// Placeholder for future txxt parsing functionality
 pub struct Parser {

--- a/src/txxt_nano/lexer/tokens.rs
+++ b/src/txxt_nano/lexer/tokens.rs
@@ -5,9 +5,10 @@
 //!
 //! See docs/specs/<version>/grammar.txxt for the grammar of the txxt format.
 use logos::Logos;
+use std::fmt;
 
 /// All possible tokens in the txxt format
-#[derive(Logos, Debug, PartialEq, Clone)]
+#[derive(Logos, Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Token {
     // Special markers
     #[token("::")]
@@ -44,6 +45,25 @@ pub enum Token {
     // Text content (catch-all for non-special characters, excluding numbers)
     #[regex(r"[^\s\n\t\-\.\(\):0-9]+")]
     Text,
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Token::TxxtMarker => "txxt-marker",
+            Token::Indent => "indent",
+            Token::Whitespace => "whitespace",
+            Token::Newline => "newline",
+            Token::Dash => "dash",
+            Token::Period => "period",
+            Token::OpenParen => "open-paren",
+            Token::CloseParen => "close-paren",
+            Token::Colon => "colon",
+            Token::Number => "number",
+            Token::Text => "text",
+        };
+        write!(f, "<{}>", name)
+    }
 }
 
 impl Token {

--- a/src/txxt_nano/processor.rs
+++ b/src/txxt_nano/processor.rs
@@ -1,0 +1,205 @@
+//! File processing API for txxt format
+//!
+//! This module provides an extensible API for processing txxt files with different
+//! stages (token, ast) and formats (simple, json, xml, etc.).
+
+use crate::txxt_nano::lexer::{tokenize, Token};
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+/// Represents the processing stage (what data to extract)
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProcessingStage {
+    Token,
+    Ast, // Future: AST processing
+}
+
+/// Represents the output format
+#[derive(Debug, Clone, PartialEq)]
+pub enum OutputFormat {
+    Simple,
+    Json,
+    Xml, // Future: XML output
+}
+
+/// Represents a complete processing specification
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessingSpec {
+    pub stage: ProcessingStage,
+    pub format: OutputFormat,
+}
+
+impl ProcessingSpec {
+    /// Parse a format string like "token-simple" or "ast-json"
+    pub fn from_string(format_str: &str) -> Result<Self, ProcessingError> {
+        let parts: Vec<&str> = format_str.split('-').collect();
+        if parts.len() != 2 {
+            return Err(ProcessingError::InvalidFormat(format_str.to_string()));
+        }
+
+        let stage = match parts[0] {
+            "token" => ProcessingStage::Token,
+            "ast" => return Err(ProcessingError::InvalidStage(parts[0].to_string())), // AST not implemented yet
+            _ => return Err(ProcessingError::InvalidStage(parts[0].to_string())),
+        };
+
+        let format = match parts[1] {
+            "simple" => OutputFormat::Simple,
+            "json" => OutputFormat::Json,
+            "xml" => return Err(ProcessingError::InvalidFormatType(parts[1].to_string())), // XML not implemented yet
+            _ => return Err(ProcessingError::InvalidFormatType(parts[1].to_string())),
+        };
+
+        Ok(ProcessingSpec { stage, format })
+    }
+
+    /// Get all available processing specifications
+    pub fn available_specs() -> Vec<ProcessingSpec> {
+        vec![
+            ProcessingSpec {
+                stage: ProcessingStage::Token,
+                format: OutputFormat::Simple,
+            },
+            ProcessingSpec {
+                stage: ProcessingStage::Token,
+                format: OutputFormat::Json,
+            },
+            // Future: AST formats
+        ]
+    }
+}
+
+/// Errors that can occur during processing
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProcessingError {
+    FileNotFound(String),
+    InvalidFormat(String),
+    InvalidStage(String),
+    InvalidFormatType(String),
+    IoError(String),
+}
+
+impl fmt::Display for ProcessingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProcessingError::FileNotFound(path) => write!(f, "File not found: {}", path),
+            ProcessingError::InvalidFormat(format) => write!(f, "Invalid format: {}", format),
+            ProcessingError::InvalidStage(stage) => write!(f, "Invalid stage: {}", stage),
+            ProcessingError::InvalidFormatType(format_type) => {
+                write!(f, "Invalid format type: {}", format_type)
+            }
+            ProcessingError::IoError(msg) => write!(f, "IO error: {}", msg),
+        }
+    }
+}
+
+/// Process a txxt file according to the given specification
+pub fn process_file<P: AsRef<Path>>(
+    file_path: P,
+    spec: &ProcessingSpec,
+) -> Result<String, ProcessingError> {
+    let file_path = file_path.as_ref();
+
+    // Read the file
+    let content =
+        fs::read_to_string(file_path).map_err(|e| ProcessingError::IoError(e.to_string()))?;
+
+    // Process according to stage
+    match spec.stage {
+        ProcessingStage::Token => {
+            let tokens = tokenize(&content);
+            format_tokens(&tokens, &spec.format)
+        }
+        ProcessingStage::Ast => {
+            // Future: AST processing
+            Err(ProcessingError::InvalidStage("ast".to_string()))
+        }
+    }
+}
+
+/// Format tokens according to the specified format
+fn format_tokens(tokens: &[Token], format: &OutputFormat) -> Result<String, ProcessingError> {
+    match format {
+        OutputFormat::Simple => {
+            let mut result = String::new();
+            for token in tokens {
+                result.push_str(&format!("{}", token));
+                if matches!(token, Token::Newline) {
+                    result.push('\n');
+                }
+            }
+            Ok(result)
+        }
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(tokens)
+                .map_err(|e| ProcessingError::IoError(e.to_string()))?;
+            Ok(json)
+        }
+        OutputFormat::Xml => {
+            // Future: XML formatting
+            Err(ProcessingError::InvalidFormatType("xml".to_string()))
+        }
+    }
+}
+
+/// Get all available format strings
+pub fn available_formats() -> Vec<String> {
+    ProcessingSpec::available_specs()
+        .into_iter()
+        .map(|spec| {
+            format!(
+                "{}-{}",
+                match spec.stage {
+                    ProcessingStage::Token => "token",
+                    ProcessingStage::Ast => "ast",
+                },
+                match spec.format {
+                    OutputFormat::Simple => "simple",
+                    OutputFormat::Json => "json",
+                    OutputFormat::Xml => "xml",
+                }
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_processing_spec_parsing() {
+        let spec = ProcessingSpec::from_string("token-simple").unwrap();
+        assert_eq!(spec.stage, ProcessingStage::Token);
+        assert_eq!(spec.format, OutputFormat::Simple);
+
+        let spec = ProcessingSpec::from_string("token-json").unwrap();
+        assert_eq!(spec.stage, ProcessingStage::Token);
+        assert_eq!(spec.format, OutputFormat::Json);
+
+        assert!(ProcessingSpec::from_string("invalid").is_err());
+        assert!(ProcessingSpec::from_string("token-invalid").is_err());
+        assert!(ProcessingSpec::from_string("invalid-simple").is_err());
+    }
+
+    #[test]
+    fn test_token_formatting() {
+        let tokens = vec![Token::Text, Token::Whitespace, Token::Text, Token::Newline];
+
+        let simple = format_tokens(&tokens, &OutputFormat::Simple).unwrap();
+        assert_eq!(simple, "<text><whitespace><text><newline>\n");
+
+        let json = format_tokens(&tokens, &OutputFormat::Json).unwrap();
+        assert!(json.contains("\"Text\""));
+        assert!(json.contains("\"Whitespace\""));
+        assert!(json.contains("\"Newline\""));
+    }
+
+    #[test]
+    fn test_available_formats() {
+        let formats = available_formats();
+        assert!(formats.contains(&"token-simple".to_string()));
+        assert!(formats.contains(&"token-json".to_string()));
+    }
+}

--- a/tests/processor_api_test.rs
+++ b/tests/processor_api_test.rs
@@ -1,0 +1,219 @@
+//! Unit tests for the txxt processor API
+
+use std::fs;
+use txxt_nano::txxt_nano::lexer::Token;
+use txxt_nano::txxt_nano::processor::{
+    process_file, OutputFormat, ProcessingError, ProcessingSpec, ProcessingStage,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_processing_spec_parsing() {
+        // Test valid specs
+        let spec = ProcessingSpec::from_string("token-simple").unwrap();
+        assert_eq!(spec.stage, ProcessingStage::Token);
+        assert_eq!(spec.format, OutputFormat::Simple);
+
+        let spec = ProcessingSpec::from_string("token-json").unwrap();
+        assert_eq!(spec.stage, ProcessingStage::Token);
+        assert_eq!(spec.format, OutputFormat::Json);
+
+        // Test invalid specs
+        assert!(ProcessingSpec::from_string("invalid").is_err());
+        assert!(ProcessingSpec::from_string("token-invalid").is_err());
+        assert!(ProcessingSpec::from_string("invalid-simple").is_err());
+        assert!(ProcessingSpec::from_string("ast-simple").is_err()); // AST not implemented yet
+    }
+
+    #[test]
+    fn test_available_specs() {
+        let specs = ProcessingSpec::available_specs();
+        assert_eq!(specs.len(), 2);
+
+        let token_simple = specs
+            .iter()
+            .find(|s| s.stage == ProcessingStage::Token && s.format == OutputFormat::Simple);
+        assert!(token_simple.is_some());
+
+        let token_json = specs
+            .iter()
+            .find(|s| s.stage == ProcessingStage::Token && s.format == OutputFormat::Json);
+        assert!(token_json.is_some());
+    }
+
+    #[test]
+    fn test_token_display_format() {
+        // Test that tokens display with lowercase dash-separated names
+        assert_eq!(format!("{}", Token::TxxtMarker), "<txxt-marker>");
+        assert_eq!(format!("{}", Token::Indent), "<indent>");
+        assert_eq!(format!("{}", Token::Whitespace), "<whitespace>");
+        assert_eq!(format!("{}", Token::Newline), "<newline>");
+        assert_eq!(format!("{}", Token::Dash), "<dash>");
+        assert_eq!(format!("{}", Token::Period), "<period>");
+        assert_eq!(format!("{}", Token::OpenParen), "<open-paren>");
+        assert_eq!(format!("{}", Token::CloseParen), "<close-paren>");
+        assert_eq!(format!("{}", Token::Colon), "<colon>");
+        assert_eq!(format!("{}", Token::Number), "<number>");
+        assert_eq!(format!("{}", Token::Text), "<text>");
+    }
+
+    #[test]
+    fn test_token_simple_formatting() {
+        let tokens = vec![
+            Token::Text,
+            Token::Whitespace,
+            Token::Text,
+            Token::Newline,
+            Token::Indent,
+            Token::Dash,
+        ];
+
+        let spec = ProcessingSpec {
+            stage: ProcessingStage::Token,
+            format: OutputFormat::Simple,
+        };
+
+        let result = process_file_with_tokens(&tokens, &spec).unwrap();
+        let expected = "<text><whitespace><text><newline>\n<indent><dash>";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_token_json_formatting() {
+        let tokens = vec![Token::Text, Token::Whitespace, Token::Newline];
+
+        let spec = ProcessingSpec {
+            stage: ProcessingStage::Token,
+            format: OutputFormat::Json,
+        };
+
+        let result = process_file_with_tokens(&tokens, &spec).unwrap();
+        assert!(result.contains("\"Text\""));
+        assert!(result.contains("\"Whitespace\""));
+        assert!(result.contains("\"Newline\""));
+        assert!(result.starts_with('['));
+        assert!(result.ends_with(']'));
+    }
+
+    #[test]
+    fn test_file_processing() {
+        // Create a temporary test file
+        let test_content = "1. Hello world\n    - Item 1";
+        let test_file = "test_api.txxt";
+
+        fs::write(test_file, test_content).unwrap();
+
+        // Test token-simple processing
+        let spec = ProcessingSpec::from_string("token-simple").unwrap();
+        let result = process_file(test_file, &spec).unwrap();
+
+        assert!(result.contains("<number>"));
+        assert!(result.contains("<period>"));
+        assert!(result.contains("<text>"));
+        assert!(result.contains("<newline>"));
+        assert!(result.contains("<indent>"));
+        assert!(result.contains("<dash>"));
+
+        // Test token-json processing
+        let spec = ProcessingSpec::from_string("token-json").unwrap();
+        let result = process_file(test_file, &spec).unwrap();
+
+        assert!(result.contains("\"Number\""));
+        assert!(result.contains("\"Period\""));
+        assert!(result.contains("\"Text\""));
+        assert!(result.contains("\"Newline\""));
+        assert!(result.contains("\"Indent\""));
+        assert!(result.contains("\"Dash\""));
+
+        // Clean up
+        fs::remove_file(test_file).unwrap();
+    }
+
+    #[test]
+    fn test_file_not_found_error() {
+        let spec = ProcessingSpec::from_string("token-simple").unwrap();
+        let result = process_file("nonexistent.txxt", &spec);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ProcessingError::IoError(_) => {} // Expected
+            _ => panic!("Expected IoError"),
+        }
+    }
+
+    #[test]
+    fn test_ast_processing_not_implemented() {
+        let result = ProcessingSpec::from_string("ast-simple");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ProcessingError::InvalidStage(_) => {} // Expected
+            _ => panic!("Expected InvalidStage error"),
+        }
+    }
+
+    #[test]
+    fn test_xml_format_not_implemented() {
+        let result = ProcessingSpec::from_string("token-xml");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ProcessingError::InvalidFormatType(_) => {} // Expected
+            _ => panic!("Expected InvalidFormatType error"),
+        }
+    }
+
+    #[test]
+    fn test_line_break_handling_in_simple_format() {
+        let tokens = vec![
+            Token::Text,
+            Token::Newline,
+            Token::Text,
+            Token::Newline,
+            Token::Text,
+        ];
+
+        let spec = ProcessingSpec {
+            stage: ProcessingStage::Token,
+            format: OutputFormat::Simple,
+        };
+
+        let result = process_file_with_tokens(&tokens, &spec).unwrap();
+        let lines: Vec<&str> = result.split('\n').collect();
+
+        // Should have 3 lines (2 newlines + 1 final line)
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "<text><newline>");
+        assert_eq!(lines[1], "<text><newline>");
+        assert_eq!(lines[2], "<text>");
+    }
+
+    // Helper function to test formatting without file I/O
+    fn process_file_with_tokens(
+        tokens: &[Token],
+        spec: &ProcessingSpec,
+    ) -> Result<String, ProcessingError> {
+        match spec.stage {
+            ProcessingStage::Token => match spec.format {
+                OutputFormat::Simple => {
+                    let mut result = String::new();
+                    for token in tokens {
+                        result.push_str(&format!("{}", token));
+                        if matches!(token, Token::Newline) {
+                            result.push('\n');
+                        }
+                    }
+                    Ok(result)
+                }
+                OutputFormat::Json => {
+                    let json = serde_json::to_string_pretty(tokens)
+                        .map_err(|e| ProcessingError::IoError(e.to_string()))?;
+                    Ok(json)
+                }
+                OutputFormat::Xml => Err(ProcessingError::InvalidFormatType("xml".to_string())),
+            },
+            ProcessingStage::Ast => Err(ProcessingError::InvalidStage("ast".to_string())),
+        }
+    }
+}


### PR DESCRIPTION
## Overview

This PR implements the txxt binary tool for inspecting token streams and ASTs from txxt files.

## Features

### 🏗️ Extensible Architecture
- **Processing stages**: token (implemented), ast (future)
- **Output formats**: simple (implemented), json (implemented), xml (future)
- Clean separation between CLI and core API logic

### 🎯 Token Inspection Formats

#### token-simple
- Displays tokens as `<token-name>` format
- Uses lowercase dash-separated names (e.g., `<txxt-marker>`, `<open-paren>`)
- Inserts line breaks after `Newline` tokens for visual clarity
- Preserves all tokens including line-break tokens

#### token-json
- Outputs properly indented JSON array of token names
- Uses serde serialization for clean formatting

### 🖥️ CLI Interface
- Uses clap for argument parsing
- Thin layer over the main API
- Supports `--list-formats` option
- Proper error handling and user feedback

## Usage

```bash
# List available formats
txxt --list-formats

# Process with token-simple format
txxt file.txxt token-simple

# Process with token-json format  
txxt file.txxt token-json
```

## Example Output

### token-simple
```
<number><period><whitespace><text><newline>
<indent><dash><whitespace><text><newline>
```

### token-json
```json
[
  "Number",
  "Period",
  "Whitespace",
  "Text",
  "Newline",
  "Indent",
  "Dash",
  "Whitespace",
  "Text",
  "Newline"
]
```

## Testing

- ✅ Comprehensive unit tests for API functionality
- ✅ Tests for error conditions and edge cases
- ✅ All existing tests still pass
- ✅ Pre-commit checks pass (formatting, clippy, tests, docs)

## Implementation Details

- Added `Display` trait to `Token` enum with proper formatting
- Created extensible `ProcessingSpec` system for stage + format combinations
- Implemented clean error handling with custom `ProcessingError` types
- Added serde support for JSON serialization
- CLI is a thin wrapper over the main library API

## Future Extensions

The architecture is designed to easily support:
- AST processing (`ast-simple`, `ast-json`, `ast-xml`)
- Additional output formats (XML, YAML, etc.)
- Additional processing stages (semantic analysis, etc.)

Closes #(issue-number-if-applicable)