### PR TITLE
Refactor: Reorganize AST building code for clarity and encapsulation

### DIFF
--- a/docs/dev/guides/on-location.lex
+++ b/docs/dev/guides/on-location.lex
@@ -57,14 +57,15 @@ Source String Location / Range Tracking in lex
 		2.1.3. Preservation, Not Transformation: Crucially, these container tokens should simply store the original `source_tokens` that comprise them. They should not calculate or store their own aggregate spans. The LineToken for "Title:" would contain the (Token::Text("Title"), 0..5) and (Token::Colon, 5..6) tokens, and that's it.
 		2.1.4. Parser's Role: The line-based parser uses the simplified tree structure (LineToken, LineContainerToken) to easily match grammar rules (e.g., "a SubjectLine followed by a Container is a Definition").
 	
-	5. AST Building: When a rule is matched, the parser gathers all the LineTokens involved in that match. It then "unrolls" them, creating a flat 
+	5. AST Building: When a rule is matched, the parser gathers all the LineTokens involved in that match. It then "unrolls" them, creating a flat
 		list of all the original source_tokens from the immutable log. This list is then used to:
 
 		- Compute a single, final bounding-box Range<usize>.
 		- Convert that Range<usize> to a Location struct.
 		- Pass the final Location and extracted text to the common AST builder
 
-			This code is trivial, and that is all the location tracking we need to do: 
+			This code is trivial, and that is all the location tracking we need to do:
+			:: file src/lex/parsers/ast/token/processing.rs ::
 
 				fn compute_bounding_box(
 					flat_list: &[(Token, Range<usize>)]) -> Option<Range<usize>> {

--- a/docs/dev/guides/on-parsing.lex
+++ b/docs/dev/guides/on-parsing.lex
@@ -15,10 +15,10 @@ AST Construction
 
 	1. Input
 		The ast building can handle input in the common structures (flat list, lines , tree).
-		It then converts them to Vec<Vec<(Token, Range<usize>)>> in token_normalization.rs[4]
+		It then converts them to Vec<Vec<(Token, Range<usize>)>> in ast/token/normalization.rs[4]
 	2. Data Extraction
 		Extract the token data into a pure structu / object format, ready to be injected in the ast node.
-		This includes de span / byte range calculation and wall stripping for foreing lines at data_extraction.rs
+		This includes de span / byte range calculation and wall stripping for foreing lines at ast/extraction.rs
 	3. AST Instantiation	
 		Now , with the pure and transformed data to create the ast nodes, we finally create them.
 5. Parser Integration
@@ -39,10 +39,10 @@ AST Construction
 		:: file src/lex/parsers/linebased/declarative_grammar.rs ::
 
 	Flow for line-based parser:
-		Pattern Match → unwrap_* → ast_builder::build_* → AST Node
+		Pattern Match → unwrap_* → ast::build_* → AST Node
 
 	Flow for reference parser:
-		Combinator → Extract Text → ast_builder::build_*_from_text → AST Node
+		Combinator → Extract Text → ast::build_*_from_text → AST Node
 
 
 
@@ -51,5 +51,5 @@ Notes:
  2. The token stream guide:  docs/dev/guides/on-tokenstreams.lex
  1. The core tokens: src/lex/lexers/tokens_core.rs and it's grammar docs/specs/v1/grammar.lex
  3. Adapters: src/lex/pipeline/adapters_linebased.rs and src/lex/pipeline/adapters.rs
- 4. Normalization File: src/lex/parsers/common/token_normalization.rs ::
- 5. Data Extraction File: src/lex/parsers/common/data_extraction.rs
+ 4. Normalization File: src/lex/parsers/ast/token/normalization.rs ::
+ 5. Data Extraction File: src/lex/parsers/ast/extraction.rs

--- a/src/lex/parsers.rs
+++ b/src/lex/parsers.rs
@@ -15,6 +15,7 @@
 //! for comprehensive documentation on using verified lex sources and AST assertions.
 
 // Parser implementations
+pub mod ast;
 pub mod common;
 pub mod linebased;
 pub mod reference;

--- a/src/lex/parsers/ast/builders.rs
+++ b/src/lex/parsers/ast/builders.rs
@@ -28,15 +28,16 @@
 //! This layer receives **primitives** and produces **AST types**. The byte→line/column
 //! conversion happens here using `byte_range_to_ast_range()`.
 
+use super::extraction::{
+    AnnotationData, DefinitionData, ForeignBlockData, ListItemData, ParagraphData, SessionData,
+};
+use super::location::{
+    aggregate_locations, byte_range_to_ast_range, compute_location_from_locations,
+};
 use crate::lex::ast::{
     Annotation, Definition, ForeignBlock, Label, List, ListItem, Paragraph, Range, Session,
     TextContent, TextLine,
 };
-use crate::lex::parsers::common::data_extraction::{
-    AnnotationData, DefinitionData, ForeignBlockData, ListItemData, ParagraphData, SessionData,
-};
-use crate::lex::parsers::common::location::{aggregate_locations, compute_location_from_locations};
-use crate::lex::parsers::common::token_processing::byte_range_to_ast_range;
 use crate::lex::parsers::ContentItem;
 
 // ============================================================================
@@ -56,7 +57,7 @@ use crate::lex::parsers::ContentItem;
 /// # Returns
 ///
 /// A Paragraph ContentItem with proper ast::Range locations
-pub fn create_paragraph(data: ParagraphData, source: &str) -> ContentItem {
+pub(super) fn create_paragraph(data: ParagraphData, source: &str) -> ContentItem {
     // Convert byte ranges to AST ranges and build TextLines
     let lines: Vec<ContentItem> = data
         .text_lines
@@ -96,7 +97,11 @@ pub fn create_paragraph(data: ParagraphData, source: &str) -> ContentItem {
 /// # Returns
 ///
 /// A Session ContentItem
-pub fn create_session(data: SessionData, content: Vec<ContentItem>, source: &str) -> ContentItem {
+pub(super) fn create_session(
+    data: SessionData,
+    content: Vec<ContentItem>,
+    source: &str,
+) -> ContentItem {
     let title_location = byte_range_to_ast_range(data.title_byte_range, source);
     let title = TextContent::from_string(data.title_text, Some(title_location.clone()));
     let location = aggregate_locations(title_location, &content);
@@ -123,7 +128,7 @@ pub fn create_session(data: SessionData, content: Vec<ContentItem>, source: &str
 /// # Returns
 ///
 /// A Definition ContentItem
-pub fn create_definition(
+pub(super) fn create_definition(
     data: DefinitionData,
     content: Vec<ContentItem>,
     source: &str,
@@ -151,7 +156,7 @@ pub fn create_definition(
 /// # Returns
 ///
 /// A List ContentItem
-pub fn create_list(items: Vec<ListItem>) -> ContentItem {
+pub(super) fn create_list(items: Vec<ListItem>) -> ContentItem {
     // Convert ListItems to ContentItems
     let content: Vec<ContentItem> = items.into_iter().map(ContentItem::ListItem).collect();
 
@@ -191,7 +196,11 @@ pub fn create_list(items: Vec<ListItem>) -> ContentItem {
 /// # Returns
 ///
 /// A ListItem node (not wrapped in ContentItem)
-pub fn create_list_item(data: ListItemData, content: Vec<ContentItem>, source: &str) -> ListItem {
+pub(super) fn create_list_item(
+    data: ListItemData,
+    content: Vec<ContentItem>,
+    source: &str,
+) -> ListItem {
     let marker_location = byte_range_to_ast_range(data.marker_byte_range, source);
     let marker = TextContent::from_string(data.marker_text, Some(marker_location.clone()));
     let location = aggregate_locations(marker_location, &content);
@@ -217,7 +226,7 @@ pub fn create_list_item(data: ListItemData, content: Vec<ContentItem>, source: &
 /// # Returns
 ///
 /// An Annotation ContentItem
-pub fn create_annotation(
+pub(super) fn create_annotation(
     data: AnnotationData,
     content: Vec<ContentItem>,
     source: &str,
@@ -272,7 +281,7 @@ pub fn create_annotation(
 /// # Returns
 ///
 /// A ForeignBlock ContentItem
-pub fn create_foreign_block(
+pub(super) fn create_foreign_block(
     data: ForeignBlockData,
     closing_annotation: Annotation,
     source: &str,

--- a/src/lex/parsers/ast/extraction.rs
+++ b/src/lex/parsers/ast/extraction.rs
@@ -28,8 +28,8 @@
 //! This layer works with **primitives only**. Byte ranges stay as `Range<usize>`.
 //! The conversion to `ast::Range` happens later in the ast_creation layer.
 
+use super::token::processing::{compute_bounding_box, extract_text};
 use crate::lex::lexers::tokens_core::Token;
-use crate::lex::parsers::common::token_processing::{compute_bounding_box, extract_text};
 use std::ops::Range as ByteRange;
 
 // ============================================================================
@@ -41,7 +41,7 @@ use std::ops::Range as ByteRange;
 /// Contains the text and byte ranges for each line, plus the overall byte range.
 /// All ranges are byte offsets (Range<usize>), not ast::Range.
 #[derive(Debug, Clone)]
-pub struct ParagraphData {
+pub(super) struct ParagraphData {
     /// Text and byte range for each line in the paragraph
     pub text_lines: Vec<(String, ByteRange<usize>)>,
     /// Overall byte range spanning all lines
@@ -52,7 +52,7 @@ pub struct ParagraphData {
 ///
 /// Contains the title text and its byte range.
 #[derive(Debug, Clone)]
-pub struct SessionData {
+pub(super) struct SessionData {
     /// The session title text
     pub title_text: String,
     /// Byte range of the title
@@ -63,7 +63,7 @@ pub struct SessionData {
 ///
 /// Contains the subject text and its byte range.
 #[derive(Debug, Clone)]
-pub struct DefinitionData {
+pub(super) struct DefinitionData {
     /// The definition subject text
     pub subject_text: String,
     /// Byte range of the subject
@@ -74,7 +74,7 @@ pub struct DefinitionData {
 ///
 /// Contains the marker text and its byte range.
 #[derive(Debug, Clone)]
-pub struct ListItemData {
+pub(super) struct ListItemData {
     /// The list item marker text (e.g., "-", "1.", "a)")
     pub marker_text: String,
     /// Byte range of the marker
@@ -85,14 +85,16 @@ pub struct ListItemData {
 ///
 /// Contains primitive data (text and byte ranges) for constructing a Parameter AST node.
 #[derive(Debug, Clone)]
-pub struct ParameterData {
+pub(super) struct ParameterData {
     /// The parameter key text
     pub key_text: String,
     /// The parameter value text (optional)
     pub value_text: Option<String>,
     /// Byte range of the key
+    #[allow(dead_code)]
     pub key_byte_range: ByteRange<usize>,
     /// Byte range of the value (if present)
+    #[allow(dead_code)]
     pub value_byte_range: Option<ByteRange<usize>>,
     /// Overall byte range spanning the entire parameter
     pub overall_byte_range: ByteRange<usize>,
@@ -102,7 +104,7 @@ pub struct ParameterData {
 ///
 /// Contains the label text, parameters, and their byte ranges.
 #[derive(Debug, Clone)]
-pub struct AnnotationData {
+pub(super) struct AnnotationData {
     /// The annotation label text
     pub label_text: String,
     /// Byte range of the label
@@ -116,7 +118,7 @@ pub struct AnnotationData {
 /// Contains subject, content, and their byte ranges.
 /// The content text has the indentation wall already stripped.
 #[derive(Debug, Clone)]
-pub struct ForeignBlockData {
+pub(super) struct ForeignBlockData {
     /// The foreign block subject text
     pub subject_text: String,
     /// Byte range of the subject
@@ -155,7 +157,7 @@ pub struct ForeignBlockData {
 /// let data = extract_paragraph_data(token_lines, source);
 /// assert_eq!(data.text_lines.len(), 2);
 /// ```
-pub fn extract_paragraph_data(
+pub(super) fn extract_paragraph_data(
     token_lines: Vec<Vec<(Token, ByteRange<usize>)>>,
     source: &str,
 ) -> ParagraphData {
@@ -196,7 +198,10 @@ pub fn extract_paragraph_data(
 /// # Returns
 ///
 /// SessionData containing the title text and byte range
-pub fn extract_session_data(tokens: Vec<(Token, ByteRange<usize>)>, source: &str) -> SessionData {
+pub(super) fn extract_session_data(
+    tokens: Vec<(Token, ByteRange<usize>)>,
+    source: &str,
+) -> SessionData {
     let title_byte_range = compute_bounding_box(&tokens);
     let title_text = extract_text(title_byte_range.clone(), source);
 
@@ -220,7 +225,7 @@ pub fn extract_session_data(tokens: Vec<(Token, ByteRange<usize>)>, source: &str
 /// # Returns
 ///
 /// DefinitionData containing the subject text and byte range
-pub fn extract_definition_data(
+pub(super) fn extract_definition_data(
     tokens: Vec<(Token, ByteRange<usize>)>,
     source: &str,
 ) -> DefinitionData {
@@ -247,7 +252,7 @@ pub fn extract_definition_data(
 /// # Returns
 ///
 /// ListItemData containing the marker text and byte range
-pub fn extract_list_item_data(
+pub(super) fn extract_list_item_data(
     tokens: Vec<(Token, ByteRange<usize>)>,
     source: &str,
 ) -> ListItemData {
@@ -492,7 +497,7 @@ fn parse_parameter(
 ///   ]
 /// }
 /// ```
-pub fn extract_annotation_data(
+pub(super) fn extract_annotation_data(
     tokens: Vec<(Token, ByteRange<usize>)>,
     source: &str,
 ) -> AnnotationData {
@@ -627,7 +632,7 @@ fn strip_indentation_wall(
 ///
 /// // After extraction, both have identical content: "line1\nline2"
 /// ```
-pub fn extract_foreign_block_data(
+pub(super) fn extract_foreign_block_data(
     subject_tokens: Vec<(Token, ByteRange<usize>)>,
     mut content_token_lines: Vec<Vec<(Token, ByteRange<usize>)>>,
     source: &str,

--- a/src/lex/parsers/ast/mod.rs
+++ b/src/lex/parsers/ast/mod.rs
@@ -1,0 +1,20 @@
+//! AST building utilities for parsers
+//!
+//! This module provides utilities for building AST nodes from tokens.
+//! It follows a three-layer architecture:
+//!
+//! 1. Token Normalization - Convert various token formats to standard vectors
+//! 2. Data Extraction - Extract primitive data (text, byte ranges) from tokens
+//! 3. AST Creation - Convert primitives to AST nodes with ast::Range
+//!
+//! Parsers should primarily use the `api` module which provides the public API.
+
+pub mod api;
+pub mod location;
+
+pub(super) mod builders;
+pub(super) mod extraction;
+pub(super) mod token;
+
+// Re-export public API
+pub use api::*;

--- a/src/lex/parsers/ast/token/mod.rs
+++ b/src/lex/parsers/ast/token/mod.rs
@@ -1,0 +1,5 @@
+//! Token processing utilities for AST building
+
+pub mod processing;
+
+pub(crate) mod normalization;

--- a/src/lex/parsers/ast/token/normalization.rs
+++ b/src/lex/parsers/ast/token/normalization.rs
@@ -20,7 +20,7 @@
 //! # Usage
 //!
 //! ```rust,ignore
-//! use crate::lex::parsers::common::token_normalization;
+//! use crate::lex::parsers::ast::token::normalization;
 //!
 //! // Normalize a single line token
 //! let tokens = token_normalization::normalize_line_token(&line_token);
@@ -36,7 +36,7 @@ use crate::lex::lexers::linebased::tokens_linebased::LineToken;
 use crate::lex::lexers::tokens_core::Token;
 use std::ops::Range as ByteRange;
 
-use super::token_processing::flatten_token_vecs;
+use super::processing::flatten_token_vecs;
 
 // ============================================================================
 // SINGLE LINE TOKEN NORMALIZATION
@@ -63,7 +63,7 @@ use super::token_processing::flatten_token_vecs;
 /// let tokens = normalize_line_token(&line_token);
 /// // tokens is now Vec<(Token, Range<usize>)>
 /// ```
-pub fn normalize_line_token(token: &LineToken) -> Vec<(Token, ByteRange<usize>)> {
+pub(crate) fn normalize_line_token(token: &LineToken) -> Vec<(Token, ByteRange<usize>)> {
     token.source_token_pairs()
 }
 
@@ -93,7 +93,7 @@ pub fn normalize_line_token(token: &LineToken) -> Vec<(Token, ByteRange<usize>)>
 /// // token_lines[0] is the tokens from the first line
 /// // token_lines[1] is the tokens from the second line, etc.
 /// ```
-pub fn normalize_line_tokens(tokens: &[LineToken]) -> Vec<Vec<(Token, ByteRange<usize>)>> {
+pub(crate) fn normalize_line_tokens(tokens: &[LineToken]) -> Vec<Vec<(Token, ByteRange<usize>)>> {
     tokens.iter().map(normalize_line_token).collect()
 }
 
@@ -121,7 +121,10 @@ pub fn normalize_line_tokens(tokens: &[LineToken]) -> Vec<Vec<(Token, ByteRange<
 /// let all_tokens = flatten(&token_lines);
 /// // all_tokens contains every token from every line
 /// ```
-pub fn flatten(token_lines: &[Vec<(Token, ByteRange<usize>)>]) -> Vec<(Token, ByteRange<usize>)> {
+#[allow(dead_code)]
+pub(crate) fn flatten(
+    token_lines: &[Vec<(Token, ByteRange<usize>)>],
+) -> Vec<(Token, ByteRange<usize>)> {
     flatten_token_vecs(token_lines)
 }
 
@@ -149,7 +152,8 @@ pub fn flatten(token_lines: &[Vec<(Token, ByteRange<usize>)>]) -> Vec<(Token, By
 /// let normalized = normalize_token_pairs(&tokens);
 /// // Same as input, but owned
 /// ```
-pub fn normalize_token_pairs(
+#[allow(dead_code)]
+pub(crate) fn normalize_token_pairs(
     tokens: &[(Token, ByteRange<usize>)],
 ) -> Vec<(Token, ByteRange<usize>)> {
     tokens.to_vec()

--- a/src/lex/parsers/ast/token/processing.rs
+++ b/src/lex/parsers/ast/token/processing.rs
@@ -140,7 +140,6 @@ pub fn tokens_to_text(tokens: &[(Token, ByteRange<usize>)], source: &str) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
-    
 
     // Mock token provider for testing
     struct MockToken {

--- a/src/lex/parsers/common/mod.rs
+++ b/src/lex/parsers/common/mod.rs
@@ -1,19 +1,9 @@
 //! Common parser module
 //!
-//! This module contains shared interfaces and utilities for parser implementations.
+//! This module contains shared interfaces for parser implementations.
 
-pub mod ast_builder;
-pub mod ast_creation;
-pub mod data_extraction;
 pub mod interface;
-pub mod location;
-pub mod token_normalization;
-pub mod token_processing;
 
 pub use interface::{
     LineBasedParserImpl, ParseError, Parser, ParserInput, ParserRegistry, ReferenceParserImpl,
-};
-pub use location::{
-    aggregate_locations, byte_range_to_location, compute_byte_range_bounds,
-    compute_location_from_locations, default_location,
 };

--- a/src/lex/parsers/linebased/builders.rs
+++ b/src/lex/parsers/linebased/builders.rs
@@ -14,8 +14,8 @@
 use crate::lex::ast::range::SourceLocation;
 use crate::lex::ast::Range;
 use crate::lex::lexers::LineToken;
-use crate::lex::parsers::common::ast_builder;
-use crate::lex::parsers::common::location::default_location;
+use crate::lex::parsers::ast::api as ast_builder;
+use crate::lex::parsers::ast::location::default_location;
 use crate::lex::parsers::ContentItem;
 
 // ============================================================================

--- a/src/lex/parsers/linebased/engine.rs
+++ b/src/lex/parsers/linebased/engine.rs
@@ -40,7 +40,7 @@ pub fn parse_experimental_v2(tree: LineContainer, source: &str) -> Result<Docume
     let content = declarative_grammar::parse_with_declarative_grammar(children, source)?;
 
     // Create the root session containing all top-level content using ast_builder
-    use crate::lex::parsers::common::ast_builder;
+    use crate::lex::parsers::ast::api as ast_builder;
     let root_location = Range {
         span: 0..0,
         start: Position { line: 0, column: 0 },

--- a/src/lex/parsers/reference/builders.rs
+++ b/src/lex/parsers/reference/builders.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 
 use crate::lex::ast::{ContentItem, ForeignBlock, Paragraph};
 use crate::lex::lexers::Token;
-// Location utilities and AST builders are now imported from crate::lex::parsers::common
-use crate::lex::parsers::common::ast_builder;
+// Location utilities and AST builders are now imported from crate::lex::parsers::ast
+use crate::lex::parsers::ast::api as ast_builder;
 
 /// Type alias for token with location
 pub(crate) type TokenLocation = (Token, ByteRange<usize>);
@@ -73,7 +73,7 @@ fn group_tokens_by_line(tokens: Vec<TokenLocation>) -> Vec<Vec<TokenLocation>> {
 // LOCATION UTILITIES
 // ============================================================================
 //
-// Location utilities are now provided by crate::lex::parsers::common::location
+// Location utilities are now provided by crate::lex::parsers::ast::location
 // See that module for byte_range_to_location, compute_location_from_locations, etc.
 
 /// Check if a token is a text-like token (content that can appear in lines)
@@ -441,7 +441,7 @@ pub(crate) fn foreign_block(
                 };
 
                 // Use new ast_builder API with tokens (enables indentation wall stripping)
-                use crate::lex::parsers::common::ast_builder;
+                use crate::lex::parsers::ast::api as ast_builder;
                 if let ContentItem::ForeignBlock(fb) = ast_builder::build_foreign_block_from_tokens(
                     subject_tokens,
                     content_token_lines,

--- a/src/lex/parsers/reference/document.rs
+++ b/src/lex/parsers/reference/document.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use crate::lex::ast::{AstNode, Document};
 use crate::lex::lexers::Token;
-use crate::lex::parsers::common::location::compute_location_from_locations;
+use crate::lex::parsers::ast::location::compute_location_from_locations;
 
 /// Type alias for token with location
 type TokenLocation = (Token, Range<usize>);


### PR DESCRIPTION
## Summary

Reorganize `src/lex/parsers/common` to clearly separate public API from internal implementation details, eliminate duplication, and make the three-layer AST building architecture more explicit.

## Changes

### Structure
- Move all AST building code into `src/lex/parsers/ast/`
- Nest token processing under `ast/token/` (tokens serve AST building)
- Make internal modules private with `pub(super)`
- Expose only `ast::api` and `ast::location` as public

### Deduplication  
- Merge duplicate `byte_range_to_ast_range` functions into `ast/location.rs`
- Remove duplicate `tokens_to_ast_range` from `token/processing.rs`
- Consolidate all location conversion utilities

### Visibility
- `ast/api.rs`: ✅ PUBLIC - parsers use `build_*` functions
- `ast/location.rs`: ✅ PUBLIC - for `compute_location_from_locations`
- `ast/builders.rs`: 🔒 internal (was `ast_creation.rs`)
- `ast/extraction.rs`: 🔒 internal (was `data_extraction.rs`)
- `ast/token/*`: 🔒 internal (all token processing)

## Benefits

- ✅ Clear public/private boundaries
- ✅ Single source of truth for location conversion
- ✅ Explicit three-layer architecture (normalize → extract → create)
- ✅ Better encapsulation with `pub(super)`
- ✅ Conceptual alignment: tokens nested under AST shows their relationship

## Testing

All tests pass:
- ✅ 400 lib tests
- ✅ Pre-commit hooks (format, clippy, build, tests)

## Migration

**Before:**
```rust
use crate::lex::parsers::common::ast_builder;
ast_builder::build_paragraph(...)
```

**After:**
```rust
use crate::lex::parsers::ast;
ast::build_paragraph(...)
```

Fixes #172