### PR TITLE
Fix: Pre v1 Parser Bugs, issues 212-216

### DIFF
--- a/docs/specs/v1/elements/session/session-09-flat-colon-title.lex
+++ b/docs/specs/v1/elements/session/session-09-flat-colon-title.lex
@@ -1,0 +1,5 @@
+Subject Title:
+
+	This is content under a session whose title ends with a colon.
+
+	Sessions can have colons in their titles, unlike definitions which require the colon to be immediately followed by indented content.

--- a/src/lex/building/extraction.rs
+++ b/src/lex/building/extraction.rs
@@ -409,17 +409,22 @@ fn parse_parameter(
             }
         } else {
             is_quoted = false;
-            // Unquoted value - collect until comma or end
+            // Unquoted value - collect until comma, LexMarker, BlankLine, or end
             while i < tokens.len() {
                 match &tokens[i].0 {
-                    Token::Comma => break,
+                    Token::Comma | Token::LexMarker | Token::BlankLine(_) => break,
                     Token::Whitespace => {
-                        // Check if there's a comma after whitespace
+                        // Check if there's a comma, LexMarker, or BlankLine after whitespace
                         let mut peek = i + 1;
                         while peek < tokens.len() && matches!(tokens[peek].0, Token::Whitespace) {
                             peek += 1;
                         }
-                        if peek < tokens.len() && matches!(tokens[peek].0, Token::Comma) {
+                        if peek < tokens.len()
+                            && matches!(
+                                tokens[peek].0,
+                                Token::Comma | Token::LexMarker | Token::BlankLine(_)
+                            )
+                        {
                             break;
                         }
                         val_tokens.push(tokens[i].clone());

--- a/src/lex/parsing/reference/builders.rs
+++ b/src/lex/parsing/reference/builders.rs
@@ -229,9 +229,10 @@ pub(crate) fn definition_subject(
     filter(|(t, _location): &TokenLocation| !matches!(t, Token::Colon | Token::BlankLine(_)))
         .repeated()
         .at_least(1)
-        .then_ignore(filter(|(t, _): &TokenLocation| matches!(t, Token::Colon)).ignored())
-        .then_ignore(filter(|(t, _): &TokenLocation| matches!(t, Token::BlankLine(_))).ignored())
+        .then_ignore(filter(|(t, _): &TokenLocation| matches!(t, Token::Colon)))
     // No .map() - preserve tokens!
+    // Note: Colon is REQUIRED (no .ignored()). The blank line is NOT consumed here,
+    // allowing proper backtracking for session parser when definition match fails.
 }
 
 /// Build a definition parser
@@ -243,6 +244,7 @@ where
     P: Parser<TokenLocation, Vec<ParseNode>, Error = ParserError> + Clone + 'static,
 {
     definition_subject()
+        .then_ignore(filter(|(t, _)| matches!(t, Token::BlankLine(_)))) // consume newline after colon
         .then(
             filter(|(t, _)| matches!(t, Token::Indent(_)))
                 .ignore_then(items)

--- a/tests/elements_annotations.rs
+++ b/tests/elements_annotations.rs
@@ -283,7 +283,8 @@ fn test_annotation_10_nested_complex(parser: Parser) {
 }
 
 #[rstest(parser => [Parser::Reference, Parser::Linebased])]
-#[ignore]
+#[ignore] // TODO: Complex document - Reference parser has issues with session titles ending in colons
+          // This is tested more simply in test_session_09_flat_colon_title
 fn test_annotations_overview_document(parser: Parser) {
     // annotations.lex: Specification overview document for annotations
     let doc =

--- a/tests/elements_annotations.rs
+++ b/tests/elements_annotations.rs
@@ -112,7 +112,6 @@ fn test_annotation_06_flat_block_multi_paragraph(parser: Parser) {
 }
 
 #[rstest(parser => [Parser::Reference, Parser::Linebased])]
-#[ignore]
 fn test_annotation_07_flat_block_with_list(parser: Parser) {
     // annotation-07-flat-block-with-list.lex: Block annotation mixing paragraph and list content
     let doc = Lexplore::annotation(7).parse_with(parser);
@@ -224,7 +223,6 @@ fn test_annotation_09_nested_definition_inside(parser: Parser) {
 }
 
 #[rstest(parser => [Parser::Reference, Parser::Linebased])]
-#[ignore]
 fn test_annotation_10_nested_complex(parser: Parser) {
     // annotation-10-nested-complex.lex: Mixed paragraphs, nested lists, and parameters
     let doc = Lexplore::annotation(10).parse_with(parser);

--- a/tests/elements_lists.rs
+++ b/tests/elements_lists.rs
@@ -145,13 +145,14 @@ fn test_list_04_flat_mixed_markers(parser: Parser) {
             item.assert_list()
                 .item_count(3)
                 .item(0, |list_item| {
-                    list_item.text_contains("First item");
+                    // First item establishes the decoration style for the whole list.
+                    list_item.text_starts_with("1. First item").child_count(0);
                 })
                 .item(1, |list_item| {
-                    list_item.text_contains("Second item");
+                    list_item.text_starts_with("- Second item").child_count(0);
                 })
                 .item(2, |list_item| {
-                    list_item.text_contains("Third item");
+                    list_item.text_starts_with("a. Third item").child_count(0);
                 });
         });
 }

--- a/tests/elements_sessions.rs
+++ b/tests/elements_sessions.rs
@@ -213,3 +213,21 @@ fn test_session_08_paragraphs_sessions_nested_multiple(parser: Parser) {
                 });
         });
 }
+
+#[rstest(parser => [Parser::Reference, Parser::Linebased])]
+fn test_session_09_flat_colon_title(parser: Parser) {
+    // session-09-flat-colon-title.lex: Session title ending with colon (bug #212)
+    // Tests that sessions can have colons in their titles, distinguished from definitions
+    // by blank lines between title and content
+    let doc = Lexplore::session(9).parse_with(parser);
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_session()
+            .label("Subject Title:")
+            .child(0, |child| {
+                child
+                    .assert_paragraph()
+                    .text_contains("session whose title ends with a colon");
+            });
+    });
+}


### PR DESCRIPTION
- **test(lists): lock mixed marker styling (#216)**
- **fix(parser): require colon in definition subjects (for issue #212)**
- **fix: Stop including '::' in annotation parameter values (for issue #211)**
