### PR TITLE
Renamed span to location

### DIFF
--- a/src/bin/viewer/app.rs
+++ b/src/bin/viewer/app.rs
@@ -131,9 +131,9 @@ impl App {
             Selection::TreeSelection(node_id) => {
                 // User selected a node in tree
                 // FileViewer's cursor should move to the node's text location
-                if let Some(span) = self.model.get_span_for_node(node_id) {
+                if let Some(location) = self.model.get_location_for_node(node_id) {
                     self.file_viewer
-                        .sync_cursor_to_position(span.start.line, span.start.column);
+                        .sync_cursor_to_position(location.start.line, location.start.column);
                 }
             }
             Selection::TextSelection(row, col) => {

--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashSet;
 use txxt_nano::txxt_nano::ast::elements::content_item::ContentItem;
-use txxt_nano::txxt_nano::ast::span::{Position, Span};
+use txxt_nano::txxt_nano::ast::span::{Location, Position};
 use txxt_nano::txxt_nano::parser::Document;
 
 /// Which viewer currently has keyboard focus
@@ -253,11 +253,11 @@ impl Model {
     ///
     /// Returns the text range (start and end position) for the given node.
     /// The span indicates where in the source text this node is located.
-    pub fn get_span_for_node(&self, node_id: NodeId) -> Option<Span> {
+    pub fn get_span_for_node(&self, node_id: NodeId) -> Option<Location> {
         use txxt_nano::txxt_nano::ast::traits::AstNode;
         self.get_node(node_id).and_then(|(item, _depth)| {
             // Use the AstNode trait to get the span
-            item.span()
+            item.location()
         })
     }
 

--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -226,7 +226,7 @@ impl Model {
 
     /// Find the innermost node at the given position
     ///
-    /// Uses the AST's span information to map a file position (line, col) to
+    /// Uses the AST's location information to map a file position (line, col) to
     /// the deepest AST node containing that position.
     ///
     /// This is the core of the line-to-node mapping: when the file viewer
@@ -238,7 +238,7 @@ impl Model {
     pub fn get_node_at_position(&self, row: usize, col: usize) -> Option<NodeId> {
         let pos = Position::new(row, col);
 
-        // Find all elements at this position (deepest first) using AST spans
+        // Find all elements at this position (deepest first) using AST locations
         let elements = self.document.elements_at(pos);
 
         // Return the first (deepest) element's NodeId
@@ -249,14 +249,14 @@ impl Model {
         }
     }
 
-    /// Get the span for a node
+    /// Get the location for a node
     ///
     /// Returns the text range (start and end position) for the given node.
-    /// The span indicates where in the source text this node is located.
-    pub fn get_span_for_node(&self, node_id: NodeId) -> Option<Location> {
+    /// The location indicates where in the source text this node is located.
+    pub fn get_location_for_node(&self, node_id: NodeId) -> Option<Location> {
         use txxt_nano::txxt_nano::ast::traits::AstNode;
         self.get_node(node_id).and_then(|(item, _depth)| {
-            // Use the AstNode trait to get the span
+            // Use the AstNode trait to get the location
             item.location()
         })
     }

--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashSet;
 use txxt_nano::txxt_nano::ast::elements::content_item::ContentItem;
-use txxt_nano::txxt_nano::ast::span::{Location, Position};
+use txxt_nano::txxt_nano::ast::location::{Location, Position};
 use txxt_nano::txxt_nano::parser::Document;
 
 /// Which viewer currently has keyboard focus

--- a/src/bin/viewer/tests.rs
+++ b/src/bin/viewer/tests.rs
@@ -525,7 +525,7 @@ fn test_text_view_cursor_on_nested_element_updates_model() {
                 );
 
                 // Try to find the node using document.elements_at
-                use txxt_nano::txxt_nano::ast::span::Position;
+                use txxt_nano::txxt_nano::ast::location::Position;
                 let pos = Position::new(span.start.line, span.start.column);
                 let elements = app.app().model.document.elements_at(pos);
                 // Verify document.elements_at() now finds nested elements

--- a/src/bin/viewer/ui.rs
+++ b/src/bin/viewer/ui.rs
@@ -128,39 +128,39 @@ fn render_info_panel(frame: &mut Frame, area: Rect, app: &App) {
     use ratatui::text::Span;
 
     // Build status line content as a single line
-    let mut spans = Vec::new();
+    let mut locations = Vec::new();
 
     match app.model.selection() {
         Selection::TreeSelection(node_id) => {
-            spans.push(Span::styled(
+            locations.push(Span::styled(
                 "🌳 Tree",
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             ));
-            spans.push(Span::raw(" | "));
+            locations.push(Span::raw(" | "));
 
             let path = node_id.path();
             if path.is_empty() {
-                spans.push(Span::styled(
+                locations.push(Span::styled(
                     "Selection: ",
                     Style::default().fg(Color::Yellow),
                 ));
-                spans.push(Span::raw("Root (Document)"));
+                locations.push(Span::raw("Root (Document)"));
             } else {
-                spans.push(Span::styled("Path: ", Style::default().fg(Color::Yellow)));
+                locations.push(Span::styled("Path: ", Style::default().fg(Color::Yellow)));
                 let path_str = path
                     .iter()
                     .map(|i| i.to_string())
                     .collect::<Vec<_>>()
                     .join("→");
-                spans.push(Span::raw(format!("[{}]", path_str)));
+                locations.push(Span::raw(format!("[{}]", path_str)));
 
                 // Show if node is expanded
                 let is_expanded = app.model.is_node_expanded(node_id);
-                spans.push(Span::raw(" | "));
-                spans.push(Span::styled("State: ", Style::default().fg(Color::Yellow)));
-                spans.push(Span::raw(if is_expanded {
+                locations.push(Span::raw(" | "));
+                locations.push(Span::styled("State: ", Style::default().fg(Color::Yellow)));
+                locations.push(Span::raw(if is_expanded {
                     "Expanded"
                 } else {
                     "Collapsed"
@@ -168,38 +168,38 @@ fn render_info_panel(frame: &mut Frame, area: Rect, app: &App) {
             }
         }
         Selection::TextSelection(row, col) => {
-            spans.push(Span::styled(
+            locations.push(Span::styled(
                 "📝 Text",
                 Style::default()
                     .fg(Color::Green)
                     .add_modifier(Modifier::BOLD),
             ));
-            spans.push(Span::raw(" | "));
+            locations.push(Span::raw(" | "));
 
-            spans.push(Span::styled("Cursor: ", Style::default().fg(Color::Yellow)));
-            spans.push(Span::raw(format!("Line {}, Col {}", row, col)));
+            locations.push(Span::styled("Cursor: ", Style::default().fg(Color::Yellow)));
+            locations.push(Span::raw(format!("Line {}, Col {}", row, col)));
 
             if let Some(node_id) = app.model.get_node_at_position(row, col) {
                 let path = node_id.path();
-                spans.push(Span::raw(" | "));
-                spans.push(Span::styled("Node: ", Style::default().fg(Color::Yellow)));
+                locations.push(Span::raw(" | "));
+                locations.push(Span::styled("Node: ", Style::default().fg(Color::Yellow)));
 
                 if path.is_empty() {
-                    spans.push(Span::raw("Root (Document)"));
+                    locations.push(Span::raw("Root (Document)"));
                 } else {
                     let path_str = path
                         .iter()
                         .map(|i| i.to_string())
                         .collect::<Vec<_>>()
                         .join("→");
-                    spans.push(Span::raw(format!("[{}]", path_str)));
+                    locations.push(Span::raw(format!("[{}]", path_str)));
                 }
 
                 // Show if node is expanded
                 let is_expanded = app.model.is_node_expanded(node_id);
-                spans.push(Span::raw(" | "));
-                spans.push(Span::styled("State: ", Style::default().fg(Color::Yellow)));
-                spans.push(Span::raw(if is_expanded {
+                locations.push(Span::raw(" | "));
+                locations.push(Span::styled("State: ", Style::default().fg(Color::Yellow)));
+                locations.push(Span::raw(if is_expanded {
                     "Expanded"
                 } else {
                     "Collapsed"
@@ -209,7 +209,7 @@ fn render_info_panel(frame: &mut Frame, area: Rect, app: &App) {
     }
 
     // Render as a simple single-line status without borders
-    let paragraph = Paragraph::new(ratatui::text::Line::from(spans))
+    let paragraph = Paragraph::new(ratatui::text::Line::from(locations))
         .style(Style::default().bg(Color::Black).fg(Color::White));
 
     frame.render_widget(paragraph, area);

--- a/src/txxt_nano/ast/elements/annotation.rs
+++ b/src/txxt_nano/ast/elements/annotation.rs
@@ -1,6 +1,6 @@
 //! Annotation element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use super::super::traits::{AstNode, Container};
 use super::content_item::ContentItem;
 use super::label::Label;
@@ -93,9 +93,9 @@ mod tests {
 
     #[test]
     fn test_annotation_with_span() {
-        let span = super::super::super::span::Location::new(
-            super::super::super::span::Position::new(1, 0),
-            super::super::super::span::Position::new(1, 10),
+        let span = super::super::super::location::Location::new(
+            super::super::super::location::Position::new(1, 0),
+            super::super::super::location::Position::new(1, 10),
         );
         let annotation = Annotation::marker(Label::new("test".to_string())).with_span(Some(span));
         assert_eq!(annotation.span, Some(span));

--- a/src/txxt_nano/ast/elements/annotation.rs
+++ b/src/txxt_nano/ast/elements/annotation.rs
@@ -13,7 +13,7 @@ pub struct Annotation {
     pub label: Label,
     pub parameters: Vec<Parameter>,
     pub content: Vec<ContentItem>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Annotation {
@@ -22,7 +22,7 @@ impl Annotation {
             label,
             parameters,
             content,
-            span: None,
+            location: None,
         }
     }
     pub fn marker(label: Label) -> Self {
@@ -30,7 +30,7 @@ impl Annotation {
             label,
             parameters: Vec::new(),
             content: Vec::new(),
-            span: None,
+            location: None,
         }
     }
     pub fn with_parameters(label: Label, parameters: Vec<Parameter>) -> Self {
@@ -38,11 +38,11 @@ impl Annotation {
             label,
             parameters,
             content: Vec::new(),
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -59,7 +59,7 @@ impl AstNode for Annotation {
         }
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 
@@ -93,12 +93,12 @@ mod tests {
 
     #[test]
     fn test_annotation_with_location() {
-        let span = super::super::super::location::Location::new(
+        let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
         let annotation =
-            Annotation::marker(Label::new("test".to_string())).with_location(Some(span));
-        assert_eq!(annotation.span, Some(span));
+            Annotation::marker(Label::new("test".to_string())).with_location(Some(location));
+        assert_eq!(annotation.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/annotation.rs
+++ b/src/txxt_nano/ast/elements/annotation.rs
@@ -41,7 +41,7 @@ impl Annotation {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -92,12 +92,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_annotation_with_span() {
+    fn test_annotation_with_location() {
         let span = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let annotation = Annotation::marker(Label::new("test".to_string())).with_span(Some(span));
+        let annotation =
+            Annotation::marker(Label::new("test".to_string())).with_location(Some(span));
         assert_eq!(annotation.span, Some(span));
     }
 }

--- a/src/txxt_nano/ast/elements/annotation.rs
+++ b/src/txxt_nano/ast/elements/annotation.rs
@@ -1,6 +1,6 @@
 //! Annotation element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use super::super::traits::{AstNode, Container};
 use super::content_item::ContentItem;
 use super::label::Label;
@@ -13,7 +13,7 @@ pub struct Annotation {
     pub label: Label,
     pub parameters: Vec<Parameter>,
     pub content: Vec<ContentItem>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Annotation {
@@ -41,7 +41,7 @@ impl Annotation {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -58,7 +58,7 @@ impl AstNode for Annotation {
             format!("{} ({} params)", self.label.value, self.parameters.len())
         }
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_annotation_with_span() {
-        let span = super::super::super::span::Span::new(
+        let span = super::super::super::span::Location::new(
             super::super::super::span::Position::new(1, 0),
             super::super::super::span::Position::new(1, 10),
         );

--- a/src/txxt_nano/ast/elements/content_item.rs
+++ b/src/txxt_nano/ast/elements/content_item.rs
@@ -1,6 +1,6 @@
 //! ContentItem enum definition
 
-use super::super::span::{Position, Span};
+use super::super::span::{Location, Position};
 use super::super::traits::{AstNode, Container};
 use super::annotation::Annotation;
 use super::definition::Definition;
@@ -44,14 +44,14 @@ impl AstNode for ContentItem {
         }
     }
 
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         match self {
-            ContentItem::Paragraph(p) => p.span(),
-            ContentItem::Session(s) => s.span(),
-            ContentItem::List(l) => l.span(),
-            ContentItem::Definition(d) => d.span(),
-            ContentItem::Annotation(a) => a.span(),
-            ContentItem::ForeignBlock(fb) => fb.span(),
+            ContentItem::Paragraph(p) => p.location(),
+            ContentItem::Session(s) => s.location(),
+            ContentItem::List(l) => l.location(),
+            ContentItem::Definition(d) => d.location(),
+            ContentItem::Annotation(a) => a.location(),
+            ContentItem::ForeignBlock(fb) => fb.location(),
         }
     }
 }
@@ -308,14 +308,16 @@ impl fmt::Display for ContentItem {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::span::{Position, Span};
+    use super::super::super::span::{Location, Position};
     use super::super::paragraph::Paragraph;
     use super::*;
 
     #[test]
     fn test_elements_at_simple_paragraph() {
-        let para = Paragraph::from_line("Test".to_string())
-            .with_span(Some(Span::new(Position::new(0, 0), Position::new(0, 4))));
+        let para = Paragraph::from_line("Test".to_string()).with_span(Some(Location::new(
+            Position::new(0, 0),
+            Position::new(0, 4),
+        )));
         let item = ContentItem::Paragraph(para);
 
         let pos = Position::new(0, 2);
@@ -329,8 +331,10 @@ mod tests {
 
     #[test]
     fn test_elements_at_position_outside_span() {
-        let para = Paragraph::from_line("Test".to_string())
-            .with_span(Some(Span::new(Position::new(0, 0), Position::new(0, 4))));
+        let para = Paragraph::from_line("Test".to_string()).with_span(Some(Location::new(
+            Position::new(0, 0),
+            Position::new(0, 4),
+        )));
         let item = ContentItem::Paragraph(para);
 
         let pos = Position::new(0, 10);
@@ -355,8 +359,10 @@ mod tests {
 
     #[test]
     fn test_elements_at_nested_session() {
-        let para = Paragraph::from_line("Nested".to_string())
-            .with_span(Some(Span::new(Position::new(1, 0), Position::new(1, 6))));
+        let para = Paragraph::from_line("Nested".to_string()).with_span(Some(Location::new(
+            Position::new(1, 0),
+            Position::new(1, 6),
+        )));
         let session = Session::new(
             super::super::super::text_content::TextContent::from_string(
                 "Section".to_string(),
@@ -364,7 +370,10 @@ mod tests {
             ),
             vec![ContentItem::Paragraph(para)],
         )
-        .with_span(Some(Span::new(Position::new(0, 0), Position::new(2, 0))));
+        .with_span(Some(Location::new(
+            Position::new(0, 0),
+            Position::new(2, 0),
+        )));
         let item = ContentItem::Session(session);
 
         let pos = Position::new(1, 3);

--- a/src/txxt_nano/ast/elements/content_item.rs
+++ b/src/txxt_nano/ast/elements/content_item.rs
@@ -233,7 +233,7 @@ impl ContentItem {
         };
 
         // Check nested items first - even if parent location doesn't contain position,
-        // nested elements might. This is important because parent spans (like sessions)
+        // nested elements might. This is important because parent locations (like sessions)
         // may only cover their title, not their nested content.
         let mut results = Vec::new();
         let children = self.children();

--- a/src/txxt_nano/ast/elements/content_item.rs
+++ b/src/txxt_nano/ast/elements/content_item.rs
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn test_elements_at_simple_paragraph() {
-        let para = Paragraph::from_line("Test".to_string()).with_span(Some(Location::new(
+        let para = Paragraph::from_line("Test".to_string()).with_location(Some(Location::new(
             Position::new(0, 0),
             Position::new(0, 4),
         )));
@@ -330,8 +330,8 @@ mod tests {
     }
 
     #[test]
-    fn test_elements_at_position_outside_span() {
-        let para = Paragraph::from_line("Test".to_string()).with_span(Some(Location::new(
+    fn test_elements_at_position_outside_location() {
+        let para = Paragraph::from_line("Test".to_string()).with_location(Some(Location::new(
             Position::new(0, 0),
             Position::new(0, 4),
         )));
@@ -343,7 +343,7 @@ mod tests {
     }
 
     #[test]
-    fn test_elements_at_no_span() {
+    fn test_elements_at_no_location() {
         // Item with no location should match any position
         let para = Paragraph::from_line("Test".to_string());
         let item = ContentItem::Paragraph(para);
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_elements_at_nested_session() {
-        let para = Paragraph::from_line("Nested".to_string()).with_span(Some(Location::new(
+        let para = Paragraph::from_line("Nested".to_string()).with_location(Some(Location::new(
             Position::new(1, 0),
             Position::new(1, 6),
         )));
@@ -370,7 +370,7 @@ mod tests {
             ),
             vec![ContentItem::Paragraph(para)],
         )
-        .with_span(Some(Location::new(
+        .with_location(Some(Location::new(
             Position::new(0, 0),
             Position::new(2, 0),
         )));

--- a/src/txxt_nano/ast/elements/definition.rs
+++ b/src/txxt_nano/ast/elements/definition.rs
@@ -11,7 +11,7 @@ use std::fmt;
 pub struct Definition {
     pub subject: TextContent,
     pub content: Vec<ContentItem>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Definition {
@@ -19,18 +19,18 @@ impl Definition {
         Self {
             subject,
             content,
-            span: None,
+            location: None,
         }
     }
     pub fn with_subject(subject: String) -> Self {
         Self {
             subject: TextContent::from_string(subject, None),
             content: Vec::new(),
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -48,7 +48,7 @@ impl AstNode for Definition {
         }
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 
@@ -81,11 +81,12 @@ mod tests {
 
     #[test]
     fn test_definition_with_location() {
-        let span = super::super::super::location::Location::new(
+        let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let definition = Definition::with_subject("Subject".to_string()).with_location(Some(span));
-        assert_eq!(definition.span, Some(span));
+        let definition =
+            Definition::with_subject("Subject".to_string()).with_location(Some(location));
+        assert_eq!(definition.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/definition.rs
+++ b/src/txxt_nano/ast/elements/definition.rs
@@ -1,6 +1,6 @@
 //! Definition element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container};
 use super::content_item::ContentItem;
@@ -11,7 +11,7 @@ use std::fmt;
 pub struct Definition {
     pub subject: TextContent,
     pub content: Vec<ContentItem>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Definition {
@@ -29,7 +29,7 @@ impl Definition {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -47,7 +47,7 @@ impl AstNode for Definition {
             subject_text.to_string()
         }
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_definition_with_span() {
-        let span = super::super::super::span::Span::new(
+        let span = super::super::super::span::Location::new(
             super::super::super::span::Position::new(1, 0),
             super::super::super::span::Position::new(1, 10),
         );

--- a/src/txxt_nano/ast/elements/definition.rs
+++ b/src/txxt_nano/ast/elements/definition.rs
@@ -1,6 +1,6 @@
 //! Definition element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container};
 use super::content_item::ContentItem;
@@ -81,9 +81,9 @@ mod tests {
 
     #[test]
     fn test_definition_with_span() {
-        let span = super::super::super::span::Location::new(
-            super::super::super::span::Position::new(1, 0),
-            super::super::super::span::Position::new(1, 10),
+        let span = super::super::super::location::Location::new(
+            super::super::super::location::Position::new(1, 0),
+            super::super::super::location::Position::new(1, 10),
         );
         let definition = Definition::with_subject("Subject".to_string()).with_span(Some(span));
         assert_eq!(definition.span, Some(span));

--- a/src/txxt_nano/ast/elements/definition.rs
+++ b/src/txxt_nano/ast/elements/definition.rs
@@ -29,7 +29,7 @@ impl Definition {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -80,12 +80,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_definition_with_span() {
+    fn test_definition_with_location() {
         let span = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let definition = Definition::with_subject("Subject".to_string()).with_span(Some(span));
+        let definition = Definition::with_subject("Subject".to_string()).with_location(Some(span));
         assert_eq!(definition.span, Some(span));
     }
 }

--- a/src/txxt_nano/ast/elements/document.rs
+++ b/src/txxt_nano/ast/elements/document.rs
@@ -1,6 +1,6 @@
 //! Document element definition
 
-use super::super::span::{Location, Position};
+use super::super::location::{Location, Position};
 use super::annotation::Annotation;
 use super::content_item::ContentItem;
 use super::foreign::ForeignBlock;
@@ -108,7 +108,7 @@ impl fmt::Display for Document {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::span::Position;
+    use super::super::super::location::Position;
     use super::super::paragraph::Paragraph;
     use super::super::session::Session;
     use super::*;

--- a/src/txxt_nano/ast/elements/document.rs
+++ b/src/txxt_nano/ast/elements/document.rs
@@ -42,7 +42,7 @@ impl Document {
         }
     }
 
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -125,11 +125,11 @@ mod tests {
 
     #[test]
     fn test_document_elements_at() {
-        let para1 = Paragraph::from_line("First".to_string()).with_span(Some(Location::new(
+        let para1 = Paragraph::from_line("First".to_string()).with_location(Some(Location::new(
             Position::new(0, 0),
             Position::new(0, 5),
         )));
-        let para2 = Paragraph::from_line("Second".to_string()).with_span(Some(Location::new(
+        let para2 = Paragraph::from_line("Second".to_string()).with_location(Some(Location::new(
             Position::new(1, 0),
             Position::new(1, 6),
         )));

--- a/src/txxt_nano/ast/elements/document.rs
+++ b/src/txxt_nano/ast/elements/document.rs
@@ -1,6 +1,6 @@
 //! Document element definition
 
-use super::super::span::{Position, Span};
+use super::super::span::{Location, Position};
 use super::annotation::Annotation;
 use super::content_item::ContentItem;
 use super::foreign::ForeignBlock;
@@ -14,7 +14,7 @@ use std::fmt;
 pub struct Document {
     pub metadata: Vec<Annotation>,
     pub content: Vec<ContentItem>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Document {
@@ -42,7 +42,7 @@ impl Document {
         }
     }
 
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -125,10 +125,14 @@ mod tests {
 
     #[test]
     fn test_document_elements_at() {
-        let para1 = Paragraph::from_line("First".to_string())
-            .with_span(Some(Span::new(Position::new(0, 0), Position::new(0, 5))));
-        let para2 = Paragraph::from_line("Second".to_string())
-            .with_span(Some(Span::new(Position::new(1, 0), Position::new(1, 6))));
+        let para1 = Paragraph::from_line("First".to_string()).with_span(Some(Location::new(
+            Position::new(0, 0),
+            Position::new(0, 5),
+        )));
+        let para2 = Paragraph::from_line("Second".to_string()).with_span(Some(Location::new(
+            Position::new(1, 0),
+            Position::new(1, 6),
+        )));
 
         let doc = Document::with_content(vec![
             ContentItem::Paragraph(para1),

--- a/src/txxt_nano/ast/elements/document.rs
+++ b/src/txxt_nano/ast/elements/document.rs
@@ -14,7 +14,7 @@ use std::fmt;
 pub struct Document {
     pub metadata: Vec<Annotation>,
     pub content: Vec<ContentItem>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Document {
@@ -22,7 +22,7 @@ impl Document {
         Self {
             metadata: Vec::new(),
             content: Vec::new(),
-            span: None,
+            location: None,
         }
     }
 
@@ -30,7 +30,7 @@ impl Document {
         Self {
             metadata: Vec::new(),
             content,
-            span: None,
+            location: None,
         }
     }
 
@@ -38,12 +38,12 @@ impl Document {
         Self {
             metadata,
             content,
-            span: None,
+            location: None,
         }
     }
 
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 

--- a/src/txxt_nano/ast/elements/foreign.rs
+++ b/src/txxt_nano/ast/elements/foreign.rs
@@ -12,7 +12,7 @@ pub struct ForeignBlock {
     pub subject: TextContent,
     pub content: TextContent,
     pub closing_annotation: Annotation,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl ForeignBlock {
@@ -21,7 +21,7 @@ impl ForeignBlock {
             subject: TextContent::from_string(subject, None),
             content: TextContent::from_string(content, None),
             closing_annotation,
-            span: None,
+            location: None,
         }
     }
     pub fn marker(subject: String, closing_annotation: Annotation) -> Self {
@@ -29,11 +29,11 @@ impl ForeignBlock {
             subject: TextContent::from_string(subject, None),
             content: TextContent::from_string(String::new(), None),
             closing_annotation,
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -51,7 +51,7 @@ impl AstNode for ForeignBlock {
         }
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 

--- a/src/txxt_nano/ast/elements/foreign.rs
+++ b/src/txxt_nano/ast/elements/foreign.rs
@@ -1,6 +1,6 @@
 //! Foreign block element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::AstNode;
 use super::annotation::Annotation;

--- a/src/txxt_nano/ast/elements/foreign.rs
+++ b/src/txxt_nano/ast/elements/foreign.rs
@@ -32,7 +32,7 @@ impl ForeignBlock {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }

--- a/src/txxt_nano/ast/elements/foreign.rs
+++ b/src/txxt_nano/ast/elements/foreign.rs
@@ -1,6 +1,6 @@
 //! Foreign block element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::AstNode;
 use super::annotation::Annotation;
@@ -12,7 +12,7 @@ pub struct ForeignBlock {
     pub subject: TextContent,
     pub content: TextContent,
     pub closing_annotation: Annotation,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl ForeignBlock {
@@ -32,7 +32,7 @@ impl ForeignBlock {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -50,7 +50,7 @@ impl AstNode for ForeignBlock {
             subject_text.to_string()
         }
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }

--- a/src/txxt_nano/ast/elements/label.rs
+++ b/src/txxt_nano/ast/elements/label.rs
@@ -1,13 +1,13 @@
 //! Label element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use std::fmt;
 
 /// A label represents a named identifier in txxt documents
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Label {
     pub value: String,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Label {
@@ -20,7 +20,7 @@ impl Label {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -38,7 +38,7 @@ mod tests {
 
     #[test]
     fn test_label_with_span() {
-        let span = super::super::super::span::Span::new(
+        let span = super::super::super::span::Location::new(
             super::super::super::span::Position::new(1, 0),
             super::super::super::span::Position::new(1, 10),
         );

--- a/src/txxt_nano/ast/elements/label.rs
+++ b/src/txxt_nano/ast/elements/label.rs
@@ -1,6 +1,6 @@
 //! Label element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use std::fmt;
 
 /// A label represents a named identifier in txxt documents
@@ -38,9 +38,9 @@ mod tests {
 
     #[test]
     fn test_label_with_span() {
-        let span = super::super::super::span::Location::new(
-            super::super::super::span::Position::new(1, 0),
-            super::super::super::span::Position::new(1, 10),
+        let span = super::super::super::location::Location::new(
+            super::super::super::location::Position::new(1, 0),
+            super::super::super::location::Position::new(1, 10),
         );
         let label = Label::new("test".to_string()).with_span(Some(span));
         assert_eq!(label.span, Some(span));

--- a/src/txxt_nano/ast/elements/label.rs
+++ b/src/txxt_nano/ast/elements/label.rs
@@ -7,21 +7,24 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Label {
     pub value: String,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Label {
     pub fn new(value: String) -> Self {
-        Self { value, span: None }
+        Self {
+            value,
+            location: None,
+        }
     }
     pub fn from_string(value: &str) -> Self {
         Self {
             value: value.to_string(),
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -38,11 +41,11 @@ mod tests {
 
     #[test]
     fn test_label_with_location() {
-        let span = super::super::super::location::Location::new(
+        let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let label = Label::new("test".to_string()).with_location(Some(span));
-        assert_eq!(label.span, Some(span));
+        let label = Label::new("test".to_string()).with_location(Some(location));
+        assert_eq!(label.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/label.rs
+++ b/src/txxt_nano/ast/elements/label.rs
@@ -20,7 +20,7 @@ impl Label {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -37,12 +37,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_label_with_span() {
+    fn test_label_with_location() {
         let span = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let label = Label::new("test".to_string()).with_span(Some(span));
+        let label = Label::new("test".to_string()).with_location(Some(span));
         assert_eq!(label.span, Some(span));
     }
 }

--- a/src/txxt_nano/ast/elements/list.rs
+++ b/src/txxt_nano/ast/elements/list.rs
@@ -11,7 +11,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct List {
     pub items: Vec<ListItem>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 /// A list item has text and optional nested content
@@ -19,15 +19,18 @@ pub struct List {
 pub struct ListItem {
     pub(crate) text: Vec<TextContent>,
     pub content: Vec<ContentItem>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl List {
     pub fn new(items: Vec<ListItem>) -> Self {
-        Self { items, span: None }
+        Self {
+            items,
+            location: None,
+        }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -40,7 +43,7 @@ impl AstNode for List {
         format!("{} items", self.items.len())
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 
@@ -55,26 +58,26 @@ impl ListItem {
         Self {
             text: vec![TextContent::from_string(text, None)],
             content: Vec::new(),
-            span: None,
+            location: None,
         }
     }
     pub fn with_content(text: String, content: Vec<ContentItem>) -> Self {
         Self {
             text: vec![TextContent::from_string(text, None)],
             content,
-            span: None,
+            location: None,
         }
     }
-    /// Create a ListItem with TextContent that may have span information
+    /// Create a ListItem with TextContent that may have location information
     pub fn with_text_content(text_content: TextContent, content: Vec<ContentItem>) -> Self {
         Self {
             text: vec![text_content],
             content,
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
     pub fn text(&self) -> &str {
@@ -95,7 +98,7 @@ impl AstNode for ListItem {
         }
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 
@@ -123,11 +126,11 @@ mod tests {
 
     #[test]
     fn test_list_with_location() {
-        let span = super::super::super::location::Location::new(
+        let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let list = List::new(vec![]).with_location(Some(span));
-        assert_eq!(list.span, Some(span));
+        let list = List::new(vec![]).with_location(Some(location));
+        assert_eq!(list.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/list.rs
+++ b/src/txxt_nano/ast/elements/list.rs
@@ -1,6 +1,6 @@
 //! List element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::AstNode;
 use super::super::traits::Container;
@@ -11,7 +11,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct List {
     pub items: Vec<ListItem>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 /// A list item has text and optional nested content
@@ -19,14 +19,14 @@ pub struct List {
 pub struct ListItem {
     pub(crate) text: Vec<TextContent>,
     pub content: Vec<ContentItem>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl List {
     pub fn new(items: Vec<ListItem>) -> Self {
         Self { items, span: None }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -39,7 +39,7 @@ impl AstNode for List {
     fn display_label(&self) -> String {
         format!("{} items", self.items.len())
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }
@@ -73,7 +73,7 @@ impl ListItem {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -94,7 +94,7 @@ impl AstNode for ListItem {
             text.to_string()
         }
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_list_with_span() {
-        let span = super::super::super::span::Span::new(
+        let span = super::super::super::span::Location::new(
             super::super::super::span::Position::new(1, 0),
             super::super::super::span::Position::new(1, 10),
         );

--- a/src/txxt_nano/ast/elements/list.rs
+++ b/src/txxt_nano/ast/elements/list.rs
@@ -26,7 +26,7 @@ impl List {
     pub fn new(items: Vec<ListItem>) -> Self {
         Self { items, span: None }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -73,7 +73,7 @@ impl ListItem {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -122,12 +122,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_list_with_span() {
+    fn test_list_with_location() {
         let span = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let list = List::new(vec![]).with_span(Some(span));
+        let list = List::new(vec![]).with_location(Some(span));
         assert_eq!(list.span, Some(span));
     }
 }

--- a/src/txxt_nano/ast/elements/list.rs
+++ b/src/txxt_nano/ast/elements/list.rs
@@ -1,6 +1,6 @@
 //! List element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::AstNode;
 use super::super::traits::Container;
@@ -123,9 +123,9 @@ mod tests {
 
     #[test]
     fn test_list_with_span() {
-        let span = super::super::super::span::Location::new(
-            super::super::super::span::Position::new(1, 0),
-            super::super::super::span::Position::new(1, 10),
+        let span = super::super::super::location::Location::new(
+            super::super::super::location::Position::new(1, 0),
+            super::super::super::location::Position::new(1, 10),
         );
         let list = List::new(vec![]).with_span(Some(span));
         assert_eq!(list.span, Some(span));

--- a/src/txxt_nano/ast/elements/paragraph.rs
+++ b/src/txxt_nano/ast/elements/paragraph.rs
@@ -1,6 +1,6 @@
 //! Paragraph element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, TextNode};
 use std::fmt;
@@ -88,8 +88,8 @@ mod tests {
     #[test]
     fn test_paragraph_with_span() {
         let span = Location::new(
-            super::super::super::span::Position::new(0, 0),
-            super::super::super::span::Position::new(0, 5),
+            super::super::super::location::Position::new(0, 0),
+            super::super::super::location::Position::new(0, 5),
         );
         let para = Paragraph::from_line("Hello".to_string()).with_span(Some(span));
 

--- a/src/txxt_nano/ast/elements/paragraph.rs
+++ b/src/txxt_nano/ast/elements/paragraph.rs
@@ -1,6 +1,6 @@
 //! Paragraph element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, TextNode};
 use std::fmt;
@@ -9,7 +9,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Paragraph {
     pub lines: Vec<TextContent>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Paragraph {
@@ -22,7 +22,7 @@ impl Paragraph {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -47,7 +47,7 @@ impl AstNode for Paragraph {
             text
         }
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn test_paragraph_with_span() {
-        let span = Span::new(
+        let span = Location::new(
             super::super::super::span::Position::new(0, 0),
             super::super::super::span::Position::new(0, 5),
         );

--- a/src/txxt_nano/ast/elements/paragraph.rs
+++ b/src/txxt_nano/ast/elements/paragraph.rs
@@ -9,21 +9,24 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Paragraph {
     pub lines: Vec<TextContent>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Paragraph {
     pub fn new(lines: Vec<TextContent>) -> Self {
-        Self { lines, span: None }
+        Self {
+            lines,
+            location: None,
+        }
     }
     pub fn from_line(line: String) -> Self {
         Self {
             lines: vec![TextContent::from_string(line, None)],
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
     pub fn text(&self) -> String {
@@ -48,7 +51,7 @@ impl AstNode for Paragraph {
         }
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 
@@ -87,12 +90,12 @@ mod tests {
 
     #[test]
     fn test_paragraph_with_location() {
-        let span = Location::new(
+        let location = Location::new(
             super::super::super::location::Position::new(0, 0),
             super::super::super::location::Position::new(0, 5),
         );
-        let para = Paragraph::from_line("Hello".to_string()).with_location(Some(span));
+        let para = Paragraph::from_line("Hello".to_string()).with_location(Some(location));
 
-        assert_eq!(para.span, Some(span));
+        assert_eq!(para.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/paragraph.rs
+++ b/src/txxt_nano/ast/elements/paragraph.rs
@@ -22,7 +22,7 @@ impl Paragraph {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -86,12 +86,12 @@ mod tests {
     }
 
     #[test]
-    fn test_paragraph_with_span() {
+    fn test_paragraph_with_location() {
         let span = Location::new(
             super::super::super::location::Position::new(0, 0),
             super::super::super::location::Position::new(0, 5),
         );
-        let para = Paragraph::from_line("Hello".to_string()).with_span(Some(span));
+        let para = Paragraph::from_line("Hello".to_string()).with_location(Some(span));
 
         assert_eq!(para.span, Some(span));
     }

--- a/src/txxt_nano/ast/elements/parameter.rs
+++ b/src/txxt_nano/ast/elements/parameter.rs
@@ -33,7 +33,7 @@ impl Parameter {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -53,13 +53,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parameter_with_span() {
+    fn test_parameter_with_location() {
         let span = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
         let param =
-            Parameter::new("key".to_string(), Some("value".to_string())).with_span(Some(span));
+            Parameter::new("key".to_string(), Some("value".to_string())).with_location(Some(span));
         assert_eq!(param.span, Some(span));
     }
 }

--- a/src/txxt_nano/ast/elements/parameter.rs
+++ b/src/txxt_nano/ast/elements/parameter.rs
@@ -1,6 +1,6 @@
 //! Parameter element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use std::fmt;
 
 /// A parameter represents a key-value pair, with optional value
@@ -8,7 +8,7 @@ use std::fmt;
 pub struct Parameter {
     pub key: String,
     pub value: Option<String>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Parameter {
@@ -33,7 +33,7 @@ impl Parameter {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_parameter_with_span() {
-        let span = super::super::super::span::Span::new(
+        let span = super::super::super::span::Location::new(
             super::super::super::span::Position::new(1, 0),
             super::super::super::span::Position::new(1, 10),
         );

--- a/src/txxt_nano/ast/elements/parameter.rs
+++ b/src/txxt_nano/ast/elements/parameter.rs
@@ -1,6 +1,6 @@
 //! Parameter element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use std::fmt;
 
 /// A parameter represents a key-value pair, with optional value
@@ -54,9 +54,9 @@ mod tests {
 
     #[test]
     fn test_parameter_with_span() {
-        let span = super::super::super::span::Location::new(
-            super::super::super::span::Position::new(1, 0),
-            super::super::super::span::Position::new(1, 10),
+        let span = super::super::super::location::Location::new(
+            super::super::super::location::Position::new(1, 0),
+            super::super::super::location::Position::new(1, 10),
         );
         let param =
             Parameter::new("key".to_string(), Some("value".to_string())).with_span(Some(span));

--- a/src/txxt_nano/ast/elements/parameter.rs
+++ b/src/txxt_nano/ast/elements/parameter.rs
@@ -8,7 +8,7 @@ use std::fmt;
 pub struct Parameter {
     pub key: String,
     pub value: Option<String>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Parameter {
@@ -16,25 +16,25 @@ impl Parameter {
         Self {
             key,
             value,
-            span: None,
+            location: None,
         }
     }
     pub fn boolean(key: String) -> Self {
         Self {
             key,
             value: None,
-            span: None,
+            location: None,
         }
     }
     pub fn with_value(key: String, value: String) -> Self {
         Self {
             key,
             value: Some(value),
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -54,12 +54,12 @@ mod tests {
 
     #[test]
     fn test_parameter_with_location() {
-        let span = super::super::super::location::Location::new(
+        let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let param =
-            Parameter::new("key".to_string(), Some("value".to_string())).with_location(Some(span));
-        assert_eq!(param.span, Some(span));
+        let param = Parameter::new("key".to_string(), Some("value".to_string()))
+            .with_location(Some(location));
+        assert_eq!(param.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/session.rs
+++ b/src/txxt_nano/ast/elements/session.rs
@@ -29,7 +29,7 @@ impl Session {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Location>) -> Self {
+    pub fn with_location(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -88,12 +88,12 @@ mod tests {
     }
 
     #[test]
-    fn test_session_with_span() {
+    fn test_session_with_location() {
         let span = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let session = Session::with_title("Title".to_string()).with_span(Some(span));
+        let session = Session::with_title("Title".to_string()).with_location(Some(span));
         assert_eq!(session.span, Some(span));
     }
 }

--- a/src/txxt_nano/ast/elements/session.rs
+++ b/src/txxt_nano/ast/elements/session.rs
@@ -1,6 +1,6 @@
 //! Session element definition
 
-use super::super::span::Span;
+use super::super::span::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container};
 use super::content_item::ContentItem;
@@ -11,7 +11,7 @@ use std::fmt;
 pub struct Session {
     pub title: TextContent,
     pub content: Vec<ContentItem>,
-    pub span: Option<Span>,
+    pub span: Option<Location>,
 }
 
 impl Session {
@@ -29,7 +29,7 @@ impl Session {
             span: None,
         }
     }
-    pub fn with_span(mut self, span: Option<Span>) -> Self {
+    pub fn with_span(mut self, span: Option<Location>) -> Self {
         self.span = span;
         self
     }
@@ -42,7 +42,7 @@ impl AstNode for Session {
     fn display_label(&self) -> String {
         self.title.as_string().to_string()
     }
-    fn span(&self) -> Option<Span> {
+    fn location(&self) -> Option<Location> {
         self.span
     }
 }
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_session_with_span() {
-        let span = super::super::super::span::Span::new(
+        let span = super::super::super::span::Location::new(
             super::super::super::span::Position::new(1, 0),
             super::super::super::span::Position::new(1, 10),
         );

--- a/src/txxt_nano/ast/elements/session.rs
+++ b/src/txxt_nano/ast/elements/session.rs
@@ -11,7 +11,7 @@ use std::fmt;
 pub struct Session {
     pub title: TextContent,
     pub content: Vec<ContentItem>,
-    pub span: Option<Location>,
+    pub location: Option<Location>,
 }
 
 impl Session {
@@ -19,18 +19,18 @@ impl Session {
         Self {
             title,
             content,
-            span: None,
+            location: None,
         }
     }
     pub fn with_title(title: String) -> Self {
         Self {
             title: TextContent::from_string(title, None),
             content: Vec::new(),
-            span: None,
+            location: None,
         }
     }
-    pub fn with_location(mut self, span: Option<Location>) -> Self {
-        self.span = span;
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
         self
     }
 }
@@ -43,7 +43,7 @@ impl AstNode for Session {
         self.title.as_string().to_string()
     }
     fn location(&self) -> Option<Location> {
-        self.span
+        self.location
     }
 }
 
@@ -89,11 +89,11 @@ mod tests {
 
     #[test]
     fn test_session_with_location() {
-        let span = super::super::super::location::Location::new(
+        let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let session = Session::with_title("Title".to_string()).with_location(Some(span));
-        assert_eq!(session.span, Some(span));
+        let session = Session::with_title("Title".to_string()).with_location(Some(location));
+        assert_eq!(session.location, Some(location));
     }
 }

--- a/src/txxt_nano/ast/elements/session.rs
+++ b/src/txxt_nano/ast/elements/session.rs
@@ -1,6 +1,6 @@
 //! Session element definition
 
-use super::super::span::Location;
+use super::super::location::Location;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container};
 use super::content_item::ContentItem;
@@ -89,9 +89,9 @@ mod tests {
 
     #[test]
     fn test_session_with_span() {
-        let span = super::super::super::span::Location::new(
-            super::super::super::span::Position::new(1, 0),
-            super::super::super::span::Position::new(1, 10),
+        let span = super::super::super::location::Location::new(
+            super::super::super::location::Position::new(1, 0),
+            super::super::super::location::Position::new(1, 10),
         );
         let session = Session::with_title("Title".to_string()).with_span(Some(span));
         assert_eq!(session.span, Some(span));

--- a/src/txxt_nano/ast/location.rs
+++ b/src/txxt_nano/ast/location.rs
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_creation() {
+    fn test_location_creation() {
         let start = Position::new(0, 0);
         let end = Position::new(2, 5);
         let location = Location::new(start, end);
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_contains_single_line() {
+    fn test_location_contains_single_line() {
         let location = Location::new(Position::new(0, 0), Position::new(0, 10));
 
         assert!(location.contains(Position::new(0, 0)));
@@ -104,7 +104,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_contains_multiline() {
+    fn test_location_contains_multiline() {
         let location = Location::new(Position::new(1, 5), Position::new(2, 10));
 
         // Before location
@@ -123,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_overlaps() {
+    fn test_location_overlaps() {
         let span1 = Location::new(Position::new(0, 0), Position::new(1, 5));
         let span2 = Location::new(Position::new(1, 0), Position::new(2, 5));
         let span3 = Location::new(Position::new(3, 0), Position::new(4, 5));
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_display() {
+    fn test_location_display() {
         let location = Location::new(Position::new(1, 0), Position::new(2, 5));
         assert_eq!(format!("{}", location), "1:0..2:5");
     }

--- a/src/txxt_nano/ast/location.rs
+++ b/src/txxt_nano/ast/location.rs
@@ -1,4 +1,4 @@
-//! Position and span tracking for source code locations
+//! Position and location tracking for source code locations
 //!
 //! This module defines the data structures for representing positions
 //! and spans in source code.
@@ -24,7 +24,7 @@ impl fmt::Display for Position {
     }
 }
 
-/// Represents a span in source code (start and end positions)
+/// Represents a location in source code (start and end positions)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Location {
     pub start: Position,
@@ -36,7 +36,7 @@ impl Location {
         Self { start, end }
     }
 
-    /// Check if a position is contained within this span
+    /// Check if a position is contained within this location
     pub fn contains(&self, pos: Position) -> bool {
         (self.start.line < pos.line
             || (self.start.line == pos.line && self.start.column <= pos.column))
@@ -44,7 +44,7 @@ impl Location {
                 || (self.end.line == pos.line && self.end.column >= pos.column))
     }
 
-    /// Check if another span overlaps with this span
+    /// Check if another location overlaps with this location
     pub fn overlaps(&self, other: Location) -> bool {
         self.contains(other.start)
             || self.contains(other.end)
@@ -85,41 +85,41 @@ mod tests {
     fn test_span_creation() {
         let start = Position::new(0, 0);
         let end = Position::new(2, 5);
-        let span = Location::new(start, end);
+        let location = Location::new(start, end);
 
-        assert_eq!(span.start, start);
-        assert_eq!(span.end, end);
+        assert_eq!(location.start, start);
+        assert_eq!(location.end, end);
     }
 
     #[test]
     fn test_span_contains_single_line() {
-        let span = Location::new(Position::new(0, 0), Position::new(0, 10));
+        let location = Location::new(Position::new(0, 0), Position::new(0, 10));
 
-        assert!(span.contains(Position::new(0, 0)));
-        assert!(span.contains(Position::new(0, 5)));
-        assert!(span.contains(Position::new(0, 10)));
+        assert!(location.contains(Position::new(0, 0)));
+        assert!(location.contains(Position::new(0, 5)));
+        assert!(location.contains(Position::new(0, 10)));
 
-        assert!(!span.contains(Position::new(0, 11)));
-        assert!(!span.contains(Position::new(1, 0)));
+        assert!(!location.contains(Position::new(0, 11)));
+        assert!(!location.contains(Position::new(1, 0)));
     }
 
     #[test]
     fn test_span_contains_multiline() {
-        let span = Location::new(Position::new(1, 5), Position::new(2, 10));
+        let location = Location::new(Position::new(1, 5), Position::new(2, 10));
 
-        // Before span
-        assert!(!span.contains(Position::new(1, 4)));
-        assert!(!span.contains(Position::new(0, 5)));
+        // Before location
+        assert!(!location.contains(Position::new(1, 4)));
+        assert!(!location.contains(Position::new(0, 5)));
 
-        // In span
-        assert!(span.contains(Position::new(1, 5)));
-        assert!(span.contains(Position::new(1, 10)));
-        assert!(span.contains(Position::new(2, 0)));
-        assert!(span.contains(Position::new(2, 10)));
+        // In location
+        assert!(location.contains(Position::new(1, 5)));
+        assert!(location.contains(Position::new(1, 10)));
+        assert!(location.contains(Position::new(2, 0)));
+        assert!(location.contains(Position::new(2, 10)));
 
-        // After span
-        assert!(!span.contains(Position::new(2, 11)));
-        assert!(!span.contains(Position::new(3, 0)));
+        // After location
+        assert!(!location.contains(Position::new(2, 11)));
+        assert!(!location.contains(Position::new(3, 0)));
     }
 
     #[test]
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_span_display() {
-        let span = Location::new(Position::new(1, 0), Position::new(2, 5));
-        assert_eq!(format!("{}", span), "1:0..2:5");
+        let location = Location::new(Position::new(1, 0), Position::new(2, 5));
+        assert_eq!(format!("{}", location), "1:0..2:5");
     }
 }

--- a/src/txxt_nano/ast/location.rs
+++ b/src/txxt_nano/ast/location.rs
@@ -1,7 +1,7 @@
 //! Position and location tracking for source code locations
 //!
 //! This module defines the data structures for representing positions
-//! and spans in source code.
+//! and locations in source code.
 
 use std::fmt;
 
@@ -124,14 +124,14 @@ mod tests {
 
     #[test]
     fn test_location_overlaps() {
-        let span1 = Location::new(Position::new(0, 0), Position::new(1, 5));
-        let span2 = Location::new(Position::new(1, 0), Position::new(2, 5));
-        let span3 = Location::new(Position::new(3, 0), Position::new(4, 5));
+        let location1 = Location::new(Position::new(0, 0), Position::new(1, 5));
+        let location2 = Location::new(Position::new(1, 0), Position::new(2, 5));
+        let location3 = Location::new(Position::new(3, 0), Position::new(4, 5));
 
-        assert!(span1.overlaps(span2));
-        assert!(span2.overlaps(span1));
-        assert!(!span1.overlaps(span3));
-        assert!(!span3.overlaps(span1));
+        assert!(location1.overlaps(location2));
+        assert!(location2.overlaps(location1));
+        assert!(!location1.overlaps(location3));
+        assert!(!location3.overlaps(location1));
     }
 
     #[test]

--- a/src/txxt_nano/ast/location_test.rs
+++ b/src/txxt_nano/ast/location_test.rs
@@ -2,13 +2,13 @@
 mod tests {
     use crate::txxt_nano::ast::{
         elements::Session,
-        span::{Position, Span},
+        span::{Location, Position},
         traits::{AstNode, Container},
     };
 
     #[test]
     fn test_get_location() {
-        let span = Span::new(Position::new(1, 0), Position::new(1, 10));
+        let span = Location::new(Position::new(1, 0), Position::new(1, 10));
         let session = Session::with_title("Title".to_string()).with_span(Some(span));
         assert_eq!(session.get_location(), Some(Position::new(1, 0)));
     }
@@ -19,8 +19,8 @@ mod tests {
         use crate::txxt_nano::ast::elements::Document;
         use crate::txxt_nano::ast::find_nodes_at_position;
 
-        let span1 = Span::new(Position::new(1, 0), Position::new(1, 10));
-        let span2 = Span::new(Position::new(2, 0), Position::new(2, 10));
+        let span1 = Location::new(Position::new(1, 0), Position::new(1, 10));
+        let span2 = Location::new(Position::new(2, 0), Position::new(2, 10));
         let session1 = Session::with_title("Title1".to_string()).with_span(Some(span1));
         let session2 = Session::with_title("Title2".to_string()).with_span(Some(span2));
         let document = Document::with_content(vec![
@@ -38,9 +38,9 @@ mod tests {
         use crate::txxt_nano::ast::elements::{ContentItem, Document, Paragraph};
         use crate::txxt_nano::ast::find_nodes_at_position;
 
-        let para_span = Span::new(Position::new(2, 0), Position::new(2, 10));
+        let para_span = Location::new(Position::new(2, 0), Position::new(2, 10));
         let paragraph = Paragraph::from_line("Nested".to_string()).with_span(Some(para_span));
-        let session_span = Span::new(Position::new(1, 0), Position::new(3, 0));
+        let session_span = Location::new(Position::new(1, 0), Position::new(3, 0));
         let mut session = Session::with_title("Title".to_string()).with_span(Some(session_span));
         session
             .children_mut()

--- a/src/txxt_nano/ast/location_test.rs
+++ b/src/txxt_nano/ast/location_test.rs
@@ -2,14 +2,14 @@
 mod tests {
     use crate::txxt_nano::ast::{
         elements::Session,
-        span::{Location, Position},
+        location::{Location, Position},
         traits::{AstNode, Container},
     };
 
     #[test]
     fn test_get_location() {
-        let span = Location::new(Position::new(1, 0), Position::new(1, 10));
-        let session = Session::with_title("Title".to_string()).with_span(Some(span));
+        let location = Location::new(Position::new(1, 0), Position::new(1, 10));
+        let session = Session::with_title("Title".to_string()).with_span(Some(location));
         assert_eq!(session.get_location(), Some(Position::new(1, 0)));
     }
 

--- a/src/txxt_nano/ast/location_test.rs
+++ b/src/txxt_nano/ast/location_test.rs
@@ -9,7 +9,7 @@ mod tests {
     #[test]
     fn test_get_location() {
         let location = Location::new(Position::new(1, 0), Position::new(1, 10));
-        let session = Session::with_title("Title".to_string()).with_span(Some(location));
+        let session = Session::with_title("Title".to_string()).with_location(Some(location));
         assert_eq!(session.get_location(), Some(Position::new(1, 0)));
     }
 
@@ -21,8 +21,8 @@ mod tests {
 
         let span1 = Location::new(Position::new(1, 0), Position::new(1, 10));
         let span2 = Location::new(Position::new(2, 0), Position::new(2, 10));
-        let session1 = Session::with_title("Title1".to_string()).with_span(Some(span1));
-        let session2 = Session::with_title("Title2".to_string()).with_span(Some(span2));
+        let session1 = Session::with_title("Title1".to_string()).with_location(Some(span1));
+        let session2 = Session::with_title("Title2".to_string()).with_location(Some(span2));
         let document = Document::with_content(vec![
             ContentItem::Session(session1),
             ContentItem::Session(session2),
@@ -38,10 +38,12 @@ mod tests {
         use crate::txxt_nano::ast::elements::{ContentItem, Document, Paragraph};
         use crate::txxt_nano::ast::find_nodes_at_position;
 
-        let para_span = Location::new(Position::new(2, 0), Position::new(2, 10));
-        let paragraph = Paragraph::from_line("Nested".to_string()).with_span(Some(para_span));
-        let session_span = Location::new(Position::new(1, 0), Position::new(3, 0));
-        let mut session = Session::with_title("Title".to_string()).with_span(Some(session_span));
+        let para_location = Location::new(Position::new(2, 0), Position::new(2, 10));
+        let paragraph =
+            Paragraph::from_line("Nested".to_string()).with_location(Some(para_location));
+        let session_location = Location::new(Position::new(1, 0), Position::new(3, 0));
+        let mut session =
+            Session::with_title("Title".to_string()).with_location(Some(session_location));
         session
             .children_mut()
             .push(ContentItem::Paragraph(paragraph));

--- a/src/txxt_nano/ast/location_test.rs
+++ b/src/txxt_nano/ast/location_test.rs
@@ -19,10 +19,10 @@ mod tests {
         use crate::txxt_nano::ast::elements::Document;
         use crate::txxt_nano::ast::find_nodes_at_position;
 
-        let span1 = Location::new(Position::new(1, 0), Position::new(1, 10));
-        let span2 = Location::new(Position::new(2, 0), Position::new(2, 10));
-        let session1 = Session::with_title("Title1".to_string()).with_location(Some(span1));
-        let session2 = Session::with_title("Title2".to_string()).with_location(Some(span2));
+        let location1 = Location::new(Position::new(1, 0), Position::new(1, 10));
+        let location2 = Location::new(Position::new(2, 0), Position::new(2, 10));
+        let session1 = Session::with_title("Title1".to_string()).with_location(Some(location1));
+        let session2 = Session::with_title("Title2".to_string()).with_location(Some(location2));
         let document = Document::with_content(vec![
             ContentItem::Session(session1),
             ContentItem::Session(session2),

--- a/src/txxt_nano/ast/lookup.rs
+++ b/src/txxt_nano/ast/lookup.rs
@@ -1,5 +1,5 @@
 use super::elements::Document;
-use super::span::Position;
+use super::location::Position;
 use super::traits::AstNode;
 
 pub fn find_nodes_at_position(document: &Document, position: Position) -> Vec<&dyn AstNode> {

--- a/src/txxt_nano/ast/mod.rs
+++ b/src/txxt_nano/ast/mod.rs
@@ -29,7 +29,7 @@ pub use elements::{
 pub use error::PositionLookupError;
 pub use lookup::{find_nodes_at_position, format_at_position};
 pub use position::SourceLocation;
-pub use span::{Position, Span};
+pub use span::{Location, Position};
 pub use text_content::TextContent;
 pub use traits::{AstNode, Container, TextNode};
 #[cfg(test)]

--- a/src/txxt_nano/ast/mod.rs
+++ b/src/txxt_nano/ast/mod.rs
@@ -15,9 +15,9 @@
 
 pub mod elements;
 pub mod error;
+pub mod location;
 pub mod lookup;
 pub mod position;
-pub mod span;
 pub mod text_content;
 pub mod traits;
 
@@ -27,9 +27,9 @@ pub use elements::{
     Parameter, Session,
 };
 pub use error::PositionLookupError;
+pub use location::{Location, Position};
 pub use lookup::{find_nodes_at_position, format_at_position};
 pub use position::SourceLocation;
-pub use span::{Location, Position};
 pub use text_content::TextContent;
 pub use traits::{AstNode, Container, TextNode};
 #[cfg(test)]

--- a/src/txxt_nano/ast/mod.rs
+++ b/src/txxt_nano/ast/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Modules
 //!
-//! - `span` - Position and Span types for source code locations
+//! - `location` - Position and location types for source code locations
 //! - `elements` - AST node type definitions organized by element type
 //! - `traits` - Common traits for AST nodes
 //! - `position` - Source location utilities for converting byte offsets

--- a/src/txxt_nano/ast/position.rs
+++ b/src/txxt_nano/ast/position.rs
@@ -40,7 +40,7 @@ impl SourceLocation {
     }
 
     /// Convert a byte range to a location
-    pub fn range_to_span(&self, range: &Range<usize>) -> Location {
+    pub fn range_to_location(&self, range: &Range<usize>) -> Location {
         Location::new(
             self.byte_to_position(range.start),
             self.byte_to_position(range.end),
@@ -96,18 +96,18 @@ mod tests {
     }
 
     #[test]
-    fn test_range_to_span_single_line() {
+    fn test_range_to_location_single_line() {
         let loc = SourceLocation::new("Hello World");
-        let location = loc.range_to_span(&(0..5));
+        let location = loc.range_to_location(&(0..5));
 
         assert_eq!(location.start, Position::new(0, 0));
         assert_eq!(location.end, Position::new(0, 5));
     }
 
     #[test]
-    fn test_range_to_span_multiline() {
+    fn test_range_to_location_multiline() {
         let loc = SourceLocation::new("Hello\nWorld\nTest");
-        let location = loc.range_to_span(&(6..12));
+        let location = loc.range_to_location(&(6..12));
 
         assert_eq!(location.start, Position::new(1, 0));
         assert_eq!(location.end, Position::new(2, 0));
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_overlaps() {
+    fn test_location_overlaps() {
         let span1 = Location::new(Position::new(0, 0), Position::new(1, 5));
         let span2 = Location::new(Position::new(1, 0), Position::new(2, 5));
         let span3 = Location::new(Position::new(3, 0), Position::new(4, 5));

--- a/src/txxt_nano/ast/position.rs
+++ b/src/txxt_nano/ast/position.rs
@@ -4,7 +4,7 @@
 //! to human-readable line and column positions, useful for error reporting
 //! and position tracking in AST nodes.
 
-use super::span::{Position, Span};
+use super::span::{Location, Position};
 use std::ops::Range;
 
 /// Provides fast conversion from byte offsets to line/column positions
@@ -40,8 +40,8 @@ impl SourceLocation {
     }
 
     /// Convert a byte range to a span
-    pub fn range_to_span(&self, range: &Range<usize>) -> Span {
-        Span::new(
+    pub fn range_to_span(&self, range: &Range<usize>) -> Location {
+        Location::new(
             self.byte_to_position(range.start),
             self.byte_to_position(range.end),
         )
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_position_contains() {
-        let span = Span::new(Position::new(1, 5), Position::new(2, 10));
+        let span = Location::new(Position::new(1, 5), Position::new(2, 10));
 
         // Start position
         assert!(span.contains(Position::new(1, 5)));
@@ -152,9 +152,9 @@ mod tests {
 
     #[test]
     fn test_span_overlaps() {
-        let span1 = Span::new(Position::new(0, 0), Position::new(1, 5));
-        let span2 = Span::new(Position::new(1, 0), Position::new(2, 5));
-        let span3 = Span::new(Position::new(3, 0), Position::new(4, 5));
+        let span1 = Location::new(Position::new(0, 0), Position::new(1, 5));
+        let span2 = Location::new(Position::new(1, 0), Position::new(2, 5));
+        let span3 = Location::new(Position::new(3, 0), Position::new(4, 5));
 
         // Overlapping spans
         assert!(span1.overlaps(span2));

--- a/src/txxt_nano/ast/position.rs
+++ b/src/txxt_nano/ast/position.rs
@@ -152,16 +152,16 @@ mod tests {
 
     #[test]
     fn test_location_overlaps() {
-        let span1 = Location::new(Position::new(0, 0), Position::new(1, 5));
-        let span2 = Location::new(Position::new(1, 0), Position::new(2, 5));
-        let span3 = Location::new(Position::new(3, 0), Position::new(4, 5));
+        let location1 = Location::new(Position::new(0, 0), Position::new(1, 5));
+        let location2 = Location::new(Position::new(1, 0), Position::new(2, 5));
+        let location3 = Location::new(Position::new(3, 0), Position::new(4, 5));
 
-        // Overlapping spans
-        assert!(span1.overlaps(span2));
-        assert!(span2.overlaps(span1));
+        // Overlapping locations
+        assert!(location1.overlaps(location2));
+        assert!(location2.overlaps(location1));
 
-        // Non-overlapping spans
-        assert!(!span1.overlaps(span3));
-        assert!(!span3.overlaps(span1));
+        // Non-overlapping locations
+        assert!(!location1.overlaps(location3));
+        assert!(!location3.overlaps(location1));
     }
 }

--- a/src/txxt_nano/ast/position.rs
+++ b/src/txxt_nano/ast/position.rs
@@ -4,7 +4,7 @@
 //! to human-readable line and column positions, useful for error reporting
 //! and position tracking in AST nodes.
 
-use super::span::{Location, Position};
+use super::location::{Location, Position};
 use std::ops::Range;
 
 /// Provides fast conversion from byte offsets to line/column positions
@@ -39,7 +39,7 @@ impl SourceLocation {
         Position::new(line, column)
     }
 
-    /// Convert a byte range to a span
+    /// Convert a byte range to a location
     pub fn range_to_span(&self, range: &Range<usize>) -> Location {
         Location::new(
             self.byte_to_position(range.start),
@@ -98,19 +98,19 @@ mod tests {
     #[test]
     fn test_range_to_span_single_line() {
         let loc = SourceLocation::new("Hello World");
-        let span = loc.range_to_span(&(0..5));
+        let location = loc.range_to_span(&(0..5));
 
-        assert_eq!(span.start, Position::new(0, 0));
-        assert_eq!(span.end, Position::new(0, 5));
+        assert_eq!(location.start, Position::new(0, 0));
+        assert_eq!(location.end, Position::new(0, 5));
     }
 
     #[test]
     fn test_range_to_span_multiline() {
         let loc = SourceLocation::new("Hello\nWorld\nTest");
-        let span = loc.range_to_span(&(6..12));
+        let location = loc.range_to_span(&(6..12));
 
-        assert_eq!(span.start, Position::new(1, 0));
-        assert_eq!(span.end, Position::new(2, 0));
+        assert_eq!(location.start, Position::new(1, 0));
+        assert_eq!(location.end, Position::new(2, 0));
     }
 
     #[test]
@@ -132,22 +132,22 @@ mod tests {
 
     #[test]
     fn test_position_contains() {
-        let span = Location::new(Position::new(1, 5), Position::new(2, 10));
+        let location = Location::new(Position::new(1, 5), Position::new(2, 10));
 
         // Start position
-        assert!(span.contains(Position::new(1, 5)));
+        assert!(location.contains(Position::new(1, 5)));
 
         // End position
-        assert!(span.contains(Position::new(2, 10)));
+        assert!(location.contains(Position::new(2, 10)));
 
-        // Inside span
-        assert!(span.contains(Position::new(1, 8)));
-        assert!(span.contains(Position::new(2, 0)));
+        // Inside location
+        assert!(location.contains(Position::new(1, 8)));
+        assert!(location.contains(Position::new(2, 0)));
 
-        // Outside span
-        assert!(!span.contains(Position::new(1, 4)));
-        assert!(!span.contains(Position::new(2, 11)));
-        assert!(!span.contains(Position::new(0, 0)));
+        // Outside location
+        assert!(!location.contains(Position::new(1, 4)));
+        assert!(!location.contains(Position::new(2, 11)));
+        assert!(!location.contains(Position::new(0, 0)));
     }
 
     #[test]

--- a/src/txxt_nano/ast/span.rs
+++ b/src/txxt_nano/ast/span.rs
@@ -26,12 +26,12 @@ impl fmt::Display for Position {
 
 /// Represents a span in source code (start and end positions)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Span {
+pub struct Location {
     pub start: Position,
     pub end: Position,
 }
 
-impl Span {
+impl Location {
     pub fn new(start: Position, end: Position) -> Self {
         Self { start, end }
     }
@@ -45,7 +45,7 @@ impl Span {
     }
 
     /// Check if another span overlaps with this span
-    pub fn overlaps(&self, other: Span) -> bool {
+    pub fn overlaps(&self, other: Location) -> bool {
         self.contains(other.start)
             || self.contains(other.end)
             || other.contains(self.start)
@@ -53,7 +53,7 @@ impl Span {
     }
 }
 
-impl fmt::Display for Span {
+impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}..{}", self.start, self.end)
     }
@@ -85,7 +85,7 @@ mod tests {
     fn test_span_creation() {
         let start = Position::new(0, 0);
         let end = Position::new(2, 5);
-        let span = Span::new(start, end);
+        let span = Location::new(start, end);
 
         assert_eq!(span.start, start);
         assert_eq!(span.end, end);
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_span_contains_single_line() {
-        let span = Span::new(Position::new(0, 0), Position::new(0, 10));
+        let span = Location::new(Position::new(0, 0), Position::new(0, 10));
 
         assert!(span.contains(Position::new(0, 0)));
         assert!(span.contains(Position::new(0, 5)));
@@ -105,7 +105,7 @@ mod tests {
 
     #[test]
     fn test_span_contains_multiline() {
-        let span = Span::new(Position::new(1, 5), Position::new(2, 10));
+        let span = Location::new(Position::new(1, 5), Position::new(2, 10));
 
         // Before span
         assert!(!span.contains(Position::new(1, 4)));
@@ -124,9 +124,9 @@ mod tests {
 
     #[test]
     fn test_span_overlaps() {
-        let span1 = Span::new(Position::new(0, 0), Position::new(1, 5));
-        let span2 = Span::new(Position::new(1, 0), Position::new(2, 5));
-        let span3 = Span::new(Position::new(3, 0), Position::new(4, 5));
+        let span1 = Location::new(Position::new(0, 0), Position::new(1, 5));
+        let span2 = Location::new(Position::new(1, 0), Position::new(2, 5));
+        let span3 = Location::new(Position::new(3, 0), Position::new(4, 5));
 
         assert!(span1.overlaps(span2));
         assert!(span2.overlaps(span1));
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_span_display() {
-        let span = Span::new(Position::new(1, 0), Position::new(2, 5));
+        let span = Location::new(Position::new(1, 0), Position::new(2, 5));
         assert_eq!(format!("{}", span), "1:0..2:5");
     }
 }

--- a/src/txxt_nano/ast/text_content.rs
+++ b/src/txxt_nano/ast/text_content.rs
@@ -12,7 +12,7 @@
 //! (.as_string(), future: .as_inlines()), which work regardless of the
 //! internal representation.
 
-use super::span::Span;
+use super::span::Location;
 
 /// Represents user-provided text content with source position tracking.
 ///
@@ -22,7 +22,7 @@ use super::span::Span;
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextContent {
     /// Span in the source covering this text
-    pub span: Option<Span>,
+    pub span: Option<Location>,
     /// Internal representation (evolves over time)
     inner: TextRepresentation,
 }
@@ -52,7 +52,7 @@ impl TextContent {
     /// ```ignore
     /// let content = TextContent::from_string("Hello world".to_string(), Some(span));
     /// ```
-    pub fn from_string(text: String, span: Option<Span>) -> Self {
+    pub fn from_string(text: String, span: Option<Location>) -> Self {
         Self {
             span,
             inner: TextRepresentation::Text(text),
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_with_span() {
-        let span = Span::new(Position::new(0, 0), Position::new(0, 5));
+        let span = Location::new(Position::new(0, 0), Position::new(0, 5));
         let content = TextContent::from_string("Hello".to_string(), Some(span));
         assert_eq!(content.span, Some(span));
     }

--- a/src/txxt_nano/ast/text_content.rs
+++ b/src/txxt_nano/ast/text_content.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_span() {
+    fn test_with_location() {
         let span = Location::new(Position::new(0, 0), Position::new(0, 5));
         let content = TextContent::from_string("Hello".to_string(), Some(span));
         assert_eq!(content.span, Some(span));

--- a/src/txxt_nano/ast/text_content.rs
+++ b/src/txxt_nano/ast/text_content.rs
@@ -21,8 +21,8 @@ use super::location::Location;
 /// Currently stores plain text; future versions will support parsed inline nodes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextContent {
-    /// Span in the source covering this text
-    pub span: Option<Location>,
+    /// Location in the source covering this text
+    pub location: Option<Location>,
     /// Internal representation (evolves over time)
     inner: TextRepresentation,
 }
@@ -42,19 +42,19 @@ enum TextRepresentation {
 }
 
 impl TextContent {
-    /// Create TextContent from a string and optional source span.
+    /// Create TextContent from a string and optional source location.
     ///
     /// # Arguments
     /// * `text` - The raw text content
-    /// * `span` - Optional source location of this text
+    /// * `location` - Optional source location of this text
     ///
     /// # Example
     /// ```ignore
-    /// let content = TextContent::from_string("Hello world".to_string(), Some(span));
+    /// let content = TextContent::from_string("Hello world".to_string(), Some(location));
     /// ```
-    pub fn from_string(text: String, span: Option<Location>) -> Self {
+    pub fn from_string(text: String, location: Option<Location>) -> Self {
         Self {
-            span,
+            location,
             inner: TextRepresentation::Text(text),
         }
     }
@@ -62,7 +62,7 @@ impl TextContent {
     /// Create empty TextContent.
     pub fn empty() -> Self {
         Self {
-            span: None,
+            location: None,
             inner: TextRepresentation::Text(String::new()),
         }
     }
@@ -173,9 +173,9 @@ mod tests {
 
     #[test]
     fn test_with_location() {
-        let span = Location::new(Position::new(0, 0), Position::new(0, 5));
-        let content = TextContent::from_string("Hello".to_string(), Some(span));
-        assert_eq!(content.span, Some(span));
+        let location = Location::new(Position::new(0, 0), Position::new(0, 5));
+        let content = TextContent::from_string("Hello".to_string(), Some(location));
+        assert_eq!(content.location, Some(location));
     }
 
     #[test]

--- a/src/txxt_nano/ast/text_content.rs
+++ b/src/txxt_nano/ast/text_content.rs
@@ -12,7 +12,7 @@
 //! (.as_string(), future: .as_inlines()), which work regardless of the
 //! internal representation.
 
-use super::span::Location;
+use super::location::Location;
 
 /// Represents user-provided text content with source position tracking.
 ///
@@ -185,5 +185,5 @@ mod tests {
         assert_eq!(content.as_string(), "World");
     }
 
-    use super::super::span::Position;
+    use super::super::location::Position;
 }

--- a/src/txxt_nano/ast/traits.rs
+++ b/src/txxt_nano/ast/traits.rs
@@ -4,16 +4,16 @@
 //! to AST node information across all node types.
 
 use super::elements::ContentItem;
-use super::span::{Position, Span};
+use super::span::{Location, Position};
 use super::text_content::TextContent;
 
 /// Common interface for all AST nodes
 pub trait AstNode {
     fn node_type(&self) -> &'static str;
     fn display_label(&self) -> String;
-    fn span(&self) -> Option<Span>;
+    fn location(&self) -> Option<Location>;
     fn get_location(&self) -> Option<Position> {
-        self.span().map(|s| s.start)
+        self.location().map(|s| s.start)
     }
 }
 

--- a/src/txxt_nano/ast/traits.rs
+++ b/src/txxt_nano/ast/traits.rs
@@ -4,7 +4,7 @@
 //! to AST node information across all node types.
 
 use super::elements::ContentItem;
-use super::span::{Location, Position};
+use super::location::{Location, Position};
 use super::text_content::TextContent;
 
 /// Common interface for all AST nodes

--- a/src/txxt_nano/formats/tag/tag.rs
+++ b/src/txxt_nano/formats/tag/tag.rs
@@ -567,13 +567,13 @@ mod tests {
     #[test]
     fn test_serialize_nested_lists_from_sample_file() {
         // Integration test: Parse a sample file and verify nested lists are serialized correctly
-        use crate::txxt_nano::lexer::lex_with_spans;
+        use crate::txxt_nano::lexer::lex_with_locations;
         use crate::txxt_nano::parser::api::parse_with_source;
         use crate::txxt_nano::processor::txxt_sources::TxxtSources;
 
         let source = TxxtSources::get_string("070-nested-lists-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).expect("Failed to parse");
 
         let result = serialize_document(&doc);
@@ -596,13 +596,13 @@ mod tests {
     #[test]
     fn test_serialize_mixed_content_lists_from_sample_file() {
         // Integration test: Verify lists with paragraphs and nested lists are serialized correctly
-        use crate::txxt_nano::lexer::lex_with_spans;
+        use crate::txxt_nano::lexer::lex_with_locations;
         use crate::txxt_nano::parser::api::parse_with_source;
         use crate::txxt_nano::processor::txxt_sources::TxxtSources;
 
         let source = TxxtSources::get_string("080-nested-lists-mixed-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).expect("Failed to parse");
 
         let result = serialize_document(&doc);

--- a/src/txxt_nano/lexer.rs
+++ b/src/txxt_nano/lexer.rs
@@ -26,7 +26,7 @@ pub mod tokens;
 
 pub use blank_line_transform::{transform_blank_lines, transform_blank_lines_with_locations};
 pub use detokenizer::detokenize;
-pub use indentation_transform::{transform_indentation, transform_indentation_with_spans};
+pub use indentation_transform::{transform_indentation, transform_indentation_with_locations};
 pub use lexer_impl::{tokenize, tokenize_with_locations};
 pub use tokens::Token;
 
@@ -48,14 +48,14 @@ pub fn lex(source: &str) -> Vec<Token> {
     transform_blank_lines(tokens)
 }
 
-/// Lexing function that preserves source spans for parser
-/// Returns tokens with their corresponding source spans
-/// Synthetic tokens (IndentLevel, DedentLevel, BlankLine) have empty spans (0..0)
+/// Lexing function that preserves source locations for parser
+/// Returns tokens with their corresponding source locations
+/// Synthetic tokens (IndentLevel, DedentLevel, BlankLine) have empty locations (0..0)
 /// Processing pipeline:
-/// 1. tokenize_with_spans() - creates raw tokens with spans
-/// 2. transform_indentation_with_spans() - converts Indent tokens to semantic IndentLevel/DedentLevel tokens
-/// 3. transform_blank_lines_with_spans() - converts consecutive Newline tokens to BlankLine tokens
-pub fn lex_with_spans(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
+/// 1. tokenize_with_locations() - creates raw tokens with locations
+/// 2. transform_indentation_with_locations() - converts Indent tokens to semantic IndentLevel/DedentLevel tokens
+/// 3. transform_blank_lines_with_locations() - converts consecutive Newline tokens to BlankLine tokens
+pub fn lex_with_locations(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
     // Ensure source ends with newline to help with paragraph parsing at EOF
     let source_with_newline = if !source.is_empty() && !source.ends_with('\n') {
         format!("{}\n", source)
@@ -63,7 +63,7 @@ pub fn lex_with_spans(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
         source.to_string()
     };
 
-    let raw_tokens_with_spans = tokenize_with_locations(&source_with_newline);
-    let tokens = transform_indentation_with_spans(raw_tokens_with_spans);
+    let raw_tokens_with_locations = tokenize_with_locations(&source_with_newline);
+    let tokens = transform_indentation_with_locations(raw_tokens_with_locations);
     transform_blank_lines_with_locations(tokens)
 }

--- a/src/txxt_nano/lexer.rs
+++ b/src/txxt_nano/lexer.rs
@@ -24,10 +24,10 @@ pub mod indentation_transform;
 pub mod lexer_impl;
 pub mod tokens;
 
-pub use blank_line_transform::{transform_blank_lines, transform_blank_lines_with_spans};
+pub use blank_line_transform::{transform_blank_lines, transform_blank_lines_with_locations};
 pub use detokenizer::detokenize;
 pub use indentation_transform::{transform_indentation, transform_indentation_with_spans};
-pub use lexer_impl::{tokenize, tokenize_with_spans};
+pub use lexer_impl::{tokenize, tokenize_with_locations};
 pub use tokens::Token;
 
 /// Main lexer function that returns fully processed tokens
@@ -63,7 +63,7 @@ pub fn lex_with_spans(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
         source.to_string()
     };
 
-    let raw_tokens_with_spans = tokenize_with_spans(&source_with_newline);
+    let raw_tokens_with_spans = tokenize_with_locations(&source_with_newline);
     let tokens = transform_indentation_with_spans(raw_tokens_with_spans);
-    transform_blank_lines_with_spans(tokens)
+    transform_blank_lines_with_locations(tokens)
 }

--- a/src/txxt_nano/lexer/indentation_transform.rs
+++ b/src/txxt_nano/lexer/indentation_transform.rs
@@ -768,7 +768,7 @@ mod tests {
         );
     }
 
-    // ========== SPAN TESTS ==========
+    // ========== location TESTS ==========
     // Tests to verify that synthetic tokens (IndentLevel, DedentLevel) have correct locations
 
     #[test]

--- a/src/txxt_nano/lexer/indentation_transform.rs
+++ b/src/txxt_nano/lexer/indentation_transform.rs
@@ -919,7 +919,7 @@ mod tests {
         //            13..20 "Subitem", 20..21 " ", 21..22 "A", 22..23 "\n",
         //            23..27 "    ", 27..28 "-", 28..29 " ", 29..36 "Subitem", 36..37 " ", 37..38 "B"
 
-        let tokens_with_spans = crate::txxt_nano::lexer::tokenize_with_spans(source);
+        let tokens_with_spans = crate::txxt_nano::lexer::tokenize_with_locations(source);
         let result = transform_indentation_with_spans(tokens_with_spans);
 
         // Find the IndentLevel token

--- a/src/txxt_nano/lexer/indentation_transform.rs
+++ b/src/txxt_nano/lexer/indentation_transform.rs
@@ -154,7 +154,7 @@ fn count_line_indent_steps(tokens: &[Token], start: usize) -> usize {
 /// Synthetic tokens (IndentLevel, DedentLevel) are given meaningful spans:
 /// - IndentLevel: span covers the Indent tokens it represents
 /// - DedentLevel: span at the start of the line where dedentation occurs
-pub fn transform_indentation_with_spans(
+pub fn transform_indentation_with_locations(
     tokens_with_spans: Vec<(Token, std::ops::Range<usize>)>,
 ) -> Vec<(Token, std::ops::Range<usize>)> {
     // Extract just the tokens for processing
@@ -779,7 +779,7 @@ mod tests {
             (Token::Text("b".to_string()), 6..7), // "b" at position 6-7
         ];
 
-        let result = transform_indentation_with_spans(input);
+        let result = transform_indentation_with_locations(input);
 
         // Expected:
         // - Text("a") with span 0..1
@@ -818,7 +818,7 @@ mod tests {
             (Token::Text("b".to_string()), 10..11), // "b"
         ];
 
-        let result = transform_indentation_with_spans(input);
+        let result = transform_indentation_with_locations(input);
 
         // Should have: Text, Newline, IndentLevel, IndentLevel, Text, DedentLevel, DedentLevel
         assert_eq!(result.len(), 7);
@@ -845,7 +845,7 @@ mod tests {
             (Token::Text("c".to_string()), 8..9), // "c" (dedented back to level 0)
         ];
 
-        let result = transform_indentation_with_spans(input);
+        let result = transform_indentation_with_locations(input);
 
         // Expected:
         // - Text("a"), Newline, IndentLevel, Text("b"), Newline, DedentLevel, Text("c")
@@ -872,7 +872,7 @@ mod tests {
             (Token::Text("c".to_string()), 12..13), // Back to level 0
         ];
 
-        let result = transform_indentation_with_spans(input);
+        let result = transform_indentation_with_locations(input);
 
         // Expected: Text("a"), Newline, IndentLevel, IndentLevel, Text("b"), Newline, DedentLevel, DedentLevel, Text("c")
         // Should have 2 DedentLevel tokens before Text("c")
@@ -903,7 +903,7 @@ mod tests {
             (Token::Text("b".to_string()), 6..7),
         ];
 
-        let result = transform_indentation_with_spans(input);
+        let result = transform_indentation_with_locations(input);
 
         // Last token should be DedentLevel with span at EOF (7..7)
         let last = result.last().unwrap();
@@ -920,7 +920,7 @@ mod tests {
         //            23..27 "    ", 27..28 "-", 28..29 " ", 29..36 "Subitem", 36..37 " ", 37..38 "B"
 
         let tokens_with_spans = crate::txxt_nano::lexer::tokenize_with_locations(source);
-        let result = transform_indentation_with_spans(tokens_with_spans);
+        let result = transform_indentation_with_locations(tokens_with_spans);
 
         // Find the IndentLevel token
         let indent_level_pos = result
@@ -959,7 +959,7 @@ mod tests {
             (Token::Text("b".to_string()), 7..8),
         ];
 
-        let result = transform_indentation_with_spans(input);
+        let result = transform_indentation_with_locations(input);
 
         // The IndentLevel should still have correct span
         let indent_pos = result

--- a/src/txxt_nano/lexer/lexer_impl.rs
+++ b/src/txxt_nano/lexer/lexer_impl.rs
@@ -8,8 +8,8 @@ use logos::Logos;
 
 /// Convenience function to tokenize a string and collect all tokens
 pub fn tokenize(source: &str) -> Vec<Token> {
-    let tokens_with_spans = tokenize_with_locations(source);
-    process_whitespace_remainders(tokens_with_spans)
+    let tokens_with_locations = tokenize_with_locations(source);
+    process_whitespace_remainders(tokens_with_locations)
 }
 
 /// Process whitespace remainders according to txxt specification
@@ -20,12 +20,12 @@ pub fn tokenize(source: &str) -> Vec<Token> {
 ///
 /// This function removes Whitespace tokens that follow Indent tokens and precede Text tokens,
 /// effectively merging the whitespace remainder into the text content.
-fn process_whitespace_remainders(tokens_with_spans: Vec<(Token, logos::Span)>) -> Vec<Token> {
+fn process_whitespace_remainders(tokens_with_locations: Vec<(Token, logos::Span)>) -> Vec<Token> {
     let mut result = Vec::new();
     let mut i = 0;
 
-    while i < tokens_with_spans.len() {
-        let (token, _span) = &tokens_with_spans[i];
+    while i < tokens_with_locations.len() {
+        let (token, _location) = &tokens_with_locations[i];
 
         match token {
             Token::Whitespace => {
@@ -34,7 +34,7 @@ fn process_whitespace_remainders(tokens_with_spans: Vec<(Token, logos::Span)>) -
                 let mut j = i;
 
                 // Count consecutive Indent tokens before this Whitespace
-                while j > 0 && matches!(tokens_with_spans[j - 1].0, Token::Indent) {
+                while j > 0 && matches!(tokens_with_locations[j - 1].0, Token::Indent) {
                     indent_count += 1;
                     j -= 1;
                 }
@@ -42,8 +42,8 @@ fn process_whitespace_remainders(tokens_with_spans: Vec<(Token, logos::Span)>) -
                 // If we have indentation and this whitespace is followed by text,
                 // skip this whitespace token (it will be considered part of the text)
                 if indent_count > 0
-                    && i + 1 < tokens_with_spans.len()
-                    && matches!(tokens_with_spans[i + 1].0, Token::Text(_))
+                    && i + 1 < tokens_with_locations.len()
+                    && matches!(tokens_with_locations[i + 1].0, Token::Text(_))
                 {
                     // Skip this whitespace token
                     i += 1;

--- a/src/txxt_nano/lexer/lexer_impl.rs
+++ b/src/txxt_nano/lexer/lexer_impl.rs
@@ -8,7 +8,7 @@ use logos::Logos;
 
 /// Convenience function to tokenize a string and collect all tokens
 pub fn tokenize(source: &str) -> Vec<Token> {
-    let tokens_with_spans = tokenize_with_spans(source);
+    let tokens_with_spans = tokenize_with_locations(source);
     process_whitespace_remainders(tokens_with_spans)
 }
 
@@ -64,7 +64,7 @@ fn process_whitespace_remainders(tokens_with_spans: Vec<(Token, logos::Span)>) -
 }
 
 /// Convenience function to tokenize a string and collect tokens with their spans
-pub fn tokenize_with_spans(source: &str) -> Vec<(Token, logos::Span)> {
+pub fn tokenize_with_locations(source: &str) -> Vec<(Token, logos::Span)> {
     let mut lexer = Token::lexer(source);
     let mut tokens = Vec::new();
 
@@ -114,14 +114,14 @@ mod tests {
     }
 
     #[test]
-    fn test_tokenize_with_spans() {
-        let tokens_with_spans = tokenize_with_spans("hello world");
-        assert_eq!(tokens_with_spans.len(), 3);
+    fn test_tokenize_with_locations() {
+        let tokens_with_locations = tokenize_with_locations("hello world");
+        assert_eq!(tokens_with_locations.len(), 3);
 
         // Check that tokens are correct (spans are not preserved in current implementation)
-        assert_eq!(tokens_with_spans[0].0, Token::Text("hello".to_string()));
-        assert_eq!(tokens_with_spans[1].0, Token::Whitespace);
-        assert_eq!(tokens_with_spans[2].0, Token::Text("world".to_string()));
+        assert_eq!(tokens_with_locations[0].0, Token::Text("hello".to_string()));
+        assert_eq!(tokens_with_locations[1].0, Token::Whitespace);
+        assert_eq!(tokens_with_locations[2].0, Token::Text("world".to_string()));
     }
 
     #[test]

--- a/src/txxt_nano/lexer/lexer_impl.rs
+++ b/src/txxt_nano/lexer/lexer_impl.rs
@@ -63,7 +63,7 @@ fn process_whitespace_remainders(tokens_with_locations: Vec<(Token, logos::Span)
     result
 }
 
-/// Convenience function to tokenize a string and collect tokens with their spans
+/// Convenience function to tokenize a string and collect tokens with their locations
 pub fn tokenize_with_locations(source: &str) -> Vec<(Token, logos::Span)> {
     let mut lexer = Token::lexer(source);
     let mut tokens = Vec::new();
@@ -118,7 +118,7 @@ mod tests {
         let tokens_with_locations = tokenize_with_locations("hello world");
         assert_eq!(tokens_with_locations.len(), 3);
 
-        // Check that tokens are correct (spans are not preserved in current implementation)
+        // Check that tokens are correct (locations are not preserved in current implementation)
         assert_eq!(tokens_with_locations[0].0, Token::Text("hello".to_string()));
         assert_eq!(tokens_with_locations[1].0, Token::Whitespace);
         assert_eq!(tokens_with_locations[2].0, Token::Text("world".to_string()));

--- a/src/txxt_nano/parser.rs
+++ b/src/txxt_nano/parser.rs
@@ -36,6 +36,6 @@ type ParseResult = Result<
 /// Main parser function that takes source text and returns a parsed document
 /// This is the primary entry point for parsing txxt documents
 pub fn parse_document(source: &str) -> ParseResult {
-    let tokens_with_spans = crate::txxt_nano::lexer::lex_with_locations(source);
-    parse_with_source(tokens_with_spans, source)
+    let tokens_with_locations = crate::txxt_nano::lexer::lex_with_locations(source);
+    parse_with_source(tokens_with_locations, source)
 }

--- a/src/txxt_nano/parser.rs
+++ b/src/txxt_nano/parser.rs
@@ -36,6 +36,6 @@ type ParseResult = Result<
 /// Main parser function that takes source text and returns a parsed document
 /// This is the primary entry point for parsing txxt documents
 pub fn parse_document(source: &str) -> ParseResult {
-    let tokens_with_spans = crate::txxt_nano::lexer::lex_with_spans(source);
+    let tokens_with_spans = crate::txxt_nano::lexer::lex_with_locations(source);
     parse_with_source(tokens_with_spans, source)
 }

--- a/src/txxt_nano/parser.rs
+++ b/src/txxt_nano/parser.rs
@@ -19,8 +19,8 @@ mod tests;
 // Re-export AST types and utilities from the ast module
 pub use crate::txxt_nano::ast::{
     format_at_position, Annotation, AstNode, Container, ContentItem, Definition, Document,
-    ForeignBlock, Label, List, ListItem, Paragraph, Parameter, Position, Session, SourceLocation,
-    Span, TextNode,
+    ForeignBlock, Label, List, ListItem, Location, Paragraph, Parameter, Position, Session,
+    SourceLocation, TextNode,
 };
 
 pub use crate::txxt_nano::formats::{serialize_ast_tag, to_treeviz_str};

--- a/src/txxt_nano/parser/api.rs
+++ b/src/txxt_nano/parser/api.rs
@@ -15,24 +15,24 @@ type ParserError = Simple<TokenSpan>;
 
 /// Parse with source text - returns final Document with full span information
 pub fn parse_with_source(
-    tokens_with_spans: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenSpan>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    document(source).parse(tokens_with_spans)
+    document(source).parse(tokens_with_locations)
 }
 
 /// Parse a txxt document from tokens with source, preserving position information
 /// Note: All parsed documents now include complete span information automatically
 pub fn parse_with_source_positions(
-    tokens_with_spans: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenSpan>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    document(source).parse(tokens_with_spans)
+    document(source).parse(tokens_with_locations)
 }
 
 /// Parse a txxt document from a token stream (legacy - doesn't preserve source text)
 pub fn parse(tokens: Vec<Token>) -> Result<Document, Vec<Simple<Token>>> {
-    let tokens_with_spans: Vec<TokenSpan> = tokens.into_iter().map(|t| (t, 0..0)).collect();
-    parse_with_source(tokens_with_spans, "")
+    let tokens_with_locations: Vec<TokenSpan> = tokens.into_iter().map(|t| (t, 0..0)).collect();
+    parse_with_source(tokens_with_locations, "")
         .map_err(|errs| errs.into_iter().map(|e| e.map(|(t, _)| t)).collect())
 }

--- a/src/txxt_nano/parser/api.rs
+++ b/src/txxt_nano/parser/api.rs
@@ -7,13 +7,13 @@ use crate::txxt_nano::ast::Document;
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::elements::document::document;
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
 type ParserError = Simple<TokenLocation>;
 
-/// Parse with source text - returns final Document with full span information
+/// Parse with source text - returns final Document with full location information
 pub fn parse_with_source(
     tokens_with_locations: Vec<TokenLocation>,
     source: &str,
@@ -22,7 +22,7 @@ pub fn parse_with_source(
 }
 
 /// Parse a txxt document from tokens with source, preserving position information
-/// Note: All parsed documents now include complete span information automatically
+/// Note: All parsed documents now include complete location information automatically
 pub fn parse_with_source_positions(
     tokens_with_locations: Vec<TokenLocation>,
     source: &str,

--- a/src/txxt_nano/parser/api.rs
+++ b/src/txxt_nano/parser/api.rs
@@ -8,14 +8,14 @@ use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::elements::document::document;
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 /// Parse with source text - returns final Document with full span information
 pub fn parse_with_source(
-    tokens_with_locations: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
     document(source).parse(tokens_with_locations)
@@ -24,7 +24,7 @@ pub fn parse_with_source(
 /// Parse a txxt document from tokens with source, preserving position information
 /// Note: All parsed documents now include complete span information automatically
 pub fn parse_with_source_positions(
-    tokens_with_locations: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
     document(source).parse(tokens_with_locations)
@@ -32,7 +32,7 @@ pub fn parse_with_source_positions(
 
 /// Parse a txxt document from a token stream (legacy - doesn't preserve source text)
 pub fn parse(tokens: Vec<Token>) -> Result<Document, Vec<Simple<Token>>> {
-    let tokens_with_locations: Vec<TokenSpan> = tokens.into_iter().map(|t| (t, 0..0)).collect();
+    let tokens_with_locations: Vec<TokenLocation> = tokens.into_iter().map(|t| (t, 0..0)).collect();
     parse_with_source(tokens_with_locations, "")
         .map_err(|errs| errs.into_iter().map(|e| e.map(|(t, _)| t)).collect())
 }

--- a/src/txxt_nano/parser/combinators.rs
+++ b/src/txxt_nano/parser/combinators.rs
@@ -49,7 +49,7 @@ fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
 
 /// Helper: compute span bounds from multiple spans
 pub(crate) fn compute_span_from_spans(spans: &[Location]) -> Location {
-    use crate::txxt_nano::ast::span::Position;
+    use crate::txxt_nano::ast::location::Position;
     let start_line = spans.iter().map(|sp| sp.start.line).min().unwrap_or(0);
     let start_col = spans.iter().map(|sp| sp.start.column).min().unwrap_or(0);
     let end_line = spans.iter().map(|sp| sp.end.line).max().unwrap_or(0);

--- a/src/txxt_nano/parser/combinators.rs
+++ b/src/txxt_nano/parser/combinators.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::txxt_nano::ast::position::SourceLocation;
-use crate::txxt_nano::ast::{Paragraph, Parameter, Span, TextContent};
+use crate::txxt_nano::ast::{Location, Paragraph, Parameter, TextContent};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::elements::labels::parse_label_from_tokens;
 use crate::txxt_nano::parser::elements::parameters::{
@@ -39,7 +39,7 @@ pub(crate) fn is_text_token(token: &Token) -> bool {
 }
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Span> {
+fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }
@@ -48,21 +48,21 @@ fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Span> {
 }
 
 /// Helper: compute span bounds from multiple spans
-pub(crate) fn compute_span_from_spans(spans: &[Span]) -> Span {
+pub(crate) fn compute_span_from_spans(spans: &[Location]) -> Location {
     use crate::txxt_nano::ast::span::Position;
     let start_line = spans.iter().map(|sp| sp.start.line).min().unwrap_or(0);
     let start_col = spans.iter().map(|sp| sp.start.column).min().unwrap_or(0);
     let end_line = spans.iter().map(|sp| sp.end.line).max().unwrap_or(0);
     let end_col = spans.iter().map(|sp| sp.end.column).max().unwrap_or(0);
-    Span::new(
+    Location::new(
         Position::new(start_line, start_col),
         Position::new(end_line, end_col),
     )
 }
 
 /// Helper: compute span bounds from multiple optional spans
-pub(crate) fn compute_span_from_optional_spans(spans: &[Option<Span>]) -> Option<Span> {
-    let actual_spans: Vec<Span> = spans.iter().filter_map(|s| *s).collect();
+pub(crate) fn compute_span_from_optional_spans(spans: &[Option<Location>]) -> Option<Location> {
+    let actual_spans: Vec<Location> = spans.iter().filter_map(|s| *s).collect();
     if actual_spans.is_empty() {
         None
     } else {

--- a/src/txxt_nano/parser/elements/annotations.rs
+++ b/src/txxt_nano/parser/elements/annotations.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::txxt_nano::ast::position::SourceLocation;
-use crate::txxt_nano::ast::{Annotation, ContentItem, Label, Paragraph, Span, TextContent};
+use crate::txxt_nano::ast::{Annotation, ContentItem, Label, Location, Paragraph, TextContent};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{
     annotation_header, compute_span_from_spans, extract_text_from_spans, text_line, token,
@@ -21,7 +21,7 @@ type TokenSpan = (Token, Range<usize>);
 type ParserError = Simple<TokenSpan>;
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Span> {
+fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }
@@ -61,7 +61,7 @@ where
                 let label = Label::new(label_text).with_span(label_position);
                 // Compute overall span from content spans if available
                 let span = if !content.is_empty() {
-                    let content_spans: Vec<Span> = content
+                    let content_spans: Vec<Location> = content
                         .iter()
                         .filter_map(|item| match item {
                             ContentItem::Paragraph(p) => p.span,

--- a/src/txxt_nano/parser/elements/annotations.rs
+++ b/src/txxt_nano/parser/elements/annotations.rs
@@ -127,14 +127,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::parser::api::parse_with_source;
     use crate::txxt_nano::processor::txxt_sources::TxxtSources;
 
     #[test]
     fn test_annotation_marker_minimal() {
         let source = "Para one. {{paragraph}}\n\n:: note ::\n\nPara two. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.content.len(), 3); // paragraph, annotation, paragraph
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn test_annotation_single_line() {
         let source = "Para one. {{paragraph}}\n\n:: note :: This is inline text\n\nPara two. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.content.len(), 3); // paragraph, annotation, paragraph
@@ -158,7 +158,7 @@ mod tests {
     fn test_verified_annotations_simple() {
         let source = TxxtSources::get_string("120-annotations-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Verify document parses successfully and contains expected structure
@@ -215,7 +215,7 @@ mod tests {
     fn test_verified_annotations_block_content() {
         let source = TxxtSources::get_string("130-annotations-block-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find and verify :: note author="Jane Doe" :: annotation with block content

--- a/src/txxt_nano/parser/elements/annotations.rs
+++ b/src/txxt_nano/parser/elements/annotations.rs
@@ -16,10 +16,10 @@ use crate::txxt_nano::parser::combinators::{
 };
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 /// Helper: convert a byte range to a Span using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
@@ -34,9 +34,9 @@ fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location
 pub(crate) fn build_annotation_parser<P>(
     source: Arc<String>,
     items: P,
-) -> impl Parser<TokenSpan, ContentItem, Error = ParserError> + Clone
+) -> impl Parser<TokenLocation, ContentItem, Error = ParserError> + Clone
 where
-    P: Parser<TokenSpan, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
+    P: Parser<TokenLocation, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
 {
     let source_for_header = source.clone();
     let header = token(Token::TxxtMarker)

--- a/src/txxt_nano/parser/elements/annotations.rs
+++ b/src/txxt_nano/parser/elements/annotations.rs
@@ -15,13 +15,13 @@ use crate::txxt_nano::parser::combinators::{
     token,
 };
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
 type ParserError = Simple<TokenLocation>;
 
-/// Helper: convert a byte range to a Span using source location
+/// Helper: convert a byte range to a location using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
@@ -60,17 +60,17 @@ where
                 let label_position =
                     label_location.and_then(|s| byte_range_to_location(&source_for_block, &s));
                 let label = Label::new(label_text).with_location(label_position);
-                // Compute overall span from content spans if available
-                let span = if !content.is_empty() {
+                // Compute overall location from content locations if available
+                let location = if !content.is_empty() {
                     let content_locations: Vec<Location> = content
                         .iter()
                         .filter_map(|item| match item {
-                            ContentItem::Paragraph(p) => p.span,
-                            ContentItem::Session(s) => s.span,
-                            ContentItem::Definition(d) => d.span,
-                            ContentItem::List(l) => l.span,
-                            ContentItem::Annotation(a) => a.span,
-                            ContentItem::ForeignBlock(f) => f.span,
+                            ContentItem::Paragraph(p) => p.location,
+                            ContentItem::Session(s) => s.location,
+                            ContentItem::Definition(d) => d.location,
+                            ContentItem::List(l) => l.location,
+                            ContentItem::Annotation(a) => a.location,
+                            ContentItem::ForeignBlock(f) => f.location,
                         })
                         .collect();
                     if !content_locations.is_empty() {
@@ -85,7 +85,7 @@ where
                     label,
                     parameters,
                     content,
-                    span,
+                    location,
                 })
             })
     };
@@ -104,22 +104,22 @@ where
                     let label = Label::new(label_text).with_location(label_position);
 
                     // Handle content if present
-                    let content = if let Some(spans) = content_location {
-                        let text = extract_text_from_locations(&source_for_single_line, &spans);
+                    let content = if let Some(locations) = content_location {
+                        let text = extract_text_from_locations(&source_for_single_line, &locations);
                         vec![ContentItem::Paragraph(Paragraph {
                             lines: vec![TextContent::from_string(text, None)],
-                            span: None,
+                            location: None,
                         })]
                     } else {
                         vec![]
                     };
-                    let span = label_position; // For single-line, span is just the label
+                    let location = label_position; // For single-line, location is just the label
 
                     ContentItem::Annotation(Annotation {
                         label,
                         parameters,
                         content,
-                        span,
+                        location,
                     })
                 },
             )

--- a/src/txxt_nano/parser/elements/definitions.rs
+++ b/src/txxt_nano/parser/elements/definitions.rs
@@ -13,10 +13,10 @@ use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{definition_subject, token};
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 /// Helper: convert a byte range to a Span using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
@@ -31,9 +31,9 @@ fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location
 pub(crate) fn build_definition_parser<P>(
     source: Arc<String>,
     items: P,
-) -> impl Parser<TokenSpan, ContentItem, Error = ParserError> + Clone
+) -> impl Parser<TokenLocation, ContentItem, Error = ParserError> + Clone
 where
-    P: Parser<TokenSpan, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
+    P: Parser<TokenLocation, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
 {
     let source_for_definition = source.clone();
     definition_subject(source.clone())

--- a/src/txxt_nano/parser/elements/definitions.rs
+++ b/src/txxt_nano/parser/elements/definitions.rs
@@ -12,13 +12,13 @@ use crate::txxt_nano::ast::{ContentItem, Definition, Location, TextContent};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{definition_subject, token};
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
 type ParserError = Simple<TokenLocation>;
 
-/// Helper: convert a byte range to a Span using source location
+/// Helper: convert a byte range to a location using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
@@ -43,11 +43,11 @@ where
                 .then_ignore(token(Token::DedentLevel)),
         )
         .map(move |((subject_text, subject_location), content)| {
-            let span = byte_range_to_location(&source_for_definition, &subject_location);
+            let location = byte_range_to_location(&source_for_definition, &subject_location);
             ContentItem::Definition(Definition {
                 subject: TextContent::from_string(subject_text, None),
                 content,
-                span,
+                location,
             })
         })
 }

--- a/src/txxt_nano/parser/elements/definitions.rs
+++ b/src/txxt_nano/parser/elements/definitions.rs
@@ -19,12 +19,12 @@ type TokenSpan = (Token, Range<usize>);
 type ParserError = Simple<TokenSpan>;
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
+fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }
     let source_loc = SourceLocation::new(source);
-    Some(source_loc.range_to_span(range))
+    Some(source_loc.range_to_location(range))
 }
 
 /// Build a definition parser
@@ -42,8 +42,8 @@ where
                 .ignore_then(items)
                 .then_ignore(token(Token::DedentLevel)),
         )
-        .map(move |((subject_text, subject_span), content)| {
-            let span = byte_range_to_span(&source_for_definition, &subject_span);
+        .map(move |((subject_text, subject_location), content)| {
+            let span = byte_range_to_location(&source_for_definition, &subject_location);
             ContentItem::Definition(Definition {
                 subject: TextContent::from_string(subject_text, None),
                 content,

--- a/src/txxt_nano/parser/elements/definitions.rs
+++ b/src/txxt_nano/parser/elements/definitions.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::txxt_nano::ast::position::SourceLocation;
-use crate::txxt_nano::ast::{ContentItem, Definition, Span, TextContent};
+use crate::txxt_nano::ast::{ContentItem, Definition, Location, TextContent};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{definition_subject, token};
 
@@ -19,7 +19,7 @@ type TokenSpan = (Token, Range<usize>);
 type ParserError = Simple<TokenSpan>;
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Span> {
+fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }

--- a/src/txxt_nano/parser/elements/definitions.rs
+++ b/src/txxt_nano/parser/elements/definitions.rs
@@ -56,7 +56,7 @@ where
 mod tests {
     use crate::txxt_nano::ast::Container;
     use crate::txxt_nano::ast::ContentItem;
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::parser::api::parse_with_source;
     use crate::txxt_nano::processor::txxt_sources::TxxtSources;
     use crate::txxt_nano::testing::assert_ast;
@@ -65,7 +65,7 @@ mod tests {
     fn test_unified_recursive_parser_simple() {
         // Minimal test for the unified recursive parser
         let source = "First paragraph\n\nDefinition:\n    Content of definition\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         println!("Testing simple definition with unified parser:");
         println!("Source: {:?}", source);
 
@@ -82,7 +82,7 @@ mod tests {
     fn test_unified_recursive_nested_definitions() {
         // Test nested definitions with the unified parser
         let source = "Outer:\n    Inner:\n        Nested content\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         println!("Testing nested definitions with unified parser:");
         println!("Source: {:?}", source);
 
@@ -125,7 +125,7 @@ mod tests {
     fn test_unified_parser_paragraph_then_definition() {
         // Test paragraph followed by definition - similar to failing test
         let source = "Simple paragraph\n\nAnother paragraph\n\nFirst Definition:\n    Definition content\n\nSecond Definition:\n    More content\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         println!("Testing paragraph then definition:");
         println!("Source: {:?}", source);
 
@@ -161,7 +161,7 @@ mod tests {
     fn test_verified_definitions_simple() {
         let source = TxxtSources::get_string("090-definitions-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
 
         // Debug: print first few tokens
         println!("First 10 tokens:");
@@ -266,7 +266,7 @@ mod tests {
     fn test_verified_definitions_mixed_content() {
         let source = TxxtSources::get_string("100-definitions-mixed-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs

--- a/src/txxt_nano/parser/elements/document.rs
+++ b/src/txxt_nano/parser/elements/document.rs
@@ -7,17 +7,17 @@ use crate::txxt_nano::ast::Document;
 use crate::txxt_nano::lexer::Token;
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 /// Parse a document
 ///
 /// Parses the entire token stream as document content.
 /// This function is focused on document-level parsing and delegates to parser.rs
 /// for the actual document content parsing logic.
-pub fn document(source: &str) -> impl Parser<TokenSpan, Document, Error = ParserError> + Clone {
+pub fn document(source: &str) -> impl Parser<TokenLocation, Document, Error = ParserError> + Clone {
     crate::txxt_nano::parser::parser::build_document_content_parser(source).map(|content| {
         Document {
             metadata: Vec::new(),

--- a/src/txxt_nano/parser/elements/document.rs
+++ b/src/txxt_nano/parser/elements/document.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use crate::txxt_nano::ast::Document;
 use crate::txxt_nano::lexer::Token;
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
@@ -22,7 +22,7 @@ pub fn document(source: &str) -> impl Parser<TokenLocation, Document, Error = Pa
         Document {
             metadata: Vec::new(),
             content,
-            span: None,
+            location: None,
         }
     })
 }

--- a/src/txxt_nano/parser/elements/foreign.rs
+++ b/src/txxt_nano/parser/elements/foreign.rs
@@ -112,14 +112,14 @@ pub(crate) fn foreign_block(
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::parser::api::parse_with_source;
     use crate::txxt_nano::processor::txxt_sources::TxxtSources;
 
     #[test]
     fn test_foreign_block_simple_with_content() {
         let source = "Code Example:\n    function hello() {\n        return \"world\";\n    }\n:: javascript caption=\"Hello World\" ::\n\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         println!("Tokens: {:?}", tokens);
         let doc = parse_with_source(tokens, source).unwrap();
 
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn test_foreign_block_marker_form() {
         let source = "Image Reference:\n\n:: image type=jpg, src=sunset.jpg :: As the sun sets, we see a colored sea bed.\n\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.content.len(), 1);
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn test_foreign_block_preserves_whitespace() {
         let source = "Indented Code:\n\n    // This has    multiple    spaces\n    const regex = /[a-z]+/g;\n    \n    console.log(\"Hello, World!\");\n\n:: javascript ::\n\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let foreign_block = doc.content[0].as_foreign_block().unwrap();
@@ -191,7 +191,7 @@ mod tests {
         // trying them first resolves the ambiguity
 
         let source = "First Block:\n\n    code1\n\n:: lang1 ::\n\nSecond Block:\n\n    code2\n\n:: lang2 ::\n\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.content.len(), 2);
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn test_foreign_block_with_paragraphs() {
         let source = "Intro paragraph.\n\nCode Block:\n\n    function test() {\n        return true;\n    }\n\n:: javascript ::\n\nOutro paragraph.\n\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.content.len(), 3);
@@ -223,7 +223,7 @@ mod tests {
     fn test_verified_foreign_blocks_simple() {
         let source = TxxtSources::get_string("140-foreign-blocks-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find JavaScript code block
@@ -278,7 +278,7 @@ mod tests {
     fn test_verified_foreign_blocks_no_content() {
         let source = TxxtSources::get_string("150-foreign-blocks-no-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find image reference

--- a/src/txxt_nano/parser/elements/foreign.rs
+++ b/src/txxt_nano/parser/elements/foreign.rs
@@ -13,7 +13,7 @@ use crate::txxt_nano::parser::combinators::{
     annotation_header, definition_subject, extract_text_from_locations, text_line, token,
 };
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
@@ -71,11 +71,11 @@ pub(crate) fn foreign_block(
                 let label = Label::new(label_opt.unwrap_or_default());
 
                 let content = content_location
-                    .map(|spans| {
-                        let text = extract_text_from_locations(&source_for_annotation, &spans);
+                    .map(|locations| {
+                        let text = extract_text_from_locations(&source_for_annotation, &locations);
                         vec![ContentItem::Paragraph(Paragraph {
                             lines: vec![TextContent::from_string(text, None)],
-                            span: None,
+                            location: None,
                         })]
                     })
                     .unwrap_or_default();
@@ -84,7 +84,7 @@ pub(crate) fn foreign_block(
                     label,
                     parameters,
                     content,
-                    span: None,
+                    location: None,
                 }
             },
         );
@@ -97,14 +97,14 @@ pub(crate) fn foreign_block(
         .map(
             move |(((subject_text, _subject_location), content_locations), closing_annotation)| {
                 let content = content_locations
-                    .map(|spans| extract_text_from_locations(&source, &spans))
+                    .map(|locations| extract_text_from_locations(&source, &locations))
                     .unwrap_or_default();
 
                 ForeignBlock {
                     subject: TextContent::from_string(subject_text, None),
                     content: TextContent::from_string(content, None),
                     closing_annotation,
-                    span: None,
+                    location: None,
                 }
             },
         )

--- a/src/txxt_nano/parser/elements/labels.rs
+++ b/src/txxt_nano/parser/elements/labels.rs
@@ -12,7 +12,7 @@ use crate::txxt_nano::lexer::Token;
 use std::ops::Range;
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Parse label from a token slice
 ///
@@ -33,7 +33,7 @@ type TokenSpan = (Token, Range<usize>);
 /// :: note key=val ::   -> Some(label_location for "note")
 /// :: key=val ::        -> None (this is a parameter, not a label)
 /// ```
-pub(crate) fn parse_label_from_tokens(tokens: &[TokenSpan]) -> (Option<Range<usize>>, usize) {
+pub(crate) fn parse_label_from_tokens(tokens: &[TokenLocation]) -> (Option<Range<usize>>, usize) {
     let mut i = 0;
 
     // Skip leading whitespace

--- a/src/txxt_nano/parser/elements/labels.rs
+++ b/src/txxt_nano/parser/elements/labels.rs
@@ -11,12 +11,12 @@
 use crate::txxt_nano::lexer::Token;
 use std::ops::Range;
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Parse label from a token slice
 ///
-/// Extracts a label span from the beginning of the token slice if present.
+/// Extracts a label location from the beginning of the token slice if present.
 /// A label is identified as an identifier (Text, Dash, Number, Period tokens)
 /// that is NOT followed by an equals sign.
 ///
@@ -24,7 +24,7 @@ type TokenLocation = (Token, Range<usize>);
 /// * `tokens` - Slice of tokens to parse
 ///
 /// # Returns
-/// * `Some(Range<usize>)` - The span of the label in the source text
+/// * `Some(Range<usize>)` - The location of the label in the source text
 /// * `None` - No label found (either no identifier, or identifier followed by '=')
 ///
 /// # Examples

--- a/src/txxt_nano/parser/elements/labels.rs
+++ b/src/txxt_nano/parser/elements/labels.rs
@@ -92,13 +92,13 @@ pub(crate) fn parse_label_from_tokens(tokens: &[TokenSpan]) -> (Option<Range<usi
 #[cfg(test)]
 mod tests {
 
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::parser::parse_with_source;
 
     #[test]
     fn test_annotation_with_label_only() {
         let source = ":: note ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn test_annotation_with_label_and_parameters() {
         let source = ":: warning severity=high ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_annotation_with_dotted_label() {
         let source = ":: python.typing ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn test_annotation_parameters_only_no_label() {
         let source = ":: version=3.11 ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn test_annotation_with_dashed_label() {
         let source = ":: code-review ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();

--- a/src/txxt_nano/parser/elements/labels.rs
+++ b/src/txxt_nano/parser/elements/labels.rs
@@ -29,8 +29,8 @@ type TokenSpan = (Token, Range<usize>);
 ///
 /// # Examples
 /// ```text
-/// :: note ::           -> Some(label_span for "note")
-/// :: note key=val ::   -> Some(label_span for "note")
+/// :: note ::           -> Some(label_location for "note")
+/// :: note key=val ::   -> Some(label_location for "note")
 /// :: key=val ::        -> None (this is a parameter, not a label)
 /// ```
 pub(crate) fn parse_label_from_tokens(tokens: &[TokenSpan]) -> (Option<Range<usize>>, usize) {
@@ -76,16 +76,16 @@ pub(crate) fn parse_label_from_tokens(tokens: &[TokenSpan]) -> (Option<Range<usi
         (None, 0) // Return 0 to indicate we should restart parsing from beginning
     } else {
         // This is a label
-        let first_span = &tokens[start].1;
-        let last_span = &tokens[i - 1].1;
-        let label_span = Some(first_span.start..last_span.end);
+        let first_location = &tokens[start].1;
+        let last_location = &tokens[i - 1].1;
+        let label_location = Some(first_location.start..last_location.end);
 
         // Skip trailing whitespace after label
         while i < tokens.len() && matches!(tokens[i].0, Token::Whitespace) {
             i += 1;
         }
 
-        (label_span, i)
+        (label_location, i)
     }
 }
 

--- a/src/txxt_nano/parser/elements/lists.rs
+++ b/src/txxt_nano/parser/elements/lists.rs
@@ -14,13 +14,13 @@ use crate::txxt_nano::parser::combinators::{
     compute_location_from_optional_locations, list_item_line, token,
 };
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
 type ParserError = Simple<TokenLocation>;
 
-/// Helper: convert a byte range to a Span using source location
+/// Helper: convert a byte range to a location using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
@@ -47,14 +47,14 @@ where
                 .or_not(),
         )
         .map(move |((text, text_location), maybe_content)| {
-            let span = byte_range_to_location(&source_for_list, &text_location);
-            ListItem::with_content(text, maybe_content.unwrap_or_default()).with_location(span)
+            let location = byte_range_to_location(&source_for_list, &text_location);
+            ListItem::with_content(text, maybe_content.unwrap_or_default()).with_location(location)
         });
 
     single_list_item.repeated().at_least(2).map(|items| {
-        let spans: Vec<Option<Location>> = items.iter().map(|item| item.span).collect();
-        let span = compute_location_from_optional_locations(&spans);
-        ContentItem::List(List { items, span })
+        let locations: Vec<Option<Location>> = items.iter().map(|item| item.location).collect();
+        let location = compute_location_from_optional_locations(&locations);
+        ContentItem::List(List { items, location })
     })
 }
 

--- a/src/txxt_nano/parser/elements/lists.rs
+++ b/src/txxt_nano/parser/elements/lists.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::txxt_nano::ast::position::SourceLocation;
-use crate::txxt_nano::ast::{ContentItem, List, ListItem, Span};
+use crate::txxt_nano::ast::{ContentItem, List, ListItem, Location};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{
     compute_span_from_optional_spans, list_item_line, token,
@@ -21,7 +21,7 @@ type TokenSpan = (Token, Range<usize>);
 type ParserError = Simple<TokenSpan>;
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Span> {
+fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }
@@ -52,7 +52,7 @@ where
         });
 
     single_list_item.repeated().at_least(2).map(|items| {
-        let spans: Vec<Option<Span>> = items.iter().map(|item| item.span).collect();
+        let spans: Vec<Option<Location>> = items.iter().map(|item| item.span).collect();
         let span = compute_span_from_optional_spans(&spans);
         ContentItem::List(List { items, span })
     })

--- a/src/txxt_nano/parser/elements/lists.rs
+++ b/src/txxt_nano/parser/elements/lists.rs
@@ -15,10 +15,10 @@ use crate::txxt_nano::parser::combinators::{
 };
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 /// Helper: convert a byte range to a Span using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
@@ -33,9 +33,9 @@ fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location
 pub(crate) fn build_list_parser<P>(
     source: Arc<String>,
     items: P,
-) -> impl Parser<TokenSpan, ContentItem, Error = ParserError> + Clone
+) -> impl Parser<TokenLocation, ContentItem, Error = ParserError> + Clone
 where
-    P: Parser<TokenSpan, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
+    P: Parser<TokenLocation, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
 {
     let source_for_list = source.clone();
     let single_list_item = list_item_line(source.clone())

--- a/src/txxt_nano/parser/elements/lists.rs
+++ b/src/txxt_nano/parser/elements/lists.rs
@@ -60,7 +60,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::parser::api::parse_with_source;
     use crate::txxt_nano::processor::txxt_sources::TxxtSources;
     use crate::txxt_nano::testing::assert_ast;
@@ -69,7 +69,7 @@ mod tests {
     fn test_simplest_dash_list() {
         // Simplest possible list: 2 dashed items
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find the first list (after "Plain dash lists:" paragraph)
@@ -99,7 +99,7 @@ mod tests {
     fn test_numbered_list() {
         // Test numbered list: "1. ", "2. ", "3. "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Numerical lists (item 5)
@@ -122,7 +122,7 @@ mod tests {
     fn test_alphabetical_list() {
         // Test alphabetical list: "a. ", "b. ", "c. "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Alphabetical lists (item 7)
@@ -145,7 +145,7 @@ mod tests {
     fn test_mixed_decoration_list() {
         // Test mixed decorations: different markers in same list
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Mixed decoration lists (item 9)
@@ -168,7 +168,7 @@ mod tests {
     fn test_parenthetical_list() {
         // Test parenthetical numbering: "(1) ", "(2) ", "(3) "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Parenthetical numbering (item 11)
@@ -191,7 +191,7 @@ mod tests {
     fn test_paragraph_list_disambiguation() {
         // Critical test: single list-like line becomes paragraph, 2+ with blank line become list
         let source = TxxtSources::get_string("050-paragraph-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Items 2-4: Single list-item-lines merged into paragraphs
@@ -222,7 +222,7 @@ mod tests {
     fn test_verified_lists_document() {
         // Full document test with lists from TxxtSources
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Verify document structure: paragraphs + lists alternating
@@ -259,7 +259,7 @@ mod tests {
         // Critical test: Lists MUST have a preceding blank line for disambiguation
         // Without the blank line, consecutive list-item-lines should be parsed as paragraphs
         let source = "First paragraph\n- Item one\n- Item two\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         // Should be parsed as a single paragraph, NOT a paragraph + list
@@ -278,7 +278,7 @@ mod tests {
 
         // Now test the positive case: with blank line, it becomes separate items
         let source_with_blank = "First paragraph\n\n- Item one\n- Item two\n";
-        let tokens2 = lex_with_spans(source_with_blank);
+        let tokens2 = lex_with_locations(source_with_blank);
         let doc2 = parse_with_source(tokens2, source_with_blank).unwrap();
 
         // Should be parsed as paragraph + list
@@ -307,7 +307,7 @@ mod tests {
     fn test_verified_nested_lists_simple() {
         let source = TxxtSources::get_string("070-nested-lists-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -391,7 +391,7 @@ mod tests {
     fn test_verified_nested_lists_mixed_content() {
         let source = TxxtSources::get_string("080-nested-lists-mixed-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs

--- a/src/txxt_nano/parser/elements/parameters.rs
+++ b/src/txxt_nano/parser/elements/parameters.rs
@@ -11,7 +11,7 @@ use crate::txxt_nano::lexer::Token;
 use std::ops::Range;
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Parameter with source text spans for later extraction
 #[derive(Debug, Clone)]
@@ -48,7 +48,7 @@ fn extract_text<'a>(source: &'a str, span: &Range<usize>) -> &'a str {
 /// 1. Split by comma
 /// 2. For each segment, split by '=' to get key/value
 /// 3. Whitespace around parameters is ignored
-pub(crate) fn parse_parameters_from_tokens(tokens: &[TokenSpan]) -> Vec<ParameterWithSpans> {
+pub(crate) fn parse_parameters_from_tokens(tokens: &[TokenLocation]) -> Vec<ParameterWithSpans> {
     let mut params = Vec::new();
     let mut i = 0;
 

--- a/src/txxt_nano/parser/elements/parameters.rs
+++ b/src/txxt_nano/parser/elements/parameters.rs
@@ -178,13 +178,13 @@ pub(crate) fn parse_parameters_from_tokens(tokens: &[TokenSpan]) -> Vec<Paramete
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::parser::parse_with_source;
 
     #[test]
     fn test_annotation_comma_separated_parameters() {
         let source = ":: warning severity=high,priority=urgent ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -200,7 +200,7 @@ mod tests {
     fn test_annotation_quoted_string_values() {
         let source =
             ":: note author=\"Jane Doe\" title=\"Important Note\" ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn test_annotation_mixed_separators_and_quotes() {
         let source = ":: task priority=high,status=\"in progress\",assigned=alice ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();
@@ -238,7 +238,7 @@ mod tests {
     fn test_annotation_whitespace_around_commas() {
         // Test that whitespace around commas is properly ignored
         let source = ":: note key1=val1 , key2=val2 , key3=val3 ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_spans(source);
+        let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.content[0].as_annotation().unwrap();

--- a/src/txxt_nano/parser/elements/parameters.rs
+++ b/src/txxt_nano/parser/elements/parameters.rs
@@ -10,20 +10,20 @@ use crate::txxt_nano::ast::Parameter;
 use crate::txxt_nano::lexer::Token;
 use std::ops::Range;
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
-/// Parameter with source text spans for later extraction
+/// Parameter with source text locations for later extraction
 #[derive(Debug, Clone)]
-pub(crate) struct ParameterWithSpans {
+pub(crate) struct ParameterWithLocations {
     pub(crate) key_location: Range<usize>,
     pub(crate) value_location: Option<Range<usize>>,
 }
 
-/// Convert a parameter from spans to final AST
+/// Convert a parameter from locations to final AST
 ///
-/// Extracts the key and value text from the source using the stored spans
-pub(crate) fn convert_parameter(source: &str, param: ParameterWithSpans) -> Parameter {
+/// Extracts the key and value text from the source using the stored locations
+pub(crate) fn convert_parameter(source: &str, param: ParameterWithLocations) -> Parameter {
     let key = extract_text(source, &param.key_location).to_string();
 
     let value = param
@@ -33,13 +33,13 @@ pub(crate) fn convert_parameter(source: &str, param: ParameterWithSpans) -> Para
     Parameter {
         key,
         value,
-        span: None,
+        location: None,
     }
 }
 
-/// Extract text from source using a span range
-fn extract_text<'a>(source: &'a str, span: &Range<usize>) -> &'a str {
-    &source[span.start..span.end]
+/// Extract text from source using a location range
+fn extract_text<'a>(source: &'a str, location: &Range<usize>) -> &'a str {
+    &source[location.start..location.end]
 }
 
 /// Helper function to parse parameters from a token slice
@@ -48,7 +48,9 @@ fn extract_text<'a>(source: &'a str, span: &Range<usize>) -> &'a str {
 /// 1. Split by comma
 /// 2. For each segment, split by '=' to get key/value
 /// 3. Whitespace around parameters is ignored
-pub(crate) fn parse_parameters_from_tokens(tokens: &[TokenLocation]) -> Vec<ParameterWithSpans> {
+pub(crate) fn parse_parameters_from_tokens(
+    tokens: &[TokenLocation],
+) -> Vec<ParameterWithLocations> {
     let mut params = Vec::new();
     let mut i = 0;
 
@@ -157,7 +159,7 @@ pub(crate) fn parse_parameters_from_tokens(tokens: &[TokenLocation]) -> Vec<Para
             }
         };
 
-        params.push(ParameterWithSpans {
+        params.push(ParameterWithLocations {
             key_location,
             value_location,
         });

--- a/src/txxt_nano/parser/elements/sessions.rs
+++ b/src/txxt_nano/parser/elements/sessions.rs
@@ -19,12 +19,12 @@ type TokenSpan = (Token, Range<usize>);
 type ParserError = Simple<TokenSpan>;
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
+fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }
     let source_loc = SourceLocation::new(source);
-    Some(source_loc.range_to_span(range))
+    Some(source_loc.range_to_location(range))
 }
 
 /// Build a session parser
@@ -42,8 +42,8 @@ where
                 .ignore_then(items)
                 .then_ignore(token(Token::DedentLevel)),
         )
-        .map(move |((title_text, title_span), content)| {
-            let span = byte_range_to_span(&source_for_session, &title_span);
+        .map(move |((title_text, title_location), content)| {
+            let span = byte_range_to_location(&source_for_session, &title_location);
             ContentItem::Session(Session {
                 title: TextContent::from_string(title_text, None),
                 content,

--- a/src/txxt_nano/parser/elements/sessions.rs
+++ b/src/txxt_nano/parser/elements/sessions.rs
@@ -12,13 +12,13 @@ use crate::txxt_nano::ast::{ContentItem, Location, Session, TextContent};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{session_title, token};
 
-/// Type alias for token with span
+/// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
 type ParserError = Simple<TokenLocation>;
 
-/// Helper: convert a byte range to a Span using source location
+/// Helper: convert a byte range to a location using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
@@ -43,11 +43,11 @@ where
                 .then_ignore(token(Token::DedentLevel)),
         )
         .map(move |((title_text, title_location), content)| {
-            let span = byte_range_to_location(&source_for_session, &title_location);
+            let location = byte_range_to_location(&source_for_session, &title_location);
             ContentItem::Session(Session {
                 title: TextContent::from_string(title_text, None),
                 content,
-                span,
+                location,
             })
         })
 }

--- a/src/txxt_nano/parser/elements/sessions.rs
+++ b/src/txxt_nano/parser/elements/sessions.rs
@@ -13,10 +13,10 @@ use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{session_title, token};
 
 /// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 /// Helper: convert a byte range to a Span using source location
 fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location> {
@@ -31,9 +31,9 @@ fn byte_range_to_location(source: &str, range: &Range<usize>) -> Option<Location
 pub(crate) fn build_session_parser<P>(
     source: Arc<String>,
     items: P,
-) -> impl Parser<TokenSpan, ContentItem, Error = ParserError> + Clone
+) -> impl Parser<TokenLocation, ContentItem, Error = ParserError> + Clone
 where
-    P: Parser<TokenSpan, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
+    P: Parser<TokenLocation, Vec<ContentItem>, Error = ParserError> + Clone + 'static,
 {
     let source_for_session = source.clone();
     session_title(source.clone())

--- a/src/txxt_nano/parser/elements/sessions.rs
+++ b/src/txxt_nano/parser/elements/sessions.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::txxt_nano::ast::position::SourceLocation;
-use crate::txxt_nano::ast::{ContentItem, Session, Span, TextContent};
+use crate::txxt_nano::ast::{ContentItem, Location, Session, TextContent};
 use crate::txxt_nano::lexer::Token;
 use crate::txxt_nano::parser::combinators::{session_title, token};
 
@@ -19,7 +19,7 @@ type TokenSpan = (Token, Range<usize>);
 type ParserError = Simple<TokenSpan>;
 
 /// Helper: convert a byte range to a Span using source location
-fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Span> {
+fn byte_range_to_span(source: &str, range: &Range<usize>) -> Option<Location> {
     if range.start > range.end {
         return None;
     }

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -144,14 +144,14 @@ pub fn parse(tokens: Vec<Token>) -> Result<Document, Vec<Simple<Token>>> {
 mod tests {
     use super::*;
     use crate::txxt_nano::ast::{AstNode, Position};
-    use crate::txxt_nano::lexer::lex_with_spans;
+    use crate::txxt_nano::lexer::lex_with_locations;
     use crate::txxt_nano::processor::txxt_sources::TxxtSources;
     use std::sync::Arc;
 
     #[test]
     fn test_simple_paragraph() {
         let input = "Hello world\n\n";
-        let tokens_with_spans = lex_with_spans(input);
+        let tokens_with_spans = lex_with_locations(input);
 
         let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_spans);
         assert!(result.is_ok(), "Failed to parse paragraph: {:?}", result);
@@ -208,7 +208,7 @@ mod tests {
         use crate::txxt_nano::testing::assert_ast;
 
         let source = TxxtSources::get_string("050-trifecta-flat-simple.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -302,7 +302,7 @@ mod tests {
         use crate::txxt_nano::testing::assert_ast;
 
         let source = TxxtSources::get_string("060-trifecta-nesting.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -419,7 +419,7 @@ mod tests {
         use crate::txxt_nano::testing::assert_ast;
 
         let source = TxxtSources::get_string("110-ensemble-with-definitions.txxt").unwrap();
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -475,7 +475,7 @@ mod tests {
             "docs/specs/v1/regression-bugs/parser-definition-list-transition.txxt",
         )
         .expect("Failed to load regression test file");
-        let tokens = lex_with_spans(&source);
+        let tokens = lex_with_locations(&source);
 
         // This should parse successfully but currently fails with:
         // Parse error at span 14..15: reason=Unexpected, found=Some((Newline, 34..35))
@@ -499,7 +499,7 @@ mod tests {
     #[test]
     fn test_parse_with_source_positions_simple() {
         let input = "Hello world\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn test_parse_with_source_positions_multiline() {
         let input = "First line\nSecond line\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn test_elements_at_query_on_parsed_document() {
         let input = "First paragraph\n\n2. Session Title\n\n    Session content\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
@@ -551,7 +551,7 @@ mod tests {
     #[test]
     fn test_elements_at_nested_position() {
         let input = "Title\n\n1. Item one\n\n    Nested content\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
@@ -569,7 +569,7 @@ mod tests {
     #[test]
     fn test_position_comparison_in_query() {
         let input = "Line 0\n\nLine 2\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn test_backward_compatibility_without_positions() {
         let input = "Simple paragraph\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
 
         // Old parser should still work (without positions)
         let doc_old =
@@ -626,7 +626,7 @@ mod tests {
     #[test]
     fn test_span_boundary_containment() {
         let input = "0123456789\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
@@ -650,7 +650,7 @@ mod tests {
     fn test_nested_paragraph_has_span() {
         // Test that nested paragraphs inside sessions have span information
         let input = "Title\n\n1. Session Title\n\n    Nested paragraph\n\n";
-        let tokens = lex_with_spans(input);
+        let tokens = lex_with_locations(input);
         let doc =
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -15,11 +15,11 @@ use std::ops::Range;
 use crate::txxt_nano::ast::{Container, ContentItem, Document};
 use crate::txxt_nano::lexer::Token;
 
-/// Type alias for token with span
-type TokenSpan = (Token, Range<usize>);
+/// Type alias for token with location
+type TokenLocation = (Token, Range<usize>);
 
 /// Type alias for parser error
-type ParserError = Simple<TokenSpan>;
+type ParserError = Simple<TokenLocation>;
 
 // Parser combinators - kept for test support if needed
 #[allow(unused_imports)]
@@ -40,22 +40,22 @@ use std::sync::Arc;
 /// All combinators now take source parameter and return final types.
 pub(crate) fn build_document_content_parser(
     source: &str,
-) -> impl Parser<TokenSpan, Vec<ContentItem>, Error = ParserError> + Clone {
+) -> impl Parser<TokenLocation, Vec<ContentItem>, Error = ParserError> + Clone {
     let source = Arc::new(source.to_string());
 
     recursive(move |items| {
         let source = source.clone();
         let single_item = {
-            // Session parser - now builds final Session type with span
+            // Session parser - now builds final Session type with location
             let session_parser = build_session_parser(source.clone(), items.clone());
 
-            // Definition parser - now builds final Definition type with span
+            // Definition parser - now builds final Definition type with location
             let definition_parser = build_definition_parser(source.clone(), items.clone());
 
-            // List parser - now builds final List type with span
+            // List parser - now builds final List type with location
             let list_parser = build_list_parser(source.clone(), items.clone());
 
-            // Annotation parser - now builds final Annotation type with span
+            // Annotation parser - now builds final Annotation type with location
             let annotation_parser = build_annotation_parser(source.clone(), items.clone());
 
             choice((
@@ -98,19 +98,19 @@ pub(crate) fn build_document_content_parser(
 use super::elements::document as document_module;
 
 /// Parse a document - delegated to document module
-/// Phase 5: The document parser requires source text to populate span information
-pub fn document() -> impl Parser<TokenSpan, Document, Error = ParserError> {
+/// Phase 5: The document parser requires source text to populate location information
+pub fn document() -> impl Parser<TokenLocation, Document, Error = ParserError> {
     // This function is kept for backward compatibility but delegates to document_module::document(source)
     // Since this function doesn't have access to source, it uses an empty string.
     // For proper position tracking, use parse_with_source_positions or parse_with_source instead.
     document_module::document("")
 }
 
-/// Parse with source text - extracts actual content from spans
+/// Parse with source text - extracts actual content from locations
 ///
 /// Re-exports the canonical implementation from api.rs
 pub fn parse_with_source(
-    tokens_with_locations: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
     super::api::parse_with_source(tokens_with_locations, source)
@@ -124,7 +124,7 @@ pub fn parse_with_source(
 ///
 /// Re-exports the canonical implementation from api.rs
 pub fn parse_with_source_positions(
-    tokens_with_locations: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
     super::api::parse_with_source_positions(tokens_with_locations, source)
@@ -132,8 +132,8 @@ pub fn parse_with_source_positions(
 
 /// Parse a txxt document from a token stream (legacy - doesn't preserve source text)
 pub fn parse(tokens: Vec<Token>) -> Result<Document, Vec<Simple<Token>>> {
-    // Convert tokens to token-span tuples with empty spans
-    let tokens_with_locations: Vec<TokenSpan> = tokens.into_iter().map(|t| (t, 0..0)).collect();
+    // Convert tokens to token-location tuples with empty locations
+    let tokens_with_locations: Vec<TokenLocation> = tokens.into_iter().map(|t| (t, 0..0)).collect();
 
     // Parse with empty source
     parse_with_source(tokens_with_locations, "")
@@ -478,7 +478,7 @@ mod tests {
         let tokens = lex_with_locations(&source);
 
         // This should parse successfully but currently fails with:
-        // Parse error at span 14..15: reason=Unexpected, found=Some((Newline, 34..35))
+        // Parse error at location 14..15: reason=Unexpected, found=Some((Newline, 34..35))
         let doc = parse_with_source(tokens, &source)
             .expect("Parser should handle definition with list followed by definition");
 
@@ -505,11 +505,11 @@ mod tests {
 
         assert_eq!(doc.content.len(), 1);
         let para = doc.content[0].as_paragraph().unwrap();
-        assert!(para.span.is_some(), "Paragraph should have span");
+        assert!(para.location().is_some(), "Paragraph should have location");
 
-        let span = para.span.unwrap();
-        assert_eq!(span.start.line, 0);
-        assert_eq!(span.start.column, 0);
+        let location = para.location().unwrap();
+        assert_eq!(location.start.line, 0);
+        assert_eq!(location.start.column, 0);
     }
 
     #[test]
@@ -526,9 +526,9 @@ mod tests {
         assert_eq!(para.lines.len(), 2);
 
         // Span should cover both lines
-        let span = para.span.unwrap();
-        assert_eq!(span.start.line, 0);
-        assert_eq!(span.end.line, 1);
+        let location = para.location().unwrap();
+        assert_eq!(location.start.line, 0);
+        assert_eq!(location.end.line, 1);
     }
 
     #[test]
@@ -561,8 +561,8 @@ mod tests {
         // Query for position in the nested content
         let results = doc.elements_at(Position::new(4, 4));
 
-        // Should find elements at that position (or return empty if position is outside all spans)
-        // This is acceptable - position 4:4 might be outside all defined spans
+        // Should find elements at that position (or return empty if position is outside all locations)
+        // This is acceptable - position 4:4 might be outside all defined locations
         let _ = results;
     }
 
@@ -578,15 +578,15 @@ mod tests {
 
         // First paragraph should be at line 0
         if let Some(para) = items.first().and_then(|item| item.as_paragraph()) {
-            if let Some(span) = para.span {
-                assert_eq!(span.start.line, 0);
+            if let Some(location) = para.location() {
+                assert_eq!(location.start.line, 0);
             }
         }
 
         // Second paragraph should be at line 2
         if let Some(para) = items.get(1).and_then(|item| item.as_paragraph()) {
-            if let Some(span) = para.span {
-                assert_eq!(span.start.line, 2);
+            if let Some(location) = para.location() {
+                assert_eq!(location.start.line, 2);
             }
         }
     }
@@ -612,15 +612,15 @@ mod tests {
         let para_old = doc_old.content[0].as_paragraph().unwrap();
         let para_new = doc_new.content[0].as_paragraph().unwrap();
 
-        // Text content should be the same (ignoring span information)
+        // Text content should be the same (ignoring location information)
         assert_eq!(para_old.lines.len(), para_new.lines.len());
         for (line_old, line_new) in para_old.lines.iter().zip(para_new.lines.iter()) {
             assert_eq!(line_old.as_string(), line_new.as_string());
         }
 
         // But new version should have positions on the paragraph and text
-        assert!(para_new.span.is_some());
-        assert!(para_new.lines[0].span.is_some());
+        assert!(para_new.location().is_some());
+        assert!(para_new.lines[0].location.is_some());
     }
 
     #[test]
@@ -631,24 +631,24 @@ mod tests {
             parse_with_source_positions(tokens, input).expect("Failed to parse with positions");
 
         let para = doc.content[0].as_paragraph().unwrap();
-        let span = para.span.unwrap();
+        let location = para.location().unwrap();
 
         // Should contain position in the middle
-        assert!(span.contains(Position::new(0, 5)));
+        assert!(location.contains(Position::new(0, 5)));
 
         // Should contain start
-        assert!(span.contains(span.start));
+        assert!(location.contains(location.start));
 
         // Should contain end
-        assert!(span.contains(span.end));
+        assert!(location.contains(location.end));
 
         // Shouldมี contain position after end
-        assert!(!span.contains(Position::new(0, 11)));
+        assert!(!location.contains(Position::new(0, 11)));
     }
 
     #[test]
     fn test_nested_paragraph_has_location() {
-        // Test that nested paragraphs inside sessions have span information
+        // Test that nested paragraphs inside sessions have location information
         let input = "Title\n\n1. Session Title\n\n    Nested paragraph\n\n";
         let tokens = lex_with_locations(input);
         let doc =
@@ -663,7 +663,7 @@ mod tests {
             .find(|item| item.is_session())
             .expect("Should have a session");
 
-        assert!(session.location().is_some(), "Session should have span");
+        assert!(session.location().is_some(), "Session should have location");
 
         // Get nested content
         if let Some(children) = session.children() {
@@ -674,14 +674,17 @@ mod tests {
                 if para_item.is_paragraph() {
                     let para = para_item.as_paragraph().unwrap();
                     assert!(
-                        para.span.is_some(),
-                        "Nested paragraph should have span, but got {:?}",
-                        para.span
+                        para.location().is_some(),
+                        "Nested paragraph should have location, but got {:?}",
+                        para.location()
                     );
 
-                    if let Some(span) = para.span {
-                        println!("Nested paragraph span: {:?} to {:?}", span.start, span.end);
-                        assert_eq!(span.start.line, 4, "Paragraph should be at line 4");
+                    if let Some(location) = para.location() {
+                        println!(
+                            "Nested paragraph location: {:?} to {:?}",
+                            location.start, location.end
+                        );
+                        assert_eq!(location.start.line, 4, "Paragraph should be at line 4");
                     }
                 }
             }

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -110,10 +110,10 @@ pub fn document() -> impl Parser<TokenSpan, Document, Error = ParserError> {
 ///
 /// Re-exports the canonical implementation from api.rs
 pub fn parse_with_source(
-    tokens_with_spans: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenSpan>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    super::api::parse_with_source(tokens_with_spans, source)
+    super::api::parse_with_source(tokens_with_locations, source)
 }
 
 /// Parse a txxt document from tokens with source, preserving position information
@@ -124,19 +124,19 @@ pub fn parse_with_source(
 ///
 /// Re-exports the canonical implementation from api.rs
 pub fn parse_with_source_positions(
-    tokens_with_spans: Vec<TokenSpan>,
+    tokens_with_locations: Vec<TokenSpan>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    super::api::parse_with_source_positions(tokens_with_spans, source)
+    super::api::parse_with_source_positions(tokens_with_locations, source)
 }
 
 /// Parse a txxt document from a token stream (legacy - doesn't preserve source text)
 pub fn parse(tokens: Vec<Token>) -> Result<Document, Vec<Simple<Token>>> {
     // Convert tokens to token-span tuples with empty spans
-    let tokens_with_spans: Vec<TokenSpan> = tokens.into_iter().map(|t| (t, 0..0)).collect();
+    let tokens_with_locations: Vec<TokenSpan> = tokens.into_iter().map(|t| (t, 0..0)).collect();
 
     // Parse with empty source
-    parse_with_source(tokens_with_spans, "")
+    parse_with_source(tokens_with_locations, "")
         .map_err(|errs| errs.into_iter().map(|e| e.map(|(t, _)| t)).collect())
 }
 
@@ -151,9 +151,9 @@ mod tests {
     #[test]
     fn test_simple_paragraph() {
         let input = "Hello world\n\n";
-        let tokens_with_spans = lex_with_locations(input);
+        let tokens_with_locations = lex_with_locations(input);
 
-        let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_spans);
+        let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_locations);
         assert!(result.is_ok(), "Failed to parse paragraph: {:?}", result);
 
         let para = result.unwrap();
@@ -624,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn test_span_boundary_containment() {
+    fn test_location_boundary_containment() {
         let input = "0123456789\n\n";
         let tokens = lex_with_locations(input);
         let doc =
@@ -647,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_paragraph_has_span() {
+    fn test_nested_paragraph_has_location() {
         // Test that nested paragraphs inside sessions have span information
         let input = "Title\n\n1. Session Title\n\n    Nested paragraph\n\n";
         let tokens = lex_with_locations(input);

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -525,7 +525,7 @@ mod tests {
         // Should have 2 lines
         assert_eq!(para.lines.len(), 2);
 
-        // Span should cover both lines
+        // Location should cover both lines
         let location = para.location().unwrap();
         assert_eq!(location.start.line, 0);
         assert_eq!(location.end.line, 1);

--- a/src/txxt_nano/parser/parser.rs
+++ b/src/txxt_nano/parser/parser.rs
@@ -663,7 +663,7 @@ mod tests {
             .find(|item| item.is_session())
             .expect("Should have a session");
 
-        assert!(session.span().is_some(), "Session should have span");
+        assert!(session.location().is_some(), "Session should have span");
 
         // Get nested content
         if let Some(children) = session.children() {

--- a/src/txxt_nano/parser/tests.rs
+++ b/src/txxt_nano/parser/tests.rs
@@ -74,7 +74,11 @@ fn test_malformed_session_title_with_indent_but_no_content() {
         Err(errors) => {
             println!("\n✗ Parse failed with errors:");
             for error in errors {
-                println!("  Error at span {:?}: {:?}", error.span(), error.reason());
+                println!(
+                    "  Error at location {:?}: {:?}",
+                    error.span(),
+                    error.reason()
+                );
                 println!("  Found: {:?}", error.found());
             }
         }
@@ -121,7 +125,11 @@ fn test_session_title_followed_by_bare_indent_level() {
         Err(errors) => {
             println!("\n✗ Parse failed:");
             for error in errors {
-                println!("  Error at span {:?}: {:?}", error.span(), error.reason());
+                println!(
+                    "  Error at location {:?}: {:?}",
+                    error.span(),
+                    error.reason()
+                );
             }
         }
     }

--- a/src/txxt_nano/parser/tests.rs
+++ b/src/txxt_nano/parser/tests.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 #[test]
 fn test_simple_paragraph() {
     let input = "Hello world\n\n";
-    let tokens_with_spans = lex_with_locations(input);
+    let tokens_with_locations = lex_with_locations(input);
 
-    let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_spans);
+    let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_locations);
     assert!(result.is_ok(), "Failed to parse paragraph: {:?}", result);
 
     let para = result.unwrap();

--- a/src/txxt_nano/parser/tests.rs
+++ b/src/txxt_nano/parser/tests.rs
@@ -1,5 +1,5 @@
 use crate::txxt_nano::ast::{Container, ContentItem};
-use crate::txxt_nano::lexer::{lex, lex_with_spans, Token};
+use crate::txxt_nano::lexer::{lex, lex_with_locations, Token};
 use crate::txxt_nano::parser::api::parse;
 use crate::txxt_nano::parser::combinators::paragraph;
 use chumsky::Parser;
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[test]
 fn test_simple_paragraph() {
     let input = "Hello world\n\n";
-    let tokens_with_spans = lex_with_spans(input);
+    let tokens_with_spans = lex_with_locations(input);
 
     let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_spans);
     assert!(result.is_ok(), "Failed to parse paragraph: {:?}", result);

--- a/src/txxt_nano/processor.rs
+++ b/src/txxt_nano/processor.rs
@@ -209,7 +209,7 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
             // Parse the document with position tracking enabled for ast-position format
             let doc = if matches!(spec.format, OutputFormat::AstPosition) {
                 crate::txxt_nano::parser::parse_with_source_positions(
-                    crate::txxt_nano::lexer::lex_with_spans(&content),
+                    crate::txxt_nano::lexer::lex_with_locations(&content),
                     &content,
                 )
                 .map_err(|errs| {
@@ -506,7 +506,7 @@ pub mod txxt_sources {
         let content = r#"First paragraph
 Second paragraph"#;
 
-        let tokens = crate::txxt_nano::lexer::lex_with_spans(content);
+        let tokens = crate::txxt_nano::lexer::lex_with_locations(content);
         let doc = crate::txxt_nano::parser::parse_with_source_positions(tokens, content).unwrap();
 
         // Check if spans are populated

--- a/src/txxt_nano/processor.rs
+++ b/src/txxt_nano/processor.rs
@@ -509,13 +509,13 @@ Second paragraph"#;
         let tokens = crate::txxt_nano::lexer::lex_with_locations(content);
         let doc = crate::txxt_nano::parser::parse_with_source_positions(tokens, content).unwrap();
 
-        // Check if spans are populated
+        // Check if locations are populated
         if let Some(first_item) = doc.content.first() {
-            // The first paragraph should have a span
+            // The first paragraph should have a location
             match first_item {
                 crate::txxt_nano::parser::ContentItem::Paragraph(p) => {
                     assert!(
-                        p.span.is_some(),
+                        p.location.is_some(),
                         "Paragraph should have position information"
                     );
                 }


### PR DESCRIPTION
- **Renmed span -> position**
- **Renamed span -> position**
- **Renamed span -> position**
- **Renamed span -> position**
- **Renamed span -> position**
- **Renamed span -> position**
- **Update error logging in tests to use 'location' instead of 'span' for clarity**
