### PR TITLE
Add support for Definition element

### DIFF
--- a/docs/specs/v1/general.txxt
+++ b/docs/specs/v1/general.txxt
@@ -33,13 +33,21 @@ The txxt language
 
         List items can mix different decoration styles (remember, they are not content, but formatting). The list style is defined by the style of the first list item.
 
-    2. Sessions
+    2. Definitions
+
+        Definitions consist of a subject line ending with a colon, immediately followed by indented content with no blank line between them.
+
+        The subject line identifies what is being defined, while the indented content provides the definition or explanation.
+
+        Definition content can include paragraphs and lists, but cannot contain sessions. This restriction ensures definitions remain focused explanatory units.
+
+    3. Sessions
 
         Sessions contain a session title line, followed by at least one blank line, then at least one child content, which must be indented relative to the session title.
 
         Sessions can be arbitrarily nested, with the only requirement that they must have at least one item as content (aside from the title).
 
-    3. Paragraphs
+    4. Paragraphs
 
         Paragraphs are one or more consecutive non-blank lines.
 

--- a/docs/specs/v1/grammar.txxt
+++ b/docs/specs/v1/grammar.txxt
@@ -158,7 +158,7 @@ Grammar for txxt
 
 3. Element Grammar
 
-    These are the trifecta elements of txxt: sessions, paragraphs and lists:
+    These are the core elements of txxt: sessions, paragraphs, lists, and definitions:
 
     <list> = <blank-line> <list-item-line>{2,*}
 
@@ -167,6 +167,14 @@ Grammar for txxt
     - Blank lines between list items are NOT allowed (would terminate the list)
     - Single list-item-lines become paragraphs (not lists)
 
+    <definition> = <subject-line> <indent> <definition-content>
+    <definition-content> = (<paragraph> | <list>)+
+
+    Note: Definitions differ from sessions in two key ways:
+    - NO blank line between subject and content (immediate indent)
+    - Content cannot include sessions (only paragraphs and lists)
+    - Subject line must end with a colon (:)
+
     <session> = <session-title-line> <blank-line> <indent> <session-content>
     <session-content> = (<paragraph> | <list> | <session>)+
 
@@ -174,4 +182,6 @@ Grammar for txxt
 
     <document> = <metadata>? <content>
     <metadata> = (document metadata, non-content information)
-    <content> = (<paragraph> | <list> | <session>)*
+    <content> = (<paragraph> | <list> | <definition> | <session>)*
+
+    Parse order: <list> | <definition> | <session> | <paragraph>

--- a/docs/specs/v1/samples/090-definitions-simple.txxt
+++ b/docs/specs/v1/samples/090-definitions-simple.txxt
@@ -1,0 +1,24 @@
+Simple Definitions Test {{paragraph}}
+
+This document tests the basic Definition element. {{paragraph}}
+
+First Definition:
+    This is the content of the first definition. {{paragraph}} {{definition}}
+
+Second Definition:
+    This definition has content that explains the second term. {{paragraph}} {{definition}}
+
+Glossary Term:
+    A glossary term is a word or phrase that needs explanation. {{paragraph}} {{definition}}
+
+    This definition contains multiple paragraphs to show that definitions can have complex content. {{paragraph}}
+
+API Endpoint:
+    A specific URL path that provides access to a resource or function. {{paragraph}} {{definition}}
+
+Regular paragraph after definitions. {{paragraph}}
+
+Another Term:
+    Definitions can appear anywhere in the document. {{paragraph}} {{definition}}
+
+Final paragraph. {{paragraph}}

--- a/docs/specs/v1/samples/100-definitions-mixed-content.txxt
+++ b/docs/specs/v1/samples/100-definitions-mixed-content.txxt
@@ -1,0 +1,47 @@
+Definitions with Mixed Content Test {{paragraph}}
+
+This document tests definitions containing both paragraphs and lists. {{paragraph}}
+
+Programming Language:
+    A formal language comprising a set of instructions that produce various kinds of output. {{paragraph}} {{definition}}
+
+    - Compiled languages {{list-item}}
+    - Interpreted languages {{list-item}}
+    - Scripting languages {{list-item}}
+
+HTTP Methods:
+    - GET: Retrieve a resource {{list-item}} {{definition}}
+    - POST: Create a new resource {{list-item}}
+    - PUT: Update an existing resource {{list-item}}
+    - DELETE: Remove a resource {{list-item}}
+
+Data Structure:
+    A way of organizing and storing data so that it can be accessed and modified efficiently. {{paragraph}} {{definition}}
+
+    - Arrays {{list-item}}
+    - Linked lists {{list-item}}
+    - Stacks {{list-item}}
+    - Queues {{list-item}}
+
+    - Trees {{list-item}}
+    - Graphs {{list-item}}
+    - Hash tables {{list-item}}
+
+Regular paragraph between definitions. {{paragraph}}
+
+Design Pattern:
+    A reusable solution to a commonly occurring problem in software design. {{paragraph}} {{definition}}
+
+    - Singleton {{list-item}}
+    - Factory {{list-item}}
+    - Builder {{list-item}}
+
+    - Adapter {{list-item}}
+    - Decorator {{list-item}}
+    - Facade {{list-item}}
+
+    - Observer {{list-item}}
+    - Strategy {{list-item}}
+    - Command {{list-item}}
+
+End of document. {{paragraph}}

--- a/docs/specs/v1/samples/110-ensemble-with-definitions.txxt
+++ b/docs/specs/v1/samples/110-ensemble-with-definitions.txxt
@@ -1,0 +1,117 @@
+Ensemble Test with Definitions {{paragraph}}
+
+This document tests all core elements (paragraphs, sessions, lists, and definitions) in complex nesting scenarios. {{paragraph}}
+
+Introduction:
+    This ensemble test demonstrates how definitions integrate with other txxt elements. {{paragraph}} {{definition}}
+
+    - Paragraphs provide narrative content {{list-item}}
+    - Lists organize items {{list-item}}
+    - Sessions structure hierarchical content {{list-item}}
+    - Definitions explain terms and concepts {{list-item}}
+
+1. Simple Elements Section {{session}}
+
+    First, let's demonstrate each element in isolation. {{paragraph}}
+
+    API Endpoint:
+        A URL that provides access to a specific resource or function. {{paragraph}} {{definition}}
+
+    Database Types:
+        - Relational databases {{list-item}} {{definition}}
+        - NoSQL databases {{list-item}}
+        - Graph databases {{list-item}}
+
+    Here's a simple list at the session level {{paragraph}}
+
+    - First item {{list-item}}
+    - Second item {{list-item}}
+    - Third item {{list-item}}
+
+2. Nested Elements Section {{session}}
+
+    Now we'll test more complex nesting patterns. {{paragraph}}
+
+    2.1. Subsection with Definitions {{session}}
+
+        Microservice:
+            An architectural style that structures an application as a collection of loosely coupled services. {{paragraph}} {{definition}}
+
+            Key characteristics {{paragraph}}
+
+            - Independence {{list-item}}
+            - Scalability {{list-item}}
+            - Resilience {{list-item}}
+
+        Container:
+            A lightweight, standalone executable package that includes everything needed to run software. {{paragraph}} {{definition}}
+
+        Regular paragraph between definitions. {{paragraph}}
+
+        Orchestration:
+            The automated arrangement, coordination, and management of complex systems. {{paragraph}} {{definition}}
+
+            - Kubernetes {{list-item}}
+            - Docker Swarm {{list-item}}
+
+    2.2. Subsection with Mixed Content {{session}}
+
+        This subsection contains a mix of all element types. {{paragraph}}
+
+        REST API:
+            Representational State Transfer Application Programming Interface. {{paragraph}} {{definition}}
+
+            - GET: Retrieve resources {{list-item}}
+            - POST: Create resources {{list-item}}
+            - PUT: Update resources {{list-item}}
+            - DELETE: Remove resources {{list-item}}
+
+        Middleware paragraph explaining the concept. {{paragraph}}
+
+        Authentication Methods:
+            - OAuth 2.0 {{list-item}} {{definition}}
+            - JWT tokens {{list-item}}
+            - API keys {{list-item}}
+
+        Another paragraph with context. {{paragraph}}
+
+        - Session-level list item one {{list-item}}
+        - Session-level list item two {{list-item}}
+
+3. Deep Nesting Section {{session}}
+
+    This section tests deeper nesting levels. {{paragraph}}
+
+    3.1. Level One {{session}}
+
+        Content at level one. {{paragraph}}
+
+        Design Pattern:
+            A reusable solution to a commonly occurring problem. {{paragraph}} {{definition}}
+
+            - Creational patterns {{list-item}}
+            - Structural patterns {{list-item}}
+            - Behavioral patterns {{list-item}}
+
+        3.1.1. Level Two {{session}}
+
+            Content at level two. {{paragraph}}
+
+            Singleton Pattern:
+                Ensures a class has only one instance. {{paragraph}} {{definition}}
+
+            Factory Pattern:
+                Creates objects without specifying exact classes. {{paragraph}} {{definition}}
+
+                - Simple Factory {{list-item}}
+                - Factory Method {{list-item}}
+                - Abstract Factory {{list-item}}
+
+            More level two content. {{paragraph}}
+
+Regular paragraph after all sessions. {{paragraph}}
+
+Final Definition:
+    Definitions can appear at any level of the document structure. {{paragraph}} {{definition}}
+
+End of ensemble test. {{paragraph}}

--- a/docs/tips-tricks.txxt
+++ b/docs/tips-tricks.txxt
@@ -5,30 +5,47 @@ Parsing TXXT Tips and Tricks
 
     That is not to say, however, that is it not parsable, it is, but it requires careful planning and attention to detail. 
 
-1. Parsing The Trifecta
+1. Parsing The Core Elements
 
-    The core elements: sessions, paragraphs and lists of txxt are the ones where these difficulties are more evident.
-    
-    The cause being: there is big syntatic overlap between session titles and list items, and all session titles and list items are valid paragraph.
+    The core elements: sessions, paragraphs, lists, and definitions of txxt are the ones where these difficulties are more evident.
 
-    1. Parse lists first: 
+    The cause being: there is big syntatic overlap between session titles, definitions, and list items, and all of these are valid paragraphs.
 
-        Lists requires: 
+    Parse order is critical: List → Definition → Session → Paragraph
+
+    1. Parse lists first:
+
+        Lists requires:
             - ListItem Line types
             - At least 2, contiguos (that is one list item line, blank line and other list item line is not a list)
+            - Must be preceded by a blank line
 
-    2. Once lists get out of the way, parsing is simpler. 
+    2. Parse definitions second:
 
-        A sessino will have a SessionTitle Line, then a blank line, indent, and any line.
+        Definitions require:
+            - Subject line ending with a colon (:)
+            - NO blank line after the subject
+            - Immediate indent with content
+            - Content can include paragraphs and lists, but NOT sessions
 
-        IN general terms: 
+        In general terms:
 
-        <blank-line>
+        <subject-line-ending-with-colon>
+        <indent><paragraph-or-list>
+
+    3. Parse sessions third:
+
+        A session will have a SessionTitle Line, then a blank line, indent, and any line.
+
+        IN general terms:
+
         <session-title-line>
         <blank-line>
         <indent><any-line>
 
-    3. Anything else will be a paragraph.
+        The blank line distinguishes sessions from definitions.
+
+    4. Anything else will be a paragraph.
 
 2. Recursion
 

--- a/src/txxt_nano/parser/ast_tag_serializer.rs
+++ b/src/txxt_nano/parser/ast_tag_serializer.rs
@@ -77,6 +77,23 @@ fn serialize_content_item(item: &ContentItem, indent_level: usize, output: &mut 
             }
             output.push_str(&format!("{}</list>\n", indent));
         }
+        ContentItem::Definition(d) => {
+            // <definition>subject<content>...</content></definition>
+            output.push_str(&format!("{}<definition>", indent));
+            output.push_str(&escape_xml(&d.subject));
+
+            if d.children().is_empty() {
+                // Empty definition
+                output.push_str("</definition>\n");
+            } else {
+                // Definition with children
+                output.push_str("<content>\n");
+                for child in d.children() {
+                    serialize_content_item(child, indent_level + 1, output);
+                }
+                output.push_str(&format!("{}</content></definition>\n", indent));
+            }
+        }
     }
 }
 

--- a/src/txxt_nano/processor.rs
+++ b/src/txxt_nano/processor.rs
@@ -263,6 +263,7 @@ pub mod txxt_sources {
         "080-nested-lists-mixed-content.txxt",
         "090-definitions-simple.txxt",
         "100-definitions-mixed-content.txxt",
+        "110-ensemble-with-definitions.txxt",
     ];
 
     /// Format options for sample content
@@ -434,7 +435,7 @@ pub mod txxt_sources {
             assert!(samples.contains(&"080-nested-lists-mixed-content.txxt"));
             assert!(samples.contains(&"090-definitions-simple.txxt"));
             assert!(samples.contains(&"100-definitions-mixed-content.txxt"));
-            assert_eq!(samples.len(), 12);
+            assert_eq!(samples.len(), 13);
         }
 
         #[test]

--- a/src/txxt_nano/processor.rs
+++ b/src/txxt_nano/processor.rs
@@ -261,6 +261,8 @@ pub mod txxt_sources {
         "060-trifecta-nesting.txxt",
         "070-nested-lists-simple.txxt",
         "080-nested-lists-mixed-content.txxt",
+        "090-definitions-simple.txxt",
+        "100-definitions-mixed-content.txxt",
     ];
 
     /// Format options for sample content
@@ -430,7 +432,9 @@ pub mod txxt_sources {
             assert!(samples.contains(&"040-lists.txxt"));
             assert!(samples.contains(&"070-nested-lists-simple.txxt"));
             assert!(samples.contains(&"080-nested-lists-mixed-content.txxt"));
-            assert_eq!(samples.len(), 10);
+            assert!(samples.contains(&"090-definitions-simple.txxt"));
+            assert!(samples.contains(&"100-definitions-mixed-content.txxt"));
+            assert_eq!(samples.len(), 12);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Implements the Definition element as specified in issue #13. A definition consists of a subject line ending with a colon (`:`) immediately followed by indented content with **no blank line** between them.

## Key Features

- **Subject Validation**: Definition subjects must end with a colon
- **Content Restrictions**: Can contain paragraphs and lists, but NOT sessions
- **Parser Precedence**: List → Definition → Session → Paragraph
- **Trailing Colon Removal**: Subject stored without the trailing colon for cleaner display

## Changes

- ✅ Add `Definition` struct to AST with `Container` and `AstNode` traits
- ✅ Add definition parser with subject validation
- ✅ Add `Definition` variant to `ContentItem` enum  
- ✅ Update AST tag serializer with Definition support (`<definition>subject<content>...</content></definition>`)
- ✅ Add `assert_definition()` fluent API for testing
- ✅ Create sample files:
  - `090-definitions-simple.txxt` - Basic definitions
  - `100-definitions-mixed-content.txxt` - Definitions with paragraphs and lists
- ✅ Add comprehensive tests for both samples
- ✅ Update test helper match statements to handle Definition case

## Format Example

```
Programming Language:
    A formal language comprising instructions. {{paragraph}} {{definition}}

    - Compiled languages {{list-item}}
    - Interpreted languages {{list-item}}
    - Scripting languages {{list-item}}
```

## Test Results

All 98 tests passing ✅

## Closes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)