### PR TITLE
refactor: Location tracking refactoring (phases 1-5) - Rename Location to Range

### DIFF
--- a/docs/dev/guides/on-testting.txxt
+++ b/docs/dev/guides/on-testting.txxt
@@ -1,0 +1,7 @@
+Actionable Testing Guide for txxt
+
+	This document goes over some specifics of testing the txxt parser.
+
+	1. txxt is a novel format, with no outside reference parsers nor document corpus. This means that you cannot create reliable txxt sources, few people can. 
+     2. If you can't generate the initial source string, never mind correctly imagine how that would look like in the various transformations steps, but them in the lexer or in the parser phases.
+    3. The spec is still in flux, and changes are frequent. If tests created their own ad hoc in test-file txxt sources, at each change we must review all test code and judge the spec changes and string by string, that is not doable.

--- a/src/bin/viewer/model.rs
+++ b/src/bin/viewer/model.rs
@@ -10,7 +10,8 @@
 
 use std::collections::HashSet;
 use txxt::txxt::ast::elements::content_item::ContentItem;
-use txxt::txxt::ast::location::{Location, Position};
+use txxt::txxt::ast::range::{Position, Range};
+use txxt::txxt::ast::traits::AstNode;
 use txxt::txxt::ast::{snapshot_visitor::snapshot_from_document, AstSnapshot};
 use txxt::txxt::parsers::Document;
 
@@ -251,14 +252,14 @@ impl Model {
     ///
     /// Returns the text range (start and end position) for the given node.
     /// The location indicates where in the source text this node is located.
-    pub fn get_location_for_node(&self, node_id: NodeId) -> Option<Location> {
-        use txxt::txxt::ast::traits::AstNode;
+    pub fn get_location_for_node(&self, node_id: NodeId) -> Option<Range> {
         if node_id.path().is_empty() {
             // Document doesn't have a location; the root session does
-            return Some(self.document.root.location());
+            return Some(self.document.root.location.clone());
         }
 
-        self.get_node(node_id).map(|(item, _depth)| item.location())
+        self.get_node(node_id)
+            .map(|(item, _depth)| item.range().clone())
     }
 
     /// Get the ancestors of a node (path from root to node, not including the node itself)

--- a/src/bin/viewer/tests.rs
+++ b/src/bin/viewer/tests.rs
@@ -528,7 +528,7 @@ fn test_text_view_cursor_on_nested_element_updates_model() {
                 );
 
                 // Try to find the node using document.element_at
-                use txxt::txxt::ast::location::Position;
+                use txxt::txxt::ast::range::Position;
                 let pos = Position::new(location.start.line, location.start.column);
                 let element = app.app().model.document.element_at(pos);
                 // Verify document.element_at() now finds nested elements

--- a/src/txxt/ast.rs
+++ b/src/txxt/ast.rs
@@ -14,8 +14,8 @@
 
 pub mod elements;
 pub mod error;
-pub mod location;
 pub mod lookup;
+pub mod range;
 pub mod snapshot;
 pub mod snapshot_visitor;
 pub mod text_content;
@@ -27,8 +27,8 @@ pub use elements::{
     Parameter, Session, TextLine,
 };
 pub use error::PositionLookupError;
-pub use location::{Location, Position, SourceLocation};
 pub use lookup::{find_nodes_at_position, format_at_position};
+pub use range::{Position, Range, SourceLocation};
 pub use snapshot::AstSnapshot;
 pub use snapshot_visitor::snapshot_node;
 pub use text_content::TextContent;

--- a/src/txxt/ast/elements/annotation.rs
+++ b/src/txxt/ast/elements/annotation.rs
@@ -41,7 +41,7 @@
 //! - Labels: docs/specs/v1/elements/labels.txxt
 //! - Parameters: docs/specs/v1/elements/parameters.txxt
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::traits::{AstNode, Container, Visitor};
 use super::content_item::ContentItem;
 use super::label::Label;
@@ -54,12 +54,12 @@ pub struct Annotation {
     pub label: Label,
     pub parameters: Vec<Parameter>,
     pub content: Vec<ContentItem>,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl Annotation {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(label: Label, parameters: Vec<Parameter>, content: Vec<ContentItem>) -> Self {
         Self {
@@ -86,11 +86,11 @@ impl Annotation {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -107,8 +107,8 @@ impl AstNode for Annotation {
             format!("{} ({} params)", self.label.value, self.parameters.len())
         }
     }
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -147,11 +147,12 @@ mod tests {
 
     #[test]
     fn test_annotation_with_location() {
-        let location = super::super::super::location::Location::new(
-            super::super::super::location::Position::new(1, 0),
-            super::super::super::location::Position::new(1, 10),
+        let location = super::super::super::range::Range::new(
+            0..0,
+            super::super::super::range::Position::new(1, 0),
+            super::super::super::range::Position::new(1, 10),
         );
-        let annotation = Annotation::marker(Label::new("test".to_string())).at(location);
+        let annotation = Annotation::marker(Label::new("test".to_string())).at(location.clone());
         assert_eq!(annotation.location, location);
     }
 }

--- a/src/txxt/ast/elements/blank_line_group.rs
+++ b/src/txxt/ast/elements/blank_line_group.rs
@@ -26,7 +26,7 @@
 //! - Simplify grammar matching (no need for blank-line+)
 //! - Make the AST less noisy while maintaining fidelity
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::traits::{AstNode, Visitor};
 use crate::txxt::lexers::Token;
 use std::fmt;
@@ -39,12 +39,12 @@ pub struct BlankLineGroup {
     /// The source tokens that make up this group
     pub source_tokens: Vec<Token>,
     /// The location of this group in the source
-    pub location: Location,
+    pub location: Range,
 }
 
 impl BlankLineGroup {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
 
     pub fn new(count: usize, source_tokens: Vec<Token>) -> Self {
@@ -55,7 +55,7 @@ impl BlankLineGroup {
         }
     }
 
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -74,8 +74,8 @@ impl AstNode for BlankLineGroup {
         }
     }
 
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {

--- a/src/txxt/ast/elements/definition.rs
+++ b/src/txxt/ast/elements/definition.rs
@@ -21,7 +21,7 @@
 //! - The definition spec: docs/specs/v1/elements/definitions.txxt
 //! - The definition sample: docs/specs/v1/samples/element-based/definitions/definitions.simple.txxt
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container, Visitor};
 use super::content_item::ContentItem;
@@ -32,12 +32,12 @@ use std::fmt;
 pub struct Definition {
     pub subject: TextContent,
     pub content: Vec<ContentItem>,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl Definition {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(subject: TextContent, content: Vec<ContentItem>) -> Self {
         Self {
@@ -54,11 +54,11 @@ impl Definition {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -76,8 +76,8 @@ impl AstNode for Definition {
             subject_text.to_string()
         }
     }
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -115,11 +115,12 @@ mod tests {
 
     #[test]
     fn test_definition() {
-        let location = super::super::super::location::Location::new(
-            super::super::super::location::Position::new(1, 0),
-            super::super::super::location::Position::new(1, 10),
+        let location = super::super::super::range::Range::new(
+            0..0,
+            super::super::super::range::Position::new(1, 0),
+            super::super::super::range::Position::new(1, 10),
         );
-        let definition = Definition::with_subject("Subject".to_string()).at(location);
+        let definition = Definition::with_subject("Subject".to_string()).at(location.clone());
         assert_eq!(definition.location, location);
     }
 }

--- a/src/txxt/ast/elements/document.rs
+++ b/src/txxt/ast/elements/document.rs
@@ -20,7 +20,7 @@
 //! - Document-level metadata via annotations
 //! - All body content accessible via document.root.content
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::traits::{AstNode, Container, Visitor};
 use super::annotation::Annotation;
 use super::content_item::ContentItem;
@@ -60,7 +60,7 @@ impl Document {
         Self { metadata, root }
     }
 
-    pub fn with_root_location(mut self, location: Location) -> Self {
+    pub fn with_root_location(mut self, location: Range) -> Self {
         self.root.location = location;
         self
     }
@@ -95,8 +95,8 @@ impl Document {
     }
 
     /// Convenience accessor for the root session's location
-    pub fn root_location(&self) -> Location {
-        self.root.location
+    pub fn root_location(&self) -> Range {
+        self.root.location.clone()
     }
 
     pub fn count_by_type(&self) -> (usize, usize, usize, usize) {
@@ -132,8 +132,8 @@ impl AstNode for Document {
         )
     }
 
-    fn location(&self) -> Location {
-        self.root.location
+    fn range(&self) -> &Range {
+        &self.root.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -177,7 +177,7 @@ impl fmt::Display for Document {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::location::Position;
+    use super::super::super::range::Position;
     use super::super::paragraph::Paragraph;
     use super::super::session::Session;
     use super::*;
@@ -199,15 +199,21 @@ mod tests {
 
         // Create paragraph 1 with properly located TextLine
         let text_line1 = TextLine::new(TextContent::from_string("First".to_string(), None))
-            .at(Location::new(Position::new(0, 0), Position::new(0, 5)));
-        let para1 = Paragraph::new(vec![ContentItem::TextLine(text_line1)])
-            .at(Location::new(Position::new(0, 0), Position::new(0, 5)));
+            .at(Range::new(0..0, Position::new(0, 0), Position::new(0, 5)));
+        let para1 = Paragraph::new(vec![ContentItem::TextLine(text_line1)]).at(Range::new(
+            0..0,
+            Position::new(0, 0),
+            Position::new(0, 5),
+        ));
 
         // Create paragraph 2 with properly located TextLine
         let text_line2 = TextLine::new(TextContent::from_string("Second".to_string(), None))
-            .at(Location::new(Position::new(1, 0), Position::new(1, 6)));
-        let para2 = Paragraph::new(vec![ContentItem::TextLine(text_line2)])
-            .at(Location::new(Position::new(1, 0), Position::new(1, 6)));
+            .at(Range::new(0..0, Position::new(1, 0), Position::new(1, 6)));
+        let para2 = Paragraph::new(vec![ContentItem::TextLine(text_line2)]).at(Range::new(
+            0..0,
+            Position::new(1, 0),
+            Position::new(1, 6),
+        ));
 
         let doc = Document::with_content(vec![
             ContentItem::Paragraph(para1),

--- a/src/txxt/ast/elements/foreign.rs
+++ b/src/txxt/ast/elements/foreign.rs
@@ -32,7 +32,7 @@
 //! - Foreign blocks spec: docs/specs/v1/elements/foreign.txxt
 //!
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
 use super::super::traits::AstNode;
 use super::super::traits::Visitor;
@@ -45,12 +45,12 @@ pub struct ForeignBlock {
     pub subject: TextContent,
     pub content: TextContent,
     pub closing_annotation: Annotation,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl ForeignBlock {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(subject: String, content: String, closing_annotation: Annotation) -> Self {
         Self {
@@ -69,11 +69,11 @@ impl ForeignBlock {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -91,8 +91,8 @@ impl AstNode for ForeignBlock {
             subject_text.to_string()
         }
     }
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {

--- a/src/txxt/ast/elements/label.rs
+++ b/src/txxt/ast/elements/label.rs
@@ -16,19 +16,19 @@
 //! Learn More:
 //! - Labels spec: docs/specs/v1/elements/labels.txxt
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use std::fmt;
 
 /// A label represents a named identifier in txxt documents
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Label {
     pub value: String,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl Label {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(value: String) -> Self {
         Self {
@@ -43,11 +43,11 @@ impl Label {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder: `at(location)`
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -65,11 +65,12 @@ mod tests {
 
     #[test]
     fn test_label() {
-        let location = super::super::super::location::Location::new(
-            super::super::super::location::Position::new(1, 0),
-            super::super::super::location::Position::new(1, 10),
+        let location = super::super::super::range::Range::new(
+            0..0,
+            super::super::super::range::Position::new(1, 0),
+            super::super::super::range::Position::new(1, 10),
         );
-        let label = Label::new("test".to_string()).at(location);
+        let label = Label::new("test".to_string()).at(location.clone());
         assert_eq!(label.location, location);
     }
 }

--- a/src/txxt/ast/elements/list.rs
+++ b/src/txxt/ast/elements/list.rs
@@ -23,7 +23,7 @@
 //! - Labels (used by annotations in lists): docs/specs/v1/elements/labels.txxt
 //! - Parameters (used by annotations in lists): docs/specs/v1/elements/parameters.txxt
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
 use super::super::traits::AstNode;
 use super::super::traits::Container;
@@ -35,7 +35,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct List {
     pub content: Vec<ContentItem>,
-    pub location: Location,
+    pub location: Range,
 }
 
 /// A list item has text and optional nested content
@@ -43,12 +43,12 @@ pub struct List {
 pub struct ListItem {
     pub(crate) text: Vec<TextContent>,
     pub content: Vec<ContentItem>,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl List {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(items: Vec<ContentItem>) -> Self {
         Self {
@@ -57,11 +57,11 @@ impl List {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -74,8 +74,8 @@ impl AstNode for List {
     fn display_label(&self) -> String {
         format!("{} items", self.content.len())
     }
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -91,8 +91,8 @@ impl fmt::Display for List {
 }
 
 impl ListItem {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(text: String) -> Self {
         Self {
@@ -117,11 +117,11 @@ impl ListItem {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -142,8 +142,8 @@ impl AstNode for ListItem {
             text.to_string()
         }
     }
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -176,11 +176,12 @@ mod tests {
 
     #[test]
     fn test_list() {
-        let location = super::super::super::location::Location::new(
-            super::super::super::location::Position::new(1, 0),
-            super::super::super::location::Position::new(1, 10),
+        let location = super::super::super::range::Range::new(
+            0..0,
+            super::super::super::range::Position::new(1, 0),
+            super::super::super::range::Position::new(1, 10),
         );
-        let list = List::new(vec![]).at(location);
+        let list = List::new(vec![]).at(location.clone());
         assert_eq!(list.location, location);
     }
 }

--- a/src/txxt/ast/elements/parameter.rs
+++ b/src/txxt/ast/elements/parameter.rs
@@ -14,7 +14,7 @@
 //! Learn More:
 //! - Parameters spec: docs/specs/v1/elements/parameters.txxt
 
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use std::fmt;
 
 /// A parameter represents a key-value pair
@@ -22,12 +22,12 @@ use std::fmt;
 pub struct Parameter {
     pub key: String,
     pub value: String,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl Parameter {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
 
     pub fn new(key: String, value: String) -> Self {
@@ -38,11 +38,11 @@ impl Parameter {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -60,11 +60,12 @@ mod tests {
 
     #[test]
     fn test_parameter() {
-        let location = super::super::super::location::Location::new(
-            super::super::super::location::Position::new(1, 0),
-            super::super::super::location::Position::new(1, 10),
+        let location = super::super::super::range::Range::new(
+            0..0,
+            super::super::super::range::Position::new(1, 0),
+            super::super::super::range::Position::new(1, 10),
         );
-        let param = Parameter::new("key".to_string(), "value".to_string()).at(location);
+        let param = Parameter::new("key".to_string(), "value".to_string()).at(location.clone());
         assert_eq!(param.location, location);
     }
 }

--- a/src/txxt/ast/elements/session.rs
+++ b/src/txxt/ast/elements/session.rs
@@ -23,7 +23,7 @@
 //!
 //!     Here is where we stop.
 //!
-use super::super::location::{Location, Position};
+use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container, Visitor};
 use super::content_item::ContentItem;
@@ -34,12 +34,12 @@ use std::fmt;
 pub struct Session {
     pub title: TextContent,
     pub content: Vec<ContentItem>,
-    pub location: Location,
+    pub location: Range,
 }
 
 impl Session {
-    fn default_location() -> Location {
-        Location::new(Position::new(0, 0), Position::new(0, 0))
+    fn default_location() -> Range {
+        Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
     pub fn new(title: TextContent, content: Vec<ContentItem>) -> Self {
         Self {
@@ -56,11 +56,11 @@ impl Session {
         }
     }
     #[deprecated(note = "Use at(location) instead")]
-    pub fn with_location(self, location: Location) -> Self {
+    pub fn with_location(self, location: Range) -> Self {
         self.at(location)
     }
     /// Preferred builder
-    pub fn at(mut self, location: Location) -> Self {
+    pub fn at(mut self, location: Range) -> Self {
         self.location = location;
         self
     }
@@ -73,8 +73,8 @@ impl AstNode for Session {
     fn display_label(&self) -> String {
         self.title.as_string().to_string()
     }
-    fn location(&self) -> Location {
-        self.location
+    fn range(&self) -> &Range {
+        &self.location
     }
 
     fn accept(&self, visitor: &mut dyn Visitor) {
@@ -125,11 +125,12 @@ mod tests {
 
     #[test]
     fn test_session() {
-        let location = super::super::super::location::Location::new(
-            super::super::super::location::Position::new(1, 0),
-            super::super::super::location::Position::new(1, 10),
+        let location = super::super::super::range::Range::new(
+            0..0,
+            super::super::super::range::Position::new(1, 0),
+            super::super::super::range::Position::new(1, 10),
         );
-        let session = Session::with_title("Title".to_string()).at(location);
+        let session = Session::with_title("Title".to_string()).at(location.clone());
         assert_eq!(session.location, location);
     }
 }

--- a/src/txxt/ast/lookup.rs
+++ b/src/txxt/ast/lookup.rs
@@ -1,5 +1,5 @@
 use super::elements::Document;
-use super::location::Position;
+use super::range::Position;
 use super::traits::AstNode;
 
 pub fn find_nodes_at_position(document: &Document, position: Position) -> Vec<&dyn AstNode> {

--- a/src/txxt/ast/text_content.rs
+++ b/src/txxt/ast/text_content.rs
@@ -12,7 +12,7 @@
 //! (.as_string(), future: .as_inlines()), which work regardless of the
 //! internal representation.
 
-use super::location::Location;
+use super::range::Range;
 
 /// Represents user-provided text content with source position tracking.
 ///
@@ -22,7 +22,7 @@ use super::location::Location;
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextContent {
     /// Location in the source covering this text
-    pub location: Option<Location>,
+    pub location: Option<Range>,
     /// Internal representation (evolves over time)
     inner: TextRepresentation,
 }
@@ -49,7 +49,7 @@ impl TextContent {
     /// * `location` - Optional source location of this text
     ///
     /// ```
-    pub fn from_string(text: String, location: Option<Location>) -> Self {
+    pub fn from_string(text: String, location: Option<Range>) -> Self {
         Self {
             location,
             inner: TextRepresentation::Text(text),
@@ -167,8 +167,8 @@ mod tests {
 
     #[test]
     fn test() {
-        let location = Location::new(Position::new(0, 0), Position::new(0, 5));
-        let content = TextContent::from_string("Hello".to_string(), Some(location));
+        let location = Range::new(0..0, Position::new(0, 0), Position::new(0, 5));
+        let content = TextContent::from_string("Hello".to_string(), Some(location.clone()));
         assert_eq!(content.location, Some(location));
     }
 
@@ -179,5 +179,5 @@ mod tests {
         assert_eq!(content.as_string(), "World");
     }
 
-    use super::super::location::Position;
+    use super::super::range::Position;
 }

--- a/src/txxt/ast/traits.rs
+++ b/src/txxt/ast/traits.rs
@@ -4,7 +4,7 @@
 //! to AST node information across all node types.
 
 use super::elements::ContentItem;
-use super::location::{Location, Position};
+use super::range::{Position, Range};
 use super::text_content::TextContent;
 
 /// Visitor trait for traversing the AST
@@ -56,9 +56,9 @@ pub fn visit_children(visitor: &mut dyn Visitor, items: &[ContentItem]) {
 pub trait AstNode {
     fn node_type(&self) -> &'static str;
     fn display_label(&self) -> String;
-    fn location(&self) -> Location;
+    fn range(&self) -> &Range;
     fn start_position(&self) -> Position {
-        self.location().start
+        self.range().start
     }
 
     /// Accept a visitor for traversing this node and its children

--- a/src/txxt/parsers.rs
+++ b/src/txxt/parsers.rs
@@ -25,7 +25,7 @@ pub use common::{ParseError, Parser, ParserInput, ParserRegistry};
 // Re-export AST types and utilities from the ast module
 pub use crate::txxt::ast::{
     format_at_position, Annotation, AstNode, Container, ContentItem, Definition, Document,
-    ForeignBlock, Label, List, ListItem, Location, Paragraph, Parameter, Position, Session,
+    ForeignBlock, Label, List, ListItem, Paragraph, Parameter, Position, Range, Session,
     SourceLocation, TextNode,
 };
 

--- a/src/txxt/parsers/common/ast_construction.rs
+++ b/src/txxt/parsers/common/ast_construction.rs
@@ -1,0 +1,372 @@
+//! AST Construction Facade
+//!
+//! This module provides the facade layer that sits between parsers and base builders.
+//! It handles the conversion from parser-specific token structures to the data format
+//! expected by the common AST builders.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Parser (linebased/reference)
+//!     ↓ sends: LineTokens + source string
+//!     ↓
+//! Facade Layer (this module)
+//!     ↓ does 3 things:
+//!     1. Unroll tokens → Vec<(Token, Range<usize>)>
+//!     2. Convert Range<usize> → Location
+//!     3. Extract text
+//!     ↓ calls base builders with correct data
+//!     ↓
+//! Base Builders (builders.rs)
+//!     ↓ creates AST nodes
+//! ```
+//!
+//! # Usage
+//!
+//! Parsers should call these facade functions instead of the base builders directly:
+//!
+//! ```rust,ignore
+//! use crate::txxt::parsers::common::ast_construction;
+//!
+//! // In linebased parser:
+//! let paragraph = ast_construction::build_paragraph_from_line_tokens(
+//!     &line_tokens,
+//!     source
+//! );
+//!
+//! // Facade handles unrolling, location conversion, and calls base builder
+//! ```
+
+use crate::txxt::lexers::linebased::tokens::LineToken;
+use crate::txxt::lexers::tokens::Token;
+use crate::txxt::parsers::ContentItem;
+use std::ops::Range;
+
+use super::builders;
+use super::token_processing::{
+    compute_bounding_box, extract_text, flatten_token_vecs, range_to_location,
+};
+
+// ============================================================================
+// PARAGRAPH CONSTRUCTION
+// ============================================================================
+
+/// Build a Paragraph from LineTokens.
+///
+/// This facade function:
+/// 1. Extracts source tokens from each LineToken
+/// 2. Computes location for each line from its tokens
+/// 3. Extracts text for each line
+/// 4. Calls the base paragraph builder
+///
+/// # Arguments
+///
+/// * `line_tokens` - The LineTokens representing paragraph lines
+/// * `source` - The original source string (needed for text extraction and location conversion)
+///
+/// # Returns
+///
+/// A Paragraph ContentItem with accurate locations
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let paragraph_tokens: Vec<LineToken> = /* ... from parser ... */;
+/// let paragraph = build_paragraph_from_line_tokens(&paragraph_tokens, source);
+/// ```
+pub fn build_paragraph_from_line_tokens(line_tokens: &[LineToken], source: &str) -> ContentItem {
+    // Extract (text, location) for each line
+    let text_lines: Vec<(String, crate::txxt::ast::Location)> = line_tokens
+        .iter()
+        .map(|line_token| {
+            // Get source tokens for this line
+            let tokens = line_token.source_token_pairs();
+
+            // Compute bounding box
+            let range = compute_bounding_box(&tokens);
+
+            // Convert to location and extract text
+            let location = range_to_location(range.clone(), source);
+            let text = extract_text(range, source);
+
+            (text, location)
+        })
+        .collect();
+
+    // Compute overall location from all line tokens
+    let all_token_vecs: Vec<Vec<(Token, Range<usize>)>> = line_tokens
+        .iter()
+        .map(|lt| lt.source_token_pairs())
+        .collect();
+    let all_tokens = flatten_token_vecs(&all_token_vecs);
+    let overall_range = compute_bounding_box(&all_tokens);
+    let overall_location = range_to_location(overall_range, source);
+
+    // Call base builder
+    builders::build_paragraph(text_lines, overall_location)
+}
+
+// ============================================================================
+// SESSION CONSTRUCTION
+// ============================================================================
+
+/// Build a Session from a title LineToken and content items.
+///
+/// # Arguments
+///
+/// * `title_token` - The LineToken for the session title
+/// * `content` - The child content items (already constructed)
+/// * `source` - The original source string
+///
+/// # Returns
+///
+/// A Session ContentItem with accurate location
+pub fn build_session_from_line_token(
+    title_token: &LineToken,
+    content: Vec<ContentItem>,
+    source: &str,
+) -> ContentItem {
+    // Extract title text and location
+    let title_tokens = title_token.source_token_pairs();
+    let title_range = compute_bounding_box(&title_tokens);
+    let title_location = range_to_location(title_range.clone(), source);
+    let title_text = extract_text(title_range, source);
+
+    // Call base builder
+    builders::build_session(title_text, title_location, content)
+}
+
+// ============================================================================
+// DEFINITION CONSTRUCTION
+// ============================================================================
+
+/// Build a Definition from a subject LineToken and content items.
+///
+/// # Arguments
+///
+/// * `subject_token` - The LineToken for the definition subject
+/// * `content` - The child content items (already constructed)
+/// * `source` - The original source string
+///
+/// # Returns
+///
+/// A Definition ContentItem with accurate location
+pub fn build_definition_from_line_token(
+    subject_token: &LineToken,
+    content: Vec<ContentItem>,
+    source: &str,
+) -> ContentItem {
+    // Extract subject text and location
+    let subject_tokens = subject_token.source_token_pairs();
+    let subject_range = compute_bounding_box(&subject_tokens);
+    let subject_location = range_to_location(subject_range.clone(), source);
+    let subject_text = extract_text(subject_range, source);
+
+    // Call base builder
+    builders::build_definition(subject_text, subject_location, content)
+}
+
+// ============================================================================
+// LIST CONSTRUCTION
+// ============================================================================
+
+/// Build a List from ListItems.
+///
+/// # Arguments
+///
+/// * `items` - The list items (already constructed)
+/// * `source` - The original source string
+///
+/// # Returns
+///
+/// A List ContentItem with location computed from all items
+pub fn build_list_from_items(items: Vec<ContentItem>, _source: &str) -> ContentItem {
+    // The base builder will compute location from items
+    // We just pass through since items already have locations
+    builders::build_list(items)
+}
+
+/// Build a ListItem from a marker LineToken and content items.
+///
+/// # Arguments
+///
+/// * `marker_token` - The LineToken containing the list marker and item text
+/// * `content` - The child content items (already constructed)
+/// * `source` - The original source string
+///
+/// # Returns
+///
+/// A ListItem ContentItem with accurate location
+pub fn build_list_item_from_line_token(
+    marker_token: &LineToken,
+    content: Vec<ContentItem>,
+    source: &str,
+) -> ContentItem {
+    // Extract marker tokens
+    let marker_tokens = marker_token.source_token_pairs();
+    let marker_range = compute_bounding_box(&marker_tokens);
+    let marker_location = range_to_location(marker_range.clone(), source);
+    let item_text = extract_text(marker_range, source);
+
+    // Call base builder
+    builders::build_list_item(item_text, marker_location, content)
+}
+
+// ============================================================================
+// ANNOTATION CONSTRUCTION
+// ============================================================================
+
+/// Build an Annotation from LineTokens.
+///
+/// # Arguments
+///
+/// * `label_token` - LineToken for the annotation label
+/// * `parameters` - The annotation parameters (already parsed)
+/// * `content` - The child content items (already constructed)
+/// * `source` - The original source string
+///
+/// # Returns
+///
+/// An Annotation ContentItem with accurate location
+pub fn build_annotation_from_line_token(
+    label_token: &LineToken,
+    parameters: Vec<crate::txxt::ast::Parameter>,
+    content: Vec<ContentItem>,
+    source: &str,
+) -> ContentItem {
+    // Extract label
+    let label_tokens = label_token.source_token_pairs();
+    let label_range = compute_bounding_box(&label_tokens);
+    let label_location = range_to_location(label_range.clone(), source);
+    let label_text = extract_text(label_range, source);
+
+    // Call base builder
+    builders::build_annotation(label_text, label_location, parameters, content)
+}
+
+// ============================================================================
+// FOREIGN BLOCK CONSTRUCTION
+// ============================================================================
+
+/// Build a ForeignBlock from a title LineToken and raw content.
+///
+/// # Arguments
+///
+/// * `subject_token` - The LineToken for the foreign block subject/title
+/// * `content_text` - The raw string content of the block
+/// * `content_location` - The location of the content
+/// * `closing_annotation` - The closing annotation marker
+/// * `source` - The original source string
+///
+/// # Returns
+///
+/// A ForeignBlock ContentItem with accurate location
+pub fn build_foreign_block_from_line_token(
+    subject_token: &LineToken,
+    content_text: String,
+    content_location: crate::txxt::ast::Location,
+    closing_annotation: crate::txxt::ast::Annotation,
+    source: &str,
+) -> ContentItem {
+    // Extract subject
+    let subject_tokens = subject_token.source_token_pairs();
+    let subject_range = compute_bounding_box(&subject_tokens);
+    let subject_location = range_to_location(subject_range.clone(), source);
+    let subject_text = extract_text(subject_range, source);
+
+    // Call base builder
+    builders::build_foreign_block(
+        subject_text,
+        subject_location,
+        content_text,
+        content_location,
+        closing_annotation,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::txxt::lexers::linebased::tokens::LineTokenType;
+    use crate::txxt::lexers::tokens::Token;
+
+    #[test]
+    fn test_build_paragraph_from_line_tokens() {
+        // Create mock line tokens
+        #[allow(clippy::single_range_in_vec_init)]
+        let line_tokens = vec![
+            LineToken {
+                source_tokens: vec![Token::Text("Hello".to_string())],
+                token_spans: vec![0..5],
+                line_type: LineTokenType::ParagraphLine,
+                source_span: Some(0..5),
+            },
+            LineToken {
+                source_tokens: vec![Token::Text("World".to_string())],
+                token_spans: vec![6..11],
+                line_type: LineTokenType::ParagraphLine,
+                source_span: Some(6..11),
+            },
+        ];
+
+        let source = "Hello\nWorld";
+        let paragraph = build_paragraph_from_line_tokens(&line_tokens, source);
+
+        // Verify it's a paragraph
+        match paragraph {
+            ContentItem::Paragraph(p) => {
+                assert_eq!(p.lines.len(), 2);
+                // Verify location spans the entire paragraph
+                assert_eq!(p.location.start.line, 0);
+                assert_eq!(p.location.end.line, 1);
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+
+    #[test]
+    fn test_build_session_from_line_token() {
+        let title_token = LineToken {
+            source_tokens: vec![Token::Text("Title".to_string()), Token::Colon],
+            token_spans: vec![0..5, 5..6],
+            line_type: LineTokenType::SubjectLine,
+            source_span: Some(0..6),
+        };
+
+        let source = "Title:";
+        let content = vec![]; // Empty content for test
+
+        let session = build_session_from_line_token(&title_token, content, source);
+
+        match session {
+            ContentItem::Session(s) => {
+                assert_eq!(s.title.as_ref(), "Title:");
+                assert_eq!(s.location.start.line, 0);
+            }
+            _ => panic!("Expected Session"),
+        }
+    }
+
+    #[test]
+    fn test_build_definition_from_line_token() {
+        let subject_token = LineToken {
+            source_tokens: vec![Token::Text("Subject".to_string()), Token::Colon],
+            token_spans: vec![0..7, 7..8],
+            line_type: LineTokenType::SubjectLine,
+            source_span: Some(0..8),
+        };
+
+        let source = "Subject:";
+        let content = vec![];
+
+        let definition = build_definition_from_line_token(&subject_token, content, source);
+
+        match definition {
+            ContentItem::Definition(d) => {
+                assert_eq!(d.subject.as_ref(), "Subject:");
+                assert_eq!(d.location.start.line, 0);
+            }
+            _ => panic!("Expected Definition"),
+        }
+    }
+}

--- a/src/txxt/parsers/common/ast_construction_tests.rs
+++ b/src/txxt/parsers/common/ast_construction_tests.rs
@@ -1,0 +1,138 @@
+//! Integration tests for AST construction facade using real txxt samples
+//!
+//! Following testing guidelines from src/txxt/testing.rs:
+//! - Use TxxtSources for verified txxt content
+//! - Use TxxtPipeline to generate real tokens
+//! - Test with actual parsed data, not mocked structures
+
+use super::ast_construction::*;
+use crate::txxt::parsers::ContentItem;
+use crate::txxt::processor::txxt_sources::TxxtSources;
+
+#[test]
+fn test_build_paragraph_from_real_tokens() {
+    // Use verified txxt sample
+    let source = TxxtSources::get_string("000-paragraphs.txxt").expect("Failed to load sample");
+
+    // Get real tokens using the linebased pipeline
+    let result = crate::txxt::lexers::_lex(&source);
+    assert!(result.is_ok(), "Failed to lex source");
+
+    let container = result.unwrap();
+
+    // Get line tokens from the container
+    let line_tokens = crate::txxt::lexers::linebased::transformations::indentation_to_token_tree::unwrap_container_to_token_tree(&container);
+
+    // Extract paragraph line tokens (skip blank lines)
+    let paragraph_tokens: Vec<crate::txxt::lexers::linebased::tokens::LineToken> = line_tokens
+        .iter()
+        .filter_map(|tree| match tree {
+            crate::txxt::lexers::linebased::tokens::LineTokenTree::Token(lt)
+                if matches!(
+                    lt.line_type,
+                    crate::txxt::lexers::linebased::tokens::LineTokenType::ParagraphLine
+                ) =>
+            {
+                Some(lt.clone())
+            }
+            _ => None,
+        })
+        .take(2) // Take first 2 paragraph lines
+        .collect();
+
+    // Only run test if we have paragraph tokens
+    if !paragraph_tokens.is_empty() {
+        let paragraph = build_paragraph_from_line_tokens(&paragraph_tokens, &source);
+
+        // Verify it's a paragraph
+        match paragraph {
+            ContentItem::Paragraph(p) => {
+                assert!(!p.lines.is_empty(), "Paragraph should have lines");
+                // Verify location is valid (not default)
+                assert!(p.location.start.line < 100, "Location should be reasonable");
+            }
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+}
+
+#[test]
+fn test_build_session_with_real_tokens() {
+    // Use sample with sessions
+    let source = TxxtSources::get_string("010-paragraphs-sessions-flat-single.txxt")
+        .expect("Failed to load sample");
+
+    // Parse to get real tokens
+    let result = crate::txxt::lexers::_lex(&source);
+    assert!(result.is_ok(), "Failed to lex source");
+
+    let container = result.unwrap();
+    let line_tokens = crate::txxt::lexers::linebased::transformations::indentation_to_token_tree::unwrap_container_to_token_tree(&container);
+
+    // Find a subject line (session title)
+    let subject_token = line_tokens.iter().find_map(|tree| match tree {
+        crate::txxt::lexers::linebased::tokens::LineTokenTree::Token(lt)
+            if matches!(
+                lt.line_type,
+                crate::txxt::lexers::linebased::tokens::LineTokenType::SubjectLine
+            ) =>
+        {
+            Some(lt)
+        }
+        _ => None,
+    });
+
+    if let Some(title_token) = subject_token {
+        let session = build_session_from_line_token(title_token, vec![], &source);
+
+        match session {
+            ContentItem::Session(s) => {
+                assert!(!s.title.as_ref().is_empty(), "Title should not be empty");
+                assert!(s.location.start.line < 100, "Location should be reasonable");
+            }
+            _ => panic!("Expected Session"),
+        }
+    }
+}
+
+#[test]
+fn test_build_definition_with_real_tokens() {
+    // Use sample with definitions
+    let source =
+        TxxtSources::get_string("090-definitions-simple.txxt").expect("Failed to load sample");
+
+    // Parse to get real tokens
+    let result = crate::txxt::lexers::_lex(&source);
+    assert!(result.is_ok(), "Failed to lex source");
+
+    let container = result.unwrap();
+    let line_tokens = crate::txxt::lexers::linebased::transformations::indentation_to_token_tree::unwrap_container_to_token_tree(&container);
+
+    // Find a subject line (definition subject)
+    let subject_token = line_tokens.iter().find_map(|tree| match tree {
+        crate::txxt::lexers::linebased::tokens::LineTokenTree::Token(lt)
+            if matches!(
+                lt.line_type,
+                crate::txxt::lexers::linebased::tokens::LineTokenType::SubjectLine
+            ) =>
+        {
+            Some(lt)
+        }
+        _ => None,
+    });
+
+    if let Some(subj_token) = subject_token {
+        let definition = build_definition_from_line_token(subj_token, vec![], &source);
+
+        match definition {
+            ContentItem::Definition(d) => {
+                assert!(
+                    !d.subject.as_ref().is_empty(),
+                    "Subject should not be empty"
+                );
+                assert!(d.location.start.line < 100, "Location should be reasonable");
+            }
+            _ => panic!("Expected Definition"),
+        }
+    }
+}

--- a/src/txxt/parsers/common/location.rs
+++ b/src/txxt/parsers/common/location.rs
@@ -4,18 +4,18 @@
 //! These utilities handle the conversion from byte ranges to line/column positions and
 //! compute bounding boxes for container nodes (sessions, lists, definitions, etc.).
 
-use std::ops::Range;
+use std::ops::Range as ByteRange;
 
-use crate::txxt::ast::location::SourceLocation;
+use crate::txxt::ast::range::SourceLocation;
 use crate::txxt::ast::traits::AstNode;
-use crate::txxt::ast::{ContentItem, Location};
+use crate::txxt::ast::{ContentItem, Range};
 
 /// Convert a byte range to a Location (line:column positions)
 ///
 /// This is the canonical implementation used throughout both parsers.
 /// Converts byte offsets from token ranges to line/column coordinates
 /// using the SourceLocation utility (O(log n) binary search).
-pub fn byte_range_to_location(source: &str, range: &Range<usize>) -> Location {
+pub fn byte_range_to_location(source: &str, range: &ByteRange<usize>) -> Range {
     debug_assert!(
         range.start <= range.end,
         "Invalid byte range: {}..{} (start > end)",
@@ -23,7 +23,7 @@ pub fn byte_range_to_location(source: &str, range: &Range<usize>) -> Location {
         range.end
     );
     let source_loc = SourceLocation::new(source);
-    source_loc.range_to_location(range)
+    source_loc.byte_range_to_ast_range(range)
 }
 
 /// Compute location bounds from multiple locations
@@ -33,8 +33,8 @@ pub fn byte_range_to_location(source: &str, range: &Range<usize>) -> Location {
 /// - The maximum end line/column across all locations
 ///
 /// This matches both parsers' approach for location aggregation.
-pub fn compute_location_from_locations(locations: &[Location]) -> Location {
-    use crate::txxt::ast::location::Position;
+pub fn compute_location_from_locations(locations: &[Range]) -> Range {
+    use crate::txxt::ast::range::Position;
     let start_line = locations.iter().map(|sp| sp.start.line).min().unwrap_or(0);
     let start_col = locations
         .iter()
@@ -43,7 +43,8 @@ pub fn compute_location_from_locations(locations: &[Location]) -> Location {
         .unwrap_or(0);
     let end_line = locations.iter().map(|sp| sp.end.line).max().unwrap_or(0);
     let end_col = locations.iter().map(|sp| sp.end.column).max().unwrap_or(0);
-    Location::new(
+    Range::new(
+        0..0, // This is an aggregated range, the original spans may not be contiguous
         Position::new(start_line, start_col),
         Position::new(end_line, end_col),
     )
@@ -59,9 +60,9 @@ pub fn compute_location_from_locations(locations: &[Location]) -> Location {
 /// ```ignore
 /// let location = aggregate_locations(title_location, &session_content);
 /// ```
-pub fn aggregate_locations(primary: Location, children: &[ContentItem]) -> Location {
+pub fn aggregate_locations(primary: Range, children: &[ContentItem]) -> Range {
     let mut sources = vec![primary];
-    sources.extend(children.iter().map(|item| item.location()));
+    sources.extend(children.iter().map(|item| item.range().clone()));
     compute_location_from_locations(&sources)
 }
 
@@ -69,7 +70,7 @@ pub fn aggregate_locations(primary: Location, children: &[ContentItem]) -> Locat
 ///
 /// Finds the minimum start and maximum end across all byte ranges.
 /// Used when combining multiple token ranges into a single location.
-pub fn compute_byte_range_bounds(ranges: &[Range<usize>]) -> Range<usize> {
+pub fn compute_byte_range_bounds(ranges: &[ByteRange<usize>]) -> ByteRange<usize> {
     if ranges.is_empty() {
         0..0
     } else {
@@ -82,9 +83,10 @@ pub fn compute_byte_range_bounds(ranges: &[Range<usize>]) -> Range<usize> {
 /// Create a default location (0,0)..(0,0)
 ///
 /// Used when source span information is not available.
-pub fn default_location() -> Location {
-    Location {
-        start: crate::txxt::ast::location::Position { line: 0, column: 0 },
-        end: crate::txxt::ast::location::Position { line: 0, column: 0 },
+pub fn default_location() -> Range {
+    Range {
+        span: 0..0,
+        start: crate::txxt::ast::range::Position { line: 0, column: 0 },
+        end: crate::txxt::ast::range::Position { line: 0, column: 0 },
     }
 }

--- a/src/txxt/parsers/common/mod.rs
+++ b/src/txxt/parsers/common/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains shared interfaces and utilities for parser implementations.
 
+pub mod ast_construction;
 pub mod builders;
 pub mod interface;
 pub mod location;

--- a/src/txxt/parsers/common/mod.rs
+++ b/src/txxt/parsers/common/mod.rs
@@ -5,6 +5,7 @@
 pub mod builders;
 pub mod interface;
 pub mod location;
+pub mod token_processing;
 
 pub use builders::{
     build_annotation, build_definition, build_foreign_block, build_list, build_list_item,

--- a/src/txxt/parsers/common/mod.rs
+++ b/src/txxt/parsers/common/mod.rs
@@ -8,6 +8,9 @@ pub mod interface;
 pub mod location;
 pub mod token_processing;
 
+#[cfg(test)]
+mod ast_construction_tests;
+
 pub use builders::{
     build_annotation, build_definition, build_foreign_block, build_list, build_list_item,
     build_paragraph, build_session, extract_text_from_span,

--- a/src/txxt/parsers/common/token_processing.rs
+++ b/src/txxt/parsers/common/token_processing.rs
@@ -1,0 +1,293 @@
+//! Token processing utilities for location tracking
+//!
+//! This module provides the core utilities for the Immutable Log Architecture.
+//! All functions here are pure and thoroughly unit tested.
+//!
+//! # Architecture
+//!
+//! The Logos lexer produces `(Token, Range<usize>)` pairs - this is the ground truth.
+//! Transformations create aggregate tokens that store these original pairs in `source_tokens`.
+//! This module provides utilities to:
+//! 1. Unroll aggregate tokens back to flat lists
+//! 2. Compute bounding boxes from token ranges
+//! 3. Convert byte ranges to human-readable locations
+//! 4. Extract text from ranges
+
+use crate::txxt::ast::location::{Location, SourceLocation};
+use crate::txxt::lexers::tokens::Token;
+use std::ops::Range;
+
+/// Trait that any token structure can implement to provide access to source tokens.
+///
+/// This enables the unrolling system to work with any parser's token representation.
+pub trait SourceTokenProvider {
+    /// Get the original Logos tokens that comprise this token.
+    ///
+    /// For atomic tokens (direct from Logos), this returns a slice containing just that token.
+    /// For aggregate tokens (from transformations), this returns all the original tokens.
+    fn source_tokens(&self) -> &[(Token, Range<usize>)];
+}
+
+/// Unroll a collection of tokens to a flat list of original Logos tokens.
+///
+/// This recursively extracts all `source_tokens` from aggregate structures,
+/// returning a flat list of the original `(Token, Range<usize>)` pairs that
+/// came directly from the Logos lexer.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let line_tokens: Vec<LineToken> = /* ... parsed tokens ... */;
+/// let flat_tokens = unroll(&line_tokens);
+/// // flat_tokens now contains all original Logos tokens
+/// ```
+pub fn unroll<T: SourceTokenProvider>(tokens: &[T]) -> Vec<(Token, Range<usize>)> {
+    tokens
+        .iter()
+        .flat_map(|t| t.source_tokens().iter().cloned())
+        .collect()
+}
+
+/// Compute the bounding box (minimum start, maximum end) from a list of tokens.
+///
+/// Returns the smallest `Range<usize>` that encompasses all token ranges.
+///
+/// # Panics
+///
+/// Panics if the token list is empty. Callers should ensure tokens are non-empty.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let tokens = vec![
+///     (Token::Text("hello".into()), 0..5),
+///     (Token::Whitespace, 5..6),
+///     (Token::Text("world".into()), 6..11),
+/// ];
+/// let bbox = compute_bounding_box(&tokens);
+/// assert_eq!(bbox, 0..11);
+/// ```
+pub fn compute_bounding_box(tokens: &[(Token, Range<usize>)]) -> Range<usize> {
+    assert!(
+        !tokens.is_empty(),
+        "Cannot compute bounding box from empty token list"
+    );
+
+    let min_start = tokens
+        .iter()
+        .map(|(_, range)| range.start)
+        .min()
+        .unwrap_or(0);
+    let max_end = tokens.iter().map(|(_, range)| range.end).max().unwrap_or(0);
+
+    min_start..max_end
+}
+
+/// Convert a byte range to a human-readable Location (line:column).
+///
+/// This performs the one-time conversion from machine representation (`Range<usize>`)
+/// to human representation (`Location` with line and column numbers).
+///
+/// # Arguments
+///
+/// * `range` - The byte offset range from the source string
+/// * `source` - The original source string (needed to count newlines)
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let location = range_to_location(0..5, "hello world");
+/// assert_eq!(location.start.line, 0);
+/// assert_eq!(location.start.column, 0);
+/// assert_eq!(location.end.line, 0);
+/// assert_eq!(location.end.column, 5);
+/// ```
+pub fn range_to_location(range: Range<usize>, source: &str) -> Location {
+    let source_location = SourceLocation::new(source);
+    source_location.range_to_location(&range)
+}
+
+/// Extract text from the source string at the given range.
+///
+/// # Arguments
+///
+/// * `range` - The byte offset range to extract
+/// * `source` - The original source string
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let text = extract_text(0..5, "hello world");
+/// assert_eq!(text, "hello");
+/// ```
+pub fn extract_text(range: Range<usize>, source: &str) -> String {
+    source[range].to_string()
+}
+
+/// High-level convenience: convert tokens directly to a Location.
+///
+/// This combines `compute_bounding_box` and `range_to_location` for convenience.
+///
+/// # Panics
+///
+/// Panics if tokens is empty.
+pub fn tokens_to_location(tokens: &[(Token, Range<usize>)], source: &str) -> Location {
+    let range = compute_bounding_box(tokens);
+    range_to_location(range, source)
+}
+
+/// High-level convenience: extract text directly from tokens.
+///
+/// This combines `compute_bounding_box` and `extract_text` for convenience.
+///
+/// # Panics
+///
+/// Panics if tokens is empty.
+pub fn tokens_to_text(tokens: &[(Token, Range<usize>)], source: &str) -> String {
+    let range = compute_bounding_box(tokens);
+    extract_text(range, source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::txxt::ast::location::Position;
+
+    // Mock token provider for testing
+    struct MockToken {
+        tokens: Vec<(Token, Range<usize>)>,
+    }
+
+    impl SourceTokenProvider for MockToken {
+        fn source_tokens(&self) -> &[(Token, Range<usize>)] {
+            &self.tokens
+        }
+    }
+
+    #[test]
+    fn test_compute_bounding_box_single_token() {
+        let tokens = vec![(Token::Text("hello".to_string()), 0..5)];
+        let bbox = compute_bounding_box(&tokens);
+        assert_eq!(bbox, 0..5);
+    }
+
+    #[test]
+    fn test_compute_bounding_box_multiple_contiguous() {
+        let tokens = vec![
+            (Token::Text("hello".to_string()), 0..5),
+            (Token::Whitespace, 5..6),
+            (Token::Text("world".to_string()), 6..11),
+        ];
+        let bbox = compute_bounding_box(&tokens);
+        assert_eq!(bbox, 0..11);
+    }
+
+    #[test]
+    fn test_compute_bounding_box_non_contiguous() {
+        // In case tokens have gaps (shouldn't happen normally, but test it)
+        let tokens = vec![
+            (Token::Text("hello".to_string()), 0..5),
+            (Token::Text("world".to_string()), 10..15),
+        ];
+        let bbox = compute_bounding_box(&tokens);
+        assert_eq!(bbox, 0..15);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot compute bounding box from empty token list")]
+    fn test_compute_bounding_box_empty_panics() {
+        let tokens: Vec<(Token, Range<usize>)> = vec![];
+        compute_bounding_box(&tokens);
+    }
+
+    #[test]
+    fn test_extract_text_simple() {
+        let source = "hello world";
+        assert_eq!(extract_text(0..5, source), "hello");
+        assert_eq!(extract_text(6..11, source), "world");
+    }
+
+    #[test]
+    fn test_extract_text_multiline() {
+        let source = "line one\nline two\nline three";
+        assert_eq!(extract_text(0..8, source), "line one");
+        assert_eq!(extract_text(9..17, source), "line two");
+    }
+
+    #[test]
+    fn test_extract_text_unicode() {
+        let source = "hello 世界";
+        // "世界" is 6 bytes (3 bytes per character)
+        let text = extract_text(6..12, source);
+        assert_eq!(text, "世界");
+    }
+
+    #[test]
+    fn test_range_to_location_single_line() {
+        let source = "hello world";
+        let location = range_to_location(0..5, source);
+        assert_eq!(location.start, Position::new(0, 0));
+        assert_eq!(location.end, Position::new(0, 5));
+    }
+
+    #[test]
+    fn test_range_to_location_multiline() {
+        let source = "line one\nline two\nline three";
+        let location = range_to_location(0..17, source);
+        // Should span from (0,0) to end of "line two"
+        assert_eq!(location.start, Position::new(0, 0));
+        assert_eq!(location.end, Position::new(1, 8));
+    }
+
+    #[test]
+    fn test_unroll_single_token() {
+        let mock = MockToken {
+            tokens: vec![(Token::Text("hello".to_string()), 0..5)],
+        };
+        let unrolled = unroll(&[mock]);
+        assert_eq!(unrolled.len(), 1);
+        assert_eq!(unrolled[0].1, 0..5);
+    }
+
+    #[test]
+    fn test_unroll_multiple_tokens() {
+        let mock1 = MockToken {
+            tokens: vec![(Token::Text("hello".to_string()), 0..5)],
+        };
+        let mock2 = MockToken {
+            tokens: vec![
+                (Token::Whitespace, 5..6),
+                (Token::Text("world".to_string()), 6..11),
+            ],
+        };
+        let unrolled = unroll(&[mock1, mock2]);
+        assert_eq!(unrolled.len(), 3);
+        assert_eq!(unrolled[0].1, 0..5);
+        assert_eq!(unrolled[1].1, 5..6);
+        assert_eq!(unrolled[2].1, 6..11);
+    }
+
+    #[test]
+    fn test_tokens_to_location_convenience() {
+        let source = "hello world";
+        let tokens = vec![
+            (Token::Text("hello".to_string()), 0..5),
+            (Token::Whitespace, 5..6),
+            (Token::Text("world".to_string()), 6..11),
+        ];
+        let location = tokens_to_location(&tokens, source);
+        assert_eq!(location.start, Position::new(0, 0));
+        assert_eq!(location.end, Position::new(0, 11));
+    }
+
+    #[test]
+    fn test_tokens_to_text_convenience() {
+        let source = "hello world";
+        let tokens = vec![
+            (Token::Text("hello".to_string()), 0..5),
+            (Token::Whitespace, 5..6),
+        ];
+        let text = tokens_to_text(&tokens, source);
+        assert_eq!(text, "hello ");
+    }
+}

--- a/src/txxt/parsers/linebased/builders.rs
+++ b/src/txxt/parsers/linebased/builders.rs
@@ -1,20 +1,20 @@
 //! Linebased Parser Unwrapper - Pattern to AST Conversion
 //!
 //! This module handles converting matched patterns and tokens into AST nodes.
-//! It reuses existing element builders from src/txxt/parser/elements/ which properly
-//! handle location tracking and AST construction.
+//! It uses the AST construction facade from common::ast_construction which properly
+//! handles token unrolling, location conversion, and AST construction.
 //!
 //! The unwrapper is responsible for:
 //! 1. Taking matched pattern data + tokens
-//! 2. Extracting source locations from tokens via source_tokens field
-//! 3. Building appropriate AST node types using existing builders
+//! 2. Calling facade functions with tokens + source string
+//! 3. Facade handles: unrolling, location conversion, calling base builders
 //! 4. Handling recursive content from nested blocks
 
 use crate::txxt::ast::location::SourceLocation;
 use crate::txxt::lexers::LineToken;
+use crate::txxt::parsers::common::ast_construction;
 use crate::txxt::parsers::common::{
-    build_annotation, build_definition, build_foreign_block, build_list, build_list_item,
-    build_paragraph, build_session, extract_text_from_span,
+    build_annotation, build_paragraph, extract_text_from_span,
     location::{compute_location_from_locations, default_location},
 };
 use crate::txxt::parsers::{ContentItem, Location};
@@ -72,28 +72,21 @@ fn extract_text_from_token_slice(
 // Location utilities are now provided by crate::txxt::parsers::common::location
 // See that module for compute_location_from_locations, aggregate_locations, etc.
 
-/// Stub: Convert a line token to a Paragraph ContentItem.
+/// Convert a line token to a Paragraph ContentItem.
 ///
-/// This is a temporary implementation that treats any token as paragraph text.
-/// Later, this will be enhanced with pattern matching to recognize
-/// Sessions, Definitions, Lists, etc.
+/// Uses the AST construction facade which handles token unrolling,
+/// location conversion, and calls the base builder.
 pub fn unwrap_token_to_paragraph(token: &LineToken, source: &str) -> Result<ContentItem, String> {
-    // Extract text from source_span - not from token iteration
-    let text_content = extract_text_from_line_token(token, source)?;
-
-    // Extract location from source span
-    let location = extract_location_from_token(token, source);
-
-    // Use common builder to create paragraph with single line
-    let paragraph = build_paragraph(vec![(text_content, location)], location);
-
+    // Use facade to build paragraph from single token
+    let paragraph =
+        ast_construction::build_paragraph_from_line_tokens(std::slice::from_ref(token), source);
     Ok(paragraph)
 }
 
 /// Convert multiple line tokens to a single Paragraph ContentItem with multiple lines.
 ///
-/// This handles multi-line paragraphs where consecutive lines are grouped into
-/// a single paragraph node, each line becoming a TextLine in the paragraph.
+/// Uses the AST construction facade which handles token unrolling,
+/// location conversion, and calls the base builder.
 pub fn unwrap_tokens_to_paragraph(
     tokens: Vec<LineToken>,
     source: &str,
@@ -102,20 +95,8 @@ pub fn unwrap_tokens_to_paragraph(
         return Err("Cannot create paragraph from empty token list".to_string());
     }
 
-    // Extract combined location spanning all tokens
-    let overall_location = extract_location_from_tokens(&tokens, source);
-
-    // Extract text and location for each line
-    let mut text_lines = Vec::new();
-    for token in tokens.iter() {
-        let text_content = extract_text_from_line_token(token, source)?;
-        let line_location = extract_location_from_token(token, source);
-        text_lines.push((text_content, line_location));
-    }
-
-    // Use common builder to create paragraph from all lines
-    let paragraph = build_paragraph(text_lines, overall_location);
-
+    // Use facade to build paragraph from multiple tokens
+    let paragraph = ast_construction::build_paragraph_from_line_tokens(&tokens, source);
     Ok(paragraph)
 }
 
@@ -172,23 +153,24 @@ pub fn unwrap_annotation(token: &LineToken, source: &str) -> Result<ContentItem,
         )?;
 
         // Build content with optional trailing text
+        // Note: We use build_paragraph directly here because we've already extracted the text
+        // and can't easily create a proper LineToken for the facade
         let content = if !trailing_text.is_empty() {
-            let text_line_item = build_paragraph(vec![(trailing_text, location)], location);
-            vec![text_line_item]
+            vec![build_paragraph(vec![(trailing_text, location)], location)]
         } else {
             vec![]
         };
 
-        // Use common builder to create annotation
+        // Use build_annotation directly because we've already parsed the label structure
+        // The annotation facade expects unparsed LineToken, but we've done custom parsing
         let annotation = build_annotation(label_text, location, vec![], content);
         return Ok(annotation);
     }
 
     // Fallback: single-line annotation without trailing text
-    let label_text = extract_text_from_line_token(token, source)?;
-
-    // Use common builder to create annotation
-    let annotation = build_annotation(label_text, location, vec![], vec![]);
+    // Use facade to create simple annotation
+    let annotation =
+        ast_construction::build_annotation_from_line_token(token, vec![], vec![], source);
     Ok(annotation)
 }
 
@@ -198,14 +180,9 @@ pub fn unwrap_annotation_with_content(
     content: Vec<ContentItem>,
     source: &str,
 ) -> Result<ContentItem, String> {
-    // Extract text content from the opening annotation using unified span-based extraction
-    let label_text = extract_text_from_line_token(opening_token, source)?;
-
-    // Extract location from the opening token
-    let location = extract_location_from_token(opening_token, source);
-
-    // Use common builder to create annotation
-    let annotation = build_annotation(label_text, location, vec![], content);
+    // Use facade to create annotation with content
+    let annotation =
+        ast_construction::build_annotation_from_line_token(opening_token, vec![], content, source);
     Ok(annotation)
 }
 
@@ -261,20 +238,15 @@ fn extract_location_from_tokens(tokens: &[LineToken], source: &str) -> Location 
 ///
 /// Used by the parser when it matches: SUBJECT_LINE + BLANK_LINE + INDENT
 ///
-/// Location is aggregated from the subject title and all child content,
-/// matching the reference parser's hierarchical location approach.
+/// Uses the AST construction facade which handles token unrolling,
+/// location conversion, and calls the base builder.
 pub fn unwrap_session(
     subject_token: &LineToken,
     content: Vec<ContentItem>,
     source: &str,
 ) -> Result<ContentItem, String> {
-    let title_text = extract_text_from_line_token(subject_token, source)?;
-
-    // Extract location from the subject token
-    let title_location = extract_location_from_token(subject_token, source);
-
-    // Use common builder to create session
-    let session = build_session(title_text, title_location, content);
+    // Use facade to build session
+    let session = ast_construction::build_session_from_line_token(subject_token, content, source);
     Ok(session)
 }
 
@@ -282,20 +254,16 @@ pub fn unwrap_session(
 ///
 /// Used by the parser when it matches: SUBJECT_LINE + INDENT (no blank line)
 ///
-/// Location is aggregated from the subject title and all child content,
-/// matching the reference parser's hierarchical location approach.
+/// Uses the AST construction facade which handles token unrolling,
+/// location conversion, and calls the base builder.
 pub fn unwrap_definition(
     subject_token: &LineToken,
     content: Vec<ContentItem>,
     source: &str,
 ) -> Result<ContentItem, String> {
-    let subject_text = extract_text_from_line_token(subject_token, source)?;
-
-    // Extract location from the subject token
-    let subject_location = extract_location_from_token(subject_token, source);
-
-    // Use common builder to create definition
-    let definition = build_definition(subject_text, subject_location, content);
+    // Use facade to build definition
+    let definition =
+        ast_construction::build_definition_from_line_token(subject_token, content, source);
     Ok(definition)
 }
 
@@ -303,15 +271,15 @@ pub fn unwrap_definition(
 ///
 /// Used by the parser when it matches: BLANK_LINE + 2+ list items
 ///
-/// Location is computed from all child list item locations,
-/// matching the reference parser's hierarchical location approach.
-pub fn unwrap_list(list_items: Vec<ContentItem>, _source: &str) -> Result<ContentItem, String> {
+/// Uses the AST construction facade which handles location computation
+/// from all child items.
+pub fn unwrap_list(list_items: Vec<ContentItem>, source: &str) -> Result<ContentItem, String> {
     if list_items.is_empty() {
         return Err("Cannot create list with no items".to_string());
     }
 
-    // Use common builder to create list
-    let list = build_list(list_items);
+    // Use facade to build list
+    let list = ast_construction::build_list_from_items(list_items, source);
     Ok(list)
 }
 
@@ -319,20 +287,15 @@ pub fn unwrap_list(list_items: Vec<ContentItem>, _source: &str) -> Result<Conten
 ///
 /// Called for each item in a list
 ///
-/// Location is aggregated from the item text and any nested content,
-/// matching the reference parser's hierarchical location approach.
+/// Uses the AST construction facade which handles token unrolling,
+/// location conversion, and calls the base builder.
 pub fn unwrap_list_item(
     item_token: &LineToken,
     content: Vec<ContentItem>,
     source: &str,
 ) -> Result<ContentItem, String> {
-    let item_text = extract_text_from_line_token(item_token, source)?;
-
-    // Extract location from the item token
-    let item_location = extract_location_from_token(item_token, source);
-
-    // Use common builder to create list item
-    let list_item = build_list_item(item_text, item_location, content);
+    // Use facade to build list item
+    let list_item = ast_construction::build_list_item_from_line_token(item_token, content, source);
     Ok(list_item)
 }
 
@@ -340,17 +303,14 @@ pub fn unwrap_list_item(
 ///
 /// Used by the parser when it matches: SUBJECT_LINE + INDENT...DEDENT + ANNOTATION_LINE
 ///
-/// Location is aggregated from subject, content lines, and closing annotation,
-/// matching the reference parser's hierarchical location approach.
+/// Uses the AST construction facade for building the foreign block and annotation.
+/// The caller must combine content lines, as foreign blocks have special content handling.
 pub fn unwrap_foreign_block(
     subject_token: &LineToken,
     content_lines: Vec<&LineToken>,
     closing_annotation_token: &LineToken,
     source: &str,
 ) -> Result<ContentItem, String> {
-    let subject_text = extract_text_from_line_token(subject_token, source)?;
-    let subject_location = extract_location_from_token(subject_token, source);
-
     // Combine all content lines into a single text block
     let mut content_text = String::new();
     for (idx, token) in content_lines.iter().enumerate() {
@@ -369,525 +329,25 @@ pub fn unwrap_foreign_block(
         extract_location_from_tokens(&tokens, source)
     };
 
-    // Create the closing annotation with proper location using common builder
-    let annotation_text = extract_text_from_line_token(closing_annotation_token, source)?;
-    let annotation_location = extract_location_from_token(closing_annotation_token, source);
-    let closing_annotation =
-        match build_annotation(annotation_text, annotation_location, vec![], vec![]) {
-            ContentItem::Annotation(annotation) => annotation,
-            _ => unreachable!("build_annotation always returns Annotation"),
-        };
+    // Use facade to build the closing annotation
+    let closing_annotation = match ast_construction::build_annotation_from_line_token(
+        closing_annotation_token,
+        vec![],
+        vec![],
+        source,
+    ) {
+        ContentItem::Annotation(annotation) => annotation,
+        _ => unreachable!("build_annotation_from_line_token always returns Annotation"),
+    };
 
-    // Use common builder to create foreign block
-    let foreign_block = build_foreign_block(
-        subject_text,
-        subject_location,
+    // Use facade to create foreign block
+    let foreign_block = ast_construction::build_foreign_block_from_line_token(
+        subject_token,
         content_text,
         content_location,
         closing_annotation,
+        source,
     );
 
     Ok(foreign_block)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::txxt::lexers::{LineTokenType, Token};
-    use crate::txxt::parsers::Position;
-
-    fn make_line_token(line_type: LineTokenType, tokens: Vec<Token>) -> LineToken {
-        // Create a reasonable default span - in tests, source is usually small
-        // This span should work with test sources
-        // token_spans will be populated during pipeline processing
-        let num_tokens = tokens.len();
-        LineToken {
-            source_tokens: tokens,
-            token_spans: vec![0..1000; num_tokens], // Default span for each token in tests
-            line_type,
-            source_span: Some(0..1000), // Large span to accommodate test sources
-        }
-    }
-
-    #[test]
-    fn test_unwrap_simple_paragraph_token() {
-        let token = make_line_token(
-            LineTokenType::ParagraphLine,
-            vec![Token::Text("Hello world".to_string())],
-        );
-
-        let result = unwrap_token_to_paragraph(&token, "Hello world\n");
-        assert!(result.is_ok());
-
-        let item = result.unwrap();
-        assert!(matches!(item, ContentItem::Paragraph(_)));
-
-        if let ContentItem::Paragraph(para) = item {
-            assert_eq!(para.lines.len(), 1);
-        }
-    }
-
-    #[test]
-    fn test_unwrap_multiple_text_tokens() {
-        let token = make_line_token(
-            LineTokenType::ParagraphLine,
-            vec![
-                Token::Text("Hello".to_string()),
-                Token::Whitespace,
-                Token::Text("world".to_string()),
-            ],
-        );
-
-        let result = unwrap_token_to_paragraph(&token, "Hello world\n");
-        assert!(result.is_ok());
-
-        let item = result.unwrap();
-        if let ContentItem::Paragraph(para) = item {
-            assert_eq!(para.lines.len(), 1);
-            if let ContentItem::TextLine(line) = &para.lines[0] {
-                // Text should be extracted from tokens
-                assert!(!line.content.as_string().is_empty());
-            }
-        }
-    }
-
-    #[test]
-    fn test_unwrap_subject_line_token() {
-        let token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![Token::Text("Title".to_string()), Token::Colon],
-        );
-
-        let result = unwrap_token_to_paragraph(&token, "Title:\n");
-        assert!(result.is_ok());
-
-        // For now, subjects are treated as paragraphs
-        let item = result.unwrap();
-        assert!(matches!(item, ContentItem::Paragraph(_)));
-    }
-
-    #[test]
-    fn test_unwrap_list_line_token() {
-        let token = make_line_token(
-            LineTokenType::ListLine,
-            vec![
-                Token::Dash,
-                Token::Whitespace,
-                Token::Text("Item".to_string()),
-            ],
-        );
-
-        let result = unwrap_token_to_paragraph(&token, "- Item\n");
-        assert!(result.is_ok());
-
-        // For now, list items are treated as paragraphs
-        let item = result.unwrap();
-        assert!(matches!(item, ContentItem::Paragraph(_)));
-    }
-
-    #[test]
-    fn test_unwrap_blank_line_token() {
-        let token = make_line_token(LineTokenType::BlankLine, vec![Token::Newline]);
-
-        let result = unwrap_token_to_paragraph(&token, "\n");
-        assert!(result.is_ok());
-
-        let item = result.unwrap();
-        assert!(matches!(item, ContentItem::Paragraph(_)));
-    }
-
-    // ========== LOCATION PRESERVATION TESTS ==========
-    // These tests verify that location information flows from source spans
-    // through the unwrapper functions into the AST nodes
-
-    #[test]
-    fn test_unwrap_paragraph_with_span_extracts_location() {
-        let mut token = make_line_token(
-            LineTokenType::ParagraphLine,
-            vec![Token::Text("Hello world".to_string())],
-        );
-        // Simulate source span: characters 0-11 in source
-        token.source_span = Some(0..11);
-
-        let source = "Hello world\n";
-        let result = unwrap_token_to_paragraph(&token, source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Paragraph(para)) = result {
-            // When span is present, location should be extracted from it
-            // The location should span the text (columns 0-11 on line 0)
-            assert_eq!(para.location.start.line, 0);
-            assert_eq!(para.location.start.column, 0);
-            assert_eq!(para.location.end.line, 0);
-            assert_eq!(para.location.end.column, 11);
-        } else {
-            panic!("Expected Paragraph");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_annotation_with_span_extracts_location() {
-        let mut token = make_line_token(
-            LineTokenType::AnnotationStartLine,
-            vec![
-                Token::TxxtMarker,               // 0..2 (::)
-                Token::Whitespace,               // 2..3 ( )
-                Token::Text("note".to_string()), // 3..7
-                Token::Whitespace,               // 7..8 ( )
-                Token::TxxtMarker,               // 8..10 (::)
-            ],
-        );
-        // Set accurate token spans matching source
-        token.token_spans = vec![0..2, 2..3, 3..7, 7..8, 8..10];
-        token.source_span = Some(0..10);
-
-        let source = ":: note ::\nSome text\n";
-        let result = unwrap_annotation(&token, source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Annotation(anno)) = result {
-            // When span is present, location should be extracted
-            // Should span the ":: note ::" on line 0
-            assert_eq!(anno.location.start.line, 0);
-            assert_eq!(anno.location.start.column, 0);
-            assert_eq!(anno.location.end.line, 0);
-            assert_eq!(anno.location.end.column, 10);
-        } else {
-            panic!("Expected Annotation");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_session_with_span_extracts_location() {
-        let mut token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![Token::Text("Session Title".to_string()), Token::Colon],
-        );
-        // Simulate source span: "Session Title:" at bytes 0-14
-        token.source_span = Some(0..14);
-
-        let source = "Session Title:\n    Nested content\n";
-        let result = unwrap_session(&token, vec![], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Session(session)) = result {
-            // When span is present, location should be extracted
-            // Should span the title line
-            assert_eq!(session.location.start.line, 0);
-            assert_eq!(session.location.start.column, 0);
-            assert_eq!(session.location.end.line, 0);
-            assert_eq!(session.location.end.column, 14);
-        } else {
-            panic!("Expected Session");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_definition_with_span_extracts_location() {
-        let mut token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![Token::Text("Term".to_string()), Token::Colon],
-        );
-        // Simulate source span: "Term:" at bytes 0-5
-        token.source_span = Some(0..5);
-
-        let source = "Term:\n    Definition content\n";
-        let result = unwrap_definition(&token, vec![], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Definition(def)) = result {
-            // When span is present, location should be extracted
-            // Should span "Term:" on line 0
-            assert_eq!(def.location.start.line, 0);
-            assert_eq!(def.location.start.column, 0);
-            assert_eq!(def.location.end.line, 0);
-            assert_eq!(def.location.end.column, 5);
-        } else {
-            panic!("Expected Definition");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_list_item_with_span_extracts_location() {
-        let mut token = make_line_token(
-            LineTokenType::ListLine,
-            vec![
-                Token::Dash,
-                Token::Whitespace,
-                Token::Text("Item content".to_string()),
-            ],
-        );
-        // Simulate source span: "- Item content" at bytes 0-14
-        token.source_span = Some(0..14);
-
-        let source = "- Item content\n";
-        let result = unwrap_list_item(&token, vec![], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::ListItem(item)) = result {
-            // When span is present, location should be extracted
-            // Should span the list item
-            assert_eq!(item.location.start.line, 0);
-            assert_eq!(item.location.start.column, 0);
-            assert_eq!(item.location.end.line, 0);
-            assert_eq!(item.location.end.column, 14);
-        } else {
-            panic!("Expected ListItem");
-        }
-    }
-
-    #[test]
-    fn test_multiline_paragraph_with_spans_extracts_combined_location() {
-        let mut token1 = make_line_token(
-            LineTokenType::ParagraphLine,
-            vec![Token::Text("Line 1".to_string())],
-        );
-        token1.source_span = Some(0..6);
-
-        let mut token2 = make_line_token(
-            LineTokenType::ParagraphLine,
-            vec![Token::Text("Line 2".to_string())],
-        );
-        token2.source_span = Some(7..13);
-
-        let source = "Line 1\nLine 2\n";
-        let result = unwrap_tokens_to_paragraph(vec![token1, token2], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Paragraph(para)) = result {
-            // The combined location should span from start of first to end of second
-            assert_eq!(para.location.start.line, 0);
-            assert_eq!(para.location.start.column, 0);
-            assert_eq!(para.location.end.line, 1);
-            assert_eq!(para.location.end.column, 6);
-        } else {
-            panic!("Expected Paragraph");
-        }
-    }
-
-    // ========== HIERARCHICAL LOCATION AGGREGATION TESTS ==========
-    // These tests verify that container nodes properly aggregate locations
-    // from their header/subject and all child content items.
-
-    #[test]
-    fn test_unwrap_session_aggregates_header_and_child_locations() {
-        // Session title on line 0, columns 0-14
-        let mut subject_token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![Token::Text("Session Title".to_string()), Token::Colon],
-        );
-        subject_token.source_span = Some(0..14);
-
-        // Create mock child content with known locations using common builder:
-        // Child 1: line 1, columns 4-20 (nested paragraph)
-        let child1_location = Location::new(Position::new(1, 4), Position::new(1, 20));
-        let child1 = build_paragraph(vec![], child1_location);
-
-        // Child 2: line 2, columns 4-25 (another nested paragraph)
-        let child2_location = Location::new(Position::new(2, 4), Position::new(2, 25));
-        let child2 = build_paragraph(vec![], child2_location);
-
-        let source = "Session Title:\n    First line\n    Second line\n";
-        let result = unwrap_session(&subject_token, vec![child1, child2], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Session(session)) = result {
-            // Location should be bounding box: from start of header (0:0) to end of last child (2:25)
-            assert_eq!(session.location.start.line, 0);
-            assert_eq!(session.location.start.column, 0);
-            assert_eq!(session.location.end.line, 2);
-            assert_eq!(session.location.end.column, 25);
-        } else {
-            panic!("Expected Session");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_definition_aggregates_subject_and_child_locations() {
-        // Definition subject on line 0, columns 0-5
-        let mut subject_token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![Token::Text("Term".to_string()), Token::Colon],
-        );
-        subject_token.source_span = Some(0..5);
-
-        // Create mock child content with known locations using common builder:
-        // Child 1: line 1, columns 4-18
-        let child1_location = Location::new(Position::new(1, 4), Position::new(1, 18));
-        let child1 = build_paragraph(vec![], child1_location);
-
-        // Child 2: line 2, columns 4-22
-        let child2_location = Location::new(Position::new(2, 4), Position::new(2, 22));
-        let child2 = build_paragraph(vec![], child2_location);
-
-        let source = "Term:\n    Definition part 1\n    Definition part 2\n";
-        let result = unwrap_definition(&subject_token, vec![child1, child2], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Definition(definition)) = result {
-            // Location should be bounding box: from start of subject (0:0) to end of last child (2:22)
-            assert_eq!(definition.location.start.line, 0);
-            assert_eq!(definition.location.start.column, 0);
-            assert_eq!(definition.location.end.line, 2);
-            assert_eq!(definition.location.end.column, 22);
-        } else {
-            panic!("Expected Definition");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_list_item_aggregates_item_and_nested_content() {
-        // List item on line 0, columns 0-14
-        let mut item_token = make_line_token(
-            LineTokenType::ListLine,
-            vec![
-                Token::Dash,
-                Token::Whitespace,
-                Token::Text("Item text".to_string()),
-            ],
-        );
-        item_token.source_span = Some(0..14);
-
-        // Create mock nested content using common builder:
-        // Nested child: line 1, columns 4-30
-        let nested_location = Location::new(Position::new(1, 4), Position::new(1, 30));
-        let nested_content = build_paragraph(vec![], nested_location);
-
-        let source = "- Item text\n    Nested content here\n";
-        let result = unwrap_list_item(&item_token, vec![nested_content], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::ListItem(item)) = result {
-            // Location should be bounding box: from start of item (0:0) to end of nested content (1:30)
-            assert_eq!(item.location.start.line, 0);
-            assert_eq!(item.location.start.column, 0);
-            assert_eq!(item.location.end.line, 1);
-            assert_eq!(item.location.end.column, 30);
-        } else {
-            panic!("Expected ListItem");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_list_aggregates_all_item_locations() {
-        // Create mock list items with different locations
-
-        // Item 1: line 0, columns 0-8 ("- Item 1" = 8 chars) using common builder
-        let item1_location = Location::new(Position::new(0, 0), Position::new(0, 8));
-        let item1 = build_list_item("Item 1".to_string(), item1_location, vec![]);
-
-        // Item 2: line 1, columns 0-8 ("- Item 2" = 8 chars) using common builder
-        let item2_location = Location::new(Position::new(1, 0), Position::new(1, 8));
-        let item2 = build_list_item("Item 2".to_string(), item2_location, vec![]);
-
-        // Item 3: line 2, columns 0-8 ("- Item 3" = 8 chars) using common builder
-        let item3_location = Location::new(Position::new(2, 0), Position::new(2, 8));
-        let item3 = build_list_item("Item 3".to_string(), item3_location, vec![]);
-
-        let source = "- Item 1\n- Item 2\n- Item 3\n";
-        let result = unwrap_list(vec![item1, item2, item3], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::List(list)) = result {
-            // Location should be bounding box encompassing all items:
-            // from start of item 1 (0:0) to end of item 3 (2:8)
-            assert_eq!(list.location.start.line, 0);
-            assert_eq!(list.location.start.column, 0);
-            assert_eq!(list.location.end.line, 2);
-            assert_eq!(list.location.end.column, 8);
-        } else {
-            panic!("Expected List");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_session_with_children_on_different_lines() {
-        // Header spanning lines 0-1
-        let mut subject_token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![
-                Token::Text("Multi-line".to_string()),
-                Token::Whitespace,
-                Token::Text("Title".to_string()),
-                Token::Colon,
-            ],
-        );
-        // Span from line 0 col 0 to line 1 col 5
-        subject_token.source_span = Some(0..20);
-
-        // Child starting earlier on line 0 (edge case: child starts before or overlaps with header)
-        // This tests that min/max logic correctly computes bounding box using common builder
-        let child_location = Location::new(
-            Position::new(0, 15), // Overlaps with header end
-            Position::new(3, 10), // Extends beyond header
-        );
-        let child = build_paragraph(vec![], child_location);
-
-        let source = "Multi-line\n Title:\n    Content line 1\n    Content line 2\n";
-        let result = unwrap_session(&subject_token, vec![child], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Session(session)) = result {
-            // Bounding box should span from header start (0:0) to child end (3:10)
-            assert_eq!(session.location.start.line, 0);
-            assert_eq!(session.location.start.column, 0);
-            assert_eq!(session.location.end.line, 3);
-            assert_eq!(session.location.end.column, 10);
-        } else {
-            panic!("Expected Session");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_definition_empty_children_uses_subject_location() {
-        // Definition with no children should use only subject location
-        let mut subject_token = make_line_token(
-            LineTokenType::SubjectLine,
-            vec![Token::Text("Term".to_string()), Token::Colon],
-        );
-        subject_token.source_span = Some(0..5);
-
-        let source = "Term:\n";
-        let result = unwrap_definition(&subject_token, vec![], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::Definition(definition)) = result {
-            // With empty children, location should match just the subject
-            assert_eq!(definition.location.start.line, 0);
-            assert_eq!(definition.location.start.column, 0);
-            assert_eq!(definition.location.end.line, 0);
-            assert_eq!(definition.location.end.column, 5);
-        } else {
-            panic!("Expected Definition");
-        }
-    }
-
-    #[test]
-    fn test_unwrap_list_item_no_nested_content_uses_item_location() {
-        // List item with no nested content should use only item location
-        let mut item_token = make_line_token(
-            LineTokenType::ListLine,
-            vec![
-                Token::Dash,
-                Token::Whitespace,
-                Token::Text("Item".to_string()),
-            ],
-        );
-        // Span covers "- Item" (6 characters)
-        item_token.source_span = Some(0..6);
-
-        let source = "- Item\n";
-        let result = unwrap_list_item(&item_token, vec![], source);
-        assert!(result.is_ok());
-
-        if let Ok(ContentItem::ListItem(item)) = result {
-            // With no nested content, location should match just the item
-            assert_eq!(item.location.start.line, 0);
-            assert_eq!(item.location.start.column, 0);
-            assert_eq!(item.location.end.line, 0);
-            assert_eq!(item.location.end.column, 6);
-        } else {
-            panic!("Expected ListItem");
-        }
-    }
 }

--- a/src/txxt/parsers/linebased/engine.rs
+++ b/src/txxt/parsers/linebased/engine.rs
@@ -12,8 +12,9 @@
 //! making it testable and maintainable independently.
 
 use super::declarative_grammar;
+use crate::txxt::ast::Range;
 use crate::txxt::lexers::linebased::tokens::LineContainerToken;
-use crate::txxt::parsers::{ContentItem, Document, Location, Position};
+use crate::txxt::parsers::{ContentItem, Document, Position};
 
 /// Parse using the new declarative grammar engine (Delivery 2).
 ///
@@ -40,7 +41,8 @@ pub fn parse_experimental_v2(tree: LineContainerToken, source: &str) -> Result<D
 
     // Create the root session containing all top-level content using common builder
     use crate::txxt::parsers::common::builders::build_session;
-    let root_location = Location {
+    let root_location = Range {
+        span: 0..0,
         start: Position { line: 0, column: 0 },
         end: Position { line: 0, column: 0 },
     };

--- a/src/txxt/parsers/reference/document.rs
+++ b/src/txxt/parsers/reference/document.rs
@@ -20,9 +20,9 @@ type ParserError = Simple<TokenLocation>;
 /// for the actual document content parsing logic.
 pub fn document(source: &str) -> impl Parser<TokenLocation, Document, Error = ParserError> + Clone {
     super::parser::build_document_content_parser(source).map(|content| {
-        let content_locations = content
+        let content_locations: Vec<crate::txxt::ast::range::Range> = content
             .iter()
-            .map(|item| item.location())
+            .map(|item| item.range().clone())
             .collect::<Vec<_>>();
         let location = compute_location_from_locations(&content_locations);
 

--- a/src/txxt/testing/testing_assertions.rs
+++ b/src/txxt/testing/testing_assertions.rs
@@ -60,23 +60,27 @@ impl<'a> DocumentAssertion<'a> {
 
     /// Assert the root session location starts at the given line and column
     pub fn root_location_starts_at(self, expected_line: usize, expected_column: usize) -> Self {
-        let actual = self.doc.root.location;
+        let actual = self.doc.root.location.clone();
         assert_eq!(
-            actual.start.line, expected_line,
+            actual.clone().start.line,
+            expected_line,
             "Expected root session location start line {}, found {}",
-            expected_line, actual.start.line
+            expected_line,
+            actual.clone().start.line
         );
         assert_eq!(
-            actual.start.column, expected_column,
+            actual.clone().start.column,
+            expected_column,
             "Expected root session location start column {}, found {}",
-            expected_column, actual.start.column
+            expected_column,
+            actual.clone().start.column
         );
         self
     }
 
     /// Assert the root session location ends at the given line and column
     pub fn root_location_ends_at(self, expected_line: usize, expected_column: usize) -> Self {
-        let actual = self.doc.root.location;
+        let actual = self.doc.root.location.clone();
         assert_eq!(
             actual.end.line, expected_line,
             "Expected root session location end line {}, found {}",
@@ -92,10 +96,10 @@ impl<'a> DocumentAssertion<'a> {
 
     /// Assert the root session location contains the given position
     pub fn root_location_contains(self, line: usize, column: usize) -> Self {
-        use crate::txxt::ast::location::Position;
+        use crate::txxt::ast::range::Position;
 
         let pos = Position::new(line, column);
-        let location = self.doc.root.location;
+        let location = self.doc.root.location.clone();
         assert!(
             location.contains(pos),
             "Expected root session location {} to contain position {}:{}",
@@ -108,10 +112,10 @@ impl<'a> DocumentAssertion<'a> {
 
     /// Assert the root session location does NOT contain the given position
     pub fn root_location_excludes(self, line: usize, column: usize) -> Self {
-        use crate::txxt::ast::location::Position;
+        use crate::txxt::ast::range::Position;
 
         let pos = Position::new(line, column);
-        let location = self.doc.root.location;
+        let location = self.doc.root.location.clone();
         assert!(
             !location.contains(pos),
             "Expected root session location {} to NOT contain position {}:{}",
@@ -752,12 +756,12 @@ fn summarize_items(items: &[ContentItem]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::txxt::ast::location::{Location, Position};
+    use crate::txxt::ast::range::{Position, Range};
     use crate::txxt::ast::{Document, Session};
 
     #[test]
     fn test_root_location_starts_at() {
-        let location = Location::new(Position::new(0, 0), Position::new(0, 10));
+        let location = Range::new(0..0, Position::new(0, 0), Position::new(0, 10));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -772,7 +776,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Expected root session location start line 5, found 0")]
     fn test_root_location_starts_at_fails_wrong_line() {
-        let location = Location::new(Position::new(0, 0), Position::new(0, 10));
+        let location = Range::new(0..0, Position::new(0, 0), Position::new(0, 10));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -785,7 +789,7 @@ mod tests {
 
     #[test]
     fn test_root_location_ends_at() {
-        let location = Location::new(Position::new(0, 0), Position::new(2, 15));
+        let location = Range::new(0..0, Position::new(0, 0), Position::new(2, 15));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -799,7 +803,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Expected root session location end column 10, found 15")]
     fn test_root_location_ends_at_fails_wrong_column() {
-        let location = Location::new(Position::new(0, 0), Position::new(2, 15));
+        let location = Range::new(0..0, Position::new(0, 0), Position::new(2, 15));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -812,7 +816,7 @@ mod tests {
 
     #[test]
     fn test_root_location_contains() {
-        let location = Location::new(Position::new(1, 0), Position::new(3, 10));
+        let location = Range::new(0..0, Position::new(1, 0), Position::new(3, 10));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -826,7 +830,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Expected root session location")]
     fn test_root_location_contains_fails() {
-        let location = Location::new(Position::new(1, 0), Position::new(3, 10));
+        let location = Range::new(0..0, Position::new(1, 0), Position::new(3, 10));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -839,7 +843,7 @@ mod tests {
 
     #[test]
     fn test_root_location_excludes() {
-        let location = Location::new(Position::new(1, 0), Position::new(3, 10));
+        let location = Range::new(0..0, Position::new(1, 0), Position::new(3, 10));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -853,7 +857,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Expected root session location")]
     fn test_root_location_excludes_fails() {
-        let location = Location::new(Position::new(1, 0), Position::new(3, 10));
+        let location = Range::new(0..0, Position::new(1, 0), Position::new(3, 10));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {
@@ -866,7 +870,7 @@ mod tests {
 
     #[test]
     fn test_location_assertions_are_fluent() {
-        let location = Location::new(Position::new(0, 0), Position::new(5, 20));
+        let location = Range::new(0..0, Position::new(0, 0), Position::new(5, 20));
         let mut session = Session::with_title(String::new());
         session.location = location;
         let doc = Document {

--- a/tests/snapshots/experimental_parser_kitchensink___parser_kitchensink_snapshot.snap
+++ b/tests/snapshots/experimental_parser_kitchensink___parser_kitchensink_snapshot.snap
@@ -1,23 +1,29 @@
 ---
 source: tests/experimental_parser_kitchensink.rs
-assertion_line: 21
 expression: snapshot
 ---
 Document with 8 root items:
 
 [0] Paragraph with 1 line(s):   [0] TextLine: Kitchensink Test Document {{paragraph}}
+
 [1] Paragraph with 1 line(s):   [0] TextLine: This document includes all major features of the txxt language to serve as a comprehensive "kitchensink" regression test for the parser. {{paragraph}}
+
 [2] Paragraph with 2 line(s): 
   [0] TextLine: This is a two-lined paragraph.
+
   [1] TextLine: First, a simple definition at the root level. {{paragraph}}
+
 [3] Definition with 2 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This definition contains a paragraph and a list to test mixed content at the top level. {{definition}}
+
   [1] List with 2 item(s):
     [0] List item with 0 content item(s):
     [1] List item with 0 content item(s):
 [4] Paragraph with 1 line(s):   [0] TextLine: This is a marker annotation at the root level, attached to the definition above.
+
 [5] Session with 7 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session acts as the main container for testing nested structures. It starts with a simple paragraph. {{paragraph}}
+
   [1] List with 2 item(s):
     [0] List item with 0 content item(s):
     [1] List item with 0 content item(s):
@@ -25,28 +31,38 @@ Document with 8 root items:
     [0] Paragraph with 1 line(s):       [0] TextLine: This is a single-line annotation inside the session.
   [3] Session with 4 item(s):
     [0] Paragraph with 1 line(s):       [0] TextLine: This is a second-level session containing a definition and a list with nested content. {{paragraph}}
+
     [1] Definition with 2 item(s):
       [0] Paragraph with 1 line(s):         [0] TextLine: This definition is inside a nested session and contains a list. {{definition}}
+
       [1] List with 2 item(s):
         [0] List item with 0 content item(s):
         [1] List item with 0 content item(s):
     [2] Paragraph with 1 line(s):       [0] TextLine: - A list item at level 2. {{list-item}}
+
     [3] Paragraph with 1 line(s):       [0] TextLine: - Another list item at level 2. {{list-item}}
   [4] Paragraph with 1 line(s):     [0] TextLine: A paragraph back at the first level of nesting. {{paragraph}}
+
   [5] Definition with 2 item(s):
     [0] Paragraph with 2 line(s): 
       [0] TextLine: // This is a foreign block with code.
+
       [1] TextLine: function example() {
+
     [1] Paragraph with 1 line(s):       [0] TextLine: }
   [6] Annotation with 0 parameter(s) and 0 content item(s):
 [6] Session with 4 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session tests annotations with block content and marker-style foreign blocks. {{paragraph}}
+
   [1] Annotation with 0 parameter(s) and 3 content item(s):
     [0] Paragraph with 1 line(s):       [0] TextLine: This is a block annotation. {{paragraph}}
+
     [1] Paragraph with 1 line(s):       [0] TextLine: It contains a paragraph and a list. {{paragraph}}
+
     [2] List with 2 item(s):
       [0] List item with 0 content item(s):
       [1] List item with 0 content item(s):
   [2] Paragraph with 1 line(s):     [0] TextLine: Image Reference (Marker Foreign Block):
+
   [3] Annotation with 0 parameter(s) and 0 content item(s):
 [7] Paragraph with 1 line(s):   [0] TextLine: Final paragraph at the end of the document. {{paragraph}}

--- a/tests/test_blank_line_group_parsing.rs
+++ b/tests/test_blank_line_group_parsing.rs
@@ -34,11 +34,11 @@ fn test_blank_line_group_location_visitor() {
     let source = "A\n\nB";
     let doc = parse_document(source);
 
-    // Find blank line groups and verify location() works
+    // Find blank line groups and verify location field works
     for item in &doc.root.content {
         if let ContentItem::BlankLineGroup(blg) = item {
-            // Test that location() method is callable and works without panic
-            let _loc = blg.location();
+            // Test that location field is accessible and works without panic
+            let _loc = &blg.location;
             return;
         }
     }


### PR DESCRIPTION
## Summary
Implements phases 1-5 of issue #146 location tracking refactoring, plus additional renaming work:

- ✅ **Phase 1**: Token processing utilities for location tracking
- ✅ **Phase 2**: LineToken support for token processing  
- ✅ **Phase 3**: AST construction facade for all AST node types
- ✅ **Phase 4**: Integration tests using TxxtSources and real tokens
- ✅ **Phase 5**: Update linebased parser to use AST construction facade
- ✅ **Additional**: Rename `Location` → `Range` throughout entire codebase

## Changes
- Added token processing utilities in `parsers/common/token_processing.rs`
- Created AST construction facade in `parsers/common/ast_construction.rs`
- Updated linebased parser to use new facade pattern
- Renamed `Location` to `Range` across 30 files
- Deleted `ast/location.rs`, created new `ast/range.rs`
- Fixed all 18 compilation errors from renaming
- Fixed Clippy `large_enum_variant` warning by boxing `ForeignBlock`

## Test plan
- [x] All 468 tests passing
- [x] Clippy clean (no warnings with `-D warnings`)
- [x] Documentation builds successfully
- [x] Pre-commit hooks pass

## Next steps
Phases 6-7 (reference parser updates) will follow in a separate PR.

Closes #146 (partially - phases 1-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)