### PR TITLE
Make location-aware the default: tokens are spanned; new parse API; .at(Location) builders

### DIFF
--- a/src/txxt/ast/elements/annotation.rs
+++ b/src/txxt/ast/elements/annotation.rs
@@ -89,6 +89,10 @@ impl Annotation {
         self.location = location;
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl AstNode for Annotation {

--- a/src/txxt/ast/elements/annotation.rs
+++ b/src/txxt/ast/elements/annotation.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_annotation() {
+    fn test_annotation_with_location() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/elements/annotation.rs
+++ b/src/txxt/ast/elements/annotation.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_annotation_with_location() {
+    fn test_annotation() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/elements/content_item.rs
+++ b/src/txxt/ast/elements/content_item.rs
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_element_at_simple_paragraph() {
         let para = Paragraph::from_line("Test".to_string())
-            .with_location(Location::new(Position::new(0, 0), Position::new(0, 4)));
+            .at(Location::new(Position::new(0, 0), Position::new(0, 4)));
         let item = ContentItem::Paragraph(para);
 
         let pos = Position::new(0, 2);
@@ -372,7 +372,7 @@ mod tests {
     #[test]
     fn test_element_at_position_outside_location() {
         let para = Paragraph::from_line("Test".to_string())
-            .with_location(Location::new(Position::new(0, 0), Position::new(0, 4)));
+            .at(Location::new(Position::new(0, 0), Position::new(0, 4)));
         let item = ContentItem::Paragraph(para);
 
         let pos = Position::new(0, 10);
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn test_element_at_nested_session() {
         let para = Paragraph::from_line("Nested".to_string())
-            .with_location(Location::new(Position::new(1, 0), Position::new(1, 6)));
+            .at(Location::new(Position::new(1, 0), Position::new(1, 6)));
         let session = Session::new(
             super::super::super::text_content::TextContent::from_string(
                 "Section".to_string(),
@@ -401,7 +401,7 @@ mod tests {
             ),
             vec![ContentItem::Paragraph(para)],
         )
-        .with_location(Location::new(Position::new(0, 0), Position::new(2, 0)));
+        .at(Location::new(Position::new(0, 0), Position::new(2, 0)));
         let item = ContentItem::Session(session);
 
         let pos = Position::new(1, 3);

--- a/src/txxt/ast/elements/definition.rs
+++ b/src/txxt/ast/elements/definition.rs
@@ -109,7 +109,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_definition_with_location() {
+    fn test_definition() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/elements/definition.rs
+++ b/src/txxt/ast/elements/definition.rs
@@ -57,6 +57,10 @@ impl Definition {
         self.location = location;
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl AstNode for Definition {

--- a/src/txxt/ast/elements/document.rs
+++ b/src/txxt/ast/elements/document.rs
@@ -94,6 +94,11 @@ impl Document {
             .filter_map(|item| item.as_foreign_block())
     }
 
+    /// Convenience accessor for the root session's location
+    pub fn root_location(&self) -> Location {
+        self.root.location
+    }
+
     pub fn count_by_type(&self) -> (usize, usize, usize, usize) {
         let paragraphs = self.iter_paragraphs().count();
         let sessions = self.iter_sessions().count();

--- a/src/txxt/ast/elements/document.rs
+++ b/src/txxt/ast/elements/document.rs
@@ -196,13 +196,13 @@ mod tests {
         let text_line1 = TextLine::new(TextContent::from_string("First".to_string(), None))
             .with_location(Location::new(Position::new(0, 0), Position::new(0, 5)));
         let para1 = Paragraph::new(vec![ContentItem::TextLine(text_line1)])
-            .with_location(Location::new(Position::new(0, 0), Position::new(0, 5)));
+            .at(Location::new(Position::new(0, 0), Position::new(0, 5)));
 
         // Create paragraph 2 with properly located TextLine
         let text_line2 = TextLine::new(TextContent::from_string("Second".to_string(), None))
             .with_location(Location::new(Position::new(1, 0), Position::new(1, 6)));
         let para2 = Paragraph::new(vec![ContentItem::TextLine(text_line2)])
-            .with_location(Location::new(Position::new(1, 0), Position::new(1, 6)));
+            .at(Location::new(Position::new(1, 0), Position::new(1, 6)));
 
         let doc = Document::with_content(vec![
             ContentItem::Paragraph(para1),

--- a/src/txxt/ast/elements/foreign.rs
+++ b/src/txxt/ast/elements/foreign.rs
@@ -72,6 +72,10 @@ impl ForeignBlock {
         self.location = location;
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl AstNode for ForeignBlock {

--- a/src/txxt/ast/elements/label.rs
+++ b/src/txxt/ast/elements/label.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_label_with_location() {
+    fn test_label() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/elements/label.rs
+++ b/src/txxt/ast/elements/label.rs
@@ -46,6 +46,10 @@ impl Label {
         self.location = location;
         self
     }
+    /// Preferred builder: `at(location)`
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl fmt::Display for Label {

--- a/src/txxt/ast/elements/list.rs
+++ b/src/txxt/ast/elements/list.rs
@@ -60,6 +60,10 @@ impl List {
         self.location = location;
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl AstNode for List {
@@ -114,6 +118,10 @@ impl ListItem {
     pub fn with_location(mut self, location: Location) -> Self {
         self.location = location;
         self
+    }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
     }
     pub fn text(&self) -> &str {
         self.text[0].as_string()

--- a/src/txxt/ast/elements/list.rs
+++ b/src/txxt/ast/elements/list.rs
@@ -165,7 +165,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_list_with_location() {
+    fn test_list() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/elements/paragraph.rs
+++ b/src/txxt/ast/elements/paragraph.rs
@@ -101,6 +101,17 @@ impl Paragraph {
             location: Self::default_location(),
         }
     }
+    /// Create a paragraph with a single line and attach a location
+    pub fn from_line_at(line: String, location: Location) -> Self {
+        let mut para = Self {
+            lines: vec![super::content_item::ContentItem::TextLine(TextLine::new(
+                TextContent::from_string(line, None),
+            ))],
+            location: Self::default_location(),
+        };
+        para = para.with_location(location);
+        para
+    }
     pub fn with_location(mut self, location: Location) -> Self {
         self.location = location;
         // When a paragraph's location is set in tests, we should also update

--- a/src/txxt/ast/elements/paragraph.rs
+++ b/src/txxt/ast/elements/paragraph.rs
@@ -115,6 +115,10 @@ impl Paragraph {
         }
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
     pub fn text(&self) -> String {
         self.lines
             .iter()

--- a/src/txxt/ast/elements/paragraph.rs
+++ b/src/txxt/ast/elements/paragraph.rs
@@ -202,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paragraph_with_location() {
+    fn test_paragraph() {
         let location = Location::new(
             super::super::super::location::Position::new(0, 0),
             super::super::super::location::Position::new(0, 5),

--- a/src/txxt/ast/elements/parameter.rs
+++ b/src/txxt/ast/elements/parameter.rs
@@ -41,6 +41,10 @@ impl Parameter {
         self.location = location;
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl fmt::Display for Parameter {

--- a/src/txxt/ast/elements/parameter.rs
+++ b/src/txxt/ast/elements/parameter.rs
@@ -54,7 +54,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parameter_with_location() {
+    fn test_parameter() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/elements/session.rs
+++ b/src/txxt/ast/elements/session.rs
@@ -59,6 +59,10 @@ impl Session {
         self.location = location;
         self
     }
+    /// Preferred builder
+    pub fn at(self, location: Location) -> Self {
+        self.with_location(location)
+    }
 }
 
 impl AstNode for Session {

--- a/src/txxt/ast/elements/session.rs
+++ b/src/txxt/ast/elements/session.rs
@@ -119,7 +119,7 @@ mod tests {
     }
 
     #[test]
-    fn test_session_with_location() {
+    fn test_session() {
         let location = super::super::super::location::Location::new(
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),

--- a/src/txxt/ast/location.rs
+++ b/src/txxt/ast/location.rs
@@ -404,7 +404,7 @@ mod ast_integration_tests {
     #[test]
     fn test_get_location() {
         let location = Location::new(Position::new(1, 0), Position::new(1, 10));
-        let session = Session::with_title("Title".to_string()).with_location(location);
+        let session = Session::with_title("Title".to_string()).at(location);
         assert_eq!(session.get_location(), Some(Position::new(1, 0)));
     }
 
@@ -416,8 +416,8 @@ mod ast_integration_tests {
 
         let location1 = Location::new(Position::new(1, 0), Position::new(1, 10));
         let location2 = Location::new(Position::new(2, 0), Position::new(2, 10));
-        let session1 = Session::with_title("Title1".to_string()).with_location(location1);
-        let session2 = Session::with_title("Title2".to_string()).with_location(location2);
+        let session1 = Session::with_title("Title1".to_string()).at(location1);
+        let session2 = Session::with_title("Title2".to_string()).at(location2);
         let document = Document::with_content(vec![
             ContentItem::Session(session1),
             ContentItem::Session(session2),
@@ -434,9 +434,9 @@ mod ast_integration_tests {
         use crate::txxt::ast::find_nodes_at_position;
 
         let para_location = Location::new(Position::new(2, 0), Position::new(2, 10));
-        let paragraph = Paragraph::from_line("Nested".to_string()).with_location(para_location);
+        let paragraph = Paragraph::from_line("Nested".to_string()).at(para_location);
         let session_location = Location::new(Position::new(1, 0), Position::new(3, 0));
-        let mut session = Session::with_title("Title".to_string()).with_location(session_location);
+        let mut session = Session::with_title("Title".to_string()).at(session_location);
         session
             .children_mut()
             .push(ContentItem::Paragraph(paragraph));

--- a/src/txxt/ast/text_content.rs
+++ b/src/txxt/ast/text_content.rs
@@ -166,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_location() {
+    fn test() {
         let location = Location::new(Position::new(0, 0), Position::new(0, 5));
         let content = TextContent::from_string("Hello".to_string(), Some(location));
         assert_eq!(content.location, Some(location));

--- a/src/txxt/lexer.rs
+++ b/src/txxt/lexer.rs
@@ -51,8 +51,8 @@ pub fn lex(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
         source.to_string()
     };
 
-    let tokens_with_locations = tokenize(&source_with_newline);
-    let tokens_after_whitespace = process_whitespace_remainders(tokens_with_locations);
+    let tokenss = tokenize(&source_with_newline);
+    let tokens_after_whitespace = process_whitespace_remainders(tokenss);
     let tokens_after_indentation = transform_indentation(tokens_after_whitespace);
     transform_blank_lines(tokens_after_indentation)
 }

--- a/src/txxt/lexer.rs
+++ b/src/txxt/lexer.rs
@@ -29,43 +29,21 @@ pub mod tokens;
 pub mod transformations;
 
 pub use detokenizer::detokenize;
-pub use lexer_impl::tokenize_with_locations;
+pub use lexer_impl::tokenize;
 pub use tokens::Token;
 pub use transformations::{
-    process_whitespace_remainders, process_whitespace_remainders_with_locations,
-    transform_blank_lines, transform_blank_lines_with_locations, transform_indentation,
-    transform_indentation_with_locations,
+    process_whitespace_remainders, transform_blank_lines, transform_indentation,
 };
 
-/// Main lexer function that returns fully processed tokens
-/// Processing pipeline:
-/// 1. tokenize_with_locations() - raw tokens with source locations
-/// 2. process_whitespace_remainders() - handle whitespace according to txxt spec
-/// 3. transform_indentation() - convert Indent tokens to semantic IndentLevel/DedentLevel tokens
-/// 4. transform_blank_lines() - convert consecutive Newline tokens to BlankLine tokens
-pub fn lex(source: &str) -> Vec<Token> {
-    // Ensure source ends with newline to help with paragraph parsing at EOF
-    let source_with_newline = if !source.is_empty() && !source.ends_with('\n') {
-        format!("{}\n", source)
-    } else {
-        source.to_string()
-    };
-
-    let tokens_with_locations = tokenize_with_locations(&source_with_newline);
-    let tokens_after_whitespace = process_whitespace_remainders(tokens_with_locations);
-    let tokens_after_indentation = transform_indentation(tokens_after_whitespace);
-    transform_blank_lines(tokens_after_indentation)
-}
-
-/// Lexing function that preserves source locations for parser
+/// Main lexer function that returns fully processed tokens with locations
 /// Returns tokens with their corresponding source locations
 /// Synthetic tokens (IndentLevel, DedentLevel, BlankLine) have meaningful locations
 /// Processing pipeline:
-/// 1. tokenize_with_locations() - raw tokens with source locations
-/// 2. process_whitespace_remainders_with_locations() - handle whitespace with locations
-/// 3. transform_indentation_with_locations() - convert Indent tokens with location tracking
-/// 4. transform_blank_lines_with_locations() - convert Newline sequences with location tracking
-pub fn lex_with_locations(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
+/// 1. tokenize() - raw tokens with source locations
+/// 2. process_whitespace_remainders() - handle whitespace with locations
+/// 3. transform_indentation() - convert Indent tokens with location tracking
+/// 4. transform_blank_lines() - convert Newline sequences with location tracking
+pub fn lex(source: &str) -> Vec<(Token, std::ops::Range<usize>)> {
     // Ensure source ends with newline to help with paragraph parsing at EOF
     let source_with_newline = if !source.is_empty() && !source.ends_with('\n') {
         format!("{}\n", source)
@@ -73,9 +51,8 @@ pub fn lex_with_locations(source: &str) -> Vec<(Token, std::ops::Range<usize>)> 
         source.to_string()
     };
 
-    let tokens_with_locations = tokenize_with_locations(&source_with_newline);
-    let tokens_after_whitespace =
-        process_whitespace_remainders_with_locations(tokens_with_locations);
-    let tokens_after_indentation = transform_indentation_with_locations(tokens_after_whitespace);
-    transform_blank_lines_with_locations(tokens_after_indentation)
+    let tokens_with_locations = tokenize(&source_with_newline);
+    let tokens_after_whitespace = process_whitespace_remainders(tokens_with_locations);
+    let tokens_after_indentation = transform_indentation(tokens_after_whitespace);
+    transform_blank_lines(tokens_after_indentation)
 }

--- a/src/txxt/lexer/detokenizer.rs
+++ b/src/txxt/lexer/detokenizer.rs
@@ -106,9 +106,9 @@ mod tests {
     #[test]
     fn test_detokenize_with_semantic_indentation() {
         let source = "1. Session\n    - Item 1\n        - Nested Item\n    - Item 2";
-        let raw_tokens_with_locations = tokenize(source);
-        let tokens_with_locations = transform_indentation(raw_tokens_with_locations);
-        let tokens: Vec<_> = tokens_with_locations.into_iter().map(|(t, _)| t).collect();
+        let raw_tokenss = tokenize(source);
+        let tokenss = transform_indentation(raw_tokenss);
+        let tokens: Vec<_> = tokenss.into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         assert_eq!(detokenized, source);
     }
@@ -126,9 +126,9 @@ mod tests {
     }
 
     fn test_roundtrip_semantic_tokens(source: &str, snapshot_name: &str) {
-        let raw_tokens_with_locations = tokenize(source);
-        let tokens_with_locations = transform_indentation(raw_tokens_with_locations);
-        let tokens: Vec<_> = tokens_with_locations.into_iter().map(|(t, _)| t).collect();
+        let raw_tokenss = tokenize(source);
+        let tokenss = transform_indentation(raw_tokenss);
+        let tokens: Vec<_> = tokenss.into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         insta::assert_snapshot!(snapshot_name, detokenized);
     }

--- a/src/txxt/lexer/detokenizer.rs
+++ b/src/txxt/lexer/detokenizer.rs
@@ -64,17 +64,14 @@ pub fn detokenize(tokens: &[Token]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::txxt::lexer::{tokenize_with_locations, transform_indentation_with_locations};
+    use crate::txxt::lexer::{tokenize, transform_indentation};
 
     // ===== Stage 0/1: Basic detokenization with raw tokens (no indentation handling) =====
 
     #[test]
     fn test_detokenize_simple_paragraph() {
         let source = "Simple Paragraphs Test {{paragraph}}";
-        let tokens: Vec<_> = tokenize_with_locations(source)
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize(source).into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         assert_eq!(detokenized, source);
     }
@@ -82,10 +79,7 @@ mod tests {
     #[test]
     fn test_detokenize_multiline_paragraph() {
         let source = "This is a multi-line paragraph.\nIt continues on the second line.\nAnd even has a third line. {{paragraph}}";
-        let tokens: Vec<_> = tokenize_with_locations(source)
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize(source).into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         assert_eq!(detokenized, source);
     }
@@ -94,10 +88,7 @@ mod tests {
     fn test_detokenize_simple_list() {
         let source =
             "- First item {{list-item}}\n- Second item {{list-item}}\n- Third item {{list-item}}";
-        let tokens: Vec<_> = tokenize_with_locations(source)
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize(source).into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         assert_eq!(detokenized, source);
     }
@@ -105,10 +96,7 @@ mod tests {
     #[test]
     fn test_detokenize_session() {
         let source = "1. Introduction {{session-title}}\n\n    This is the content of the session. It contains a paragraph that is indented relative to the session title. {{paragraph}}";
-        let tokens: Vec<_> = tokenize_with_locations(source)
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize(source).into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         assert_eq!(detokenized, source);
     }
@@ -118,8 +106,8 @@ mod tests {
     #[test]
     fn test_detokenize_with_semantic_indentation() {
         let source = "1. Session\n    - Item 1\n        - Nested Item\n    - Item 2";
-        let raw_tokens_with_locations = tokenize_with_locations(source);
-        let tokens_with_locations = transform_indentation_with_locations(raw_tokens_with_locations);
+        let raw_tokens_with_locations = tokenize(source);
+        let tokens_with_locations = transform_indentation(raw_tokens_with_locations);
         let tokens: Vec<_> = tokens_with_locations.into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         assert_eq!(detokenized, source);
@@ -132,17 +120,14 @@ mod tests {
     // a simple "strings don't match" message.
 
     fn test_roundtrip_raw_tokens(source: &str, snapshot_name: &str) {
-        let tokens: Vec<_> = tokenize_with_locations(source)
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize(source).into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         insta::assert_snapshot!(snapshot_name, detokenized);
     }
 
     fn test_roundtrip_semantic_tokens(source: &str, snapshot_name: &str) {
-        let raw_tokens_with_locations = tokenize_with_locations(source);
-        let tokens_with_locations = transform_indentation_with_locations(raw_tokens_with_locations);
+        let raw_tokens_with_locations = tokenize(source);
+        let tokens_with_locations = transform_indentation(raw_tokens_with_locations);
         let tokens: Vec<_> = tokens_with_locations.into_iter().map(|(t, _)| t).collect();
         let detokenized = detokenize(&tokens);
         insta::assert_snapshot!(snapshot_name, detokenized);

--- a/src/txxt/lexer/lexer_impl.rs
+++ b/src/txxt/lexer/lexer_impl.rs
@@ -31,65 +31,62 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tokenize_with_locations() {
-        let tokens_with_locations = tokenize("hello world");
-        assert_eq!(tokens_with_locations.len(), 3);
+    fn test_tokenizes() {
+        let tokenss = tokenize("hello world");
+        assert_eq!(tokenss.len(), 3);
 
         // Check that tokens are correct
-        assert_eq!(tokens_with_locations[0].0, Token::Text("hello".to_string()));
-        assert_eq!(tokens_with_locations[1].0, Token::Whitespace);
-        assert_eq!(tokens_with_locations[2].0, Token::Text("world".to_string()));
+        assert_eq!(tokenss[0].0, Token::Text("hello".to_string()));
+        assert_eq!(tokenss[1].0, Token::Whitespace);
+        assert_eq!(tokenss[2].0, Token::Text("world".to_string()));
     }
 
     #[test]
     fn test_empty_input() {
-        let tokens_with_locations = tokenize("");
-        assert_eq!(tokens_with_locations, vec![]);
+        let tokenss = tokenize("");
+        assert_eq!(tokenss, vec![]);
     }
 
     #[test]
     fn test_complex_tokenization() {
         let input = "1. Session Title\n    - Item 1\n    - Item 2";
-        let tokens_with_locations = tokenize(input);
+        let tokenss = tokenize(input);
 
         // Expected tokens for "1. Session Title"
-        assert_eq!(tokens_with_locations[0].0, Token::Number("1".to_string())); // "1"
-        assert_eq!(tokens_with_locations[1].0, Token::Period); // "."
-        assert_eq!(tokens_with_locations[2].0, Token::Whitespace); // " "
-        assert_eq!(
-            tokens_with_locations[3].0,
-            Token::Text("Session".to_string())
-        ); // "Session"
-        assert_eq!(tokens_with_locations[4].0, Token::Whitespace); // " "
-        assert_eq!(tokens_with_locations[5].0, Token::Text("Title".to_string())); // "Title"
-        assert_eq!(tokens_with_locations[6].0, Token::Newline); // "\n"
+        assert_eq!(tokenss[0].0, Token::Number("1".to_string())); // "1"
+        assert_eq!(tokenss[1].0, Token::Period); // "."
+        assert_eq!(tokenss[2].0, Token::Whitespace); // " "
+        assert_eq!(tokenss[3].0, Token::Text("Session".to_string())); // "Session"
+        assert_eq!(tokenss[4].0, Token::Whitespace); // " "
+        assert_eq!(tokenss[5].0, Token::Text("Title".to_string())); // "Title"
+        assert_eq!(tokenss[6].0, Token::Newline); // "\n"
 
         // Expected tokens for "    - Item 1"
-        assert_eq!(tokens_with_locations[7].0, Token::Indent); // "    "
-        assert_eq!(tokens_with_locations[8].0, Token::Dash); // "-"
-        assert_eq!(tokens_with_locations[9].0, Token::Whitespace); // " "
-        assert_eq!(tokens_with_locations[10].0, Token::Text("Item".to_string())); // "Item"
-        assert_eq!(tokens_with_locations[11].0, Token::Whitespace); // " "
-        assert_eq!(tokens_with_locations[12].0, Token::Number("1".to_string())); // "1"
-        assert_eq!(tokens_with_locations[13].0, Token::Newline); // "\n"
+        assert_eq!(tokenss[7].0, Token::Indent); // "    "
+        assert_eq!(tokenss[8].0, Token::Dash); // "-"
+        assert_eq!(tokenss[9].0, Token::Whitespace); // " "
+        assert_eq!(tokenss[10].0, Token::Text("Item".to_string())); // "Item"
+        assert_eq!(tokenss[11].0, Token::Whitespace); // " "
+        assert_eq!(tokenss[12].0, Token::Number("1".to_string())); // "1"
+        assert_eq!(tokenss[13].0, Token::Newline); // "\n"
 
         // Expected tokens for "    - Item 2"
-        assert_eq!(tokens_with_locations[14].0, Token::Indent); // "    "
-        assert_eq!(tokens_with_locations[15].0, Token::Dash); // "-"
-        assert_eq!(tokens_with_locations[16].0, Token::Whitespace); // " "
-        assert_eq!(tokens_with_locations[17].0, Token::Text("Item".to_string())); // "Item"
-        assert_eq!(tokens_with_locations[18].0, Token::Whitespace); // " "
-        assert_eq!(tokens_with_locations[19].0, Token::Number("2".to_string()));
+        assert_eq!(tokenss[14].0, Token::Indent); // "    "
+        assert_eq!(tokenss[15].0, Token::Dash); // "-"
+        assert_eq!(tokenss[16].0, Token::Whitespace); // " "
+        assert_eq!(tokenss[17].0, Token::Text("Item".to_string())); // "Item"
+        assert_eq!(tokenss[18].0, Token::Whitespace); // " "
+        assert_eq!(tokenss[19].0, Token::Number("2".to_string()));
         // "2"
     }
 
     #[test]
     fn test_whitespace_only() {
-        let tokens_with_locations = tokenize("   \t  ");
+        let tokenss = tokenize("   \t  ");
         // Expected: 3 spaces -> Whitespace, 1 tab -> Indent, 2 spaces -> Whitespace
-        assert_eq!(tokens_with_locations.len(), 3);
-        assert_eq!(tokens_with_locations[0].0, Token::Whitespace);
-        assert_eq!(tokens_with_locations[1].0, Token::Indent);
-        assert_eq!(tokens_with_locations[2].0, Token::Whitespace);
+        assert_eq!(tokenss.len(), 3);
+        assert_eq!(tokenss[0].0, Token::Whitespace);
+        assert_eq!(tokenss[1].0, Token::Indent);
+        assert_eq!(tokenss[2].0, Token::Whitespace);
     }
 }

--- a/src/txxt/lexer/lexer_impl.rs
+++ b/src/txxt/lexer/lexer_impl.rs
@@ -13,7 +13,7 @@ use logos::Logos;
 /// This function performs raw tokenization using the logos lexer, returning tokens
 /// paired with their source locations. Additional transformations (whitespace processing,
 /// indentation handling, blank line handling) should be applied by the caller.
-pub fn tokenize_with_locations(source: &str) -> Vec<(Token, logos::Span)> {
+pub fn tokenize(source: &str) -> Vec<(Token, logos::Span)> {
     let mut lexer = Token::lexer(source);
     let mut tokens = Vec::new();
 
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_with_locations() {
-        let tokens_with_locations = tokenize_with_locations("hello world");
+        let tokens_with_locations = tokenize("hello world");
         assert_eq!(tokens_with_locations.len(), 3);
 
         // Check that tokens are correct
@@ -43,14 +43,14 @@ mod tests {
 
     #[test]
     fn test_empty_input() {
-        let tokens_with_locations = tokenize_with_locations("");
+        let tokens_with_locations = tokenize("");
         assert_eq!(tokens_with_locations, vec![]);
     }
 
     #[test]
     fn test_complex_tokenization() {
         let input = "1. Session Title\n    - Item 1\n    - Item 2";
-        let tokens_with_locations = tokenize_with_locations(input);
+        let tokens_with_locations = tokenize(input);
 
         // Expected tokens for "1. Session Title"
         assert_eq!(tokens_with_locations[0].0, Token::Number("1".to_string())); // "1"
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_whitespace_only() {
-        let tokens_with_locations = tokenize_with_locations("   \t  ");
+        let tokens_with_locations = tokenize("   \t  ");
         // Expected: 3 spaces -> Whitespace, 1 tab -> Indent, 2 spaces -> Whitespace
         assert_eq!(tokens_with_locations.len(), 3);
         assert_eq!(tokens_with_locations[0].0, Token::Whitespace);

--- a/src/txxt/lexer/tokens.rs
+++ b/src/txxt/lexer/tokens.rs
@@ -139,47 +139,32 @@ impl Token {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::txxt::lexer::tokenize_with_locations;
+    use crate::txxt::lexer::tokenize;
 
     #[test]
     fn test_txxt_marker() {
-        let tokens: Vec<_> = tokenize_with_locations("::")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize("::").into_iter().map(|(t, _)| t).collect();
         assert_eq!(tokens, vec![Token::TxxtMarker]);
     }
 
     #[test]
     fn test_indentation_tokens() {
         // Test 4 spaces
-        let tokens: Vec<_> = tokenize_with_locations("    ")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize("    ").into_iter().map(|(t, _)| t).collect();
         assert_eq!(tokens, vec![Token::Indent]);
 
         // Test tab
-        let tokens: Vec<_> = tokenize_with_locations("\t")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize("\t").into_iter().map(|(t, _)| t).collect();
         assert_eq!(tokens, vec![Token::Indent]);
 
         // Test multiple indent levels
-        let tokens: Vec<_> = tokenize_with_locations("        ")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect(); // 8 spaces = 2 indent levels
+        let tokens: Vec<_> = tokenize("        ").into_iter().map(|(t, _)| t).collect(); // 8 spaces = 2 indent levels
         assert_eq!(tokens, vec![Token::Indent, Token::Indent]);
     }
 
     #[test]
     fn test_sequence_markers() {
-        let tokens: Vec<_> = tokenize_with_locations("- . ( ) :")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize("- . ( ) :").into_iter().map(|(t, _)| t).collect();
         assert_eq!(
             tokens,
             vec![
@@ -198,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_text_tokens() {
-        let tokens: Vec<_> = tokenize_with_locations("hello world")
+        let tokens: Vec<_> = tokenize("hello world")
             .into_iter()
             .map(|(t, _)| t)
             .collect();
@@ -214,16 +199,13 @@ mod tests {
 
     #[test]
     fn test_newline_token() {
-        let tokens: Vec<_> = tokenize_with_locations("\n")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize("\n").into_iter().map(|(t, _)| t).collect();
         assert_eq!(tokens, vec![Token::Newline]);
     }
 
     #[test]
     fn test_mixed_content() {
-        let tokens: Vec<_> = tokenize_with_locations("1. Hello world\n    - Item 1")
+        let tokens: Vec<_> = tokenize("1. Hello world\n    - Item 1")
             .into_iter()
             .map(|(t, _)| t)
             .collect();
@@ -249,10 +231,7 @@ mod tests {
 
     #[test]
     fn test_number_tokens() {
-        let tokens: Vec<_> = tokenize_with_locations("123 456")
-            .into_iter()
-            .map(|(t, _)| t)
-            .collect();
+        let tokens: Vec<_> = tokenize("123 456").into_iter().map(|(t, _)| t).collect();
         assert_eq!(
             tokens,
             vec![

--- a/src/txxt/lexer/transformations.rs
+++ b/src/txxt/lexer/transformations.rs
@@ -4,7 +4,7 @@
 //! into semantically meaningful tokens for the parser.
 //!
 //! The transformations are applied in order:
-//! 1. tokenize_with_locations() - creates raw tokens with location information
+//! 1. tokenize() - creates raw tokens with location information
 //! 2. process_whitespace_remainders() - handles txxt whitespace specification
 //! 3. transform_indentation() - converts Indent tokens to IndentLevel/DedentLevel tokens
 //! 4. transform_blank_lines() - converts consecutive Newline tokens to BlankLine tokens
@@ -13,8 +13,6 @@ pub mod transform_blanklines;
 pub mod transform_indentation;
 pub mod transform_whitespace;
 
-pub use transform_blanklines::{transform_blank_lines, transform_blank_lines_with_locations};
-pub use transform_indentation::{transform_indentation, transform_indentation_with_locations};
-pub use transform_whitespace::{
-    process_whitespace_remainders, process_whitespace_remainders_with_locations,
-};
+pub use transform_blanklines::transform_blank_lines;
+pub use transform_indentation::transform_indentation;
+pub use transform_whitespace::process_whitespace_remainders;

--- a/src/txxt/lexer/transformations/transform_blanklines.rs
+++ b/src/txxt/lexer/transformations/transform_blanklines.rs
@@ -436,8 +436,8 @@ mod tests {
         let source = "First paragraph\n\nSecond paragraph";
         // Positions: "First paragraph" 0..15, "\n" 15..16, "\n" 16..17, "Second paragraph" 17..33
 
-        let tokens_with_locations = crate::txxt::lexer::tokenize(source);
-        let result = transform_blank_lines(tokens_with_locations);
+        let tokens = crate::txxt::lexer::tokenize(source);
+        let result = transform_blank_lines(tokens);
 
         // Find the BlankLine token
         let blank_line_pos = result

--- a/src/txxt/lexer/transformations/transform_blanklines.rs
+++ b/src/txxt/lexer/transformations/transform_blanklines.rs
@@ -31,33 +31,31 @@ use crate::txxt::lexer::tokens::Token;
 /// Blank lines (sequences of 2+ newlines) become Newline followed by BlankLine token
 /// The BlankLine token gets the location covering the extra newlines (from 2nd newline onwards)
 pub fn transform_blank_lines(
-    tokens_with_locations: Vec<(Token, std::ops::Range<usize>)>,
+    tokens: Vec<(Token, std::ops::Range<usize>)>,
 ) -> Vec<(Token, std::ops::Range<usize>)> {
     let mut result = Vec::new();
     let mut i = 0;
 
-    while i < tokens_with_locations.len() {
-        if matches!(tokens_with_locations[i].0, Token::Newline) {
+    while i < tokens.len() {
+        if matches!(tokens[i].0, Token::Newline) {
             // Count consecutive Newline tokens and collect their locations
             let mut newline_count = 0;
             let mut j = i;
-            while j < tokens_with_locations.len()
-                && matches!(tokens_with_locations[j].0, Token::Newline)
-            {
+            while j < tokens.len() && matches!(tokens[j].0, Token::Newline) {
                 newline_count += 1;
                 j += 1;
             }
 
             // Emit the first Newline with its original location (ends the current line)
-            result.push((Token::Newline, tokens_with_locations[i].1.clone()));
+            result.push((Token::Newline, tokens[i].1.clone()));
 
             // If we have 2+ consecutive newlines, also emit a BlankLine token
             // The BlankLine location covers all the extra newlines (from 2nd to last)
             if newline_count >= 2 {
                 // Calculate the location covering the extra newlines
                 // Start from the second newline, end at the last newline
-                let blank_line_start = tokens_with_locations[i + 1].1.start;
-                let blank_line_end = tokens_with_locations[j - 1].1.end;
+                let blank_line_start = tokens[i + 1].1.start;
+                let blank_line_end = tokens[j - 1].1.end;
                 let blank_line_location = blank_line_start..blank_line_end;
 
                 result.push((Token::BlankLine, blank_line_location));
@@ -67,7 +65,7 @@ pub fn transform_blank_lines(
             i = j;
         } else {
             // Non-newline token, just copy it with its location
-            result.push(tokens_with_locations[i].clone());
+            result.push(tokens[i].clone());
             i += 1;
         }
     }

--- a/src/txxt/lexer/transformations/transform_blanklines.rs
+++ b/src/txxt/lexer/transformations/transform_blanklines.rs
@@ -294,11 +294,12 @@ mod tests {
     fn test_blank_line_token_has_correct_location_for_double_newline() {
         // Test: BlankLine should cover the location of extra newlines (from 2nd onwards)
         // Input: "a\n\nb" where positions are: "a" 0..1, "\n" 1..2, "\n" 2..3, "b" 3..4
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Newline, 2..3),
-            (Token::Text("b".to_string()), 3..4),
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Newline, 2, 3),
+            mk_token(Token::Text("b".to_string()), 3, 4),
         ];
 
         let result = transform_blank_lines(input);
@@ -316,12 +317,13 @@ mod tests {
     fn test_blank_line_token_has_correct_location_for_triple_newline() {
         // Test: BlankLine should cover the location from 2nd to last newline
         // Input: "a\n\n\nb" where positions are: "a" 0..1, "\n" 1..2, "\n" 2..3, "\n" 3..4, "b" 4..5
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Newline, 2..3),
-            (Token::Newline, 3..4),
-            (Token::Text("b".to_string()), 4..5),
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Newline, 2, 3),
+            mk_token(Token::Newline, 3, 4),
+            mk_token(Token::Text("b".to_string()), 4, 5),
         ];
 
         let result = transform_blank_lines(input);
@@ -340,14 +342,15 @@ mod tests {
     fn test_blank_line_token_has_correct_location_for_many_newlines() {
         // Test: BlankLine should cover all extra newlines
         // Input: "a\n\n\n\n\nb" (5 newlines total)
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Newline, 2..3),
-            (Token::Newline, 3..4),
-            (Token::Newline, 4..5),
-            (Token::Newline, 5..6),
-            (Token::Text("b".to_string()), 6..7),
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Newline, 2, 3),
+            mk_token(Token::Newline, 3, 4),
+            mk_token(Token::Newline, 4, 5),
+            mk_token(Token::Newline, 5, 6),
+            mk_token(Token::Text("b".to_string()), 6, 7),
         ];
 
         let result = transform_blank_lines(input);
@@ -366,15 +369,16 @@ mod tests {
     fn test_multiple_blank_lines_each_have_correct_locations() {
         // Test: Multiple BlankLine tokens should each have their own correct locations
         // Input: "a\n\nb\n\n\nc"
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Newline, 2..3),
-            (Token::Text("b".to_string()), 3..4),
-            (Token::Newline, 4..5),
-            (Token::Newline, 5..6),
-            (Token::Newline, 6..7),
-            (Token::Text("c".to_string()), 7..8),
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Newline, 2, 3),
+            mk_token(Token::Text("b".to_string()), 3, 4),
+            mk_token(Token::Newline, 4, 5),
+            mk_token(Token::Newline, 5, 6),
+            mk_token(Token::Newline, 6, 7),
+            mk_token(Token::Text("c".to_string()), 7, 8),
         ];
 
         let result = transform_blank_lines(input);

--- a/src/txxt/lexer/transformations/transform_blanklines.rs
+++ b/src/txxt/lexer/transformations/transform_blanklines.rs
@@ -31,33 +31,31 @@ use crate::txxt::lexer::tokens::Token;
 /// Blank lines (sequences of 2+ newlines) become Newline followed by BlankLine token
 /// The BlankLine token gets the location covering the extra newlines (from 2nd newline onwards)
 pub fn transform_blank_lines(
-    tokens_with_locations: Vec<(Token, std::ops::Range<usize>)>,
+    tokenss: Vec<(Token, std::ops::Range<usize>)>,
 ) -> Vec<(Token, std::ops::Range<usize>)> {
     let mut result = Vec::new();
     let mut i = 0;
 
-    while i < tokens_with_locations.len() {
-        if matches!(tokens_with_locations[i].0, Token::Newline) {
+    while i < tokenss.len() {
+        if matches!(tokenss[i].0, Token::Newline) {
             // Count consecutive Newline tokens and collect their locations
             let mut newline_count = 0;
             let mut j = i;
-            while j < tokens_with_locations.len()
-                && matches!(tokens_with_locations[j].0, Token::Newline)
-            {
+            while j < tokenss.len() && matches!(tokenss[j].0, Token::Newline) {
                 newline_count += 1;
                 j += 1;
             }
 
             // Emit the first Newline with its original location (ends the current line)
-            result.push((Token::Newline, tokens_with_locations[i].1.clone()));
+            result.push((Token::Newline, tokenss[i].1.clone()));
 
             // If we have 2+ consecutive newlines, also emit a BlankLine token
             // The BlankLine location covers all the extra newlines (from 2nd to last)
             if newline_count >= 2 {
                 // Calculate the location covering the extra newlines
                 // Start from the second newline, end at the last newline
-                let blank_line_start = tokens_with_locations[i + 1].1.start;
-                let blank_line_end = tokens_with_locations[j - 1].1.end;
+                let blank_line_start = tokenss[i + 1].1.start;
+                let blank_line_end = tokenss[j - 1].1.end;
                 let blank_line_location = blank_line_start..blank_line_end;
 
                 result.push((Token::BlankLine, blank_line_location));
@@ -67,7 +65,7 @@ pub fn transform_blank_lines(
             i = j;
         } else {
             // Non-newline token, just copy it with its location
-            result.push(tokens_with_locations[i].clone());
+            result.push(tokenss[i].clone());
             i += 1;
         }
     }
@@ -268,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blank_line_with_locations() {
+    fn test_blank_lines() {
         let input = vec![
             (Token::Text("t".to_string()), 0..4),
             (Token::Newline, 4..5),
@@ -434,8 +432,8 @@ mod tests {
         let source = "First paragraph\n\nSecond paragraph";
         // Positions: "First paragraph" 0..15, "\n" 15..16, "\n" 16..17, "Second paragraph" 17..33
 
-        let tokens_with_locations = crate::txxt::lexer::tokenize(source);
-        let result = transform_blank_lines(tokens_with_locations);
+        let tokenss = crate::txxt::lexer::tokenize(source);
+        let result = transform_blank_lines(tokenss);
 
         // Find the BlankLine token
         let blank_line_pos = result

--- a/src/txxt/lexer/transformations/transform_indentation.rs
+++ b/src/txxt/lexer/transformations/transform_indentation.rs
@@ -708,11 +708,12 @@ mod tests {
     fn test_indent_level_tokens_have_correct_locations() {
         // Test: IndentLevel tokens should have locations that correspond to the Indent tokens they represent
         // Input: "a\n    b" (a, newline, 4 spaces, b)
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1), // "a" at position 0-1
-            (Token::Newline, 1..2),               // "\n" at position 1-2
-            (Token::Indent, 2..6),                // "    " (4 spaces) at position 2-6
-            (Token::Text("b".to_string()), 6..7), // "b" at position 6-7
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1), // "a" at position 0-1
+            mk_token(Token::Newline, 1, 2),               // "\n" at position 1-2
+            mk_token(Token::Indent, 2, 6),                // "    " (4 spaces) at position 2-6
+            mk_token(Token::Text("b".to_string()), 6, 7), // "b" at position 6-7
         ];
 
         let result: Vec<(Token, std::ops::Range<usize>)> = transform_indentation(input);
@@ -746,12 +747,13 @@ mod tests {
     fn test_multiple_indent_levels_have_correct_locations() {
         // Test: Multiple IndentLevel tokens should each have locations of their respective Indent tokens
         // Input: "a\n        b" (a, newline, 8 spaces = 2 indent levels, b)
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),   // "a"
-            (Token::Newline, 1..2),                 // "\n"
-            (Token::Indent, 2..6),                  // first 4 spaces (indent level 1)
-            (Token::Indent, 6..10),                 // second 4 spaces (indent level 2)
-            (Token::Text("b".to_string()), 10..11), // "b"
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),   // "a"
+            mk_token(Token::Newline, 1, 2),                 // "\n"
+            mk_token(Token::Indent, 2, 6),                  // first 4 spaces (indent level 1)
+            mk_token(Token::Indent, 6, 10),                 // second 4 spaces (indent level 2)
+            mk_token(Token::Text("b".to_string()), 10, 11), // "b"
         ];
 
         let result: Vec<(Token, std::ops::Range<usize>)> = transform_indentation(input);
@@ -776,13 +778,14 @@ mod tests {
     fn test_dedent_level_tokens_have_correct_locations() {
         // Test: DedentLevel tokens should have locations at the position where dedentation occurs
         // Input: "a\n    b\nc" (a, newline, 4 spaces, b, newline, c)
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1), // "a"
-            (Token::Newline, 1..2),               // "\n"
-            (Token::Indent, 2..6),                // "    "
-            (Token::Text("b".to_string()), 6..7), // "b"
-            (Token::Newline, 7..8),               // "\n"
-            (Token::Text("c".to_string()), 8..9), // "c" (dedented back to level 0)
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1), // "a"
+            mk_token(Token::Newline, 1, 2),               // "\n"
+            mk_token(Token::Indent, 2, 6),                // "    "
+            mk_token(Token::Text("b".to_string()), 6, 7), // "b"
+            mk_token(Token::Newline, 7, 8),               // "\n"
+            mk_token(Token::Text("c".to_string()), 8, 9), // "c" (dedented back to level 0)
         ];
 
         let result: Vec<(Token, std::ops::Range<usize>)> = transform_indentation(input);
@@ -802,14 +805,15 @@ mod tests {
     fn test_multiple_dedent_levels_have_correct_locations() {
         // Test: Multiple DedentLevel tokens should all have the same location (position of dedentation)
         // Input: "a\n        b\nc" (2 levels in, then 2 levels out)
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Indent, 2..6),
-            (Token::Indent, 6..10),
-            (Token::Text("b".to_string()), 10..11),
-            (Token::Newline, 11..12),
-            (Token::Text("c".to_string()), 12..13), // Back to level 0
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Indent, 2, 6),
+            mk_token(Token::Indent, 6, 10),
+            mk_token(Token::Text("b".to_string()), 10, 11),
+            mk_token(Token::Newline, 11, 12),
+            mk_token(Token::Text("c".to_string()), 12, 13), // Back to level 0
         ];
 
         let result: Vec<(Token, std::ops::Range<usize>)> = transform_indentation(input);
@@ -836,11 +840,12 @@ mod tests {
     fn test_eof_dedent_uses_correct_location() {
         // Test: DedentLevel tokens at end of file should use the EOF position
         // Input: "a\n    b" (ends while indented)
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Indent, 2..6),
-            (Token::Text("b".to_string()), 6..7),
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Indent, 2, 6),
+            mk_token(Token::Text("b".to_string()), 6, 7),
         ];
 
         let result: Vec<(Token, std::ops::Range<usize>)> = transform_indentation(input);
@@ -902,12 +907,13 @@ mod tests {
     #[test]
     fn test_blank_lines_preserve_location_tracking() {
         // Test that blank lines don't break location tracking for indentation
-        let input = vec![
-            (Token::Text("a".to_string()), 0..1),
-            (Token::Newline, 1..2),
-            (Token::Newline, 2..3), // Blank line (will be handled by blank_line_transform)
-            (Token::Indent, 3..7),
-            (Token::Text("b".to_string()), 7..8),
+        use crate::txxt::testing::factories::{mk_token, Tokens};
+        let input: Tokens = vec![
+            mk_token(Token::Text("a".to_string()), 0, 1),
+            mk_token(Token::Newline, 1, 2),
+            mk_token(Token::Newline, 2, 3), // Blank line (will be handled by blank_line_transform)
+            mk_token(Token::Indent, 3, 7),
+            mk_token(Token::Text("b".to_string()), 7, 8),
         ];
 
         let result: Vec<(Token, std::ops::Range<usize>)> = transform_indentation(input);

--- a/src/txxt/lexer/transformations/transform_indentation.rs
+++ b/src/txxt/lexer/transformations/transform_indentation.rs
@@ -68,13 +68,10 @@ fn count_line_indent_steps(tokens: &[Token], start: usize) -> usize {
 /// - IndentLevel: location covers the Indent tokens it represents
 /// - DedentLevel: location at the start of the line where dedentation occurs
 pub fn transform_indentation(
-    tokens_with_locations: Vec<(Token, std::ops::Range<usize>)>,
+    tokenss: Vec<(Token, std::ops::Range<usize>)>,
 ) -> Vec<(Token, std::ops::Range<usize>)> {
     // Extract just the tokens for processing
-    let tokens: Vec<Token> = tokens_with_locations
-        .iter()
-        .map(|(t, _)| t.clone())
-        .collect();
+    let tokens: Vec<Token> = tokenss.iter().map(|(t, _)| t.clone()).collect();
 
     let mut result = Vec::new();
     let mut current_level = 0;
@@ -98,7 +95,7 @@ pub fn transform_indentation(
             }
             if j < tokens.len() && matches!(tokens[j], Token::Newline) {
                 // Preserve the newline location
-                result.push((Token::Newline, tokens_with_locations[j].1.clone()));
+                result.push((Token::Newline, tokenss[j].1.clone()));
                 j += 1;
             }
             i = j;
@@ -115,17 +112,16 @@ pub fn transform_indentation(
                 let indent_start_idx = line_start;
                 for level_idx in 0..(target_level - current_level) {
                     let indent_token_idx = indent_start_idx + current_level + level_idx;
-                    if indent_token_idx < tokens_with_locations.len()
-                        && matches!(tokens_with_locations[indent_token_idx].0, Token::Indent)
+                    if indent_token_idx < tokenss.len()
+                        && matches!(tokenss[indent_token_idx].0, Token::Indent)
                     {
                         // Use the location of the Indent token
-                        let location = tokens_with_locations[indent_token_idx].1.clone();
+                        let location = tokenss[indent_token_idx].1.clone();
                         result.push((Token::IndentLevel, location));
                     } else {
                         // Fallback: use the location of the first content token on this line
-                        let fallback_location = if line_start < tokens_with_locations.len() {
-                            tokens_with_locations[line_start].1.start
-                                ..tokens_with_locations[line_start].1.start
+                        let fallback_location = if line_start < tokenss.len() {
+                            tokenss[line_start].1.start..tokenss[line_start].1.start
                         } else {
                             0..0
                         };
@@ -136,14 +132,14 @@ pub fn transform_indentation(
             std::cmp::Ordering::Less => {
                 // DedentLevel tokens: use the location at the start of the new line (where dedent occurs)
                 // This represents the position where we "return" to a previous indentation level
-                let dedent_location = if line_start < tokens_with_locations.len() {
+                let dedent_location = if line_start < tokenss.len() {
                     // Point to the start of the first token on the new line
-                    let start = tokens_with_locations[line_start].1.start;
+                    let start = tokenss[line_start].1.start;
                     start..start
                 } else {
                     // End of file: use empty location at the end
-                    let end = if !tokens_with_locations.is_empty() {
-                        tokens_with_locations.last().unwrap().1.end
+                    let end = if !tokenss.is_empty() {
+                        tokenss.last().unwrap().1.end
                     } else {
                         0
                     };
@@ -172,13 +168,13 @@ pub fn transform_indentation(
 
         // Process the rest of the line, keeping all remaining tokens with locations
         while j < tokens.len() && !matches!(tokens[j], Token::Newline) {
-            result.push((tokens[j].clone(), tokens_with_locations[j].1.clone()));
+            result.push((tokens[j].clone(), tokenss[j].1.clone()));
             j += 1;
         }
 
         // Add the newline token if we haven't reached the end
         if j < tokens.len() && matches!(tokens[j], Token::Newline) {
-            result.push((Token::Newline, tokens_with_locations[j].1.clone()));
+            result.push((Token::Newline, tokenss[j].1.clone()));
             j += 1;
         }
 
@@ -187,8 +183,8 @@ pub fn transform_indentation(
 
     // Add dedents to close all remaining indentation levels
     // These occur at the end of file, so use the end position
-    let eof_location = if !tokens_with_locations.is_empty() {
-        let end = tokens_with_locations.last().unwrap().1.end;
+    let eof_location = if !tokenss.is_empty() {
+        let end = tokenss.last().unwrap().1.end;
         end..end
     } else {
         0..0
@@ -859,8 +855,8 @@ mod tests {
         //            13..20 "Subitem", 20..21 " ", 21..22 "A", 22..23 "\n",
         //            23..27 "    ", 27..28 "-", 28..29 " ", 29..36 "Subitem", 36..37 " ", 37..38 "B"
 
-        let tokens_with_locations = crate::txxt::lexer::tokenize(source);
-        let result = transform_indentation(tokens_with_locations);
+        let tokenss = crate::txxt::lexer::tokenize(source);
+        let result = transform_indentation(tokenss);
 
         // Find the IndentLevel token
         let indent_level_pos = result

--- a/src/txxt/lexer/transformations/transform_whitespace.rs
+++ b/src/txxt/lexer/transformations/transform_whitespace.rs
@@ -10,13 +10,13 @@ use crate::txxt::lexer::tokens::Token;
 
 /// Process whitespace remainders while preserving source locations
 pub fn process_whitespace_remainders(
-    tokens_with_locations: Vec<(Token, std::ops::Range<usize>)>,
+    tokenss: Vec<(Token, std::ops::Range<usize>)>,
 ) -> Vec<(Token, std::ops::Range<usize>)> {
     let mut result = Vec::new();
     let mut i = 0;
 
-    while i < tokens_with_locations.len() {
-        let (token, location) = &tokens_with_locations[i];
+    while i < tokenss.len() {
+        let (token, location) = &tokenss[i];
 
         match token {
             Token::Whitespace => {
@@ -25,7 +25,7 @@ pub fn process_whitespace_remainders(
                 let mut j = i;
 
                 // Count consecutive Indent tokens before this Whitespace
-                while j > 0 && matches!(tokens_with_locations[j - 1].0, Token::Indent) {
+                while j > 0 && matches!(tokenss[j - 1].0, Token::Indent) {
                     indent_count += 1;
                     j -= 1;
                 }
@@ -33,8 +33,8 @@ pub fn process_whitespace_remainders(
                 // If we have indentation and this whitespace is followed by text,
                 // skip this whitespace token (it will be considered part of the text)
                 if indent_count > 0
-                    && i + 1 < tokens_with_locations.len()
-                    && matches!(tokens_with_locations[i + 1].0, Token::Text(_))
+                    && i + 1 < tokenss.len()
+                    && matches!(tokenss[i + 1].0, Token::Text(_))
                 {
                     // Skip this whitespace token
                     i += 1;
@@ -62,9 +62,9 @@ mod tests {
     fn test_whitespace_remainders() {
         // Test case: 10 spaces should produce 2 Indent tokens (8 spaces)
         // and the remaining 2 spaces should be part of text content
-        let tokens_with_locations = crate::txxt::lexer::tokenize("          hello");
-        let result_with_locations = process_whitespace_remainders(tokens_with_locations);
-        let result: Vec<Token> = result_with_locations.into_iter().map(|(t, _)| t).collect();
+        let tokenss = crate::txxt::lexer::tokenize("          hello");
+        let results = process_whitespace_remainders(tokenss);
+        let result: Vec<Token> = results.into_iter().map(|(t, _)| t).collect();
         println!("Tokens for '          hello': {:?}", result);
 
         // According to spec: 10 spaces = 2 indent levels (8 spaces) + 2 remaining spaces
@@ -78,33 +78,33 @@ mod tests {
     #[test]
     fn test_whitespace_without_indentation() {
         // Whitespace not following indent should be preserved
-        let tokens_with_locations = vec![
+        let tokenss = vec![
             (Token::Text("hello".to_string()), 0..5),
             (Token::Whitespace, 5..6),
             (Token::Text("world".to_string()), 6..11),
         ];
-        let result = process_whitespace_remainders(tokens_with_locations.clone());
-        assert_eq!(result, tokens_with_locations);
+        let result = process_whitespace_remainders(tokenss.clone());
+        assert_eq!(result, tokenss);
     }
 
     #[test]
     fn test_whitespace_after_indent_before_non_text() {
         // Whitespace after indent but before non-text token should be preserved
-        let tokens_with_locations = vec![
+        let tokenss = vec![
             (Token::Indent, 0..4),
             (Token::Whitespace, 4..5),
             (Token::Dash, 5..6),
         ];
-        let result = process_whitespace_remainders(tokens_with_locations.clone());
-        assert_eq!(result, tokens_with_locations);
+        let result = process_whitespace_remainders(tokenss.clone());
+        assert_eq!(result, tokenss);
     }
 
     #[test]
     fn test_multiple_whitespace_remainders() {
         // Test with multiple indent levels and remainder spaces
-        let tokens_with_locations = crate::txxt::lexer::tokenize("            hello");
-        let result_with_locations = process_whitespace_remainders(tokens_with_locations);
-        let result: Vec<Token> = result_with_locations.into_iter().map(|(t, _)| t).collect();
+        let tokenss = crate::txxt::lexer::tokenize("            hello");
+        let results = process_whitespace_remainders(tokenss);
+        let result: Vec<Token> = results.into_iter().map(|(t, _)| t).collect();
 
         // 12 spaces = 3 indent levels (no remainder)
         assert_eq!(result[0], Token::Indent);

--- a/src/txxt/lexer/transformations/transform_whitespace.rs
+++ b/src/txxt/lexer/transformations/transform_whitespace.rs
@@ -8,61 +8,8 @@
 
 use crate::txxt::lexer::tokens::Token;
 
-/// Process whitespace remainders according to txxt specification
-///
-/// The spec states: "lines that have space remainders (as in 10 spaces, which converts to
-/// 2 tab stops with 2 spaces remaining) will be parsed with no error. Only two indentation
-/// level tokens will be generated, and the remaining whitespaces will be considered part of the text."
-///
-/// This function removes Whitespace tokens that follow Indent tokens and precede Text tokens,
-/// effectively merging the whitespace remainder into the text content.
-pub fn process_whitespace_remainders(
-    tokens_with_locations: Vec<(Token, logos::Span)>,
-) -> Vec<Token> {
-    let mut result = Vec::new();
-    let mut i = 0;
-
-    while i < tokens_with_locations.len() {
-        let (token, _location) = &tokens_with_locations[i];
-
-        match token {
-            Token::Whitespace => {
-                // Check if this whitespace follows indentation tokens and precedes text content
-                let mut indent_count = 0;
-                let mut j = i;
-
-                // Count consecutive Indent tokens before this Whitespace
-                while j > 0 && matches!(tokens_with_locations[j - 1].0, Token::Indent) {
-                    indent_count += 1;
-                    j -= 1;
-                }
-
-                // If we have indentation and this whitespace is followed by text,
-                // skip this whitespace token (it will be considered part of the text)
-                if indent_count > 0
-                    && i + 1 < tokens_with_locations.len()
-                    && matches!(tokens_with_locations[i + 1].0, Token::Text(_))
-                {
-                    // Skip this whitespace token
-                    i += 1;
-                    continue;
-                }
-
-                // Otherwise, keep the whitespace token as-is
-                result.push(token.clone());
-            }
-            _ => {
-                result.push(token.clone());
-            }
-        }
-        i += 1;
-    }
-
-    result
-}
-
 /// Process whitespace remainders while preserving source locations
-pub fn process_whitespace_remainders_with_locations(
+pub fn process_whitespace_remainders(
     tokens_with_locations: Vec<(Token, std::ops::Range<usize>)>,
 ) -> Vec<(Token, std::ops::Range<usize>)> {
     let mut result = Vec::new();
@@ -115,8 +62,9 @@ mod tests {
     fn test_whitespace_remainders() {
         // Test case: 10 spaces should produce 2 Indent tokens (8 spaces)
         // and the remaining 2 spaces should be part of text content
-        let tokens_with_locations = crate::txxt::lexer::tokenize_with_locations("          hello");
-        let result = process_whitespace_remainders(tokens_with_locations);
+        let tokens_with_locations = crate::txxt::lexer::tokenize("          hello");
+        let result_with_locations = process_whitespace_remainders(tokens_with_locations);
+        let result: Vec<Token> = result_with_locations.into_iter().map(|(t, _)| t).collect();
         println!("Tokens for '          hello': {:?}", result);
 
         // According to spec: 10 spaces = 2 indent levels (8 spaces) + 2 remaining spaces
@@ -135,7 +83,7 @@ mod tests {
             (Token::Whitespace, 5..6),
             (Token::Text("world".to_string()), 6..11),
         ];
-        let result = process_whitespace_remainders_with_locations(tokens_with_locations.clone());
+        let result = process_whitespace_remainders(tokens_with_locations.clone());
         assert_eq!(result, tokens_with_locations);
     }
 
@@ -147,16 +95,16 @@ mod tests {
             (Token::Whitespace, 4..5),
             (Token::Dash, 5..6),
         ];
-        let result = process_whitespace_remainders_with_locations(tokens_with_locations.clone());
+        let result = process_whitespace_remainders(tokens_with_locations.clone());
         assert_eq!(result, tokens_with_locations);
     }
 
     #[test]
     fn test_multiple_whitespace_remainders() {
         // Test with multiple indent levels and remainder spaces
-        let tokens_with_locations =
-            crate::txxt::lexer::tokenize_with_locations("            hello");
-        let result = process_whitespace_remainders(tokens_with_locations);
+        let tokens_with_locations = crate::txxt::lexer::tokenize("            hello");
+        let result_with_locations = process_whitespace_remainders(tokens_with_locations);
+        let result: Vec<Token> = result_with_locations.into_iter().map(|(t, _)| t).collect();
 
         // 12 spaces = 3 indent levels (no remainder)
         assert_eq!(result[0], Token::Indent);

--- a/src/txxt/parser.rs
+++ b/src/txxt/parser.rs
@@ -34,6 +34,6 @@ type ParseResult = Result<
 /// Main parser function that takes source text and returns a parsed document
 /// This is the primary entry point for parsing txxt documents
 pub fn parse_document(source: &str) -> ParseResult {
-    let tokens_with_locations = crate::txxt::lexer::lex_with_locations(source);
+    let tokens_with_locations = crate::txxt::lexer::lex(source);
     parse_with_source(tokens_with_locations, source)
 }

--- a/src/txxt/parser.rs
+++ b/src/txxt/parser.rs
@@ -34,6 +34,6 @@ type ParseResult = Result<
 /// Main parser function that takes source text and returns a parsed document
 /// This is the primary entry point for parsing txxt documents
 pub fn parse_document(source: &str) -> ParseResult {
-    let tokens_with_locations = crate::txxt::lexer::lex(source);
-    parse_with_source(tokens_with_locations, source)
+    let tokenss = crate::txxt::lexer::lex(source);
+    parse_with_source(tokenss, source)
 }

--- a/src/txxt/parser/api.rs
+++ b/src/txxt/parser/api.rs
@@ -17,9 +17,18 @@ type ParserError = Simple<TokenLocation>;
 ///
 /// Parses tokens with location information and source text to produce a Document.
 /// All parsed documents include complete location information automatically.
-pub fn parse_with_source(
-    tokenss: Vec<TokenLocation>,
+pub fn parse(
+    tokens_with_locations: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    document(source).parse(tokenss)
+    document(source).parse(tokens_with_locations)
+}
+
+/// Backward-compatibility shim: prefer `parse`
+#[allow(dead_code)]
+pub fn parse_with_source(
+    tokens_with_locations: Vec<TokenLocation>,
+    source: &str,
+) -> Result<Document, Vec<ParserError>> {
+    parse(tokens_with_locations, source)
 }

--- a/src/txxt/parser/api.rs
+++ b/src/txxt/parser/api.rs
@@ -17,18 +17,15 @@ type ParserError = Simple<TokenLocation>;
 ///
 /// Parses tokens with location information and source text to produce a Document.
 /// All parsed documents include complete location information automatically.
-pub fn parse(
-    tokens_with_locations: Vec<TokenLocation>,
-    source: &str,
-) -> Result<Document, Vec<ParserError>> {
-    document(source).parse(tokens_with_locations)
+pub fn parse(tokens: Vec<TokenLocation>, source: &str) -> Result<Document, Vec<ParserError>> {
+    document(source).parse(tokens)
 }
 
 /// Backward-compatibility shim: prefer `parse`
 #[allow(dead_code)]
 pub fn parse_with_source(
-    tokens_with_locations: Vec<TokenLocation>,
+    tokens: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    parse(tokens_with_locations, source)
+    parse(tokens, source)
 }

--- a/src/txxt/parser/api.rs
+++ b/src/txxt/parser/api.rs
@@ -18,8 +18,8 @@ type ParserError = Simple<TokenLocation>;
 /// Parses tokens with location information and source text to produce a Document.
 /// All parsed documents include complete location information automatically.
 pub fn parse_with_source(
-    tokens_with_locations: Vec<TokenLocation>,
+    tokenss: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    document(source).parse(tokens_with_locations)
+    document(source).parse(tokenss)
 }

--- a/src/txxt/parser/combinators.rs
+++ b/src/txxt/parser/combinators.rs
@@ -144,9 +144,9 @@ pub(crate) fn text_line(
     filter(|(t, _location): &TokenLocation| is_text_token(t))
         .repeated()
         .at_least(1)
-        .map(|tokens_with_locations: Vec<TokenLocation>| {
+        .map(|tokenss: Vec<TokenLocation>| {
             // Collect all locations for this line
-            tokens_with_locations.into_iter().map(|(_, s)| s).collect()
+            tokenss.into_iter().map(|(_, s)| s).collect()
         })
 }
 

--- a/src/txxt/parser/elements/annotations.rs
+++ b/src/txxt/parser/elements/annotations.rs
@@ -60,7 +60,7 @@ pub(crate) fn annotation_header(
             }
         }
 
-        let params_with_locations = parse_parameters_from_tokens(&tokens[i..]);
+        let paramss = parse_parameters_from_tokens(&tokens[i..]);
 
         let header_range_start = tokens.first().map(|(_, span)| span.start).unwrap_or(0);
         let header_range_end = tokens
@@ -80,7 +80,7 @@ pub(crate) fn annotation_header(
         });
 
         // Convert parameters to final types
-        let params = params_with_locations
+        let params = paramss
             .into_iter()
             .map(|p| convert_parameter(&source, p))
             .collect();

--- a/src/txxt/parser/elements/annotations.rs
+++ b/src/txxt/parser/elements/annotations.rs
@@ -212,14 +212,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::parser::api::parse_with_source;
     use crate::txxt::processor::txxt_sources::TxxtSources;
 
     #[test]
     fn test_annotation_marker_minimal() {
         let source = "Para one. {{paragraph}}\n\n:: note ::\n\nPara two. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 3); // paragraph, annotation, paragraph
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn test_annotation_single_line() {
         let source = "Para one. {{paragraph}}\n\n:: note :: This is inline text\n\nPara two. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 3); // paragraph, annotation, paragraph
@@ -243,7 +243,7 @@ mod tests {
     fn test_verified_annotations_simple() {
         let source = TxxtSources::get_string("120-annotations-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Verify document parses successfully and contains expected structure
@@ -303,7 +303,7 @@ mod tests {
     fn test_verified_annotations_block_content() {
         let source = TxxtSources::get_string("130-annotations-block-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find and verify :: note author="Jane Doe" :: annotation with block content

--- a/src/txxt/parser/elements/annotations.rs
+++ b/src/txxt/parser/elements/annotations.rs
@@ -131,7 +131,7 @@ where
                 let label_location = label_range.map_or(Location::default(), |s| {
                     byte_range_to_location(&source_for_block, &s)
                 });
-                let label = Label::new(label_text).with_location(label_location);
+                let label = Label::new(label_text).at(label_location);
 
                 let header_location = byte_range_to_location(&source_for_block, &header_range);
 
@@ -172,7 +172,7 @@ where
                 let label_location = label_range.map_or(Location::default(), |s| {
                     byte_range_to_location(&source_for_single_line, &s)
                 });
-                let label = Label::new(label_text).with_location(label_location);
+                let label = Label::new(label_text).at(label_location);
 
                 // Handle content if present and compute paragraph location
                 let (content, paragraph_location) = if let Some(locations) = content_location {

--- a/src/txxt/parser/elements/definitions.rs
+++ b/src/txxt/parser/elements/definitions.rs
@@ -28,9 +28,7 @@ pub(crate) fn definition_subject(
     filter(|(t, _location): &TokenLocation| !matches!(t, Token::Colon | Token::Newline))
         .repeated()
         .at_least(1)
-        .map(move |tokens_with_locations| {
-            extract_tokens_to_text_and_location(&source, tokens_with_locations)
-        })
+        .map(move |tokenss| extract_tokens_to_text_and_location(&source, tokenss))
         .then_ignore(filter(|(t, _): &TokenLocation| matches!(t, Token::Colon)).ignored())
         .then_ignore(filter(|(t, _): &TokenLocation| matches!(t, Token::Newline)).ignored())
 }

--- a/src/txxt/parser/elements/definitions.rs
+++ b/src/txxt/parser/elements/definitions.rs
@@ -69,7 +69,7 @@ where
 mod tests {
     use crate::txxt::ast::Container;
     use crate::txxt::ast::ContentItem;
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::parser::api::parse_with_source;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
@@ -78,7 +78,7 @@ mod tests {
     fn test_unified_recursive_parser_simple() {
         // Minimal test for the unified recursive parser
         let source = "First paragraph\n\nDefinition:\n    Content of definition\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         println!("Testing simple definition with unified parser:");
         println!("Source: {:?}", source);
 
@@ -99,7 +99,7 @@ mod tests {
     fn test_unified_recursive_nested_definitions() {
         // Test nested definitions with the unified parser
         let source = "Outer:\n    Inner:\n        Nested content\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         println!("Testing nested definitions with unified parser:");
         println!("Source: {:?}", source);
 
@@ -150,7 +150,7 @@ mod tests {
     fn test_unified_parser_paragraph_then_definition() {
         // Test paragraph followed by definition - similar to failing test
         let source = "Simple paragraph\n\nAnother paragraph\n\nFirst Definition:\n    Definition content\n\nSecond Definition:\n    More content\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         println!("Testing paragraph then definition:");
         println!("Source: {:?}", source);
 
@@ -186,7 +186,7 @@ mod tests {
     fn test_verified_definitions_simple() {
         let source = TxxtSources::get_string("090-definitions-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
 
         // Debug: print first few tokens
         println!("First 10 tokens:");
@@ -290,7 +290,7 @@ mod tests {
     fn test_verified_definitions_mixed_content() {
         let source = TxxtSources::get_string("100-definitions-mixed-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs

--- a/src/txxt/parser/elements/foreign.rs
+++ b/src/txxt/parser/elements/foreign.rs
@@ -156,14 +156,14 @@ pub(crate) fn foreign_block(
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::parser::api::parse_with_source;
     use crate::txxt::processor::txxt_sources::TxxtSources;
 
     #[test]
     fn test_foreign_block_simple_with_content() {
         let source = "Code Example:\n    function hello() {\n        return \"world\";\n    }\n:: javascript caption=\"Hello World\" ::\n\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         println!("Tokens: {:?}", tokens);
         let doc = parse_with_source(tokens, source).unwrap();
 
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn test_foreign_block_marker_form() {
         let source = "Image Reference:\n\n:: image type=jpg, src=sunset.jpg :: As the sun sets, we see a colored sea bed.\n\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 1);
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn test_foreign_block_preserves_whitespace() {
         let source = "Indented Code:\n\n    // This has    multiple    spaces\n    const regex = /[a-z]+/g;\n    \n    console.log(\"Hello, World!\");\n\n:: javascript ::\n\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let foreign_block = doc.root.content[0].as_foreign_block().unwrap();
@@ -235,7 +235,7 @@ mod tests {
         // trying them first resolves the ambiguity
 
         let source = "First Block:\n\n    code1\n\n:: lang1 ::\n\nSecond Block:\n\n    code2\n\n:: lang2 ::\n\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 2);
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn test_foreign_block_with_paragraphs() {
         let source = "Intro paragraph.\n\nCode Block:\n\n    function test() {\n        return true;\n    }\n\n:: javascript ::\n\nOutro paragraph.\n\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 3);
@@ -267,7 +267,7 @@ mod tests {
     fn test_verified_foreign_blocks_simple() {
         let source = TxxtSources::get_string("140-foreign-blocks-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find JavaScript code block
@@ -325,7 +325,7 @@ mod tests {
     fn test_verified_foreign_blocks_no_content() {
         let source = TxxtSources::get_string("150-foreign-blocks-no-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find image reference

--- a/src/txxt/parser/elements/foreign.rs
+++ b/src/txxt/parser/elements/foreign.rs
@@ -82,7 +82,7 @@ pub(crate) fn foreign_block(
             let label_location = label_range.map_or(Location::default(), |range| {
                 byte_range_to_location(&source_for_annotation, &range)
             });
-            let label = Label::new(label_text).with_location(label_location);
+            let label = Label::new(label_text).at(label_location);
 
             let (content, paragraph_location) = if let Some(locations) = content_location {
                 let text = extract_text_from_locations(&source_for_annotation, &locations);

--- a/src/txxt/parser/elements/labels.rs
+++ b/src/txxt/parser/elements/labels.rs
@@ -112,13 +112,13 @@ pub(crate) fn parse_label_from_tokens(tokens: &[TokenLocation]) -> (Option<Range
 #[cfg(test)]
 mod tests {
 
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::parser::parse_with_source;
 
     #[test]
     fn test_annotation_with_label_only() {
         let source = ":: note ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn test_annotation_with_label_and_parameters() {
         let source = ":: warning severity=high ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_annotation_with_dotted_label() {
         let source = ":: python.typing ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn test_annotation_parameters_only_no_label() {
         let source = ":: version=3.11 ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn test_annotation_with_dashed_label() {
         let source = ":: code-review ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();

--- a/src/txxt/parser/elements/lists.rs
+++ b/src/txxt/parser/elements/lists.rs
@@ -105,7 +105,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::parser::api::parse_with_source;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
@@ -114,7 +114,7 @@ mod tests {
     fn test_simplest_dash_list() {
         // Simplest possible list: 2 dashed items
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Find the first list (after "Plain dash lists:" paragraph)
@@ -144,7 +144,7 @@ mod tests {
     fn test_numbered_list() {
         // Test numbered list: "1. ", "2. ", "3. "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Numerical lists (item 5)
@@ -167,7 +167,7 @@ mod tests {
     fn test_alphabetical_list() {
         // Test alphabetical list: "a. ", "b. ", "c. "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Alphabetical lists (item 7)
@@ -190,7 +190,7 @@ mod tests {
     fn test_mixed_decoration_list() {
         // Test mixed decorations: different markers in same list
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Mixed decoration lists (item 9)
@@ -213,7 +213,7 @@ mod tests {
     fn test_parenthetical_list() {
         // Test parenthetical numbering: "(1) ", "(2) ", "(3) "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Parenthetical numbering (item 11)
@@ -236,7 +236,7 @@ mod tests {
     fn test_paragraph_list_disambiguation() {
         // Critical test: single list-like line becomes paragraph, 2+ with blank line become list
         let source = TxxtSources::get_string("050-paragraph-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Items 2-4: Single list-item-lines merged into paragraphs
@@ -267,7 +267,7 @@ mod tests {
     fn test_verified_lists_document() {
         // Full document test with lists from TxxtSources
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Verify document structure: paragraphs + lists alternating
@@ -304,7 +304,7 @@ mod tests {
         // Critical test: Lists MUST have a preceding blank line for disambiguation
         // Without the blank line, consecutive list-item-lines should be parsed as paragraphs
         let source = "First paragraph\n- Item one\n- Item two\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         // Should be parsed as a single paragraph, NOT a paragraph + list
@@ -323,7 +323,7 @@ mod tests {
 
         // Now test the positive case: with blank line, it becomes separate items
         let source_with_blank = "First paragraph\n\n- Item one\n- Item two\n";
-        let tokens2 = lex_with_locations(source_with_blank);
+        let tokens2 = lex(source_with_blank);
         let doc2 = parse_with_source(tokens2, source_with_blank).unwrap();
 
         // Should be parsed as paragraph + list
@@ -352,7 +352,7 @@ mod tests {
     fn test_verified_nested_lists_simple() {
         let source = TxxtSources::get_string("070-nested-lists-simple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -436,7 +436,7 @@ mod tests {
     fn test_verified_nested_lists_mixed_content() {
         let source = TxxtSources::get_string("080-nested-lists-mixed-content.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs

--- a/src/txxt/parser/elements/lists.rs
+++ b/src/txxt/parser/elements/lists.rs
@@ -59,9 +59,7 @@ pub(crate) fn list_item_line(
     dash_pattern
         .or(ordered_pattern)
         .or(paren_pattern)
-        .map(move |tokens_with_locations| {
-            extract_tokens_to_text_and_location(&source, tokens_with_locations)
-        })
+        .map(move |tokenss| extract_tokens_to_text_and_location(&source, tokenss))
 }
 
 /// Build a list parser

--- a/src/txxt/parser/elements/lists.rs
+++ b/src/txxt/parser/elements/lists.rs
@@ -86,7 +86,7 @@ where
 
             let location = aggregate_locations(line_location, &content);
 
-            ListItem::with_text_content(text_content, content).with_location(location)
+            ListItem::with_text_content(text_content, content).at(location)
         });
 
     single_list_item.repeated().at_least(2).map(|items| {

--- a/src/txxt/parser/elements/parameters.rs
+++ b/src/txxt/parser/elements/parameters.rs
@@ -201,13 +201,13 @@ pub(crate) fn parse_parameters_from_tokens(
 
 #[cfg(test)]
 mod tests {
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::parser::parse_with_source;
 
     #[test]
     fn test_annotation_comma_separated_parameters() {
         let source = ":: warning severity=high,priority=urgent ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -223,7 +223,7 @@ mod tests {
     fn test_annotation_quoted_string_values() {
         let source =
             ":: note author=\"Jane Doe\" title=\"Important Note\" ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_annotation_mixed_separators_and_quotes() {
         let source = ":: task priority=high,status=\"in progress\",assigned=alice ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -255,7 +255,7 @@ mod tests {
     fn test_annotation_whitespace_around_commas() {
         // Test that whitespace around commas is properly ignored
         let source = ":: note key1=val1 , key2=val2 , key3=val3 ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn test_annotation_with_only_keyed_parameters() {
         let source = ":: warning priority=urgent ::\n\nText. {{paragraph}}\n";
-        let tokens = lex_with_locations(source);
+        let tokens = lex(source);
         let doc = parse_with_source(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();

--- a/src/txxt/parser/elements/sessions.rs
+++ b/src/txxt/parser/elements/sessions.rs
@@ -68,7 +68,7 @@ where
 mod tests {
     use crate::txxt::ast::Container;
     use crate::txxt::ast::ContentItem;
-    use crate::txxt::lexer::{lex, lex_with_locations, Token};
+    use crate::txxt::lexer::{lex, Token};
     use crate::txxt::parser::api::parse_with_source;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
@@ -90,7 +90,7 @@ mod tests {
         println!("Input: {:?}", input);
         println!("Tokens: {:?}", tokens);
 
-        let tokens_with_locations = lex_with_locations(input);
+        let tokens_with_locations = lex(input);
         let result = parse_with_source(tokens_with_locations, input);
 
         match &result {
@@ -210,7 +210,7 @@ mod tests {
     fn test_verified_single_session_sample() {
         let source = TxxtSources::get_string("010-paragraphs-sessions-flat-single.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
 
         let result = parse_with_source(tokens, &source);
         assert!(
@@ -267,7 +267,7 @@ mod tests {
     fn test_verified_multiple_sessions_sample() {
         let source = TxxtSources::get_string("020-paragraphs-sessions-flat-multiple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
 
         let result = parse_with_source(tokens, &source);
         assert!(
@@ -343,7 +343,7 @@ mod tests {
     fn test_verified_nested_sessions_sample() {
         let source = TxxtSources::get_string("030-paragraphs-sessions-nested-multiple.txxt")
             .expect("Failed to load sample file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
 
         let result = parse_with_source(tokens, &source);
         assert!(

--- a/src/txxt/parser/elements/sessions.rs
+++ b/src/txxt/parser/elements/sessions.rs
@@ -90,8 +90,8 @@ mod tests {
         println!("Input: {:?}", input);
         println!("Tokens: {:?}", tokens);
 
-        let tokens_with_locations = lex(input);
-        let result = parse_with_source(tokens_with_locations, input);
+        let tokenss = lex(input);
+        let result = parse_with_source(tokenss, input);
 
         match &result {
             Ok(doc) => {
@@ -134,8 +134,8 @@ mod tests {
         println!("\n=== Test: Session with empty content ===");
         println!("Tokens: {:?}", tokens);
 
-        let tokens_with_locations: Vec<_> = tokens.into_iter().map(|t| (t, 0..0)).collect();
-        let result = parse_with_source(tokens_with_locations, "");
+        let tokenss: Vec<_> = tokens.into_iter().map(|t| (t, 0..0)).collect();
+        let result = parse_with_source(tokenss, "");
 
         match &result {
             Ok(doc) => {

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -112,19 +112,16 @@ pub fn document() -> impl Parser<TokenLocation, Document, Error = ParserError> {
 /// All parsed documents include complete location information automatically.
 ///
 /// Re-exports the canonical implementation from api.rs
-pub fn parse(
-    tokens_with_locations: Vec<TokenLocation>,
-    source: &str,
-) -> Result<Document, Vec<ParserError>> {
-    super::api::parse(tokens_with_locations, source)
+pub fn parse(tokens: Vec<TokenLocation>, source: &str) -> Result<Document, Vec<ParserError>> {
+    super::api::parse(tokens, source)
 }
 
 /// Backward-compatibility shim
 pub fn parse_with_source(
-    tokens_with_locations: Vec<TokenLocation>,
+    tokens: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    parse(tokens_with_locations, source)
+    parse(tokens, source)
 }
 
 #[cfg(test)]

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -112,11 +112,19 @@ pub fn document() -> impl Parser<TokenLocation, Document, Error = ParserError> {
 /// All parsed documents include complete location information automatically.
 ///
 /// Re-exports the canonical implementation from api.rs
-pub fn parse_with_source(
-    tokenss: Vec<TokenLocation>,
+pub fn parse(
+    tokens_with_locations: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    super::api::parse_with_source(tokenss, source)
+    super::api::parse(tokens_with_locations, source)
+}
+
+/// Backward-compatibility shim
+pub fn parse_with_source(
+    tokens_with_locations: Vec<TokenLocation>,
+    source: &str,
+) -> Result<Document, Vec<ParserError>> {
+    parse(tokens_with_locations, source)
 }
 
 #[cfg(test)]

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -99,6 +99,9 @@ use super::elements::document as document_module;
 
 /// Parse a document - delegated to document module
 /// Phase 5: The document parser requires source text to populate location information
+#[deprecated(
+    note = "Use elements::document(source) + parse(tokens, source) for location-aware parsing"
+)]
 pub fn document() -> impl Parser<TokenLocation, Document, Error = ParserError> {
     // This function is kept for backward compatibility but delegates to document_module::document(source)
     // Since this function doesn't have access to source, it uses an empty string.

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -123,14 +123,14 @@ pub fn parse_with_source(
 mod tests {
     use super::*;
     use crate::txxt::ast::{AstNode, Position};
-    use crate::txxt::lexer::lex_with_locations;
+    use crate::txxt::lexer::lex;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use std::sync::Arc;
 
     #[test]
     fn test_simple_paragraph() {
         let input = "Hello world\n\n";
-        let tokens_with_locations = lex_with_locations(input);
+        let tokens_with_locations = lex(input);
 
         let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_locations);
         assert!(result.is_ok(), "Failed to parse paragraph: {:?}", result);
@@ -191,7 +191,7 @@ mod tests {
         use crate::txxt::testing::assert_ast;
 
         let source = TxxtSources::get_string("050-trifecta-flat-simple.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -285,7 +285,7 @@ mod tests {
         use crate::txxt::testing::assert_ast;
 
         let source = TxxtSources::get_string("060-trifecta-nesting.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -401,7 +401,7 @@ mod tests {
         use crate::txxt::testing::assert_ast;
 
         let source = TxxtSources::get_string("110-ensemble-with-definitions.txxt").unwrap();
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
@@ -456,7 +456,7 @@ mod tests {
             "docs/specs/v1/regression-bugs/parser-definition-list-transition.txxt",
         )
         .expect("Failed to load regression test file");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
 
         // This should parse successfully but currently fails with:
         // Parse error at location 14..15: reason=Unexpected, found=Some((Newline, 34..35))
@@ -480,7 +480,7 @@ mod tests {
     #[test]
     fn test_parse_with_source_simple() {
         let input = "Hello world\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         assert_eq!(doc.root.content.len(), 1);
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn test_parse_with_source_multiline() {
         let input = "First line\nSecond line\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         assert_eq!(doc.root.content.len(), 1);
@@ -513,7 +513,7 @@ mod tests {
     #[test]
     fn test_element_at_query_on_parsed_document() {
         let input = "First paragraph\n\n2. Session Title\n\n    Session content\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // Query for the session (should be at line 2)
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_element_at_nested_position() {
         let input = "Title\n\n1. Item one\n\n    Nested content\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // The document should have at least a paragraph and possibly a list
@@ -546,7 +546,7 @@ mod tests {
     #[test]
     fn test_position_comparison_in_query() {
         let input = "Line 0\n\nLine 2\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         // Get all items
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn test_backward_compatibility_without_positions() {
         let input = "Simple paragraph\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
 
         // Old parser should still work (without positions)
         let doc_old =
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn test_location_boundary_containment() {
         let input = "0123456789\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         let para = doc.root.content[0].as_paragraph().unwrap();
@@ -632,7 +632,7 @@ mod tests {
     fn test_nested_paragraph_has_location() {
         // Test that nested paragraphs inside sessions have location information
         let input = "Title\n\n1. Session Title\n\n    Nested paragraph\n\n";
-        let tokens = lex_with_locations(input);
+        let tokens = lex(input);
         let doc = parse_with_source(tokens, input).expect("Failed to parse with positions");
 
         assert!(doc.root.content.len() >= 2);
@@ -677,7 +677,7 @@ mod tests {
     fn test_location_tracking_for_core_elements() {
         let source = TxxtSources::get_string("110-ensemble-with-definitions.txxt")
             .expect("Failed to load ensemble sample");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).expect("Failed to parse ensemble sample");
 
         // Document doesn't have its own location; location comes from root
@@ -755,7 +755,7 @@ mod tests {
     fn test_location_tracking_for_annotations() {
         let source = TxxtSources::get_string("120-annotations-simple.txxt")
             .expect("Failed to load annotations sample");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc = parse_with_source(tokens, &source).expect("Failed to parse annotations sample");
 
         let annotations: Vec<_> = doc
@@ -780,7 +780,7 @@ mod tests {
     fn test_location_tracking_for_foreign_blocks() {
         let source = TxxtSources::get_string("140-foreign-blocks-simple.txxt")
             .expect("Failed to load foreign blocks sample");
-        let tokens = lex_with_locations(&source);
+        let tokens = lex(&source);
         let doc =
             parse_with_source(tokens, &source).expect("Failed to parse foreign blocks sample");
 

--- a/src/txxt/parser/parser.rs
+++ b/src/txxt/parser/parser.rs
@@ -113,10 +113,10 @@ pub fn document() -> impl Parser<TokenLocation, Document, Error = ParserError> {
 ///
 /// Re-exports the canonical implementation from api.rs
 pub fn parse_with_source(
-    tokens_with_locations: Vec<TokenLocation>,
+    tokenss: Vec<TokenLocation>,
     source: &str,
 ) -> Result<Document, Vec<ParserError>> {
-    super::api::parse_with_source(tokens_with_locations, source)
+    super::api::parse_with_source(tokenss, source)
 }
 
 #[cfg(test)]
@@ -130,9 +130,9 @@ mod tests {
     #[test]
     fn test_simple_paragraph() {
         let input = "Hello world\n\n";
-        let tokens_with_locations = lex(input);
+        let tokenss = lex(input);
 
-        let result = paragraph(Arc::new(input.to_string())).parse(tokens_with_locations);
+        let result = paragraph(Arc::new(input.to_string())).parse(tokenss);
         assert!(result.is_ok(), "Failed to parse paragraph: {:?}", result);
 
         let para = result.unwrap();

--- a/src/txxt/processor.rs
+++ b/src/txxt/processor.rs
@@ -200,33 +200,30 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
     match spec.stage {
         ProcessingStage::Token => {
             let tokens = lex(&content);
-            format_tokens(&tokens, &spec.format)
+            format_tokens_with_locations(&tokens, &spec.format)
         }
         ProcessingStage::Ast => {
             // Parse the document - all documents now include full location information
             let doc = if matches!(spec.format, OutputFormat::AstPosition) {
-                crate::txxt::parser::parse_with_source(
-                    crate::txxt::lexer::lex_with_locations(&content),
-                    &content,
-                )
-                .map_err(|errs| {
-                    let error_details = errs
-                        .iter()
-                        .map(|e| {
-                            format!(
-                                "  Parse error at span {:?}: reason={:?}, found={:?}",
-                                e.span(),
-                                e.reason(),
-                                e.found()
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    ProcessingError::IoError(format!(
-                        "Failed to parse document:\n{}",
-                        error_details
-                    ))
-                })?
+                crate::txxt::parser::parse_with_source(crate::txxt::lexer::lex(&content), &content)
+                    .map_err(|errs| {
+                        let error_details = errs
+                            .iter()
+                            .map(|e| {
+                                format!(
+                                    "  Parse error at span {:?}: reason={:?}, found={:?}",
+                                    e.span(),
+                                    e.reason(),
+                                    e.found()
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        ProcessingError::IoError(format!(
+                            "Failed to parse document:\n{}",
+                            error_details
+                        ))
+                    })?
             } else {
                 crate::txxt::parser::parse_document(&content).map_err(|errs| {
                     let error_details = errs
@@ -281,11 +278,14 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
 }
 
 /// Format tokens according to the specified format
-fn format_tokens(tokens: &[Token], format: &OutputFormat) -> Result<String, ProcessingError> {
+fn format_tokens_with_locations(
+    tokens: &[(Token, std::ops::Range<usize>)],
+    format: &OutputFormat,
+) -> Result<String, ProcessingError> {
     match format {
         OutputFormat::Simple | OutputFormat::RawSimple => {
             let mut result = String::new();
-            for token in tokens {
+            for (token, _) in tokens {
                 result.push_str(&format!("{}", token));
                 if matches!(token, Token::Newline) {
                     result.push('\n');
@@ -503,7 +503,7 @@ pub mod txxt_sources {
         let content = r#"First paragraph
 Second paragraph"#;
 
-        let tokens = crate::txxt::lexer::lex_with_locations(content);
+        let tokens = crate::txxt::lexer::lex(content);
         let doc = crate::txxt::parser::parse_with_source(tokens, content).unwrap();
 
         // Check if locations are populated
@@ -608,17 +608,17 @@ mod tests {
 
     #[test]
     fn test_token_formatting() {
-        let tokens = vec![
-            Token::Text("hello".to_string()),
-            Token::Whitespace,
-            Token::Text("world".to_string()),
-            Token::Newline,
+        let tokens: Vec<(Token, std::ops::Range<usize>)> = vec![
+            (Token::Text("hello".to_string()), 0..5),
+            (Token::Whitespace, 5..6),
+            (Token::Text("world".to_string()), 6..11),
+            (Token::Newline, 11..12),
         ];
 
-        let simple = format_tokens(&tokens, &OutputFormat::Simple).unwrap();
+        let simple = format_tokens_with_locations(&tokens, &OutputFormat::Simple).unwrap();
         assert_eq!(simple, "<text:hello><whitespace><text:world><newline>\n");
 
-        let json = format_tokens(&tokens, &OutputFormat::Json).unwrap();
+        let json = format_tokens_with_locations(&tokens, &OutputFormat::Json).unwrap();
         assert!(json.contains("\"Text\""));
         assert!(json.contains("\"Whitespace\""));
         assert!(json.contains("\"Newline\""));

--- a/src/txxt/processor.rs
+++ b/src/txxt/processor.rs
@@ -200,7 +200,7 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
     match spec.stage {
         ProcessingStage::Token => {
             let tokens = lex(&content);
-            format_tokens_with_locations(&tokens, &spec.format)
+            format_tokenss(&tokens, &spec.format)
         }
         ProcessingStage::Ast => {
             // Parse the document - all documents now include full location information
@@ -278,7 +278,7 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
 }
 
 /// Format tokens according to the specified format
-fn format_tokens_with_locations(
+fn format_tokenss(
     tokens: &[(Token, std::ops::Range<usize>)],
     format: &OutputFormat,
 ) -> Result<String, ProcessingError> {
@@ -615,10 +615,10 @@ mod tests {
             (Token::Newline, 11..12),
         ];
 
-        let simple = format_tokens_with_locations(&tokens, &OutputFormat::Simple).unwrap();
+        let simple = format_tokenss(&tokens, &OutputFormat::Simple).unwrap();
         assert_eq!(simple, "<text:hello><whitespace><text:world><newline>\n");
 
-        let json = format_tokens_with_locations(&tokens, &OutputFormat::Json).unwrap();
+        let json = format_tokenss(&tokens, &OutputFormat::Json).unwrap();
         assert!(json.contains("\"Text\""));
         assert!(json.contains("\"Whitespace\""));
         assert!(json.contains("\"Newline\""));

--- a/src/txxt/testing.rs
+++ b/src/txxt/testing.rs
@@ -153,6 +153,7 @@
 //!    ```
 
 mod testing_assertions;
+mod testing_factories;
 mod testing_matchers;
 
 pub use testing_assertions::{
@@ -161,3 +162,8 @@ pub use testing_assertions::{
     SessionAssertion,
 };
 pub use testing_matchers::TextMatch;
+
+// Public submodule path: crate::txxt::testing::factories
+pub mod factories {
+    pub use super::testing_factories::*;
+}

--- a/src/txxt/testing/testing_factories.rs
+++ b/src/txxt/testing/testing_factories.rs
@@ -1,0 +1,27 @@
+//! Test factories for creating locations and spanned tokens succinctly
+
+use std::ops::Range;
+
+use crate::txxt::lexer::Token;
+
+/// Canonical alias for spanned tokens used across tests
+pub type Tokens = Vec<(Token, Range<usize>)>;
+
+/// Make a byte range location
+pub fn make_loc(start: usize, end: usize) -> Range<usize> {
+    start..end
+}
+
+/// Make a single spanned token
+pub fn mk_token(token: Token, start: usize, end: usize) -> (Token, Range<usize>) {
+    (token, make_loc(start, end))
+}
+
+/// Make a vector of spanned tokens from a list of (Token, start, end)
+pub fn mk_tokens(specs: &[(Token, usize, usize)]) -> Tokens {
+    specs
+        .iter()
+        .cloned()
+        .map(|(t, s, e)| mk_token(t, s, e))
+        .collect()
+}


### PR DESCRIPTION
Summary
Default naming: “tokens” now means spanned (Token, Range<usize>).
Parser API: parse(tokens, source) is primary; parse_with_source remains as a shim.
AST ergonomics: added .at(Location) builder across elements; kept .with_location(...) for compatibility.
Lexer transforms:
transform_blank_lines(tokens) (param renamed from tokens_with_locations)
transform_indentation(tokens) (param renamed; introduced token_kinds internally)
Tests: added crate::txxt::testing::factories (Tokens, make_loc, mk_token, mk_tokens) and migrated select tests to factories.
What still needs migration
Migrate remaining .with_location(...) call sites to .at(...) (a few test-only spots remain).
Continue adopting testing factories across older tests that hand-roll (Token, Range) tuples.
Optional final cleanup (in a follow-up PR):
Deprecate .with_location(...) methods and eventually remove once usages are gone.
Sweep docs/comments to ensure “tokens” consistently implies spanned.
Rename any lingering local variables like token_kinds if you prefer kinds/raw_kinds style.
CI
All tests and clippy pass locally and via pre-commit.
Branch
refactor/location-aware-only
- **chore(clippy): remove empty line after doc comments in lexer transforms**
- **Removed more _with_location**
- **test(ast): fix with_location calls in location tests; rename tokenss vars for clarity**
- **test: add crate::txxt::testing::factories (mk_token, mk_tokens, make_loc) and migrate select tests**
- **refactor(parser): make  the primary API; keep  as shim**
- **feat(ast): introduce  builder to avoid collision with getter; keep**
- **refactor: migrate .with_location(...) call sites to .at(...) where available; keep compatibility methods; all tests passing**
- **chore(lexer): rename transform_blank_lines param to  (spanned by default)**
- **fix(lexer): resolve shadowing by introducing token_kinds; complete rename to  for spanned param**
