### PR TITLE
Add support for nested lists

### DIFF
--- a/docs/specs/v1/samples/070-nested-lists-simple.txxt
+++ b/docs/specs/v1/samples/070-nested-lists-simple.txxt
@@ -1,0 +1,25 @@
+Simple Nested Lists Test {{paragraph}}
+
+This document tests simple list-in-list nesting. {{paragraph}}
+
+Basic nested list: {{paragraph}}
+
+- First outer item {{list-item}}
+    - First nested item {{list-item}}
+    - Second nested item {{list-item}}
+
+- Second outer item {{list-item}}
+    - Another nested item {{list-item}}
+    - Yet another nested item {{list-item}}
+
+Numbered list with nested dashed list: {{paragraph}}
+
+1. First numbered item {{list-item}}
+    - Nested dash item one {{list-item}}
+    - Nested dash item two {{list-item}}
+
+2. Second numbered item {{list-item}}
+    - Another nested dash item {{list-item}}
+    - Yet another nested dash item {{list-item}}
+
+Final paragraph after lists. {{paragraph}}

--- a/docs/specs/v1/samples/080-nested-lists-mixed-content.txxt
+++ b/docs/specs/v1/samples/080-nested-lists-mixed-content.txxt
@@ -1,0 +1,48 @@
+Nested Lists with Mixed Content Test {{paragraph}}
+
+This document tests list items containing a mix of paragraphs and other lists. {{paragraph}}
+
+List with paragraph content: {{paragraph}}
+
+- First item with nested paragraph {{list-item}}
+    This is a paragraph nested inside the first list item. It provides additional context and detail. {{paragraph}}
+
+- Second item with multiple paragraphs {{list-item}}
+    This is the first paragraph in the second item. {{paragraph}}
+
+    This is a second paragraph, showing that list items can contain multiple paragraphs. {{paragraph}}
+
+List with mixed paragraphs and nested lists: {{paragraph}}
+
+1. First complex item {{list-item}}
+    This is a paragraph explaining the first item. {{paragraph}}
+
+    - Nested list item one {{list-item}}
+    - Nested list item two {{list-item}}
+
+    Another paragraph after the nested list. {{paragraph}}
+
+2. Second complex item {{list-item}}
+    Opening paragraph for item two. {{paragraph}}
+
+    - First nested item {{list-item}}
+    - Second nested item {{list-item}}
+
+    Closing paragraph for item two. {{paragraph}}
+
+Deeply nested structure: {{paragraph}}
+
+- Outer item one {{list-item}}
+    Paragraph in outer item. {{paragraph}}
+
+    - Middle item one {{list-item}}
+        - Inner item one {{list-item}}
+        - Inner item two {{list-item}}
+
+    - Middle item two {{list-item}}
+        Paragraph in middle item. {{paragraph}}
+
+- Outer item two {{list-item}}
+    Final paragraph. {{paragraph}}
+
+End of document. {{paragraph}}

--- a/src/txxt_nano/parser/ast.rs
+++ b/src/txxt_nano/parser/ast.rs
@@ -139,8 +139,11 @@ pub struct List {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListItem {
     /// The text content of this list item (including the marker)
-    /// Stored as a single-element vector to satisfy TextNode trait
+    /// Stored as a single-element vector to maintain backward compatibility
     text: Vec<String>,
+    /// Nested content within this list item (paragraphs and lists)
+    /// Will be empty if there's no nested content
+    pub content: Vec<ContentItem>,
 }
 
 impl Document {
@@ -235,7 +238,18 @@ impl List {
 impl ListItem {
     /// Create a new list item with the given text
     pub fn new(text: String) -> Self {
-        Self { text: vec![text] }
+        Self {
+            text: vec![text],
+            content: Vec::new(),
+        }
+    }
+
+    /// Create a new list item with text and content
+    pub fn with_content(text: String, content: Vec<ContentItem>) -> Self {
+        Self {
+            text: vec![text],
+            content,
+        }
     }
 
     /// Get the text content of this list item
@@ -352,7 +366,7 @@ impl AstNode for List {
     }
 }
 
-// ListItem - AstNode and TextNode implementation
+// ListItem - AstNode and Container implementation
 impl AstNode for ListItem {
     fn node_type(&self) -> &'static str {
         "ListItem"
@@ -368,13 +382,17 @@ impl AstNode for ListItem {
     }
 }
 
-impl TextNode for ListItem {
-    fn text(&self) -> String {
-        self.text[0].clone()
+impl Container for ListItem {
+    fn label(&self) -> &str {
+        &self.text[0]
     }
 
-    fn lines(&self) -> &[String] {
-        &self.text
+    fn children(&self) -> &[ContentItem] {
+        &self.content
+    }
+
+    fn children_mut(&mut self) -> &mut Vec<ContentItem> {
+        &mut self.content
     }
 }
 

--- a/src/txxt_nano/processor.rs
+++ b/src/txxt_nano/processor.rs
@@ -259,6 +259,8 @@ pub mod txxt_sources {
         "050-paragraph-lists.txxt",
         "050-trifecta-flat-simple.txxt",
         "060-trifecta-nesting.txxt",
+        "070-nested-lists-simple.txxt",
+        "080-nested-lists-mixed-content.txxt",
     ];
 
     /// Format options for sample content
@@ -426,7 +428,9 @@ pub mod txxt_sources {
             let samples = TxxtSources::list_samples();
             assert!(samples.contains(&"000-paragraphs.txxt"));
             assert!(samples.contains(&"040-lists.txxt"));
-            assert_eq!(samples.len(), 8);
+            assert!(samples.contains(&"070-nested-lists-simple.txxt"));
+            assert!(samples.contains(&"080-nested-lists-mixed-content.txxt"));
+            assert_eq!(samples.len(), 10);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Implements GitHub issue #11 by adding support for nested lists where list items can contain paragraphs and other lists.

## Changes

### AST Changes
- Modified `ListItem` struct to include `content` field for nested items
- Removed `TextNode` trait from `ListItem` (now a `Container`)
- Added `Container` trait implementation for `ListItem`
- Added `with_content()` constructor for creating nested list items

### Parser Changes
- Created `ListItemWithSpans` structure for parsing
- Implemented recursive `list_item()` parser with optional indented content
- Created restricted content parser (paragraphs and lists only, no sessions)
- Updated `list()` parser to use new `list_item()` parser
- Added `convert_list_item()` function for AST conversion

### Testing Infrastructure
- Enhanced `ListItemAssertion` with `child_count()`, `child()`, and `children()`
- Added comprehensive tests for nested list structures

### Sample Files
- Added `070-nested-lists-simple.txxt` for basic nesting examples
- Added `080-nested-lists-mixed-content.txxt` for complex scenarios
- Registered new samples in `TxxtSources`

## Test Results

All 128 tests passing:
- 96 unit tests
- 21 property tests
- 10 integration tests
- 1 doc test

## Example

List items can now contain nested paragraphs and lists:

```
- First item
    This is a paragraph inside the list item.

    - Nested list item
    - Another nested item

- Second item
    Another paragraph.
```

## Notes

- List items require **no blank line** before indented content (distinguishes from sessions)
- Sessions are explicitly excluded from list item content (enforced by parser)
- All existing tests continue to pass, ensuring backward compatibility

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)