### PR TITLE
Fixes Verbatim Block in Linebased Parser, Issue #199

### DIFF
--- a/src/lex/parsing/linebased/declarative_grammar.rs
+++ b/src/lex/parsing/linebased/declarative_grammar.rs
@@ -332,8 +332,7 @@ fn convert_pattern_to_item(
                 .filter(|(token, _)| {
                     !matches!(
                         token,
-                        crate::lex::lexing::Token::Colon
-                            | crate::lex::lexing::Token::BlankLine(_)
+                        crate::lex::lexing::Token::Colon | crate::lex::lexing::Token::BlankLine(_)
                     )
                 })
                 .collect();
@@ -359,18 +358,12 @@ fn convert_pattern_to_item(
             }
 
             // Create subject node
-            let subject_node = ParseNode::new(
-                NodeType::VerbatimBlockkSubject,
-                subject_tokens,
-                vec![],
-            );
+            let subject_node =
+                ParseNode::new(NodeType::VerbatimBlockkSubject, subject_tokens, vec![]);
 
             // Create content node
-            let content_node = ParseNode::new(
-                NodeType::VerbatimBlockkContent,
-                content_tokens,
-                vec![],
-            );
+            let content_node =
+                ParseNode::new(NodeType::VerbatimBlockkContent, content_tokens, vec![]);
 
             // Create closing node (it's an annotation, but we need to parse it properly)
             // The closing annotation can have content after it (caption text)
@@ -403,7 +396,11 @@ fn convert_pattern_to_item(
 
             // If there's content after the header, create a paragraph for it
             let closing_children = if !content_tokens_after.is_empty() {
-                vec![ParseNode::new(NodeType::Paragraph, content_tokens_after, vec![])]
+                vec![ParseNode::new(
+                    NodeType::Paragraph,
+                    content_tokens_after,
+                    vec![],
+                )]
             } else {
                 vec![]
             };

--- a/src/lex/parsing/linebased/declarative_grammar.rs
+++ b/src/lex/parsing/linebased/declarative_grammar.rs
@@ -30,10 +30,10 @@ static LIST_ITEM_REGEX: Lazy<Regex> =
 /// Grammar patterns as regex rules with names and patterns
 /// Order matters: patterns are tried in declaration order for correct disambiguation
 const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
-    // Verbatim Block: <subject-line>|<subject-or-list-item-line><blank-line>?<container>?<annotation-end-line>
+    // Verbatim Block: <subject-line>|<subject-or-list-item-line><blank-line>?<container>?<annotation-end-line>|<annotation-start-line>
     (
         "verbatim_block",
-        r"^(?P<subject><subject-line>|<subject-or-list-item-line>)(?P<blank><blank-line>+)?(?P<content><container>)?(?P<closing><annotation-end-line>)",
+        r"^(?P<subject><subject-line>|<subject-or-list-item-line>)(?P<blank><blank-line>+)?(?P<content><container>)?(?P<closing><annotation-end-line>|<annotation-start-line>)",
     ),
     // Annotation (multi-line with markers): <annotation-start-line><container><annotation-end-line>
     (
@@ -323,46 +323,102 @@ fn convert_pattern_to_item(
             let subject_token = extract_line_token(&tokens[pattern_offset + subject_idx])?;
             let closing_token = extract_line_token(&tokens[pattern_offset + closing_idx])?;
 
-            // Extract content lines from container if present
-            let mut content_lines = Vec::new();
-            if let Some(content_idx_val) = content_idx {
-                if let Some(LineContainer::Container { children, .. }) =
-                    tokens.get(pattern_offset + content_idx_val)
-                {
-                    content_lines = children
-                        .iter()
-                        .filter_map(|t| extract_line_token(t).ok())
-                        .collect::<Vec<_>>();
-                }
-            }
-            let mut all_tokens = subject_token
+            // Extract subject tokens (filter out Colon and BlankLine)
+            let subject_tokens: Vec<_> = subject_token
                 .source_tokens
                 .clone()
                 .into_iter()
                 .zip(subject_token.token_spans.clone())
-                .collect::<Vec<_>>();
-            for line in content_lines {
-                all_tokens.extend(
-                    line.source_tokens
-                        .clone()
-                        .into_iter()
-                        .zip(line.token_spans.clone()),
-                );
+                .filter(|(token, _)| {
+                    !matches!(
+                        token,
+                        crate::lex::lexing::Token::Colon
+                            | crate::lex::lexing::Token::BlankLine(_)
+                    )
+                })
+                .collect();
+
+            // Extract content tokens from container if present
+            let mut content_tokens = Vec::new();
+            if let Some(content_idx_val) = content_idx {
+                if let Some(LineContainer::Container { children, .. }) =
+                    tokens.get(pattern_offset + content_idx_val)
+                {
+                    for child in children {
+                        if let Ok(line_token) = extract_line_token(child) {
+                            content_tokens.extend(
+                                line_token
+                                    .source_tokens
+                                    .clone()
+                                    .into_iter()
+                                    .zip(line_token.token_spans.clone()),
+                            );
+                        }
+                    }
+                }
             }
-            let closing_node = ParseNode::new(
-                NodeType::Annotation,
-                closing_token
-                    .source_tokens
-                    .clone()
-                    .into_iter()
-                    .zip(closing_token.token_spans.clone())
-                    .collect(),
+
+            // Create subject node
+            let subject_node = ParseNode::new(
+                NodeType::VerbatimBlockkSubject,
+                subject_tokens,
                 vec![],
             );
+
+            // Create content node
+            let content_node = ParseNode::new(
+                NodeType::VerbatimBlockkContent,
+                content_tokens,
+                vec![],
+            );
+
+            // Create closing node (it's an annotation, but we need to parse it properly)
+            // The closing annotation can have content after it (caption text)
+            let closing_tokens = closing_token
+                .source_tokens
+                .clone()
+                .into_iter()
+                .zip(closing_token.token_spans.clone())
+                .collect::<Vec<_>>();
+
+            // Split closing tokens into header (up to second ::) and content (after)
+            let mut header_tokens = Vec::new();
+            let mut content_tokens_after = Vec::new();
+            let mut lex_marker_count = 0;
+            let mut content_started = false;
+
+            for (token, span) in closing_tokens {
+                if !content_started {
+                    header_tokens.push((token.clone(), span.clone()));
+                    if token == crate::lex::lexing::Token::LexMarker {
+                        lex_marker_count += 1;
+                        if lex_marker_count == 2 {
+                            content_started = true;
+                        }
+                    }
+                } else {
+                    content_tokens_after.push((token, span));
+                }
+            }
+
+            // If there's content after the header, create a paragraph for it
+            let closing_children = if !content_tokens_after.is_empty() {
+                vec![ParseNode::new(NodeType::Paragraph, content_tokens_after, vec![])]
+            } else {
+                vec![]
+            };
+
+            let closing_node = ParseNode::new(
+                NodeType::VerbatimBlockkClosing,
+                header_tokens,
+                closing_children,
+            );
+
+            // Create verbatim block with three children
             Ok(ParseNode::new(
                 NodeType::VerbatimBlock,
-                all_tokens,
-                vec![closing_node],
+                vec![],
+                vec![subject_node, content_node, closing_node],
             ))
         }
         PatternMatch::AnnotationBlock {

--- a/tests/elements_verbatim.rs
+++ b/tests/elements_verbatim.rs
@@ -65,13 +65,19 @@ fn test_verbatim_04_flat_marker_form() {
 }
 
 #[test]
+#[should_panic(expected = "Expected VerbatimBlock, found Paragraph")]
 fn test_verbatim_05_flat_special_chars() {
     // verbatim-05-flat-special-chars.lex: Verbatim with :: markers in content
-    // TODO: Currently parsed as paragraph due to :: in content - potential parser bug
+    // BUG: Reference parser incorrectly parses this as Paragraph instead of VerbatimBlock
+    // The :: markers in content confuse the reference parser
     let doc = Lexplore::verbatim(5).parse();
 
     assert_ast(&doc).item_count(1).item(0, |item| {
-        item.assert_paragraph().text_contains("Special Characters");
+        item.assert_verbatim_block()
+            .subject("Special Characters")
+            .closing_label("javascript")
+            .content_contains("// This content has :: markers")
+            .content_contains("return \"::\"");
     });
 }
 

--- a/tests/snapshots/experimental_parser_kitchensink___parser_kitchensink_snapshot.snap
+++ b/tests/snapshots/experimental_parser_kitchensink___parser_kitchensink_snapshot.snap
@@ -15,7 +15,7 @@ Document with 8 root items:
     [0] List item with 0 content item(s):
     [1] List item with 0 content item(s):
 [4] Paragraph with 1 line(s):   [0] TextLine: This is a marker annotation at the root level, attached to the definition above.
-[5] Session with 7 item(s):
+[5] Session with 6 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session acts as the main container for testing nested structures. It starts with a simple paragraph. {{paragraph}}
   [1] List with 2 item(s):
     [0] List item with 0 content item(s):
@@ -37,14 +37,8 @@ Document with 8 root items:
           [1] List item with 0 content item(s):
       [1] List item with 0 content item(s):
   [4] Paragraph with 1 line(s):     [0] TextLine: A paragraph back at the first level of nesting. {{paragraph}}
-  [5] Definition with 2 item(s):
-    [0] Paragraph with 2 line(s): 
-      [0] TextLine: // This is a verbatim block with code.
-      [1] TextLine: function example() {
-    [1] Paragraph with 1 line(s):       [0] TextLine: }
-  [6] Annotation with 0 parameter(s) and 1 content item(s):
-    [0] Paragraph with 0 line(s):
-[6] Session with 4 item(s):
+  [5] VerbatimBlock with 59 content char(s)
+[6] Session with 3 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}
   [1] Annotation with 0 parameter(s) and 3 content item(s):
     [0] Paragraph with 1 line(s):       [0] TextLine: This is a block annotation. {{paragraph}}
@@ -52,7 +46,5 @@ Document with 8 root items:
     [2] List with 2 item(s):
       [0] List item with 0 content item(s):
       [1] List item with 0 content item(s):
-  [2] Paragraph with 1 line(s):     [0] TextLine: Image Reference (Marker Verbatim Block):
-  [3] Annotation with 0 parameter(s) and 1 content item(s):
-    [0] Paragraph with 0 line(s):
+  [2] VerbatimBlock with 0 content char(s)
 [7] Paragraph with 1 line(s):   [0] TextLine: Final paragraph at the end of the document. {{paragraph}}


### PR DESCRIPTION
Refactor verbatim block parsing to include annotation start line and mprove token extraction. Update tests to reflect changes in verbatim block structure and content handling.

Closes #199 