### PR TITLE
Make locations mandatory in parser AST

### DIFF
--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -255,13 +255,10 @@ impl Model {
         use txxt::txxt::ast::traits::AstNode;
         if node_id.path().is_empty() {
             // Document doesn't have a location; the root session does
-            return self.document.root.location();
+            return Some(self.document.root.location());
         }
 
-        self.get_node(node_id).and_then(|(item, _depth)| {
-            // Use the AstNode trait to get the location
-            item.location()
-        })
+        self.get_node(node_id).map(|(item, _depth)| item.location())
     }
 
     /// Get the ancestors of a node (path from root to node, not including the node itself)

--- a/src/txxt/ast/elements/annotation.rs
+++ b/src/txxt/ast/elements/annotation.rs
@@ -85,13 +85,14 @@ impl Annotation {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -106,8 +107,8 @@ impl AstNode for Annotation {
             format!("{} ({} params)", self.label.value, self.parameters.len())
         }
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -150,7 +151,7 @@ mod tests {
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let annotation = Annotation::marker(Label::new("test".to_string())).with_location(location);
+        let annotation = Annotation::marker(Label::new("test".to_string())).at(location);
         assert_eq!(annotation.location, location);
     }
 }

--- a/src/txxt/ast/elements/content_item.rs
+++ b/src/txxt/ast/elements/content_item.rs
@@ -58,7 +58,7 @@ impl AstNode for ContentItem {
         }
     }
 
-    fn location(&self) -> Option<Location> {
+    fn location(&self) -> Location {
         match self {
             ContentItem::Paragraph(p) => p.location(),
             ContentItem::Session(s) => s.location(),
@@ -299,7 +299,7 @@ impl ContentItem {
         // location contains the position.
         // If nested elements were found, they would have been returned above.
         // If no nested results were found, this item is the deepest element at the position.
-        if self.location().is_some_and(|l| l.contains(pos)) {
+        if self.location().contains(pos) {
             Some(self)
         } else {
             None

--- a/src/txxt/ast/elements/definition.rs
+++ b/src/txxt/ast/elements/definition.rs
@@ -53,13 +53,14 @@ impl Definition {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -75,8 +76,8 @@ impl AstNode for Definition {
             subject_text.to_string()
         }
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -118,7 +119,7 @@ mod tests {
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let definition = Definition::with_subject("Subject".to_string()).with_location(location);
+        let definition = Definition::with_subject("Subject".to_string()).at(location);
         assert_eq!(definition.location, location);
     }
 }

--- a/src/txxt/ast/elements/document.rs
+++ b/src/txxt/ast/elements/document.rs
@@ -132,8 +132,8 @@ impl AstNode for Document {
         )
     }
 
-    fn location(&self) -> Option<Location> {
-        None
+    fn location(&self) -> Location {
+        self.root.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -199,13 +199,13 @@ mod tests {
 
         // Create paragraph 1 with properly located TextLine
         let text_line1 = TextLine::new(TextContent::from_string("First".to_string(), None))
-            .with_location(Location::new(Position::new(0, 0), Position::new(0, 5)));
+            .at(Location::new(Position::new(0, 0), Position::new(0, 5)));
         let para1 = Paragraph::new(vec![ContentItem::TextLine(text_line1)])
             .at(Location::new(Position::new(0, 0), Position::new(0, 5)));
 
         // Create paragraph 2 with properly located TextLine
         let text_line2 = TextLine::new(TextContent::from_string("Second".to_string(), None))
-            .with_location(Location::new(Position::new(1, 0), Position::new(1, 6)));
+            .at(Location::new(Position::new(1, 0), Position::new(1, 6)));
         let para2 = Paragraph::new(vec![ContentItem::TextLine(text_line2)])
             .at(Location::new(Position::new(1, 0), Position::new(1, 6)));
 

--- a/src/txxt/ast/elements/foreign.rs
+++ b/src/txxt/ast/elements/foreign.rs
@@ -68,13 +68,14 @@ impl ForeignBlock {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -90,8 +91,8 @@ impl AstNode for ForeignBlock {
             subject_text.to_string()
         }
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {

--- a/src/txxt/ast/elements/label.rs
+++ b/src/txxt/ast/elements/label.rs
@@ -42,13 +42,14 @@ impl Label {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder: `at(location)`
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -68,7 +69,7 @@ mod tests {
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let label = Label::new("test".to_string()).with_location(location);
+        let label = Label::new("test".to_string()).at(location);
         assert_eq!(label.location, location);
     }
 }

--- a/src/txxt/ast/elements/list.rs
+++ b/src/txxt/ast/elements/list.rs
@@ -56,13 +56,14 @@ impl List {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -73,8 +74,8 @@ impl AstNode for List {
     fn display_label(&self) -> String {
         format!("{} items", self.content.len())
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -115,13 +116,14 @@ impl ListItem {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
     pub fn text(&self) -> &str {
         self.text[0].as_string()
@@ -140,8 +142,8 @@ impl AstNode for ListItem {
             text.to_string()
         }
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -178,7 +180,7 @@ mod tests {
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let list = List::new(vec![]).with_location(location);
+        let list = List::new(vec![]).at(location);
         assert_eq!(list.location, location);
     }
 }

--- a/src/txxt/ast/elements/paragraph.rs
+++ b/src/txxt/ast/elements/paragraph.rs
@@ -36,7 +36,12 @@ impl TextLine {
         }
     }
 
-    pub fn with_location(mut self, location: Location) -> Self {
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
+    }
+
+    pub fn at(mut self, location: Location) -> Self {
         self.location = location;
         self
     }
@@ -60,8 +65,8 @@ impl AstNode for TextLine {
         }
     }
 
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -109,10 +114,15 @@ impl Paragraph {
             ))],
             location: Self::default_location(),
         };
-        para = para.with_location(location);
+        para = para.at(location);
         para
     }
-    pub fn with_location(mut self, location: Location) -> Self {
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
+    }
+    /// Preferred builder
+    pub fn at(mut self, location: Location) -> Self {
         self.location = location;
         // When a paragraph's location is set in tests, we should also update
         // the location of the single child TextLine for consistency, as this
@@ -125,10 +135,6 @@ impl Paragraph {
             }
         }
         self
-    }
-    /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
     }
     pub fn text(&self) -> String {
         self.lines
@@ -157,8 +163,8 @@ impl AstNode for Paragraph {
             text
         }
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -222,7 +228,7 @@ mod tests {
             super::super::super::location::Position::new(0, 0),
             super::super::super::location::Position::new(0, 5),
         );
-        let para = Paragraph::from_line("Hello".to_string()).with_location(location);
+        let para = Paragraph::from_line("Hello".to_string()).at(location);
 
         assert_eq!(para.location, location);
     }

--- a/src/txxt/ast/elements/parameter.rs
+++ b/src/txxt/ast/elements/parameter.rs
@@ -37,13 +37,14 @@ impl Parameter {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -63,7 +64,7 @@ mod tests {
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let param = Parameter::new("key".to_string(), "value".to_string()).with_location(location);
+        let param = Parameter::new("key".to_string(), "value".to_string()).at(location);
         assert_eq!(param.location, location);
     }
 }

--- a/src/txxt/ast/elements/session.rs
+++ b/src/txxt/ast/elements/session.rs
@@ -55,13 +55,14 @@ impl Session {
             location: Self::default_location(),
         }
     }
-    pub fn with_location(mut self, location: Location) -> Self {
-        self.location = location;
-        self
+    #[deprecated(note = "Use at(location) instead")]
+    pub fn with_location(self, location: Location) -> Self {
+        self.at(location)
     }
     /// Preferred builder
-    pub fn at(self, location: Location) -> Self {
-        self.with_location(location)
+    pub fn at(mut self, location: Location) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -72,8 +73,8 @@ impl AstNode for Session {
     fn display_label(&self) -> String {
         self.title.as_string().to_string()
     }
-    fn location(&self) -> Option<Location> {
-        Some(self.location)
+    fn location(&self) -> Location {
+        self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -128,7 +129,7 @@ mod tests {
             super::super::super::location::Position::new(1, 0),
             super::super::super::location::Position::new(1, 10),
         );
-        let session = Session::with_title("Title".to_string()).with_location(location);
+        let session = Session::with_title("Title".to_string()).at(location);
         assert_eq!(session.location, location);
     }
 }

--- a/src/txxt/ast/location.rs
+++ b/src/txxt/ast/location.rs
@@ -402,10 +402,10 @@ mod ast_integration_tests {
     };
 
     #[test]
-    fn test_get_location() {
+    fn test_start_position() {
         let location = Location::new(Position::new(1, 0), Position::new(1, 10));
         let session = Session::with_title("Title".to_string()).at(location);
-        assert_eq!(session.get_location(), Some(Position::new(1, 0)));
+        assert_eq!(session.start_position(), Position::new(1, 0));
     }
 
     #[test]

--- a/src/txxt/ast/traits.rs
+++ b/src/txxt/ast/traits.rs
@@ -51,9 +51,9 @@ pub fn visit_children(visitor: &mut dyn Visitor, items: &[ContentItem]) {
 pub trait AstNode {
     fn node_type(&self) -> &'static str;
     fn display_label(&self) -> String;
-    fn location(&self) -> Option<Location>;
-    fn get_location(&self) -> Option<Position> {
-        self.location().map(|s| s.start)
+    fn location(&self) -> Location;
+    fn start_position(&self) -> Position {
+        self.location().start
     }
 
     /// Accept a visitor for traversing this node and its children

--- a/src/txxt/lexer/transformations/transform_indentation.rs
+++ b/src/txxt/lexer/transformations/transform_indentation.rs
@@ -860,8 +860,8 @@ mod tests {
         //            13..20 "Subitem", 20..21 " ", 21..22 "A", 22..23 "\n",
         //            23..27 "    ", 27..28 "-", 28..29 " ", 29..36 "Subitem", 36..37 " ", 37..38 "B"
 
-        let tokens_with_locations = crate::txxt::lexer::tokenize(source);
-        let result = transform_indentation(tokens_with_locations);
+        let tokens = crate::txxt::lexer::tokenize(source);
+        let result = transform_indentation(tokens);
 
         // Find the IndentLevel token
         let indent_level_pos = result

--- a/src/txxt/parser.rs
+++ b/src/txxt/parser.rs
@@ -23,7 +23,7 @@ pub use crate::txxt::ast::{
 
 pub use crate::txxt::formats::{serialize_ast_tag, to_treeviz_str};
 pub use elements::document::document;
-pub use parser::parse_with_source;
+pub use parser::parse;
 
 /// Type alias for parse result with spanned tokens
 type ParseResult = Result<
@@ -34,6 +34,6 @@ type ParseResult = Result<
 /// Main parser function that takes source text and returns a parsed document
 /// This is the primary entry point for parsing txxt documents
 pub fn parse_document(source: &str) -> ParseResult {
-    let tokenss = crate::txxt::lexer::lex(source);
-    parse_with_source(tokenss, source)
+    let tokens = crate::txxt::lexer::lex(source);
+    parse(tokens, source)
 }

--- a/src/txxt/parser/api.rs
+++ b/src/txxt/parser/api.rs
@@ -23,6 +23,7 @@ pub fn parse(tokens: Vec<TokenLocation>, source: &str) -> Result<Document, Vec<P
 
 /// Backward-compatibility shim: prefer `parse`
 #[allow(dead_code)]
+#[deprecated(note = "Use parse(tokens, source) instead")]
 pub fn parse_with_source(
     tokens: Vec<TokenLocation>,
     source: &str,

--- a/src/txxt/parser/combinators.rs
+++ b/src/txxt/parser/combinators.rs
@@ -68,16 +68,6 @@ pub(crate) fn compute_location_from_locations(locations: &[Location]) -> Locatio
     )
 }
 
-/// Helper: compute location bounds from multiple optional locations
-pub(crate) fn compute_location_from_optional_locations(locations: &[Option<Location>]) -> Location {
-    let actual_locations: Vec<Location> = locations.iter().filter_map(|s| *s).collect();
-    if actual_locations.is_empty() {
-        Location::default()
-    } else {
-        compute_location_from_locations(&actual_locations)
-    }
-}
-
 /// Helper: aggregate location from a primary location and child content items
 ///
 /// Creates a bounding box that encompasses the primary location and all child content.
@@ -90,7 +80,7 @@ pub(crate) fn compute_location_from_optional_locations(locations: &[Option<Locat
 /// ```
 pub(crate) fn aggregate_locations(primary: Location, children: &[ContentItem]) -> Location {
     let mut sources = vec![primary];
-    sources.extend(children.iter().filter_map(|item| item.location()));
+    sources.extend(children.iter().map(|item| item.location()));
     compute_location_from_locations(&sources)
 }
 
@@ -172,8 +162,7 @@ pub(crate) fn paragraph(
                         byte_range_to_location(&source, &range)
                     };
                     let text_content = TextContent::from_string(text, Some(line_location));
-                    let text_line =
-                        crate::txxt::ast::TextLine::new(text_content).with_location(line_location);
+                    let text_line = crate::txxt::ast::TextLine::new(text_content).at(line_location);
                     crate::txxt::ast::ContentItem::TextLine(text_line)
                 })
                 .collect();

--- a/src/txxt/parser/elements/annotations.rs
+++ b/src/txxt/parser/elements/annotations.rs
@@ -213,14 +213,14 @@ where
 #[cfg(test)]
 mod tests {
     use crate::txxt::lexer::lex;
-    use crate::txxt::parser::api::parse_with_source;
+    use crate::txxt::parser::api::parse;
     use crate::txxt::processor::txxt_sources::TxxtSources;
 
     #[test]
     fn test_annotation_marker_minimal() {
         let source = "Para one. {{paragraph}}\n\n:: note ::\n\nPara two. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 3); // paragraph, annotation, paragraph
         assert!(doc.root.content[1].is_annotation());
@@ -230,7 +230,7 @@ mod tests {
     fn test_annotation_single_line() {
         let source = "Para one. {{paragraph}}\n\n:: note :: This is inline text\n\nPara two. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 3); // paragraph, annotation, paragraph
         let annotation = doc.root.content[1].as_annotation().unwrap();
@@ -244,7 +244,7 @@ mod tests {
         let source = TxxtSources::get_string("120-annotations-simple.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Verify document parses successfully and contains expected structure
 
@@ -304,7 +304,7 @@ mod tests {
         let source = TxxtSources::get_string("130-annotations-block-content.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Find and verify :: note author="Jane Doe" :: annotation with block content
         let note_annotation = doc

--- a/src/txxt/parser/elements/annotations.rs
+++ b/src/txxt/parser/elements/annotations.rs
@@ -137,11 +137,7 @@ where
 
                 // Collect locations from header and content to compute overall annotation span
                 let mut location_sources: Vec<Location> = vec![header_location];
-                location_sources.extend(
-                    content
-                        .iter()
-                        .map(|item| item.location().unwrap_or_default()),
-                );
+                location_sources.extend(content.iter().map(|item| item.location()));
                 location_sources.push(label_location);
                 let location = compute_location_from_locations(&location_sources);
 
@@ -181,8 +177,8 @@ where
                     let paragraph_location =
                         byte_range_to_location(&source_for_single_line, &range);
                     let text_content = TextContent::from_string(text, Some(paragraph_location));
-                    let text_line = crate::txxt::ast::TextLine::new(text_content)
-                        .with_location(paragraph_location);
+                    let text_line =
+                        crate::txxt::ast::TextLine::new(text_content).at(paragraph_location);
                     let paragraph = Paragraph {
                         lines: vec![ContentItem::TextLine(text_line)],
                         location: paragraph_location,

--- a/src/txxt/parser/elements/definitions.rs
+++ b/src/txxt/parser/elements/definitions.rs
@@ -68,7 +68,7 @@ mod tests {
     use crate::txxt::ast::Container;
     use crate::txxt::ast::ContentItem;
     use crate::txxt::lexer::lex;
-    use crate::txxt::parser::api::parse_with_source;
+    use crate::txxt::parser::api::parse;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
 
@@ -80,7 +80,7 @@ mod tests {
         println!("Testing simple definition with unified parser:");
         println!("Source: {:?}", source);
 
-        let result = parse_with_source(tokens, source);
+        let result = parse(tokens, source);
         if let Err(ref e) = result {
             println!("Parse error: {:?}", e);
         }
@@ -101,7 +101,7 @@ mod tests {
         println!("Testing nested definitions with unified parser:");
         println!("Source: {:?}", source);
 
-        let result = parse_with_source(tokens, source);
+        let result = parse(tokens, source);
         if let Err(ref e) = result {
             println!("Parse error: {:?}", e);
         }
@@ -152,7 +152,7 @@ mod tests {
         println!("Testing paragraph then definition:");
         println!("Source: {:?}", source);
 
-        let result = parse_with_source(tokens, source);
+        let result = parse(tokens, source);
         if let Err(ref e) = result {
             println!("Parse error: {:?}", e);
             println!("Error at span: {:?}", &source[e[0].span().clone()]);
@@ -192,7 +192,7 @@ mod tests {
             println!("  {}: {:?}", i, token);
         }
 
-        let result = parse_with_source(tokens, &source);
+        let result = parse(tokens, &source);
         if let Err(ref e) = result {
             println!("Parse error: {:?}", e);
         }
@@ -289,7 +289,7 @@ mod tests {
         let source = TxxtSources::get_string("100-definitions-mixed-content.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
         assert_ast(&doc)

--- a/src/txxt/parser/elements/document.rs
+++ b/src/txxt/parser/elements/document.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use crate::txxt::ast::{AstNode, Document};
 use crate::txxt::lexer::Token;
-use crate::txxt::parser::combinators::compute_location_from_optional_locations;
+use crate::txxt::parser::combinators::compute_location_from_locations;
 
 /// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);
@@ -24,7 +24,7 @@ pub fn document(source: &str) -> impl Parser<TokenLocation, Document, Error = Pa
             .iter()
             .map(|item| item.location())
             .collect::<Vec<_>>();
-        let location = compute_location_from_optional_locations(&content_locations);
+        let location = compute_location_from_locations(&content_locations);
 
         Document::with_content(content).with_root_location(location)
     })

--- a/src/txxt/parser/elements/foreign.rs
+++ b/src/txxt/parser/elements/foreign.rs
@@ -157,7 +157,7 @@ pub(crate) fn foreign_block(
 #[cfg(test)]
 mod tests {
     use crate::txxt::lexer::lex;
-    use crate::txxt::parser::api::parse_with_source;
+    use crate::txxt::parser::api::parse;
     use crate::txxt::processor::txxt_sources::TxxtSources;
 
     #[test]
@@ -165,7 +165,7 @@ mod tests {
         let source = "Code Example:\n    function hello() {\n        return \"world\";\n    }\n:: javascript caption=\"Hello World\" ::\n\n";
         let tokens = lex(source);
         println!("Tokens: {:?}", tokens);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 1);
         let foreign_block = doc.root.content[0].as_foreign_block().unwrap();
@@ -194,7 +194,7 @@ mod tests {
     fn test_foreign_block_marker_form() {
         let source = "Image Reference:\n\n:: image type=jpg, src=sunset.jpg :: As the sun sets, we see a colored sea bed.\n\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 1);
         let foreign_block = doc.root.content[0].as_foreign_block().unwrap();
@@ -218,7 +218,7 @@ mod tests {
     fn test_foreign_block_preserves_whitespace() {
         let source = "Indented Code:\n\n    // This has    multiple    spaces\n    const regex = /[a-z]+/g;\n    \n    console.log(\"Hello, World!\");\n\n:: javascript ::\n\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let foreign_block = doc.root.content[0].as_foreign_block().unwrap();
         assert!(foreign_block
@@ -236,7 +236,7 @@ mod tests {
 
         let source = "First Block:\n\n    code1\n\n:: lang1 ::\n\nSecond Block:\n\n    code2\n\n:: lang2 ::\n\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 2);
 
@@ -255,7 +255,7 @@ mod tests {
     fn test_foreign_block_with_paragraphs() {
         let source = "Intro paragraph.\n\nCode Block:\n\n    function test() {\n        return true;\n    }\n\n:: javascript ::\n\nOutro paragraph.\n\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         assert_eq!(doc.root.content.len(), 3);
         assert!(doc.root.content[0].is_paragraph());
@@ -268,7 +268,7 @@ mod tests {
         let source = TxxtSources::get_string("140-foreign-blocks-simple.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Find JavaScript code block
         let js_block = doc
@@ -326,7 +326,7 @@ mod tests {
         let source = TxxtSources::get_string("150-foreign-blocks-no-content.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Find image reference
         let image_block = doc

--- a/src/txxt/parser/elements/foreign.rs
+++ b/src/txxt/parser/elements/foreign.rs
@@ -90,7 +90,7 @@ pub(crate) fn foreign_block(
                 let paragraph_location = byte_range_to_location(&source_for_annotation, &range);
                 let text_content = TextContent::from_string(text, Some(paragraph_location));
                 let text_line =
-                    crate::txxt::ast::TextLine::new(text_content).with_location(paragraph_location);
+                    crate::txxt::ast::TextLine::new(text_content).at(paragraph_location);
                 let paragraph = Paragraph {
                     lines: vec![ContentItem::TextLine(text_line)],
                     location: paragraph_location,

--- a/src/txxt/parser/elements/labels.rs
+++ b/src/txxt/parser/elements/labels.rs
@@ -166,7 +166,7 @@ mod tests {
     fn test_annotation_with_dashed_label() {
         let source = ":: code-review ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "code-review");

--- a/src/txxt/parser/elements/labels.rs
+++ b/src/txxt/parser/elements/labels.rs
@@ -113,13 +113,13 @@ pub(crate) fn parse_label_from_tokens(tokens: &[TokenLocation]) -> (Option<Range
 mod tests {
 
     use crate::txxt::lexer::lex;
-    use crate::txxt::parser::parse_with_source;
+    use crate::txxt::parser::parse;
 
     #[test]
     fn test_annotation_with_label_only() {
         let source = ":: note ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");
@@ -130,7 +130,7 @@ mod tests {
     fn test_annotation_with_label_and_parameters() {
         let source = ":: warning severity=high ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "warning");
@@ -142,7 +142,7 @@ mod tests {
     fn test_annotation_with_dotted_label() {
         let source = ":: python.typing ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "python.typing");
@@ -153,7 +153,7 @@ mod tests {
     fn test_annotation_parameters_only_no_label() {
         let source = ":: version=3.11 ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, ""); // Empty label

--- a/src/txxt/parser/elements/lists.rs
+++ b/src/txxt/parser/elements/lists.rs
@@ -104,7 +104,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::txxt::lexer::lex;
-    use crate::txxt::parser::api::parse_with_source;
+    use crate::txxt::parser::api::parse;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
 
@@ -113,7 +113,7 @@ mod tests {
         // Simplest possible list: 2 dashed items
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Find the first list (after "Plain dash lists:" paragraph)
         // Document structure: Para Para Para List Para List...
@@ -143,7 +143,7 @@ mod tests {
         // Test numbered list: "1. ", "2. ", "3. "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Numerical lists (item 5)
         assert_ast(&doc).item(5, |item| {
@@ -166,7 +166,7 @@ mod tests {
         // Test alphabetical list: "a. ", "b. ", "c. "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Alphabetical lists (item 7)
         assert_ast(&doc).item(7, |item| {
@@ -189,7 +189,7 @@ mod tests {
         // Test mixed decorations: different markers in same list
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Mixed decoration lists (item 9)
         assert_ast(&doc).item(9, |item| {
@@ -212,7 +212,7 @@ mod tests {
         // Test parenthetical numbering: "(1) ", "(2) ", "(3) "
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Parenthetical numbering (item 11)
         assert_ast(&doc).item(11, |item| {
@@ -235,7 +235,7 @@ mod tests {
         // Critical test: single list-like line becomes paragraph, 2+ with blank line become list
         let source = TxxtSources::get_string("050-paragraph-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Items 2-4: Single list-item-lines merged into paragraphs
         assert_ast(&doc).item(2, |item| {
@@ -266,7 +266,7 @@ mod tests {
         // Full document test with lists from TxxtSources
         let source = TxxtSources::get_string("040-lists.txxt").unwrap();
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Verify document structure: paragraphs + lists alternating
         assert_ast(&doc)
@@ -303,7 +303,7 @@ mod tests {
         // Without the blank line, consecutive list-item-lines should be parsed as paragraphs
         let source = "First paragraph\n- Item one\n- Item two\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         // Should be parsed as a single paragraph, NOT a paragraph + list
         // because there's no blank line before the list-item-lines
@@ -322,7 +322,7 @@ mod tests {
         // Now test the positive case: with blank line, it becomes separate items
         let source_with_blank = "First paragraph\n\n- Item one\n- Item two\n";
         let tokens2 = lex(source_with_blank);
-        let doc2 = parse_with_source(tokens2, source_with_blank).unwrap();
+        let doc2 = parse(tokens2, source_with_blank).unwrap();
 
         // Should be parsed as paragraph + list
         assert_eq!(
@@ -351,7 +351,7 @@ mod tests {
         let source = TxxtSources::get_string("070-nested-lists-simple.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
         assert_ast(&doc)
@@ -435,7 +435,7 @@ mod tests {
         let source = TxxtSources::get_string("080-nested-lists-mixed-content.txxt")
             .expect("Failed to load sample file");
         let tokens = lex(&source);
-        let doc = parse_with_source(tokens, &source).unwrap();
+        let doc = parse(tokens, &source).unwrap();
 
         // Item 0-1: Opening paragraphs
         assert_ast(&doc)

--- a/src/txxt/parser/elements/parameters.rs
+++ b/src/txxt/parser/elements/parameters.rs
@@ -202,13 +202,13 @@ pub(crate) fn parse_parameters_from_tokens(
 #[cfg(test)]
 mod tests {
     use crate::txxt::lexer::lex;
-    use crate::txxt::parser::parse_with_source;
+    use crate::txxt::parser::parse;
 
     #[test]
     fn test_annotation_comma_separated_parameters() {
         let source = ":: warning severity=high,priority=urgent ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "warning");
@@ -224,7 +224,7 @@ mod tests {
         let source =
             ":: note author=\"Jane Doe\" title=\"Important Note\" ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");
@@ -239,7 +239,7 @@ mod tests {
     fn test_annotation_mixed_separators_and_quotes() {
         let source = ":: task priority=high,status=\"in progress\",assigned=alice ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.parameters.len(), 3);
@@ -256,7 +256,7 @@ mod tests {
         // Test that whitespace around commas is properly ignored
         let source = ":: note key1=val1 , key2=val2 , key3=val3 ::\n\nText. {{paragraph}}\n";
         let tokens = lex(source);
-        let doc = parse_with_source(tokens, source).unwrap();
+        let doc = parse(tokens, source).unwrap();
 
         let annotation = doc.root.content[0].as_annotation().unwrap();
         assert_eq!(annotation.label.value, "note");

--- a/src/txxt/parser/elements/sessions.rs
+++ b/src/txxt/parser/elements/sessions.rs
@@ -72,6 +72,7 @@ mod tests {
     use crate::txxt::parser::api::parse;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
+    use crate::txxt::testing::factories::mk_tokens;
 
     #[test]
     fn test_malformed_session_title_with_indent_but_no_content() {
@@ -122,19 +123,18 @@ mod tests {
     fn test_session_title_followed_by_bare_indent_level() {
         // Test case 1: Session with empty content (IndentLevel immediately followed by DedentLevel)
         // This actually SHOULD be allowed or give a clear error
-        let tokens = vec![
-            Token::Text("".to_string()),
-            Token::Newline,
-            Token::Newline,
-            Token::IndentLevel,
-            Token::DedentLevel,
-            Token::DedentLevel,
-        ];
+        let tokenss = mk_tokens(&[
+            (Token::Text("".to_string()), 0, 0),
+            (Token::Newline, 0, 0),
+            (Token::Newline, 0, 0),
+            (Token::IndentLevel, 0, 0),
+            (Token::DedentLevel, 0, 0),
+            (Token::DedentLevel, 0, 0),
+        ]);
 
         println!("\n=== Test: Session with empty content ===");
-        println!("Tokens: {:?}", tokens);
+        println!("Tokens: {:?}", tokenss);
 
-        let tokenss: Vec<_> = tokens.into_iter().map(|t| (t, 0..0)).collect();
         let result = parse(tokenss, "");
 
         match &result {

--- a/src/txxt/parser/elements/sessions.rs
+++ b/src/txxt/parser/elements/sessions.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::txxt::ast::Container;
     use crate::txxt::ast::ContentItem;
     use crate::txxt::lexer::{lex, Token};
-    use crate::txxt::parser::api::parse_with_source;
+    use crate::txxt::parser::api::parse;
     use crate::txxt::processor::txxt_sources::TxxtSources;
     use crate::txxt::testing::assert_ast;
 
@@ -91,7 +91,7 @@ mod tests {
         println!("Tokens: {:?}", tokens);
 
         let tokenss = lex(input);
-        let result = parse_with_source(tokenss, input);
+        let result = parse(tokenss, input);
 
         match &result {
             Ok(doc) => {
@@ -135,7 +135,7 @@ mod tests {
         println!("Tokens: {:?}", tokens);
 
         let tokenss: Vec<_> = tokens.into_iter().map(|t| (t, 0..0)).collect();
-        let result = parse_with_source(tokenss, "");
+        let result = parse(tokenss, "");
 
         match &result {
             Ok(doc) => {
@@ -212,7 +212,7 @@ mod tests {
             .expect("Failed to load sample file");
         let tokens = lex(&source);
 
-        let result = parse_with_source(tokens, &source);
+        let result = parse(tokens, &source);
         assert!(
             result.is_ok(),
             "Failed to parse 010-paragraphs-sessions-flat-single.txxt: {:?}",
@@ -269,7 +269,7 @@ mod tests {
             .expect("Failed to load sample file");
         let tokens = lex(&source);
 
-        let result = parse_with_source(tokens, &source);
+        let result = parse(tokens, &source);
         assert!(
             result.is_ok(),
             "Failed to parse 020-paragraphs-sessions-flat-multiple.txxt: {:?}",
@@ -345,7 +345,7 @@ mod tests {
             .expect("Failed to load sample file");
         let tokens = lex(&source);
 
-        let result = parse_with_source(tokens, &source);
+        let result = parse(tokens, &source);
         assert!(
             result.is_ok(),
             "Failed to parse 030-paragraphs-sessions-nested-multiple.txxt: {:?}",

--- a/src/txxt/processor.rs
+++ b/src/txxt/processor.rs
@@ -205,7 +205,7 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
         ProcessingStage::Ast => {
             // Parse the document - all documents now include full location information
             let doc = if matches!(spec.format, OutputFormat::AstPosition) {
-                crate::txxt::parser::parse_with_source(crate::txxt::lexer::lex(&content), &content)
+                crate::txxt::parser::parse(crate::txxt::lexer::lex(&content), &content)
                     .map_err(|errs| {
                         let error_details = errs
                             .iter()
@@ -504,7 +504,7 @@ pub mod txxt_sources {
 Second paragraph"#;
 
         let tokens = crate::txxt::lexer::lex(content);
-        let doc = crate::txxt::parser::parse_with_source(tokens, content).unwrap();
+        let doc = crate::txxt::parser::parse(tokens, content).unwrap();
 
         // Check if locations are populated
         if let Some(first_item) = doc.root.content.first() {

--- a/src/txxt/processor.rs
+++ b/src/txxt/processor.rs
@@ -205,8 +205,8 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
         ProcessingStage::Ast => {
             // Parse the document - all documents now include full location information
             let doc = if matches!(spec.format, OutputFormat::AstPosition) {
-                crate::txxt::parser::parse(crate::txxt::lexer::lex(&content), &content)
-                    .map_err(|errs| {
+                crate::txxt::parser::parse(crate::txxt::lexer::lex(&content), &content).map_err(
+                    |errs| {
                         let error_details = errs
                             .iter()
                             .map(|e| {
@@ -223,7 +223,8 @@ pub fn process_file_with_extras<P: AsRef<Path>>(
                             "Failed to parse document:\n{}",
                             error_details
                         ))
-                    })?
+                    },
+                )?
             } else {
                 crate::txxt::parser::parse_document(&content).map_err(|errs| {
                     let error_details = errs

--- a/src/txxt/testing/testing_factories.rs
+++ b/src/txxt/testing/testing_factories.rs
@@ -25,3 +25,9 @@ pub fn mk_tokens(specs: &[(Token, usize, usize)]) -> Tokens {
         .map(|(t, s, e)| mk_token(t, s, e))
         .collect()
 }
+
+/// Create tokens with zero-length spans for convenience in tests that only
+/// care about token order.
+pub fn mk_tokens_with_dummy_span(tokens: Vec<Token>) -> Tokens {
+    tokens.into_iter().map(|token| mk_token(token, 0, 0)).collect()
+}


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-ce5a718c-86f2-407c-84bd-df812c81ffb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce5a718c-86f2-407c-84bd-df812c81ffb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

