### PR TITLE
Refactor parser tests to use assert_ast library

### DIFF
--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -675,6 +675,8 @@ mod tests {
 
     #[test]
     fn test_verified_paragraphs_sample() {
+        use crate::txxt_nano::testing::assert_ast;
+
         let source =
             TxxtSources::get_string("000-paragraphs.txxt").expect("Failed to load sample file");
         let tokens = lex(&source);
@@ -690,83 +692,29 @@ mod tests {
 
         // Expected structure based on 000-paragraphs.txxt:
         // 7 paragraphs total, with specific line counts
-        let expected_structure = [
-            ("Paragraph", 1), // "Simple Paragraphs Test"
-            ("Paragraph", 1), // "This is a simple paragraph with just one line."
-            ("Paragraph", 3), // Multi-line paragraph
-            ("Paragraph", 1), // "Another paragraph follows..."
-            ("Paragraph", 1), // Paragraph with special chars
-            ("Paragraph", 1), // Paragraph with numbers
-            ("Paragraph", 1), // Paragraph with mixed content
-        ];
-
-        assert_eq!(
-            doc.items.len(),
-            expected_structure.len(),
-            "Expected {} paragraphs, got {}.\n\nExpected structure:\n{}\n\nActual structure:\n{}",
-            expected_structure.len(),
-            doc.items.len(),
-            expected_structure
-                .iter()
-                .enumerate()
-                .map(|(i, (t, lines))| format!("  {}: {} with {} lines", i, t, lines))
-                .collect::<Vec<_>>()
-                .join("\n"),
-            doc.items
-                .iter()
-                .enumerate()
-                .map(|(i, item)| match item {
-                    ContentItem::Paragraph(p) =>
-                        format!("  {}: Paragraph with {} lines", i, p.lines.len()),
-                    ContentItem::Session(s) => format!(
-                        "  {}: Session '{}' with {} items",
-                        i,
-                        s.title,
-                        s.content.len()
-                    ),
-                    ContentItem::List(l) => format!("  {}: List with {} items", i, l.items.len()),
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-
-        // Verify each item matches expected structure
-        for (i, (item, (expected_type, expected_lines))) in
-            doc.items.iter().zip(expected_structure.iter()).enumerate()
-        {
-            match item {
-                ContentItem::Paragraph(p) => {
-                    assert_eq!(
-                        expected_type, &"Paragraph",
-                        "Item {} should be a {}, but found Paragraph",
-                        i, expected_type
-                    );
-                    assert_eq!(
-                        p.lines.len(),
-                        *expected_lines,
-                        "Item {} (Paragraph) should have {} lines, but has {}.\nLines: {:?}",
-                        i,
-                        expected_lines,
-                        p.lines.len(),
-                        p.lines
-                    );
-                }
-                ContentItem::Session(s) => {
-                    panic!(
-                        "Item {} should be a Paragraph with {} lines, but found Session '{}' with {} items",
-                        i, expected_lines, s.title, s.content.len()
-                    );
-                }
-                ContentItem::List(l) => {
-                    panic!(
-                        "Item {} should be a Paragraph with {} lines, but found List with {} items",
-                        i,
-                        expected_lines,
-                        l.items.len()
-                    );
-                }
-            }
-        }
+        assert_ast(&doc)
+            .item_count(7)
+            .item(0, |item| {
+                item.assert_paragraph().line_count(1); // "Simple Paragraphs Test"
+            })
+            .item(1, |item| {
+                item.assert_paragraph().line_count(1); // "This is a simple paragraph with just one line."
+            })
+            .item(2, |item| {
+                item.assert_paragraph().line_count(3); // Multi-line paragraph
+            })
+            .item(3, |item| {
+                item.assert_paragraph().line_count(1); // "Another paragraph follows..."
+            })
+            .item(4, |item| {
+                item.assert_paragraph().line_count(1); // Paragraph with special chars
+            })
+            .item(5, |item| {
+                item.assert_paragraph().line_count(1); // Paragraph with numbers
+            })
+            .item(6, |item| {
+                item.assert_paragraph().line_count(1); // Paragraph with mixed content
+            });
     }
 
     #[test]

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -778,6 +778,8 @@ mod tests {
 
     #[test]
     fn test_verified_multiple_sessions_sample() {
+        use crate::txxt_nano::testing::assert_ast;
+
         let source = TxxtSources::get_string("020-paragraphs-sessions-flat-multiple.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
@@ -807,25 +809,6 @@ mod tests {
         //   Line 25: "Session titles don't require..." - nested session title with 1 paragraph
         //     Line 27: "They just need..." - paragraph (1 line)
         // Line 29: "Final paragraph..." - paragraph (1 line)
-
-        let expected_items = 9;
-        assert_eq!(
-            doc.items.len(),
-            expected_items,
-            "Expected {} root-level items, got {}.\n\nExpected:\n  0: Paragraph (1 line)\n  1: Paragraph (1 line)\n  2: Session (2 paragraphs)\n  3: Session (1 paragraph)\n  4: Paragraph (1 line)\n  5: Session (1 paragraph)\n  6: Paragraph (1 line)\n  7: Session (1 nested session)\n  8: Paragraph (1 line)\n\nActual:\n{}",
-            expected_items,
-            doc.items.len(),
-            doc.items.iter().enumerate()
-                .map(|(i, item)| match item {
-                    ContentItem::Paragraph(p) => format!("  {}: Paragraph ({} lines)", i, p.lines.len()),
-                    ContentItem::Session(s) => format!("  {}: Session ({} items)", i, s.content.len()),
-                    ContentItem::List(l) => format!("  {}: List ({} items)", i, l.items.len()),
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-
-        use crate::txxt_nano::testing::assert_ast;
 
         assert_ast(&doc)
             .item_count(9)

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -719,6 +719,8 @@ mod tests {
 
     #[test]
     fn test_verified_single_session_sample() {
+        use crate::txxt_nano::testing::assert_ast;
+
         let source = TxxtSources::get_string("010-paragraphs-sessions-flat-single.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
@@ -743,266 +745,35 @@ mod tests {
         //   Line 15: "This session demonstrates..." - paragraph (1 line)
         // Line 17: "Final paragraph..." - paragraph (1 line)
 
-        let expected_doc_items = 6;
-        assert_eq!(
-            doc.items.len(),
-            expected_doc_items,
-            "Expected {} root-level items, got {}.\n\nExpected:\n  0: Paragraph (1 line)\n  1: Paragraph (1 line)\n  2: Session with 2 paragraphs\n  3: Paragraph (1 line)\n  4: Session with 1 paragraph\n  5: Paragraph (1 line)\n\nActual:\n{}",
-            expected_doc_items,
-            doc.items.len(),
-            doc.items.iter().enumerate()
-                .map(|(i, item)| match item {
-                    ContentItem::Paragraph(p) => format!("  {}: Paragraph ({} lines)", i, p.lines.len()),
-                    ContentItem::Session(s) => format!("  {}: Session with {} items", i, s.content.len()),
-                    ContentItem::List(l) => format!("  {}: List with {} items", i, l.items.len()),
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-
-        // Verify item 0: Paragraph with 1 line
-        match &doc.items[0] {
-            ContentItem::Paragraph(p) => {
-                assert_eq!(
-                    p.lines.len(),
-                    1,
-                    "Item 0: Expected 1 line, got {}. Lines: {:?}",
-                    p.lines.len(),
-                    p.lines
-                );
-            }
-            ContentItem::Session(s) => {
-                panic!(
-                    "Item 0: Expected Paragraph, got Session '{}' with {} items",
-                    s.title,
-                    s.content.len()
-                );
-            }
-            ContentItem::List(l) => {
-                panic!(
-                    "Item 0: Expected Paragraph, got List with {} items",
-                    l.items.len()
-                );
-            }
-        }
-
-        // Verify item 1: Paragraph with 1 line
-        match &doc.items[1] {
-            ContentItem::Paragraph(p) => {
-                assert_eq!(
-                    p.lines.len(),
-                    1,
-                    "Item 1: Expected 1 line, got {}. Lines: {:?}",
-                    p.lines.len(),
-                    p.lines
-                );
-            }
-            ContentItem::Session(s) => {
-                panic!(
-                    "Item 1: Expected Paragraph, got Session '{}' with {} items",
-                    s.title,
-                    s.content.len()
-                );
-            }
-            ContentItem::List(l) => {
-                panic!(
-                    "Item 1: Expected Paragraph, got List with {} items",
-                    l.items.len()
-                );
-            }
-        }
-
-        // Verify item 2: Session with 2 paragraphs
-        match &doc.items[2] {
-            ContentItem::Session(session) => {
-                assert_eq!(
-                    session.content.len(), 2,
-                    "Item 2: Session should have 2 items, got {}.\n\nExpected:\n  0: Paragraph (1 line)\n  1: Paragraph (1 line)\n\nActual:\n{}",
-                    session.content.len(),
-                    session.content.iter().enumerate()
-                        .map(|(i, item)| match item {
-                            ContentItem::Paragraph(p) => format!("  {}: Paragraph ({} lines)", i, p.lines.len()),
-                            ContentItem::Session(s) => format!("  {}: Session with {} items", i, s.content.len()),
-                            ContentItem::List(l) => format!("  {}: List with {} items", i, l.items.len()),
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                );
-
-                // Verify session's first paragraph
-                match &session.content[0] {
-                    ContentItem::Paragraph(p) => {
-                        assert_eq!(
-                            p.lines.len(),
-                            1,
-                            "Item 2, child 0: Expected 1 line, got {}. Lines: {:?}",
-                            p.lines.len(),
-                            p.lines
-                        );
-                    }
-                    ContentItem::Session(s) => {
-                        panic!(
-                            "Item 2, child 0: Expected Paragraph, got Session '{}' with {} items",
-                            s.title,
-                            s.content.len()
-                        );
-                    }
-                    ContentItem::List(l) => {
-                        panic!(
-                            "Item 2, child 0: Expected Paragraph, got List with {} items",
-                            l.items.len()
-                        );
-                    }
-                }
-
-                // Verify session's second paragraph
-                match &session.content[1] {
-                    ContentItem::Paragraph(p) => {
-                        assert_eq!(
-                            p.lines.len(),
-                            1,
-                            "Item 2, child 1: Expected 1 line, got {}. Lines: {:?}",
-                            p.lines.len(),
-                            p.lines
-                        );
-                    }
-                    ContentItem::Session(s) => {
-                        panic!(
-                            "Item 2, child 1: Expected Paragraph, got Session '{}' with {} items",
-                            s.title,
-                            s.content.len()
-                        );
-                    }
-                    ContentItem::List(l) => {
-                        panic!(
-                            "Item 2, child 1: Expected Paragraph, got List with {} items",
-                            l.items.len()
-                        );
-                    }
-                }
-            }
-            ContentItem::Paragraph(p) => {
-                panic!(
-                    "Item 2: Expected Session with 2 items, got Paragraph with {} lines",
-                    p.lines.len()
-                );
-            }
-            ContentItem::List(l) => {
-                panic!(
-                    "Item 2: Expected Session, got List with {} items",
-                    l.items.len()
-                );
-            }
-        }
-
-        // Verify item 3: Paragraph with 1 line
-        match &doc.items[3] {
-            ContentItem::Paragraph(p) => {
-                assert_eq!(
-                    p.lines.len(),
-                    1,
-                    "Item 3: Expected 1 line, got {}. Lines: {:?}",
-                    p.lines.len(),
-                    p.lines
-                );
-            }
-            ContentItem::Session(s) => {
-                panic!(
-                    "Item 3: Expected Paragraph, got Session '{}' with {} items",
-                    s.title,
-                    s.content.len()
-                );
-            }
-            ContentItem::List(l) => {
-                panic!(
-                    "Item 3: Expected Paragraph, got List with {} items",
-                    l.items.len()
-                );
-            }
-        }
-
-        // Verify item 4: Session with 1 paragraph
-        match &doc.items[4] {
-            ContentItem::Session(session) => {
-                assert_eq!(
-                    session.content.len(), 1,
-                    "Item 4: Session should have 1 item, got {}.\n\nExpected:\n  0: Paragraph (1 line)\n\nActual:\n{}",
-                    session.content.len(),
-                    session.content.iter().enumerate()
-                        .map(|(i, item)| match item {
-                            ContentItem::Paragraph(p) => format!("  {}: Paragraph ({} lines)", i, p.lines.len()),
-                            ContentItem::Session(s) => format!("  {}: Session with {} items", i, s.content.len()),
-                            ContentItem::List(l) => format!("  {}: List with {} items", i, l.items.len()),
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                );
-
-                // Verify session's paragraph
-                match &session.content[0] {
-                    ContentItem::Paragraph(p) => {
-                        assert_eq!(
-                            p.lines.len(),
-                            1,
-                            "Item 4, child 0: Expected 1 line, got {}. Lines: {:?}",
-                            p.lines.len(),
-                            p.lines
-                        );
-                    }
-                    ContentItem::Session(s) => {
-                        panic!(
-                            "Item 4, child 0: Expected Paragraph, got Session '{}' with {} items",
-                            s.title,
-                            s.content.len()
-                        );
-                    }
-                    ContentItem::List(l) => {
-                        panic!(
-                            "Item 4, child 0: Expected Paragraph, got List with {} items",
-                            l.items.len()
-                        );
-                    }
-                }
-            }
-            ContentItem::Paragraph(p) => {
-                panic!(
-                    "Item 4: Expected Session with 1 item, got Paragraph with {} lines",
-                    p.lines.len()
-                );
-            }
-            ContentItem::List(l) => {
-                panic!(
-                    "Item 4: Expected Session, got List with {} items",
-                    l.items.len()
-                );
-            }
-        }
-
-        // Verify item 5: Paragraph with 1 line
-        match &doc.items[5] {
-            ContentItem::Paragraph(p) => {
-                assert_eq!(
-                    p.lines.len(),
-                    1,
-                    "Item 5: Expected 1 line, got {}. Lines: {:?}",
-                    p.lines.len(),
-                    p.lines
-                );
-            }
-            ContentItem::Session(s) => {
-                panic!(
-                    "Item 5: Expected Paragraph, got Session '{}' with {} items",
-                    s.title,
-                    s.content.len()
-                );
-            }
-            ContentItem::List(l) => {
-                panic!(
-                    "Item 5: Expected Paragraph, got List with {} items",
-                    l.items.len()
-                );
-            }
-        }
+        assert_ast(&doc)
+            .item_count(6)
+            .item(0, |item| {
+                item.assert_paragraph().line_count(1);
+            })
+            .item(1, |item| {
+                item.assert_paragraph().line_count(1);
+            })
+            .item(2, |item| {
+                item.assert_session()
+                    .child_count(2)
+                    .child(0, |child| {
+                        child.assert_paragraph().line_count(1);
+                    })
+                    .child(1, |child| {
+                        child.assert_paragraph().line_count(1);
+                    });
+            })
+            .item(3, |item| {
+                item.assert_paragraph().line_count(1);
+            })
+            .item(4, |item| {
+                item.assert_session().child_count(1).child(0, |child| {
+                    child.assert_paragraph().line_count(1);
+                });
+            })
+            .item(5, |item| {
+                item.assert_paragraph().line_count(1);
+            });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refactors all parser tests identified in #9 to use the `assert_ast` fluent assertion library instead of brittle match statements. This makes the test suite resilient to future changes when new `ContentItem` variants are added to the txxt grammar.

## Problem

Our test suite was brittle. When the `List` variant was added to the `ContentItem` enum, many existing tests for paragraphs and sessions failed because they used direct, exhaustive match statements to check AST node types.

This is a significant maintainability problem. Every time we add a new element to the txxt grammar (e.g., `Table`, `Blockquote`), we would have to manually update every single match statement across the entire test suite.

## Solution

All four identified tests now use the `assert_ast` library:

- ✅ `test_verified_paragraphs_sample` - 52 lines removed
- ✅ `test_verified_single_session_sample` - 229 lines removed  
- ✅ `test_verified_multiple_sessions_sample` - 17 lines removed
- ✅ `test_verified_nested_sessions_sample` - 135 lines removed

Also removed the now-unused `verify_item` helper function (83 lines).

**Total: Over 400 lines of brittle match-based code eliminated.**

## Benefits

### Before (Brittle)
```rust
match &doc.items[0] {
    ContentItem::Paragraph(p) => {
        assert_eq!(p.lines.len(), 1, "Expected 1 line, got {}", p.lines.len());
    }
    ContentItem::Session(s) => {
        panic!("Expected Paragraph, got Session");
    }
    ContentItem::List(l) => {
        panic!("Expected Paragraph, got List");
    }
    // A new arm required for every new ContentItem variant...
}
```

### After (Resilient)
```rust
assert_ast(&doc).item(0, |item| {
    item.assert_paragraph().line_count(1);
});
```

### Impact

✅ **Resilient to change** - Tests won't break when new `ContentItem` variants are added  
✅ **More concise** - Removed over 400 lines of boilerplate  
✅ **More readable** - Fluent API clearly expresses intent  
✅ **Better maintainability** - Centralized type checking in the assertion library

## Testing

All tests pass:
```
running 94 tests
test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Incremental Commits

Each test was refactored, committed, and pushed separately to allow for incremental merging if needed:

1. `65f309c` - Refactor `test_verified_paragraphs_sample`
2. `fe73c6f` - Refactor `test_verified_single_session_sample`  
3. `f507136` - Complete refactor of `test_verified_multiple_sessions_sample`
4. `d3b11bc` - Refactor `test_verified_nested_sessions_sample` and remove unused helper

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>