### PR TITLE
Refactor elements_at to element_at: return only deepest element

### DIFF
--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -239,11 +239,8 @@ impl Model {
     pub fn get_node_at_position(&self, row: usize, col: usize) -> Option<NodeId> {
         let pos = Position::new(row, col);
 
-        // Find all elements at this position (deepest first) using AST locations
-        let elements = self.document.elements_at(pos);
-
-        // Return the first (deepest) element's NodeId
-        if let Some(element) = elements.first() {
+        // Find the deepest element at this position using AST locations
+        if let Some(element) = self.document.element_at(pos) {
             self.find_node_id_for_element(element)
         } else {
             None

--- a/src/bin/viewer/tests.rs
+++ b/src/bin/viewer/tests.rs
@@ -527,14 +527,14 @@ fn test_text_view_cursor_on_nested_element_updates_model() {
                     location.end.column
                 );
 
-                // Try to find the node using document.elements_at
+                // Try to find the node using document.element_at
                 use txxt::txxt::ast::location::Position;
                 let pos = Position::new(location.start.line, location.start.column);
-                let elements = app.app().model.document.elements_at(pos);
-                // Verify document.elements_at() now finds nested elements
+                let element = app.app().model.document.element_at(pos);
+                // Verify document.element_at() now finds nested elements
                 assert!(
-                    !elements.is_empty(),
-                    "document.elements_at() should find nested elements at position {:?}",
+                    element.is_some(),
+                    "document.element_at() should find nested elements at position {:?}",
                     pos
                 );
 

--- a/src/txxt/ast/location.rs
+++ b/src/txxt/ast/location.rs
@@ -442,10 +442,8 @@ mod ast_integration_tests {
             .push(ContentItem::Paragraph(paragraph));
         let document = Document::with_content(vec![ContentItem::Session(session)]);
         let nodes = find_nodes_at_position(&document, Position::new(2, 5));
-        // Now we get: TextLine (deepest), Paragraph, Session (shallowest)
-        assert_eq!(nodes.len(), 3);
+        // Now we get only the deepest element: TextLine
+        assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0].node_type(), "TextLine");
-        assert_eq!(nodes[1].node_type(), "Paragraph");
-        assert_eq!(nodes[2].node_type(), "Session");
     }
 }

--- a/src/txxt/ast/lookup.rs
+++ b/src/txxt/ast/lookup.rs
@@ -3,11 +3,11 @@ use super::location::Position;
 use super::traits::AstNode;
 
 pub fn find_nodes_at_position(document: &Document, position: Position) -> Vec<&dyn AstNode> {
-    document
-        .elements_at(position)
-        .into_iter()
-        .map(|item| item as &dyn AstNode)
-        .collect()
+    if let Some(item) = document.element_at(position) {
+        vec![item as &dyn AstNode]
+    } else {
+        Vec::new()
+    }
 }
 
 pub fn format_at_position(document: &Document, position: Position) -> String {

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -511,23 +511,23 @@ mod tests {
     }
 
     #[test]
-    fn test_elements_at_query_on_parsed_document() {
+    fn test_element_at_query_on_parsed_document() {
         let input = "First paragraph\n\n2. Session Title\n\n    Session content\n\n";
         let tokens = lex_with_locations(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // Query for the session (should be at line 2)
-        let results = doc.elements_at(Position::new(2, 3));
+        let result = doc.element_at(Position::new(2, 3));
 
-        // Should find at least the session
-        assert!(!results.is_empty(), "Should find elements at position 2:3");
+        // Should find the element
+        assert!(result.is_some(), "Should find element at position 2:3");
 
-        // First result should be a session
-        assert!(results[0].is_session());
+        // Result should be a session
+        assert!(result.unwrap().is_session());
     }
 
     #[test]
-    fn test_elements_at_nested_position() {
+    fn test_element_at_nested_position() {
         let input = "Title\n\n1. Item one\n\n    Nested content\n\n";
         let tokens = lex_with_locations(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
@@ -536,11 +536,11 @@ mod tests {
         assert!(!doc.root_session.content.is_empty());
 
         // Query for position in the nested content
-        let results = doc.elements_at(Position::new(4, 4));
+        let result = doc.element_at(Position::new(4, 4));
 
-        // Should find elements at that position (or return empty if position is outside all locations)
+        // Should find element at that position (or return None if position is outside all locations)
         // This is acceptable - position 4:4 might be outside all defined locations
-        let _ = results;
+        let _ = result;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Simplify the element lookup API by refactoring `elements_at()` to return only the deepest (most nested) element instead of a vector of all elements from deepest to shallowest. This aligns with actual usage patterns where nearly all callers only need the deepest element.

- `ContentItem::element_at(pos) -> Option<&ContentItem>` returns the deepest element
- `Document::element_at(pos) -> Option<&ContentItem>` returns the deepest element  
- Callers needing ancestors can traverse up the tree manually if required

## Test plan

- [x] All 215+ existing tests pass
- [x] Updated all callers (lookup.rs, viewer/model.rs)
- [x] Updated all tests to match new API
- [x] Pre-commit checks pass (formatting, clippy, build, tests)

## Files changed

- `src/txxt/ast/elements/content_item.rs` - Refactored method and tests
- `src/txxt/ast/elements/document.rs` - Refactored method and tests
- `src/txxt/ast/lookup.rs` - Updated to use new API
- `src/bin/viewer/model.rs` - Updated to use new API
- `src/bin/viewer/tests.rs` - Updated test assertions
- `src/txxt/ast/location.rs` - Updated test to expect single element
- `src/txxt/parser/parser.rs` - Updated parser tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)