### PR TITLE
Issue #103 Phase 2: Implement Document root session structure

### DIFF
--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -150,7 +150,7 @@ impl Model {
 
     /// Expand all nodes in the document (for initial state)
     fn expand_all_nodes(&mut self) {
-        let content = self.document.content.clone();
+        let content = self.document.root_session.content.clone();
         self.expand_all_recursive(&content, &NodeId::new(&[]));
     }
 
@@ -351,7 +351,7 @@ impl Model {
             return None;
         }
 
-        let mut current: &[ContentItem] = &self.document.content;
+        let mut current: &[ContentItem] = &self.document.root_session.content;
         let mut depth = 0;
 
         for (path_idx, &index) in path.iter().enumerate() {
@@ -384,7 +384,7 @@ impl Model {
     /// This is a linear search through the tree to find the element.
     /// In practice, this is fast enough since txxt documents are typically small.
     fn find_node_id_for_element(&self, target: &ContentItem) -> Option<NodeId> {
-        self.find_node_id_recursive(target, &self.document.content, &mut Vec::new())
+        self.find_node_id_recursive(target, &self.document.root_session.content, &mut Vec::new())
     }
 
     #[allow(clippy::only_used_in_recursion)]

--- a/src/txxt/formats/tag/tag.rs
+++ b/src/txxt/formats/tag/tag.rs
@@ -89,11 +89,9 @@ pub fn serialize_document(doc: &Document) -> String {
     let mut serializer = TagSerializer::new();
     serializer.indent_level = 1;
 
-    for item in &doc.content {
-        let snapshot = crate::txxt::ast::snapshot_visitor::snapshot_from_content(item);
-        eprintln!("SNAPSHOT: {:?}", snapshot);
-        serializer.serialize_snapshot(&snapshot);
-    }
+    // Serialize the root session
+    let snapshot = crate::txxt::ast::snapshot_visitor::snapshot_from_document(doc);
+    serializer.serialize_snapshot(&snapshot);
 
     result.push_str(&serializer.output);
     result.push_str("</document>");

--- a/src/txxt/parser/elements/annotations.rs
+++ b/src/txxt/parser/elements/annotations.rs
@@ -226,8 +226,8 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        assert_eq!(doc.content.len(), 3); // paragraph, annotation, paragraph
-        assert!(doc.content[1].is_annotation());
+        assert_eq!(doc.root_session.content.len(), 3); // paragraph, annotation, paragraph
+        assert!(doc.root_session.content[1].is_annotation());
     }
 
     #[test]
@@ -236,8 +236,8 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        assert_eq!(doc.content.len(), 3); // paragraph, annotation, paragraph
-        let annotation = doc.content[1].as_annotation().unwrap();
+        assert_eq!(doc.root_session.content.len(), 3); // paragraph, annotation, paragraph
+        let annotation = doc.root_session.content[1].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");
         assert_eq!(annotation.content.len(), 1); // One paragraph with inline text
         assert!(annotation.content[0].is_paragraph());
@@ -254,6 +254,7 @@ mod tests {
 
         // Find and verify :: note :: annotation
         let note_annotation = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -271,6 +272,7 @@ mod tests {
 
         // Find and verify :: warning severity=high :: annotation
         let warning_annotation = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -286,6 +288,7 @@ mod tests {
 
         // Find and verify :: python.typing :: annotation (namespaced label)
         let python_annotation = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -309,6 +312,7 @@ mod tests {
 
         // Find and verify :: note author="Jane Doe" :: annotation with block content
         let note_annotation = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -329,6 +333,7 @@ mod tests {
 
         // Find and verify :: warning severity=critical :: annotation with list
         let warning_annotation = doc
+            .root_session
             .content
             .iter()
             .find(|item| {

--- a/src/txxt/parser/elements/definitions.rs
+++ b/src/txxt/parser/elements/definitions.rs
@@ -100,7 +100,11 @@ mod tests {
         }
         assert!(result.is_ok(), "Failed to parse simple definition");
         let doc = result.unwrap();
-        assert_eq!(doc.content.len(), 2, "Should have paragraph and definition");
+        assert_eq!(
+            doc.root_session.content.len(),
+            2,
+            "Should have paragraph and definition"
+        );
     }
 
     #[test]
@@ -118,10 +122,14 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse nested definitions");
 
         let doc = result.unwrap();
-        assert_eq!(doc.content.len(), 1, "Should have one outer definition");
+        assert_eq!(
+            doc.root_session.content.len(),
+            1,
+            "Should have one outer definition"
+        );
 
         // Check outer definition
-        let outer_def = doc.content[0]
+        let outer_def = doc.root_session.content[0]
             .as_definition()
             .expect("Should be a definition");
         assert_eq!(outer_def.label(), "Outer");
@@ -166,8 +174,8 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse paragraph then definition");
 
         let doc = result.unwrap();
-        println!("Parsed {} items", doc.content.len());
-        for (i, item) in doc.content.iter().enumerate() {
+        println!("Parsed {} items", doc.root_session.content.len());
+        for (i, item) in doc.root_session.content.iter().enumerate() {
             match item {
                 ContentItem::Paragraph(p) => {
                     println!("  Item {}: Paragraph with {} lines", i, p.lines.len())
@@ -179,7 +187,7 @@ mod tests {
             }
         }
         assert_eq!(
-            doc.content.len(),
+            doc.root_session.content.len(),
             4,
             "Should have 2 paragraphs and 2 definitions"
         );

--- a/src/txxt/parser/elements/document.rs
+++ b/src/txxt/parser/elements/document.rs
@@ -26,10 +26,6 @@ pub fn document(source: &str) -> impl Parser<TokenLocation, Document, Error = Pa
             .collect::<Vec<_>>();
         let location = compute_location_from_optional_locations(&content_locations);
 
-        Document {
-            metadata: Vec::new(),
-            content,
-            location,
-        }
+        Document::with_content(content).with_location(location)
     })
 }

--- a/src/txxt/parser/elements/foreign.rs
+++ b/src/txxt/parser/elements/foreign.rs
@@ -176,8 +176,8 @@ mod tests {
         println!("Tokens: {:?}", tokens);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        assert_eq!(doc.content.len(), 1);
-        let foreign_block = doc.content[0].as_foreign_block().unwrap();
+        assert_eq!(doc.root_session.content.len(), 1);
+        let foreign_block = doc.root_session.content[0].as_foreign_block().unwrap();
         assert_eq!(foreign_block.subject.as_string(), "Code Example");
         assert!(foreign_block
             .content
@@ -205,8 +205,8 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        assert_eq!(doc.content.len(), 1);
-        let foreign_block = doc.content[0].as_foreign_block().unwrap();
+        assert_eq!(doc.root_session.content.len(), 1);
+        let foreign_block = doc.root_session.content[0].as_foreign_block().unwrap();
         assert_eq!(foreign_block.subject.as_string(), "Image Reference");
         assert_eq!(foreign_block.content.as_string(), ""); // No content in marker form
         assert_eq!(foreign_block.closing_annotation.label.value, "image");
@@ -229,7 +229,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let foreign_block = doc.content[0].as_foreign_block().unwrap();
+        let foreign_block = doc.root_session.content[0].as_foreign_block().unwrap();
         assert!(foreign_block
             .content
             .as_string()
@@ -247,14 +247,14 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        assert_eq!(doc.content.len(), 2);
+        assert_eq!(doc.root_session.content.len(), 2);
 
-        let first_block = doc.content[0].as_foreign_block().unwrap();
+        let first_block = doc.root_session.content[0].as_foreign_block().unwrap();
         assert_eq!(first_block.subject.as_string(), "First Block");
         assert!(first_block.content.as_string().contains("code1"));
         assert_eq!(first_block.closing_annotation.label.value, "lang1");
 
-        let second_block = doc.content[1].as_foreign_block().unwrap();
+        let second_block = doc.root_session.content[1].as_foreign_block().unwrap();
         assert_eq!(second_block.subject.as_string(), "Second Block");
         assert!(second_block.content.as_string().contains("code2"));
         assert_eq!(second_block.closing_annotation.label.value, "lang2");
@@ -266,10 +266,10 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        assert_eq!(doc.content.len(), 3);
-        assert!(doc.content[0].is_paragraph());
-        assert!(doc.content[1].is_foreign_block());
-        assert!(doc.content[2].is_paragraph());
+        assert_eq!(doc.root_session.content.len(), 3);
+        assert!(doc.root_session.content[0].is_paragraph());
+        assert!(doc.root_session.content[1].is_foreign_block());
+        assert!(doc.root_session.content[2].is_paragraph());
     }
 
     #[test]
@@ -281,6 +281,7 @@ mod tests {
 
         // Find JavaScript code block
         let js_block = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -298,6 +299,7 @@ mod tests {
 
         // Find Python code block
         let py_block = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -313,6 +315,7 @@ mod tests {
 
         // Find SQL block
         let sql_block = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -336,6 +339,7 @@ mod tests {
 
         // Find image reference
         let image_block = doc
+            .root_session
             .content
             .iter()
             .find(|item| {
@@ -356,6 +360,7 @@ mod tests {
 
         // Find binary file reference
         let binary_block = doc
+            .root_session
             .content
             .iter()
             .find(|item| {

--- a/src/txxt/parser/elements/labels.rs
+++ b/src/txxt/parser/elements/labels.rs
@@ -121,7 +121,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");
         assert_eq!(annotation.parameters.len(), 0);
     }
@@ -132,7 +132,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "warning");
         assert_eq!(annotation.parameters.len(), 1);
         assert_eq!(annotation.parameters[0].key, "severity");
@@ -144,7 +144,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "python.typing");
         assert_eq!(annotation.parameters.len(), 0);
     }
@@ -155,7 +155,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, ""); // Empty label
         assert_eq!(annotation.parameters.len(), 1);
         assert_eq!(annotation.parameters[0].key, "version");
@@ -168,7 +168,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "code-review");
         assert_eq!(annotation.parameters.len(), 0);
     }

--- a/src/txxt/parser/elements/lists.rs
+++ b/src/txxt/parser/elements/lists.rs
@@ -322,7 +322,7 @@ mod tests {
         // Should be parsed as a single paragraph, NOT a paragraph + list
         // because there's no blank line before the list-item-lines
         assert_eq!(
-            doc.content.len(),
+            doc.root_session.content.len(),
             1,
             "Should be 1 paragraph, not paragraph + list"
         );
@@ -340,7 +340,7 @@ mod tests {
 
         // Should be parsed as paragraph + list
         assert_eq!(
-            doc2.content.len(),
+            doc2.root_session.content.len(),
             2,
             "Should be paragraph + list with blank line"
         );

--- a/src/txxt/parser/elements/parameters.rs
+++ b/src/txxt/parser/elements/parameters.rs
@@ -219,7 +219,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "warning");
         assert_eq!(annotation.parameters.len(), 2);
         assert_eq!(annotation.parameters[0].key, "severity");
@@ -235,7 +235,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");
         assert_eq!(annotation.parameters.len(), 2);
         assert_eq!(annotation.parameters[0].key, "author");
@@ -253,7 +253,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters.len(), 3);
         assert_eq!(annotation.parameters[0].key, "priority");
         assert_eq!(annotation.parameters[0].value, Some("high".to_string()));
@@ -273,7 +273,7 @@ mod tests {
         let tokens = lex_with_locations(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");
         assert_eq!(annotation.parameters.len(), 3);
         assert_eq!(annotation.parameters[0].key, "key1");

--- a/src/txxt/parser/elements/sessions.rs
+++ b/src/txxt/parser/elements/sessions.rs
@@ -108,8 +108,8 @@ mod tests {
         match &result {
             Ok(doc) => {
                 println!("\n✓ Parsed successfully");
-                println!("Document has {} items:", doc.content.len());
-                for (i, item) in doc.content.iter().enumerate() {
+                println!("Document has {} items:", doc.root_session.content.len());
+                for (i, item) in doc.root_session.content.iter().enumerate() {
                     println!("  {}: {}", i, item);
                 }
                 // This might actually be fine - the blank indented line might be ignored
@@ -152,8 +152,8 @@ mod tests {
         match &result {
             Ok(doc) => {
                 println!("\n✓ Parsed as session with 0 children");
-                println!("Document has {} items:", doc.content.len());
-                for (i, item) in doc.content.iter().enumerate() {
+                println!("Document has {} items:", doc.root_session.content.len());
+                for (i, item) in doc.root_session.content.iter().enumerate() {
                     match item {
                         ContentItem::Paragraph(p) => {
                             println!("  {}: Paragraph with {} lines", i, p.lines.len());

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -464,13 +464,13 @@ mod tests {
             .expect("Parser should handle definition with list followed by definition");
 
         // Should have 2 definitions
-        assert_eq!(doc.content.len(), 2);
+        assert_eq!(doc.root_session.content.len(), 2);
 
         // First should be a definition
-        assert!(doc.content[0].as_definition().is_some());
+        assert!(doc.root_session.content[0].as_definition().is_some());
 
         // Second should also be a definition
-        assert!(doc.content[1].as_definition().is_some());
+        assert!(doc.root_session.content[1].as_definition().is_some());
     }
 
     // ========================================================================
@@ -483,8 +483,8 @@ mod tests {
         let tokens = lex_with_locations(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
-        assert_eq!(doc.content.len(), 1);
-        let para = doc.content[0].as_paragraph().unwrap();
+        assert_eq!(doc.root_session.content.len(), 1);
+        let para = doc.root_session.content[0].as_paragraph().unwrap();
         assert!(para.location().is_some(), "Paragraph should have location");
 
         let location = para.location().unwrap();
@@ -498,8 +498,8 @@ mod tests {
         let tokens = lex_with_locations(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
-        assert_eq!(doc.content.len(), 1);
-        let para = doc.content[0].as_paragraph().unwrap();
+        assert_eq!(doc.root_session.content.len(), 1);
+        let para = doc.root_session.content[0].as_paragraph().unwrap();
 
         // Should have 2 lines
         assert_eq!(para.lines.len(), 2);
@@ -533,7 +533,7 @@ mod tests {
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // The document should have at least a paragraph and possibly a list
-        assert!(!doc.content.is_empty());
+        assert!(!doc.root_session.content.is_empty());
 
         // Query for position in the nested content
         let results = doc.elements_at(Position::new(4, 4));
@@ -550,7 +550,7 @@ mod tests {
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // Get all items
-        let items = doc.content.clone();
+        let items = doc.root_session.content.clone();
 
         // First paragraph should be at line 0
         if let Some(para) = items.first().and_then(|item| item.as_paragraph()) {
@@ -582,10 +582,13 @@ mod tests {
         let doc_new = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // Content should be identical
-        assert_eq!(doc_old.content.len(), doc_new.content.len());
+        assert_eq!(
+            doc_old.root_session.content.len(),
+            doc_new.root_session.content.len()
+        );
 
-        let para_old = doc_old.content[0].as_paragraph().unwrap();
-        let para_new = doc_new.content[0].as_paragraph().unwrap();
+        let para_old = doc_old.root_session.content[0].as_paragraph().unwrap();
+        let para_new = doc_new.root_session.content[0].as_paragraph().unwrap();
 
         // Text content should be the same (ignoring location information)
         assert_eq!(para_old.lines.len(), para_new.lines.len());
@@ -612,7 +615,7 @@ mod tests {
         let tokens = lex_with_locations(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
-        let para = doc.content[0].as_paragraph().unwrap();
+        let para = doc.root_session.content[0].as_paragraph().unwrap();
         let location = para.location().unwrap();
 
         // Should contain position in the middle
@@ -635,10 +638,11 @@ mod tests {
         let tokens = lex_with_locations(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
-        assert!(doc.content.len() >= 2);
+        assert!(doc.root_session.content.len() >= 2);
 
         // Find the session
         let session = doc
+            .root_session
             .content
             .iter()
             .find(|item| item.is_session())
@@ -681,7 +685,7 @@ mod tests {
 
         assert!(doc.location.is_some(), "Document should have a location");
 
-        for item in &doc.content {
+        for item in &doc.root_session.content {
             assert!(
                 item.location().is_some(),
                 "{} should have a location",
@@ -768,6 +772,7 @@ mod tests {
         let doc = parse_with_source(tokens, &source).expect("Failed to parse annotations sample");
 
         let annotations: Vec<_> = doc
+            .root_session
             .content
             .iter()
             .filter_map(|item| item.as_annotation())
@@ -807,6 +812,7 @@ mod tests {
             parse_with_source(tokens, &source).expect("Failed to parse foreign blocks sample");
 
         let foreign_blocks: Vec<_> = doc
+            .root_session
             .content
             .iter()
             .filter_map(|item| item.as_foreign_block())

--- a/src/txxt/processor.rs
+++ b/src/txxt/processor.rs
@@ -507,7 +507,7 @@ Second paragraph"#;
         let doc = crate::txxt::parser::parse_with_source(tokens, content).unwrap();
 
         // Check if locations are populated
-        if let Some(first_item) = doc.content.first() {
+        if let Some(first_item) = doc.root_session.content.first() {
             // The first paragraph should have a location
             match first_item {
                 crate::txxt::parser::ContentItem::Paragraph(p) => {

--- a/src/txxt/testing/testing_assertions.rs
+++ b/src/txxt/testing/testing_assertions.rs
@@ -26,14 +26,14 @@ pub struct DocumentAssertion<'a> {
 impl<'a> DocumentAssertion<'a> {
     /// Assert the number of items in the document
     pub fn item_count(self, expected: usize) -> Self {
-        let actual = self.doc.content.len();
+        let actual = self.doc.root_session.content.len();
         assert_eq!(
             actual,
             expected,
             "Expected {} items, found {} items: [{}]",
             expected,
             actual,
-            summarize_items(&self.doc.content)
+            summarize_items(&self.doc.root_session.content)
         );
         self
     }
@@ -44,13 +44,13 @@ impl<'a> DocumentAssertion<'a> {
         F: FnOnce(ContentItemAssertion<'a>),
     {
         assert!(
-            index < self.doc.content.len(),
+            index < self.doc.root_session.content.len(),
             "Item index {} out of bounds (document has {} items)",
             index,
-            self.doc.content.len()
+            self.doc.root_session.content.len()
         );
 
-        let item = &self.doc.content[index];
+        let item = &self.doc.root_session.content[index];
         assertion(ContentItemAssertion {
             item,
             context: format!("items[{}]", index),

--- a/tests/parameter_proptest.rs
+++ b/tests/parameter_proptest.rs
@@ -80,7 +80,7 @@ mod proptest_tests {
             prop_assert!(result.is_ok(), "Failed to parse: {}", source);
 
             if let Ok(doc) = result {
-                let annotation = doc.content[0].as_annotation().unwrap();
+                let annotation = doc.root_session.content[0].as_annotation().unwrap();
                 prop_assert_eq!(annotation.parameters.len(), 1);
 
                 // Extract key and value from the parameter string
@@ -98,7 +98,7 @@ mod proptest_tests {
             prop_assert!(result.is_ok(), "Failed to parse: {}", source);
 
             if let Ok(doc) = result {
-                let annotation = doc.content[0].as_annotation().unwrap();
+                let annotation = doc.root_session.content[0].as_annotation().unwrap();
                 let expected_count = params.split(',').count();
                 prop_assert_eq!(annotation.parameters.len(), expected_count);
             }
@@ -112,7 +112,7 @@ mod proptest_tests {
             prop_assert!(result.is_ok(), "Failed to parse: {}", source);
 
             if let Ok(doc) = result {
-                let annotation = doc.content[0].as_annotation().unwrap();
+                let annotation = doc.root_session.content[0].as_annotation().unwrap();
                 prop_assert_eq!(&annotation.parameters[0].key, &key);
                 prop_assert_eq!(&annotation.parameters[0].value, &Some(value));
             }
@@ -126,7 +126,7 @@ mod proptest_tests {
             prop_assert!(result.is_ok(), "Failed to parse: {}", source);
 
             if let Ok(doc) = result {
-                let annotation = doc.content[0].as_annotation().unwrap();
+                let annotation = doc.root_session.content[0].as_annotation().unwrap();
                 prop_assert_eq!(&annotation.parameters[0].key, &key);
                 prop_assert_eq!(&annotation.parameters[0].value, &Some(value));
             }
@@ -140,7 +140,7 @@ mod proptest_tests {
             prop_assert!(result.is_ok(), "Failed to parse: {}", source);
 
             if let Ok(doc) = result {
-                let annotation = doc.content[0].as_annotation().unwrap();
+                let annotation = doc.root_session.content[0].as_annotation().unwrap();
 
                 // Extract keys from the parameter string
                 let expected_keys: Vec<&str> = params
@@ -170,7 +170,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters.len(), 3);
     }
 
@@ -181,7 +181,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters.len(), 3);
         assert_eq!(annotation.parameters[0].key, "key1");
         assert_eq!(annotation.parameters[1].key, "key2");
@@ -195,7 +195,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters.len(), 2);
         assert_eq!(annotation.parameters[0].value, Some("val1".to_string()));
         assert_eq!(annotation.parameters[1].value, Some("val2".to_string()));
@@ -208,7 +208,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(
             annotation.parameters[0].value,
             Some("Hello World".to_string())
@@ -222,7 +222,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(
             annotation.parameters[0].value,
             Some("value with, comma".to_string())
@@ -236,7 +236,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters[0].value, Some("".to_string()));
     }
 
@@ -247,7 +247,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters[0].value, Some("3.11.2".to_string()));
     }
 
@@ -258,7 +258,7 @@ mod specific_tests {
         assert!(result.is_ok());
 
         let doc = result.unwrap();
-        let annotation = doc.content[0].as_annotation().unwrap();
+        let annotation = doc.root_session.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters.len(), 2);
         assert_eq!(annotation.parameters[0].key, "ref-id");
         assert_eq!(annotation.parameters[1].key, "api_version");


### PR DESCRIPTION
## Overview

This PR completes issue #103 by implementing the core architectural change: **Document now has a Session root node**.

This is Phase 2 of the issue resolution. Phase 1 (infrastructure prep) was completed in PR #105.

**Closes #103**

## Related Work

- **Phase 1**: PR #105 - Infrastructure prep and test improvements
  - Fixed Unicode corruption in tests
  - Removed test hacks
  - Added snapshot documentation
  - Prepared codebase for architectural changes

## What This PR Accomplishes

### Core Architectural Change
Document structure has been restructured from:
```rust
Document {
    metadata: Vec<Annotation>,
    content: Vec<ContentItem>,  // Flat access to content
    location: Option<Location>,
}
```

To:
```rust
Document {
    metadata: Vec<Annotation>,
    root_session: Session,      // All content in a Session
    location: Option<Location>,
}
```

### Benefits
✅ **Homogeneous AST**: Document content accessed via same Session interface as all other nodes
✅ **Simplified Traversal**: Visitor pattern and tree traversal work uniformly across entire AST
✅ **Cleaner Code**: No special casing needed for document content access
✅ **Better Architecture**: Achieves the design goal stated in issue #103

### Implementation Details

#### Root Session Creation
The parser now creates an unnamed root session containing all document content:
```rust
let mut root_session = Session::new(
    TextContent::from_string(String::new(), None),  // Empty title
    content,
);
root_session.location = location;
```

#### Snapshot Logic
Updated to flatten the root session so its children appear as direct children in the Document snapshot (maintaining backward compatibility with visualization):
```rust
pub fn snapshot_from_document(doc: &Document) -> AstSnapshot {
    let mut snapshot = AstSnapshot::new("Document", format!(...));
    for child in &doc.root_session.content {
        snapshot.children.push(snapshot_from_content(child));
    }
    snapshot
}
```

#### Visitor Pattern
Document's visitor now properly traverses the root session:
```rust
fn accept(&self, visitor: &mut dyn Visitor) {
    for annotation in &self.metadata {
        annotation.accept(visitor);
    }
    self.root_session.accept(visitor);
}
```

## Files Modified

### Core AST Changes (3 files)
- `src/txxt/ast/elements/document.rs` - Restructured Document struct with root_session
- `src/txxt/ast/snapshot_visitor.rs` - Updated snapshot building logic
- `src/txxt/formats/tag/tag.rs` - Adapted serialization for new structure

### Parser Updates (10 files)
- `src/txxt/parser/elements/document.rs` - Create root session during parsing
- `src/txxt/parser/parser.rs` - Updated core parser and tests
- `src/txxt/parser/elements/{annotations,definitions,foreign,labels,lists,parameters,sessions}.rs` - Fixed test assertions

### Infrastructure Updates (3 files)
- `src/txxt/processor.rs` - Updated location tracking
- `src/txxt/testing/testing_assertions.rs` - Updated test helpers
- `src/bin/viewer/model.rs` - Updated tree navigation logic

### Tests (1 file)
- `tests/parameter_proptest.rs` - Updated test assertions

## Testing

✅ **All 251 Tests Pass**
- 206 library tests
- 45 integration tests
- 0 failures

✅ **All Quality Checks Pass**
- Compilation: ✅ (zero warnings)
- Code formatting: ✅
- Clippy lints: ✅
- Documentation: ✅
- Pre-commit hooks: ✅

## Breaking Changes

⚠️ **API Breaking Change**: This restructures the Document AST

**Migration Required**:
```rust
// OLD (no longer works)
let first = document.content.first()

// NEW (correct way)
let first = document.root_session.content.first()
```

This is a necessary architectural improvement that makes the API more consistent and homogeneous.

## Design Rationale

Per issue #103:
> "The content should be the root node of the content tree, and hence be a session,
> the root session and it carries the document's name. This would allow parsing and
> a lot of other things to be more homogeneous and easier to understand."

This PR delivers exactly this requirement:
- ✅ Content is now the root node (in a Session)
- ✅ Root session is a proper Session node
- ✅ Makes traversal homogeneous
- ✅ Easier to understand and maintain

## Future Work

The architecture is now complete per issue #103. Future enhancements could include:
- Using the root session's title field for document metadata
- Further refinement of the metadata/content relationship
- Additional convenience methods on Document

## Summary

This PR successfully implements the core architectural change from issue #103, creating a homogeneous AST where Document content is accessed through the standard Session interface. All tests pass, code quality is high, and the implementation is production-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>