### PR TITLE
feat(verbatim): implement grouped verbatim blocks

### DIFF
--- a/docs/specs/v1/elements/verbatim/verbatim-11-group-shell.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim-11-group-shell.lex
@@ -1,0 +1,25 @@
+Installing with home brew is simple:
+
+    $ brew install lex
+From there the interactive help is available:
+
+    $ lex help
+And the built-in viewer can be used to quickly view the parsing:
+
+    $ lex view <path>
+:: shell ::
+
+This should not stop the content below, correct, from parsing however.
+
+This is block 1:
+
+    $ ls
+Which is a shell block:
+
+    $ pwd
+:: shell ::
+
+And this is a block 2:
+
+      input("Favorite fruit:")
+:: javascript ::

--- a/docs/specs/v1/elements/verbatim/verbatim.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim.lex
@@ -20,6 +20,21 @@ Syntax
 
 	Note: Optional blank line after subject is allowed in both forms.
 
+Verbatim Groups
+
+	Multiple subject/content pairs can share a single closing annotation. This is handy for
+	step-by-step shell transcripts or grouped code samples that use the same language.
+
+	Syntax:
+		(<subject-line>:
+		    <content lines>)+
+		:: label params ::
+
+		- Each subject anchors to the indentation wall established by the first subject.
+		- Content for every pair must be indented past the wall and preserves blank lines.
+		- Content remains optional for parity with marker blocks, but textual payloads are preferred.
+		- Example: docs/specs/v1/elements/verbatim/verbatim-11-group-shell.lex
+
 The Indentation Wall
 
 	Critical rule: The subject line establishes the base indentation level (the "wall").
@@ -90,3 +105,10 @@ Use Cases
 	- Binary data references (images, videos, PDFs)
 	- Command output
 	- Any non-lex text that needs exact preservation
+
+Implementation Notes
+
+	The AST exposes the first subject/content pair directly on the Verbatim node for backwards
+	compatibility. Additional pairs are available through the Verbatim::group() iterator, which
+	yields immutable subject/content views. Agents adding formatting logic should iterate over this
+	group API so multi-pair verbatim sequences stay cohesive.

--- a/src/lex/ast/elements/verbatim.rs
+++ b/src/lex/ast/elements/verbatim.rs
@@ -203,11 +203,14 @@ impl Container for Verbatim {
 
 impl fmt::Display for Verbatim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let group_count = self.group_len();
+        let group_word = if group_count == 1 { "group" } else { "groups" };
         write!(
             f,
-            "VerbatimBlock('{}', {} groups, closing: {})",
+            "VerbatimBlock('{}', {} {}, closing: {})",
             self.subject.as_string(),
-            self.group_len(),
+            group_count,
+            group_word,
             self.closing_annotation.label.value
         )
     }

--- a/src/lex/ast/elements/verbatim.rs
+++ b/src/lex/ast/elements/verbatim.rs
@@ -140,7 +140,10 @@ impl AstNode for Verbatim {
 
     fn accept(&self, visitor: &mut dyn Visitor) {
         visitor.visit_verbatim_block(self);
-        super::super::traits::visit_children(visitor, &self.children);
+        // Visit all groups, not just the first
+        for group in self.group() {
+            super::super::traits::visit_children(visitor, group.children);
+        }
     }
 }
 

--- a/src/lex/ast/snapshot_visitor.rs
+++ b/src/lex/ast/snapshot_visitor.rs
@@ -128,10 +128,17 @@ fn build_verbatim_block_snapshot(fb: &super::Verbatim) -> AstSnapshot {
     let mut snapshot = AstSnapshot::new("VerbatimBlock".to_string(), label);
 
     for (idx, group) in fb.group().enumerate() {
-        let mut group_snapshot = AstSnapshot::new(
-            "VerbatimGroup".to_string(),
-            format!("{}#{}", group.subject.as_string(), idx),
-        );
+        let label = if group_count == 1 {
+            group.subject.as_string().to_string()
+        } else {
+            format!(
+                "{} (group {} of {})",
+                group.subject.as_string(),
+                idx + 1,
+                group_count
+            )
+        };
+        let mut group_snapshot = AstSnapshot::new("VerbatimGroup".to_string(), label);
         for child in group.children.iter() {
             group_snapshot.children.push(snapshot_from_content(child));
         }

--- a/src/lex/ast/snapshot_visitor.rs
+++ b/src/lex/ast/snapshot_visitor.rs
@@ -122,7 +122,9 @@ fn build_annotation_snapshot(ann: &Annotation) -> AstSnapshot {
 }
 
 fn build_verbatim_block_snapshot(fb: &super::Verbatim) -> AstSnapshot {
-    let label = format!("{} ({} groups)", fb.display_label(), fb.group_len());
+    let group_count = fb.group_len();
+    let group_word = if group_count == 1 { "group" } else { "groups" };
+    let label = format!("{} ({} {})", fb.display_label(), group_count, group_word);
     let mut snapshot = AstSnapshot::new("VerbatimBlock".to_string(), label);
 
     for (idx, group) in fb.group().enumerate() {

--- a/src/lex/ast/snapshot_visitor.rs
+++ b/src/lex/ast/snapshot_visitor.rs
@@ -122,10 +122,20 @@ fn build_annotation_snapshot(ann: &Annotation) -> AstSnapshot {
 }
 
 fn build_verbatim_block_snapshot(fb: &super::Verbatim) -> AstSnapshot {
-    let mut snapshot = AstSnapshot::new("VerbatimBlock".to_string(), fb.display_label());
-    for child in fb.children() {
-        snapshot.children.push(snapshot_from_content(child));
+    let label = format!("{} ({} groups)", fb.display_label(), fb.group_len());
+    let mut snapshot = AstSnapshot::new("VerbatimBlock".to_string(), label);
+
+    for (idx, group) in fb.group().enumerate() {
+        let mut group_snapshot = AstSnapshot::new(
+            "VerbatimGroup".to_string(),
+            format!("{}#{}", group.subject.as_string(), idx),
+        );
+        for child in group.children.iter() {
+            group_snapshot.children.push(snapshot_from_content(child));
+        }
+        snapshot.children.push(group_snapshot);
     }
+
     snapshot
 }
 

--- a/src/lex/building/api.rs
+++ b/src/lex/building/api.rs
@@ -258,7 +258,11 @@ pub fn build_verbatim_block(
         .collect();
 
     // 3. Extract (includes indentation wall stripping)
-    let data = extraction::extract_verbatim_block_data(subject_tokens, content_token_lines, source);
+    let group = extraction::VerbatimGroupTokenLines {
+        subject_tokens,
+        content_token_lines,
+    };
+    let data = extraction::extract_verbatim_block_data(vec![group], source);
 
     // 4. Create
     builders::create_verbatim_block(data, closing_annotation, source)
@@ -433,24 +437,20 @@ pub fn build_annotation_from_tokens(
 ///
 /// ```rust,ignore
 /// // Tokens already normalized from reference parser
-/// let subject_tokens = vec![(Token::Text("Code".into()), 0..4)];
-/// let content_lines = vec![
-///     vec![(Token::Indentation, 6..10), (Token::Text("line1".into()), 10..15)],
-///     vec![(Token::Indentation, 16..20), (Token::Indentation, 20..24), (Token::Text("line2".into()), 24..29)],
-/// ];
-/// // After extraction, wall of 1 indent is stripped: "line1\n    line2"
+/// let group = extraction::VerbatimGroupTokenLines {
+///     subject_tokens: vec![(Token::Text("Code".into()), 0..4)],
+///     content_token_lines: vec![
+///         vec![(Token::Indentation, 6..10), (Token::Text("line1".into()), 10..15)],
+///     ],
+/// };
+/// // After extraction, wall of 1 indent is stripped: "line1\nline2"
 /// ```
 pub fn build_verbatim_block_from_tokens(
-    subject_tokens: Vec<(Token, ByteRange<usize>)>,
-    content_token_lines: Vec<Vec<(Token, ByteRange<usize>)>>,
+    groups: Vec<extraction::VerbatimGroupTokenLines>,
     closing_annotation: Annotation,
     source: &str,
 ) -> ContentItem {
-    // Skip normalization, tokens already normalized
-    // 1. Extract (includes indentation wall stripping)
-    let data = extraction::extract_verbatim_block_data(subject_tokens, content_token_lines, source);
-
-    // 2. Create
+    let data = extraction::extract_verbatim_block_data(groups, source);
     builders::create_verbatim_block(data, closing_annotation, source)
 }
 

--- a/src/lex/parsing/builder.rs
+++ b/src/lex/parsing/builder.rs
@@ -117,7 +117,7 @@ impl<'a> AstBuilder<'a> {
         }
 
         if pending_subject.is_some() {
-            panic!("Dangling verbatim subject without content");
+            panic!("Internal parser error: Malformed parse tree - subject node without corresponding content node. This indicates a bug in the parser, not invalid user input.");
         }
 
         let closing_annotation_node =

--- a/src/lex/parsing/builder.rs
+++ b/src/lex/parsing/builder.rs
@@ -92,22 +92,36 @@ impl<'a> AstBuilder<'a> {
     }
 
     fn build_verbatim_block(&self, node: ParseNode) -> ContentItem {
-        let mut subject_node = None;
-        let mut content_node = None;
+        use crate::lex::building::extraction::VerbatimGroupTokenLines;
+
         let mut closing_node = None;
+        let mut pending_subject: Option<ParseNode> = None;
+        let mut groups: Vec<VerbatimGroupTokenLines> = Vec::new();
 
         for child in node.children {
             match child.node_type {
-                NodeType::VerbatimBlockkSubject => subject_node = Some(child),
-                NodeType::VerbatimBlockkContent => content_node = Some(child),
+                NodeType::VerbatimBlockkSubject => pending_subject = Some(child),
+                NodeType::VerbatimBlockkContent => {
+                    let subject = pending_subject
+                        .take()
+                        .expect("Verbatim content encountered without subject");
+                    let content_lines = group_tokens_by_line(child.tokens);
+                    groups.push(VerbatimGroupTokenLines {
+                        subject_tokens: subject.tokens,
+                        content_token_lines: content_lines,
+                    });
+                }
                 NodeType::VerbatimBlockkClosing => closing_node = Some(child),
                 _ => {}
             }
         }
 
-        let subject_tokens = subject_node.unwrap().tokens;
-        let content_token_lines = group_tokens_by_line(content_node.unwrap().tokens);
-        let closing_annotation_node = closing_node.unwrap();
+        if pending_subject.is_some() {
+            panic!("Dangling verbatim subject without content");
+        }
+
+        let closing_annotation_node =
+            closing_node.expect("Missing closing annotation for verbatim block");
         let closing_annotation =
             if let ContentItem::Annotation(ann) = self.build_annotation(closing_annotation_node) {
                 ann
@@ -115,12 +129,7 @@ impl<'a> AstBuilder<'a> {
                 panic!("Expected Annotation for verbatim block closing");
             };
 
-        ast_builder::build_verbatim_block_from_tokens(
-            subject_tokens,
-            content_token_lines,
-            closing_annotation,
-            self.source,
-        )
+        ast_builder::build_verbatim_block_from_tokens(groups, closing_annotation, self.source)
     }
 }
 


### PR DESCRIPTION
# Implement Verbatim Groups

Implements the "Verbatim Groups" feature, allowing multiple subject/content pairs to share a single closing annotation. This enables more natural syntax for sequential commands, code samples, and step-by-step instructions.

## Example Syntax

```lex
Installing with home brew is simple:
    $ brew install lex
From there the interactive help is available:
    $ lex help
And the built-in viewer can be used to quickly view the parsing:
    $ lex view <path>
:: shell ::
```

This creates a single verbatim block with 3 subject/content pairs, all sharing the `:: shell ::` annotation.

## Implementation Overview

### Core Feature (`034a816`)
- **Data Model**: Modified `Verbatim` AST node to store multiple groups
  - First group stored in existing `subject`/`children` fields (backwards compatibility)
  - Additional groups in private `additional_groups` vector
  - New `group()` iterator provides unified access to all pairs
  - New `group_len()` method returns total pair count

- **Parsing**: Enhanced reference parser to collect multiple subject/content pairs
  - Validates all subjects share same indentation depth
  - Creates alternating Subject/Content ParseNodes
  - Single closing annotation terminates the group

- **Building**: Updated AST builder to handle multiple groups
  - Extracts first group into primary fields
  - Stores remaining groups in additional vector
  - Aggregates locations across all groups

- **Testing**: Comprehensive test coverage
  - New spec file: `verbatim-11-group-shell.lex`
  - Tests verify parsing, grouping, and API correctness
  - Updated documentation in `verbatim.lex` spec

## Bug Fixes & Improvements

### Critical Fix: Visitor Pattern (`7f53498`)
**Problem**: The `accept()` method only visited the first group's children, causing silent data loss in visitor-based operations.

**Fix**: Modified to iterate over all groups using the `group()` iterator.

**Test**: Added comprehensive visitor test verifying all groups are visited (`test_verbatim_11_group_visitor_sees_all_groups`).

### Major: Design Documentation (`469ca1a`)
**Problem**: The split storage pattern (first group in public fields, rest in private vector) lacked documentation.

**Fix**: Added comprehensive documentation explaining:
- Why first group is stored separately (backwards compatibility)
- How additional groups are stored
- Benefits of this approach (zero overhead, compatibility)
- Usage patterns for both single and multi-group blocks

**Impact**: Prevents future "refactorings" that would break backwards compatibility.

### Medium: Display Format Grammar (`a98f480`)
**Problem**: "1 groups" is grammatically incorrect.

**Fix**: Conditional formatting ("1 group" vs "N groups") in both `Verbatim::Display` and `snapshot_visitor`.

### Medium: Parser Error Message (`01dc72e`)
**Problem**: Panic message confused defensive check with user validation.

**Fix**: Clarified it's an "Internal parser error" indicating a parser bug, not invalid user input.

### Low: Snapshot Formatting (`7e04bdd`)
**Problem**: Group labels formatted as "subject#0" added visual noise.

**Fix**: 
- Single groups: Show only subject text (no redundant info)
- Multiple groups: Use "subject (group 1 of 3)" format
- 1-indexed groups match human expectations

## API Design

### Backwards Compatibility
Existing code accessing `verbatim.subject` and `verbatim.children` continues to work unchanged, accessing the first group.

### New API
```rust
// Iterate over all groups uniformly
for group in verbatim.group() {
    println!("Subject: {}", group.subject.as_string());
    for line in group.children.iter() {
        // Process each line
    }
}

// Get group count
let count = verbatim.group_len();
```

## Testing

✅ All 381 library tests pass  
✅ All integration tests pass  
✅ New visitor test ensures all groups are visited  
✅ Pre-commit hooks pass (formatting, clippy, docs, tests)

## Code Quality

- **No backwards compatibility breaks**: Existing code works unchanged
- **Zero overhead for single groups**: The common case has no extra allocation
- **Comprehensive documentation**: Design rationale explained in code
- **Test coverage**: New test file and visitor test
- **Clean separation**: Parser, builder, and AST layers properly separated

## Spec Documentation

Updated `docs/specs/v1/elements/verbatim/verbatim.lex` with:
- Verbatim Groups syntax and semantics
- Implementation notes for consumers
- Reference to example file

New example: `docs/specs/v1/elements/verbatim/verbatim-11-group-shell.lex`

---

**This PR is production-ready** after addressing all critical, major, medium, and low severity issues identified in code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)