### PR TITLE
feat(containers): complete type-safe pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "trybuild",
 ]
 
 [[package]]
@@ -841,6 +848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +973,69 @@ dependencies = [
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+
+[[package]]
+name = "trybuild"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -1039,6 +1124,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1207,6 +1301,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"

--- a/docs/architecture/type-safe-containers.md
+++ b/docs/architecture/type-safe-containers.md
@@ -1,0 +1,86 @@
+# Type-Safe Container System
+
+The container refactor from issues #228–#235 replaced the old "bag of `ContentItem`"
+representation with policy-driven containers. This document captures the mental model so
+future contributors can extend the AST without re-introducing runtime validation.
+
+## Policy Basics
+
+Each container in `lex_parser::lex::ast::elements::container` is backed by a
+`ContainerPolicy` implementation:
+
+| Policy | Alias | Accepted children | Used by |
+| --- | --- | --- | --- |
+| `SessionPolicy` | `SessionContainer` | `SessionContent` (sessions and general elements) | `Document.root`, `Session.children` |
+| `GeneralPolicy` | `GeneralContainer` | `ContentElement` (no sessions) | `Definition`, `Annotation`, `ListItem` |
+| `ListPolicy` | `ListContainer` | `ListContent` (only list items) | `List.items` |
+| `VerbatimPolicy` | `VerbatimContainer` | `VerbatimContent` (only verbatim lines) | `Verbatim.children`, verbatim groups |
+
+Every AST constructor now accepts the typed vector for its container. If code compiles,
+then the container invariants are satisfied—no runtime `validate_*` calls remain.
+
+## Using the Typed APIs
+
+```rust
+use lex_parser::lex::ast::elements::typed_content::ContentElement;
+use lex_parser::lex::ast::{Definition, TextContent};
+
+let subject = TextContent::from_string("Term".into(), None);
+let children: Vec<ContentElement> = vec![]; // paragraphs, lists, annotations, ...
+let def = Definition::new(subject, children);
+```
+
+`Session::new` follows the same pattern but accepts `Vec<SessionContent>`, so sessions can
+nest arbitrarily while still permitting paragraphs, lists, etc.
+
+### Verbatim Blocks
+
+Verbatim blocks expose their children as a `VerbatimContainer` and accept
+`Vec<VerbatimContent>` in their constructors. Even though only verbatim lines are legal,
+callers still get a `Container` that dereferences to `Vec<ContentItem>` for traversal.
+
+## Compile-Fail Guarantees
+
+The `lex-parser` crate now ships `trybuild` tests that prove invalid combinations fail to
+compile. For example:
+
+```rust,compile_fail
+use lex_parser::lex::ast::elements::typed_content::SessionContent;
+use lex_parser::lex::ast::{Definition, Session, TextContent};
+
+fn main() {
+    let subject = TextContent::from_string("Term".to_string(), None);
+    let session = Session::with_title("Nested".to_string());
+    let _definition = Definition::new(subject, vec![SessionContent::Session(session)]);
+    // error[E0308]: expected `Vec<ContentElement>`, found `Vec<SessionContent>`
+}
+```
+
+See `lex-parser/tests/compile_fail` for the full set of examples. Run
+`TRYBUILD=overwrite cargo test -p lex-parser --test compile_fail` if you intentionally
+change the diagnostics.
+
+## Visitor and Traversal Impact
+
+The visitor APIs still operate on `ContentItem` because traversal needs a uniform enum to
+walk heterogeneous trees. Typed content only exists at construction boundaries, so
+traversal ergonomics remain unchanged:
+
+- Constructors enforce policy at compile time.
+- Containers store `ContentItem` internally for visitor dispatch.
+- `ContentElement::try_from` remains available for ad‑hoc conversions inside tests.
+
+If a parser bug violates the policy (e.g., emits a Session under a Definition) the
+conversion inside `AstBuilder` will panic, surfacing the bug in debug builds rather than
+silently producing a malformed tree.
+
+## Migration Notes
+
+- `Container::new` and the `ContainerNode` alias have been removed—use the typed
+  constructors instead.
+- Public builder functions (`build_session`, `build_definition`, etc.) now accept typed
+  vectors, so downstream code must construct `SessionContent`/`ContentElement` directly.
+- Runtime `expect("cannot contain")` checks have been deleted; rely on the type system or
+  the compile-fail tests above.
+
+This keeps the container story simple: **if it compiles, it matches the grammar.**

--- a/docs/dev/guides/on-containers.lex
+++ b/docs/dev/guides/on-containers.lex
@@ -1,0 +1,70 @@
+Containers , Structure and Parsing in Lex
+
+	Lex is a structurally recursive language, where almost all elements can contain children. This structure gives Lex a powerful primitive, giving users a much richer representation of their data then most flat formats like HTML or markdown.
+
+	All parent -> child relationships are denoted by indentation. From the AST perspective, this means a container node. The container stack is what the parser manipulates when indentation changes.
+
+1. Container Policies
+
+	Containers now encode their nesting rules at the type level. Each container alias wraps a `ContainerPolicy`:
+		SessionContainer → `SessionContent` (sessions + general elements)
+		GeneralContainer → `ContentElement` (no sessions)
+		ListContainer → `ListContent` (only list items)
+		VerbatimContainer → `VerbatimContent` (only verbatim lines)
+
+	See :: file src/lex/ast/elements/container.rs :: for the policy definitions. The typed wrappers live in :: file src/lex/ast/elements/typed_content.rs ::
+
+2. Constructors Always Take Typed Vecs
+
+	Every AST constructor now reflects the policy at the signature level:
+		Session::new(title, Vec<SessionContent>)
+		Definition::new(subject, Vec<ContentElement>)
+		Annotation::new(label, params, Vec<ContentElement>)
+		List::new(Vec<ListItem>) (each ListItem already owns a GeneralContainer)
+		Verbatim::new(subject, Vec<VerbatimContent>, closing_annotation)
+
+	Consequences:
+		No more `ContainerNode`, `Container::new`, or `_from_text` helpers.
+		If a call site compiles, the nesting rules hold.
+		Runtime `expect("cannot contain")` checks were deleted.
+
+3. Parser / Builder Flow
+
+	`AstBuilder` converts `ParseNode` children into typed vectors before calling the builders. Example (see :: file src/lex/parsing/builder.rs ::):
+		Sessions → `build_session_from_tokens(title, Vec<SessionContent>, source)`
+		Definitions / annotations / list items → `build_*` with `Vec<ContentElement>`
+
+	Builders aggregate locations by temporarily projecting the typed vec back into `ContentItem`, but the AST structs only ever see the typed inputs.
+
+4. Compile-Fail Tests
+
+	Trybuild tests ensure regressions are caught at compile time. The harness lives in :: file tests/compile_fail.rs :: and the cases live under :: dir tests/compile_fail ::
+
+	Example (definition rejecting sessions):
+	```lex
+	:: file tests/compile_fail/definition_rejects_session.rs ::
+		let _definition = Definition::new(subject, vec![SessionContent::Session(session)]);
+	```
+
+	Running `TRYBUILD=overwrite cargo test -p lex-parser --test compile_fail` should only be necessary when intentionally changing diagnostics.
+
+5. Authoring Guidelines
+
+	When adding a new container element:
+		Define an appropriate policy in container.rs or reuse General/Session policy.
+		Create a typed enum variant under `typed_content.rs` if the container needs special rules.
+		Thread the typed vector through the builder and parser entry points.
+		Add a compile-fail test if the new container forbids certain children.
+
+	When touching existing containers:
+		Avoid reintroducing `Vec<ContentItem>` parameters.
+		Prefer `Container::<Policy>::from_typed` when constructing containers directly.
+		Keep traversal code (`ContentItem`, visitors, viewer UI) in terms of the enum—typed content is for construction, not tree walking.
+
+6. Further Reading
+
+	Architecture overview: :: file docs/architecture/type-safe-containers.md ::
+	Public crate README: :: file lex-parser/README.md ::
+	Compile-fail harness: :: file lex-parser/tests/compile_fail.rs ::
+
+	These documents explain the rationale behind issues #228 → #235 and describe how the type-safe container pipeline ties the parser, builders, and AST together.

--- a/lex-parser/Cargo.toml
+++ b/lex-parser/Cargo.toml
@@ -24,3 +24,4 @@ once_cell = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+trybuild = "1.0"

--- a/lex-parser/README.md
+++ b/lex-parser/README.md
@@ -1,0 +1,38 @@
+# lex-parser
+
+The `lex-parser` crate builds typed ASTs for the lex document format. Recent work
+(#228–#235) replaced the old dynamic container model with policy-driven containers that
+encode nesting rules at the type level.
+
+## Typed Containers
+
+Each container constructor now accepts a typed vector:
+
+- `Session::new(title, Vec<SessionContent>)`
+- `Definition::new(subject, Vec<ContentElement>)`
+- `Annotation::new(label, params, Vec<ContentElement>)`
+- `List::new(Vec<ListItem>)`
+- `Verbatim::new(subject, Vec<VerbatimContent>, closing_annotation)`
+
+If code compiles, it satisfies the nesting rules. Invalid combinations fail to compile,
+as demonstrated by the `trybuild` tests under `tests/compile_fail`.
+
+```rust,compile_fail
+use lex_parser::lex::ast::elements::typed_content::SessionContent;
+use lex_parser::lex::ast::{Definition, Session, TextContent};
+
+fn main() {
+    let subject = TextContent::from_string("Term".into(), None);
+    let session = Session::with_title("Nested".into());
+    let _definition = Definition::new(subject, vec![SessionContent::Session(session)]);
+}
+```
+
+Run the tests to see the diagnostic:
+
+```bash
+TRYBUILD=overwrite cargo test -p lex-parser --test compile_fail
+```
+
+For a deeper architectural overview read
+[`docs/architecture/type-safe-containers.md`](../docs/architecture/type-safe-containers.md).

--- a/lex-parser/src/lex/ast.rs
+++ b/lex-parser/src/lex/ast.rs
@@ -59,6 +59,13 @@
 //! - `lookup` - Position-based AST node lookup functionality
 //! - `snapshot` - Normalized intermediate representation for serialization
 //! - `error` - Error types for AST operations
+//!
+//! ## Type-Safe Containers
+//!
+//! Containers such as `Session`, `Definition`, and `Annotation` now take typed
+//! vectors (`SessionContent`, `ContentElement`, etc.) so invalid nesting is ruled
+//! out at compile time. See `docs/architecture/type-safe-containers.md` for
+//! details and compile-fail examples.
 
 pub mod elements;
 pub mod error;

--- a/lex-parser/src/lex/ast/elements.rs
+++ b/lex-parser/src/lex/ast/elements.rs
@@ -22,6 +22,7 @@ pub mod list;
 pub mod paragraph;
 pub mod parameter;
 pub mod session;
+pub mod typed_content;
 pub mod verbatim;
 pub mod verbatim_line;
 
@@ -38,5 +39,6 @@ pub use list::{List, ListItem};
 pub use paragraph::{Paragraph, TextLine};
 pub use parameter::Parameter;
 pub use session::Session;
+pub use typed_content::{ContentElement, ListContent, SessionContent, VerbatimContent};
 pub use verbatim::Verbatim;
 pub use verbatim_line::VerbatimLine;

--- a/lex-parser/src/lex/ast/elements.rs
+++ b/lex-parser/src/lex/ast/elements.rs
@@ -29,8 +29,6 @@ pub mod verbatim_line;
 // Re-export all element types
 pub use annotation::Annotation;
 pub use blank_line_group::BlankLineGroup;
-#[allow(deprecated)]
-pub use container::Container as ContainerNode;
 pub use content_item::ContentItem;
 pub use definition::Definition;
 pub use document::Document;

--- a/lex-parser/src/lex/ast/elements/annotation.rs
+++ b/lex-parser/src/lex/ast/elements/annotation.rs
@@ -47,6 +47,7 @@ use super::container::GeneralContainer;
 use super::content_item::ContentItem;
 use super::label::Label;
 use super::parameter::Parameter;
+use super::typed_content::ContentElement;
 use std::fmt;
 
 /// An annotation represents some metadata about an ast element.
@@ -62,11 +63,11 @@ impl Annotation {
     fn default_location() -> Range {
         Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
-    pub fn new(label: Label, parameters: Vec<Parameter>, children: Vec<ContentItem>) -> Self {
+    pub fn new(label: Label, parameters: Vec<Parameter>, children: Vec<ContentElement>) -> Self {
         Self {
             label,
             parameters,
-            children: GeneralContainer::new(children),
+            children: GeneralContainer::from_typed(children),
             location: Self::default_location(),
         }
     }

--- a/lex-parser/src/lex/ast/elements/container.rs
+++ b/lex-parser/src/lex/ast/elements/container.rs
@@ -20,6 +20,35 @@
 //!   - Used by: List.items
 //! - **VerbatimContainer**: Homogeneous container for VerbatimLine nodes only
 //!   - Used by: VerbatimBlock.children
+//!
+//! ## Accessing Container Children
+//!
+//! The `.children` field is private. Use one of these access patterns:
+//!
+//! **Deref coercion** (preferred for Vec operations):
+//! ```ignore
+//! let session = Session::new(...);
+//! for child in &session.children {  // Deref to &Vec<ContentItem>
+//!     // process child
+//! }
+//! let count = session.children.len();  // Works via Deref
+//! ```
+//!
+//! **ContentItem polymorphic access**:
+//! ```ignore
+//! fn process(item: &ContentItem) {
+//!     if let Some(children) = item.children() {
+//!         // Access children polymorphically
+//!     }
+//! }
+//! ```
+//!
+//! **Container trait**:
+//! ```ignore
+//! fn process<T: Container>(container: &T) {
+//!     let children = container.children();  // Returns &[ContentItem]
+//! }
+//! ```
 
 use super::super::range::Range;
 use super::super::traits::{AstNode, Visitor};
@@ -31,7 +60,7 @@ use std::fmt;
 /// Used for document-level containers where unlimited Session nesting is allowed.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SessionContainer {
-    pub children: Vec<ContentItem>,
+    children: Vec<ContentItem>,
     pub location: Range,
 }
 
@@ -41,7 +70,7 @@ pub struct SessionContainer {
 /// is prohibited.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GeneralContainer {
-    pub children: Vec<ContentItem>,
+    children: Vec<ContentItem>,
     pub location: Range,
 }
 
@@ -50,7 +79,7 @@ pub struct GeneralContainer {
 /// Used by List.items to enforce that lists only contain list items.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListContainer {
-    pub children: Vec<ContentItem>,
+    children: Vec<ContentItem>,
     pub location: Range,
 }
 
@@ -60,7 +89,7 @@ pub struct ListContainer {
 /// verbatim lines (content from other formats).
 #[derive(Debug, Clone, PartialEq)]
 pub struct VerbatimContainer {
-    pub children: Vec<ContentItem>,
+    children: Vec<ContentItem>,
     pub location: Range,
 }
 

--- a/lex-parser/src/lex/ast/elements/container.rs
+++ b/lex-parser/src/lex/ast/elements/container.rs
@@ -197,12 +197,11 @@ impl<P: ContainerPolicy> Container<P> {
     /// This is the preferred way to create containers as it enforces nesting rules
     /// at compile time via the policy's ContentType.
     ///
-    /// # Future Work
+    /// # Status
     ///
-    /// Currently, element constructors (Session::new, Definition::new, etc.) still
-    /// accept Vec<ContentItem> for backward compatibility. A future refactoring
-    /// could update these to accept typed content directly, enabling full compile-time
-    /// enforcement throughout the construction pipeline.
+    /// Element constructors (Session::new, Definition::new, Annotation::new) now accept
+    /// typed content directly. This helper remains useful for tests or manual AST
+    /// construction where callers want explicit control over container policies.
     pub fn from_typed(children: Vec<P::ContentType>) -> Self {
         Self {
             children: children.into_iter().map(|c| c.into()).collect(),

--- a/lex-parser/src/lex/ast/elements/container.rs
+++ b/lex-parser/src/lex/ast/elements/container.rs
@@ -196,6 +196,13 @@ impl<P: ContainerPolicy> Container<P> {
     ///
     /// This is the preferred way to create containers as it enforces nesting rules
     /// at compile time via the policy's ContentType.
+    ///
+    /// # Future Work
+    ///
+    /// Currently, element constructors (Session::new, Definition::new, etc.) still
+    /// accept Vec<ContentItem> for backward compatibility. A future refactoring
+    /// could update these to accept typed content directly, enabling full compile-time
+    /// enforcement throughout the construction pipeline.
     pub fn from_typed(children: Vec<P::ContentType>) -> Self {
         Self {
             children: children.into_iter().map(|c| c.into()).collect(),

--- a/lex-parser/src/lex/ast/elements/content_item.rs
+++ b/lex-parser/src/lex/ast/elements/content_item.rs
@@ -417,6 +417,7 @@ mod tests {
     use super::super::super::range::{Position, Range};
     use super::super::paragraph::Paragraph;
     use super::*;
+    use crate::lex::ast::elements::typed_content;
 
     #[test]
     fn test_element_at_simple_paragraph() {
@@ -472,7 +473,7 @@ mod tests {
                 "Section".to_string(),
                 None,
             ),
-            vec![ContentItem::Paragraph(para)],
+            typed_content::into_session_contents(vec![ContentItem::Paragraph(para)]),
         )
         .at(Range::new(0..0, Position::new(0, 0), Position::new(2, 0)));
         let item = ContentItem::Session(session);

--- a/lex-parser/src/lex/ast/elements/definition.rs
+++ b/lex-parser/src/lex/ast/elements/definition.rs
@@ -26,6 +26,7 @@ use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container, Visitor};
 use super::container::GeneralContainer;
 use super::content_item::ContentItem;
+use super::typed_content::ContentElement;
 use std::fmt;
 
 /// A definition provides a subject and associated content
@@ -40,10 +41,10 @@ impl Definition {
     fn default_location() -> Range {
         Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
-    pub fn new(subject: TextContent, children: Vec<ContentItem>) -> Self {
+    pub fn new(subject: TextContent, children: Vec<ContentElement>) -> Self {
         Self {
             subject,
-            children: GeneralContainer::new(children),
+            children: GeneralContainer::from_typed(children),
             location: Self::default_location(),
         }
     }

--- a/lex-parser/src/lex/ast/elements/document.rs
+++ b/lex-parser/src/lex/ast/elements/document.rs
@@ -27,6 +27,7 @@ use super::content_item::ContentItem;
 use super::list::List;
 use super::paragraph::Paragraph;
 use super::session::Session;
+use super::typed_content;
 use super::verbatim::Verbatim;
 use std::fmt;
 
@@ -84,7 +85,8 @@ impl Document {
 
     pub fn with_content(content: Vec<ContentItem>) -> Self {
         let mut root = Session::with_title(String::new());
-        root.children = super::container::SessionContainer::new(content);
+        let session_content = typed_content::into_session_contents(content);
+        root.children = super::container::SessionContainer::from_typed(session_content);
         Self {
             metadata: Vec::new(),
             root,
@@ -93,7 +95,8 @@ impl Document {
 
     pub fn with_metadata_and_content(metadata: Vec<Annotation>, content: Vec<ContentItem>) -> Self {
         let mut root = Session::with_title(String::new());
-        root.children = super::container::SessionContainer::new(content);
+        let session_content = typed_content::into_session_contents(content);
+        root.children = super::container::SessionContainer::from_typed(session_content);
         Self { metadata, root }
     }
 

--- a/lex-parser/src/lex/ast/elements/list.rs
+++ b/lex-parser/src/lex/ast/elements/list.rs
@@ -30,6 +30,7 @@ use super::super::traits::Container;
 use super::super::traits::Visitor;
 use super::container::{GeneralContainer, ListContainer};
 use super::content_item::ContentItem;
+use super::typed_content::{ContentElement, ListContent};
 use std::fmt;
 
 /// A list contains multiple list items
@@ -51,9 +52,13 @@ impl List {
     fn default_location() -> Range {
         Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
-    pub fn new(items: Vec<ContentItem>) -> Self {
+    pub fn new(items: Vec<ListItem>) -> Self {
+        let typed_items = items
+            .into_iter()
+            .map(ListContent::ListItem)
+            .collect::<Vec<_>>();
         Self {
-            items: ListContainer::new(items),
+            items: ListContainer::from_typed(typed_items),
             location: Self::default_location(),
         }
     }
@@ -99,18 +104,18 @@ impl ListItem {
             location: Self::default_location(),
         }
     }
-    pub fn with_content(text: String, children: Vec<ContentItem>) -> Self {
+    pub fn with_content(text: String, children: Vec<ContentElement>) -> Self {
         Self {
             text: vec![TextContent::from_string(text, None)],
-            children: GeneralContainer::new(children),
+            children: GeneralContainer::from_typed(children),
             location: Self::default_location(),
         }
     }
     /// Create a ListItem with TextContent that may have location information
-    pub fn with_text_content(text_content: TextContent, children: Vec<ContentItem>) -> Self {
+    pub fn with_text_content(text_content: TextContent, children: Vec<ContentElement>) -> Self {
         Self {
             text: vec![text_content],
-            children: GeneralContainer::new(children),
+            children: GeneralContainer::from_typed(children),
             location: Self::default_location(),
         }
     }

--- a/lex-parser/src/lex/ast/elements/paragraph.rs
+++ b/lex-parser/src/lex/ast/elements/paragraph.rs
@@ -16,8 +16,7 @@
 use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, TextNode, Visitor};
-#[allow(deprecated)]
-use super::container::Container as ContainerNode;
+use super::container::SessionContainer as ContainerNode;
 use std::fmt;
 
 /// A text line within a paragraph
@@ -81,7 +80,6 @@ impl fmt::Display for TextLine {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Paragraph {
     /// Lines stored as ContentItems (each a TextLine wrapping TextContent)
-    #[allow(deprecated)]
     pub lines: ContainerNode,
     pub location: Range,
 }

--- a/lex-parser/src/lex/ast/elements/paragraph.rs
+++ b/lex-parser/src/lex/ast/elements/paragraph.rs
@@ -16,7 +16,7 @@
 use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, TextNode, Visitor};
-use super::container::SessionContainer as ContainerNode;
+use super::content_item::ContentItem;
 use std::fmt;
 
 /// A text line within a paragraph
@@ -80,7 +80,7 @@ impl fmt::Display for TextLine {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Paragraph {
     /// Lines stored as ContentItems (each a TextLine wrapping TextContent)
-    pub lines: ContainerNode,
+    pub lines: Vec<ContentItem>,
     pub location: Range,
 }
 
@@ -88,29 +88,32 @@ impl Paragraph {
     fn default_location() -> Range {
         Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
-    pub fn new(lines: Vec<super::content_item::ContentItem>) -> Self {
+    pub fn new(lines: Vec<ContentItem>) -> Self {
+        debug_assert!(
+            lines
+                .iter()
+                .all(|item| matches!(item, ContentItem::TextLine(_))),
+            "Paragraph lines must be TextLine items"
+        );
         Self {
-            #[allow(deprecated)]
-            lines: ContainerNode::new(lines),
+            lines,
             location: Self::default_location(),
         }
     }
     pub fn from_line(line: String) -> Self {
         Self {
-            #[allow(deprecated)]
-            lines: ContainerNode::new(vec![super::content_item::ContentItem::TextLine(
-                TextLine::new(TextContent::from_string(line, None)),
-            )]),
+            lines: vec![ContentItem::TextLine(TextLine::new(
+                TextContent::from_string(line, None),
+            ))],
             location: Self::default_location(),
         }
     }
     /// Create a paragraph with a single line and attach a location
     pub fn from_line_at(line: String, location: Range) -> Self {
         let mut para = Self {
-            #[allow(deprecated)]
-            lines: ContainerNode::new(vec![super::content_item::ContentItem::TextLine(
-                TextLine::new(TextContent::from_string(line, None)),
-            )]),
+            lines: vec![ContentItem::TextLine(TextLine::new(
+                TextContent::from_string(line, None),
+            ))],
             location: Self::default_location(),
         };
         para = para.at(location);

--- a/lex-parser/src/lex/ast/elements/session.rs
+++ b/lex-parser/src/lex/ast/elements/session.rs
@@ -28,6 +28,7 @@ use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container, Visitor};
 use super::container::SessionContainer;
 use super::content_item::ContentItem;
+use super::typed_content::SessionContent;
 use std::fmt;
 
 /// A session represents a hierarchical container with a title
@@ -42,10 +43,10 @@ impl Session {
     fn default_location() -> Range {
         Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
-    pub fn new(title: TextContent, children: Vec<ContentItem>) -> Self {
+    pub fn new(title: TextContent, children: Vec<SessionContent>) -> Self {
         Self {
             title,
-            children: SessionContainer::new(children),
+            children: SessionContainer::from_typed(children),
             location: Self::default_location(),
         }
     }

--- a/lex-parser/src/lex/ast/elements/typed_content.rs
+++ b/lex-parser/src/lex/ast/elements/typed_content.rs
@@ -1,0 +1,310 @@
+//! Typed content variants for type-safe container construction
+//!
+//! This module provides specialized content types that enforce nesting rules at the type level.
+//! Instead of using the universal ContentItem enum everywhere, containers can use these
+//! restricted types to prevent invalid nesting at compile time.
+//!
+//! # Hierarchy
+//!
+//! ```text
+//! ContentItem (universal)
+//!   ├─ SessionContent (allows Sessions)
+//!   │   ├─ Session
+//!   │   └─ ContentElement
+//!   └─ ContentElement (no Sessions/Annotations)
+//!       ├─ Paragraph
+//!       ├─ List
+//!       ├─ Definition
+//!       ├─ VerbatimBlock
+//!       └─ ...
+//!
+//! ListContent (only ListItems)
+//!   └─ ListItem
+//!
+//! VerbatimContent (only VerbatimLines)
+//!   └─ VerbatimLine
+//! ```
+//!
+//! # Usage
+//!
+//! ```ignore
+//! // Convert ContentItem to typed variant
+//! let content_item: ContentItem = /* ... */;
+//! let element: ContentElement = content_item.try_into()?; // Rejects Sessions
+//!
+//! // Convert typed variant back to ContentItem
+//! let item: ContentItem = element.into();
+//! ```
+
+use super::annotation::Annotation;
+use super::blank_line_group::BlankLineGroup;
+use super::content_item::ContentItem;
+use super::definition::Definition;
+use super::list::{List, ListItem};
+use super::paragraph::{Paragraph, TextLine};
+use super::session::Session;
+use super::verbatim::Verbatim;
+use super::verbatim_line::VerbatimLine;
+
+// ============================================================================
+// CONTENT ELEMENT (No Sessions or Annotations)
+// ============================================================================
+
+/// ContentElement represents all elements EXCEPT Sessions and Annotations
+///
+/// Used by GeneralContainer (Definition.children, Annotation.children, ListItem.children)
+/// to enforce that Sessions cannot be nested in these contexts.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContentElement {
+    Paragraph(Paragraph),
+    List(List),
+    Definition(Definition),
+    VerbatimBlock(Box<Verbatim>),
+    TextLine(TextLine),
+    VerbatimLine(VerbatimLine),
+    BlankLineGroup(BlankLineGroup),
+}
+
+impl TryFrom<ContentItem> for ContentElement {
+    type Error = &'static str;
+
+    fn try_from(item: ContentItem) -> Result<Self, Self::Error> {
+        match item {
+            ContentItem::Session(_) => Err("Sessions are not allowed in ContentElement"),
+            ContentItem::Annotation(_) => Err("Annotations are not allowed in ContentElement"),
+            ContentItem::Paragraph(p) => Ok(ContentElement::Paragraph(p)),
+            ContentItem::List(l) => Ok(ContentElement::List(l)),
+            ContentItem::Definition(d) => Ok(ContentElement::Definition(d)),
+            ContentItem::VerbatimBlock(vb) => Ok(ContentElement::VerbatimBlock(vb)),
+            ContentItem::TextLine(tl) => Ok(ContentElement::TextLine(tl)),
+            ContentItem::VerbatimLine(vl) => Ok(ContentElement::VerbatimLine(vl)),
+            ContentItem::BlankLineGroup(blg) => Ok(ContentElement::BlankLineGroup(blg)),
+            ContentItem::ListItem(_) => Err("ListItem should not be used as ContentElement"),
+        }
+    }
+}
+
+impl From<ContentElement> for ContentItem {
+    fn from(element: ContentElement) -> Self {
+        match element {
+            ContentElement::Paragraph(p) => ContentItem::Paragraph(p),
+            ContentElement::List(l) => ContentItem::List(l),
+            ContentElement::Definition(d) => ContentItem::Definition(d),
+            ContentElement::VerbatimBlock(vb) => ContentItem::VerbatimBlock(vb),
+            ContentElement::TextLine(tl) => ContentItem::TextLine(tl),
+            ContentElement::VerbatimLine(vl) => ContentItem::VerbatimLine(vl),
+            ContentElement::BlankLineGroup(blg) => ContentItem::BlankLineGroup(blg),
+        }
+    }
+}
+
+// ============================================================================
+// SESSION CONTENT (Includes Sessions)
+// ============================================================================
+
+/// SessionContent represents all elements including Sessions
+///
+/// Used by SessionContainer (Document.root, Session.children) where unlimited
+/// Session nesting is allowed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionContent {
+    Session(Session),
+    Annotation(Annotation),
+    Element(ContentElement),
+}
+
+impl From<ContentItem> for SessionContent {
+    fn from(item: ContentItem) -> Self {
+        match item {
+            ContentItem::Session(s) => SessionContent::Session(s),
+            ContentItem::Annotation(a) => SessionContent::Annotation(a),
+            // Everything else goes through ContentElement
+            other => match ContentElement::try_from(other) {
+                Ok(element) => SessionContent::Element(element),
+                Err(_) => unreachable!(
+                    "All non-Session/Annotation items should convert to ContentElement"
+                ),
+            },
+        }
+    }
+}
+
+impl From<SessionContent> for ContentItem {
+    fn from(content: SessionContent) -> Self {
+        match content {
+            SessionContent::Session(s) => ContentItem::Session(s),
+            SessionContent::Annotation(a) => ContentItem::Annotation(a),
+            SessionContent::Element(e) => e.into(),
+        }
+    }
+}
+
+impl From<ContentElement> for SessionContent {
+    fn from(element: ContentElement) -> Self {
+        SessionContent::Element(element)
+    }
+}
+
+// ============================================================================
+// LIST CONTENT (Only ListItems)
+// ============================================================================
+
+/// ListContent represents only ListItem elements
+///
+/// Used by ListContainer (List.items) to enforce homogeneous list structure.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ListContent {
+    ListItem(ListItem),
+}
+
+impl TryFrom<ContentItem> for ListContent {
+    type Error = &'static str;
+
+    fn try_from(item: ContentItem) -> Result<Self, Self::Error> {
+        match item {
+            ContentItem::ListItem(li) => Ok(ListContent::ListItem(li)),
+            _ => Err("Only ListItems are allowed in ListContent"),
+        }
+    }
+}
+
+impl From<ListContent> for ContentItem {
+    fn from(content: ListContent) -> Self {
+        match content {
+            ListContent::ListItem(li) => ContentItem::ListItem(li),
+        }
+    }
+}
+
+// ============================================================================
+// VERBATIM CONTENT (Only VerbatimLines)
+// ============================================================================
+
+/// VerbatimContent represents only VerbatimLine elements
+///
+/// Used by VerbatimContainer (VerbatimBlock.children) to enforce that verbatim
+/// blocks only contain verbatim lines.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VerbatimContent {
+    VerbatimLine(VerbatimLine),
+}
+
+impl TryFrom<ContentItem> for VerbatimContent {
+    type Error = &'static str;
+
+    fn try_from(item: ContentItem) -> Result<Self, Self::Error> {
+        match item {
+            ContentItem::VerbatimLine(vl) => Ok(VerbatimContent::VerbatimLine(vl)),
+            _ => Err("Only VerbatimLines are allowed in VerbatimContent"),
+        }
+    }
+}
+
+impl From<VerbatimContent> for ContentItem {
+    fn from(content: VerbatimContent) -> Self {
+        match content {
+            VerbatimContent::VerbatimLine(vl) => ContentItem::VerbatimLine(vl),
+        }
+    }
+}
+
+// ============================================================================
+// BATCH CONVERSION HELPERS
+// ============================================================================
+
+/// Convert a Vec<ContentItem> to Vec<ContentElement>, failing if any item is a Session or Annotation
+pub fn try_into_content_elements(
+    items: Vec<ContentItem>,
+) -> Result<Vec<ContentElement>, &'static str> {
+    items.into_iter().map(ContentElement::try_from).collect()
+}
+
+/// Convert a Vec<ContentItem> to Vec<SessionContent> (always succeeds)
+pub fn into_session_contents(items: Vec<ContentItem>) -> Vec<SessionContent> {
+    items.into_iter().map(SessionContent::from).collect()
+}
+
+/// Convert a Vec<ContentItem> to Vec<ListContent>, failing if any item is not a ListItem
+pub fn try_into_list_contents(items: Vec<ContentItem>) -> Result<Vec<ListContent>, &'static str> {
+    items.into_iter().map(ListContent::try_from).collect()
+}
+
+/// Convert a Vec<ContentItem> to Vec<VerbatimContent>, failing if any item is not a VerbatimLine
+pub fn try_into_verbatim_contents(
+    items: Vec<ContentItem>,
+) -> Result<Vec<VerbatimContent>, &'static str> {
+    items.into_iter().map(VerbatimContent::try_from).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::paragraph::Paragraph;
+    use super::super::session::Session;
+    use super::*;
+
+    #[test]
+    fn test_content_element_rejects_session() {
+        let session = Session::with_title("Test".to_string());
+        let item = ContentItem::Session(session);
+
+        let result = ContentElement::try_from(item);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_content_element_accepts_paragraph() {
+        let para = Paragraph::from_line("Test".to_string());
+        let item = ContentItem::Paragraph(para.clone());
+
+        let result = ContentElement::try_from(item);
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            ContentElement::Paragraph(p) => assert_eq!(p.text(), para.text()),
+            _ => panic!("Expected Paragraph"),
+        }
+    }
+
+    #[test]
+    fn test_session_content_accepts_session() {
+        let session = Session::with_title("Test".to_string());
+        let item = ContentItem::Session(session.clone());
+
+        let content = SessionContent::from(item);
+
+        match content {
+            SessionContent::Session(s) => assert_eq!(s.title.as_string(), "Test"),
+            _ => panic!("Expected Session"),
+        }
+    }
+
+    #[test]
+    fn test_list_content_only_accepts_list_items() {
+        let para = Paragraph::from_line("Test".to_string());
+        let item = ContentItem::Paragraph(para);
+
+        let result = ListContent::try_from(item);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_conversion_content_elements() {
+        let para1 = Paragraph::from_line("Test 1".to_string());
+        let para2 = Paragraph::from_line("Test 2".to_string());
+        let items = vec![ContentItem::Paragraph(para1), ContentItem::Paragraph(para2)];
+
+        let result = try_into_content_elements(items);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_batch_conversion_rejects_session() {
+        let para = Paragraph::from_line("Test".to_string());
+        let session = Session::with_title("Test".to_string());
+        let items = vec![ContentItem::Paragraph(para), ContentItem::Session(session)];
+
+        let result = try_into_content_elements(items);
+        assert!(result.is_err());
+    }
+}

--- a/lex-parser/src/lex/ast/elements/verbatim.rs
+++ b/lex-parser/src/lex/ast/elements/verbatim.rs
@@ -48,6 +48,7 @@ use super::super::traits::{AstNode, Container, Visitor};
 use super::annotation::Annotation;
 use super::container::VerbatimContainer;
 use super::content_item::ContentItem;
+use super::typed_content::VerbatimContent;
 use std::fmt;
 use std::slice;
 
@@ -108,12 +109,12 @@ impl Verbatim {
 
     pub fn new(
         subject: TextContent,
-        children: Vec<ContentItem>,
+        children: Vec<VerbatimContent>,
         closing_annotation: Annotation,
     ) -> Self {
         Self {
             subject,
-            children: VerbatimContainer::new(children),
+            children: VerbatimContainer::from_typed(children),
             closing_annotation,
             location: Self::default_location(),
             additional_groups: Vec::new(),
@@ -229,10 +230,10 @@ pub struct VerbatimGroupItem {
 }
 
 impl VerbatimGroupItem {
-    pub fn new(subject: TextContent, children: Vec<ContentItem>) -> Self {
+    pub fn new(subject: TextContent, children: Vec<VerbatimContent>) -> Self {
         Self {
             subject,
-            children: VerbatimContainer::new(children),
+            children: VerbatimContainer::from_typed(children),
         }
     }
 }

--- a/lex-parser/src/lex/ast/snapshot.rs
+++ b/lex-parser/src/lex/ast/snapshot.rs
@@ -215,6 +215,7 @@ mod tests {
     use crate::lex::ast::elements::annotation::Annotation;
     use crate::lex::ast::elements::paragraph::Paragraph;
     use crate::lex::ast::elements::session::Session;
+    use crate::lex::ast::elements::typed_content::ContentElement;
 
     #[test]
     fn test_snapshot_from_document_empty() {
@@ -253,7 +254,11 @@ mod tests {
     fn test_snapshot_excludes_metadata() {
         use crate::lex::ast::elements::label::Label;
 
-        let annotation = Annotation::new(Label::new("test-label".to_string()), vec![], vec![]);
+        let annotation = Annotation::new(
+            Label::new("test-label".to_string()),
+            vec![],
+            Vec::<ContentElement>::new(),
+        );
         let doc = Document::with_metadata_and_content(
             vec![annotation],
             vec![ContentItem::Paragraph(Paragraph::from_line(

--- a/lex-parser/src/lex/building/api.rs
+++ b/lex-parser/src/lex/building/api.rs
@@ -30,7 +30,7 @@
 //! let session = ast_builder::build_session(&title_token, content, source);
 //! ```
 
-use crate::lex::ast::elements::typed_content;
+use crate::lex::ast::elements::typed_content::{self, ContentElement, SessionContent};
 use crate::lex::ast::traits::AstNode;
 use crate::lex::ast::{Annotation, ListItem, Parameter};
 use crate::lex::lexing::tokens_linebased::LineToken;
@@ -91,7 +91,7 @@ pub fn build_paragraph(line_tokens: &[LineToken], source: &str) -> ContentItem {
 /// A Session ContentItem
 pub fn build_session(
     title_token: &LineToken,
-    content: Vec<ContentItem>,
+    content: Vec<SessionContent>,
     source: &str,
 ) -> ContentItem {
     // 1. Normalize
@@ -121,7 +121,7 @@ pub fn build_session(
 /// A Definition ContentItem
 pub fn build_definition(
     subject_token: &LineToken,
-    content: Vec<ContentItem>,
+    content: Vec<ContentElement>,
     source: &str,
 ) -> ContentItem {
     // 1. Normalize
@@ -169,7 +169,7 @@ pub fn build_list(items: Vec<ListItem>) -> ContentItem {
 /// A ListItem node (not wrapped in ContentItem)
 pub fn build_list_item(
     marker_token: &LineToken,
-    content: Vec<ContentItem>,
+    content: Vec<ContentElement>,
     source: &str,
 ) -> ListItem {
     // 1. Normalize
@@ -201,7 +201,7 @@ pub fn build_list_item(
 /// An Annotation ContentItem
 pub fn build_annotation(
     label_token: &LineToken,
-    content: Vec<ContentItem>,
+    content: Vec<ContentElement>,
     source: &str,
 ) -> ContentItem {
     // 1. Normalize
@@ -333,7 +333,7 @@ pub fn build_paragraph_from_tokens(
 /// A Session ContentItem
 pub fn build_session_from_tokens(
     title_tokens: Vec<(Token, ByteRange<usize>)>,
-    content: Vec<ContentItem>,
+    content: Vec<SessionContent>,
     source: &str,
 ) -> ContentItem {
     // Skip normalization, tokens already normalized
@@ -357,7 +357,7 @@ pub fn build_session_from_tokens(
 /// A Definition ContentItem
 pub fn build_definition_from_tokens(
     subject_tokens: Vec<(Token, ByteRange<usize>)>,
-    content: Vec<ContentItem>,
+    content: Vec<ContentElement>,
     source: &str,
 ) -> ContentItem {
     // Skip normalization, tokens already normalized
@@ -381,7 +381,7 @@ pub fn build_definition_from_tokens(
 /// A ListItem node (not wrapped in ContentItem)
 pub fn build_list_item_from_tokens(
     marker_tokens: Vec<(Token, ByteRange<usize>)>,
-    content: Vec<ContentItem>,
+    content: Vec<ContentElement>,
     source: &str,
 ) -> ListItem {
     // Skip normalization, tokens already normalized
@@ -407,7 +407,7 @@ pub fn build_list_item_from_tokens(
 /// An Annotation ContentItem
 pub fn build_annotation_from_tokens(
     label_tokens: Vec<(Token, ByteRange<usize>)>,
-    content: Vec<ContentItem>,
+    content: Vec<ContentElement>,
     source: &str,
 ) -> ContentItem {
     // Skip normalization, tokens already normalized
@@ -699,6 +699,7 @@ pub fn build_verbatim_block_from_text(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lex::ast::elements::typed_content::SessionContent;
     use crate::lex::lexing::tokens_core::Token;
     use crate::lex::lexing::tokens_linebased::LineType;
 
@@ -740,7 +741,7 @@ mod tests {
             vec![0..7, 7..8],
         );
 
-        let result = build_session(&title_token, vec![], source);
+        let result = build_session(&title_token, Vec::<SessionContent>::new(), source);
 
         match result {
             ContentItem::Session(session) => {

--- a/lex-parser/src/lex/building/builders.rs
+++ b/lex-parser/src/lex/building/builders.rs
@@ -44,6 +44,33 @@ use crate::lex::ast::{
 use crate::lex::parsing::ContentItem;
 
 // ============================================================================
+// TYPE SAFETY STATUS
+// ============================================================================
+//
+// This module has been partially refactored for type safety (Steps 1-4 of #228):
+//
+// ✓ Step 1-4 Complete: Type conversions validate nesting rules
+//   - create_definition: Validates no Sessions via try_into_content_elements()
+//   - create_list_item: Validates no Sessions via try_into_content_elements()
+//   - create_annotation: Validates no Sessions via try_into_content_elements()
+//
+// ⚠ Step 5 Incomplete: Full type-safe pipeline
+//   - Element constructors still accept Vec<ContentItem> for backward compatibility
+//   - Parser returns Vec<ParseNode> → Vec<ContentItem>, not typed variants
+//
+// Future work (remainder of Step 5, #233):
+//   1. Update element constructors to accept typed content:
+//      - Definition::new(subject, Vec<ContentElement>)
+//      - Session::new(title, Vec<SessionContent>)
+//      - Annotation::new(label, params, Vec<ContentElement>)
+//   2. Optionally: Thread policy types through parser for parse-time validation
+//
+// Current state provides runtime type safety via conversions that fail with
+// clear error messages. Full compile-time safety would require the above changes.
+//
+// ============================================================================
+
+// ============================================================================
 // PARAGRAPH CREATION
 // ============================================================================
 

--- a/lex-parser/src/lex/formats/tag/tag.rs
+++ b/lex-parser/src/lex/formats/tag/tag.rs
@@ -215,8 +215,8 @@ mod tests {
         use crate::lex::ast::{List, ListItem};
 
         let doc = Document::with_content(vec![ContentItem::List(List::new(vec![
-            ContentItem::ListItem(ListItem::new("- First item".to_string())),
-            ContentItem::ListItem(ListItem::new("- Second item".to_string())),
+            ListItem::new("- First item".to_string()),
+            ListItem::new("- Second item".to_string()),
         ]))]);
 
         let result = serialize_document(&doc);

--- a/lex-parser/src/lex/formats/tag/tag.rs
+++ b/lex-parser/src/lex/formats/tag/tag.rs
@@ -130,6 +130,7 @@ impl crate::lex::formats::registry::Formatter for TagFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lex::ast::elements::typed_content;
     use crate::lex::ast::{ContentItem, Paragraph, Session, TextContent};
 
     #[test]
@@ -150,9 +151,9 @@ mod tests {
     fn test_serialize_session_with_paragraph() {
         let doc = Document::with_content(vec![ContentItem::Session(Session::new(
             TextContent::from_string("Introduction".to_string(), None),
-            vec![ContentItem::Paragraph(Paragraph::from_line(
-                "Welcome".to_string(),
-            ))],
+            typed_content::into_session_contents(vec![ContentItem::Paragraph(
+                Paragraph::from_line("Welcome".to_string()),
+            )]),
         ))]);
 
         let result = serialize_document(&doc);
@@ -168,15 +169,15 @@ mod tests {
     fn test_serialize_nested_sessions() {
         let doc = Document::with_content(vec![ContentItem::Session(Session::new(
             TextContent::from_string("Root".to_string(), None),
-            vec![
+            typed_content::into_session_contents(vec![
                 ContentItem::Paragraph(Paragraph::from_line("Para 1".to_string())),
                 ContentItem::Session(Session::new(
                     TextContent::from_string("Nested".to_string(), None),
-                    vec![ContentItem::Paragraph(Paragraph::from_line(
-                        "Nested para".to_string(),
-                    ))],
+                    typed_content::into_session_contents(vec![ContentItem::Paragraph(
+                        Paragraph::from_line("Nested para".to_string()),
+                    )]),
                 )),
-            ],
+            ]),
         ))]);
 
         let result = serialize_document(&doc);

--- a/lex-parser/tests/compile_fail.rs
+++ b/lex-parser/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn container_type_safety() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/lex-parser/tests/compile_fail/annotation_rejects_session.rs
+++ b/lex-parser/tests/compile_fail/annotation_rejects_session.rs
@@ -1,0 +1,8 @@
+use lex_parser::lex::ast::elements::typed_content::SessionContent;
+use lex_parser::lex::ast::{Annotation, Label, Session};
+
+fn main() {
+    let label = Label::new("note".to_string());
+    let session = Session::with_title("Nested".to_string());
+    let _annotation = Annotation::new(label, vec![], vec![SessionContent::Session(session)]);
+}

--- a/lex-parser/tests/compile_fail/annotation_rejects_session.stderr
+++ b/lex-parser/tests/compile_fail/annotation_rejects_session.stderr
@@ -1,0 +1,5 @@
+error[E0308]: mismatched types
+ --> tests/compile_fail/annotation_rejects_session.rs:7:59
+  |
+7 |     let _annotation = Annotation::new(label, vec![], vec![SessionContent::Session(session)]);
+  |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `ContentElement`, found `SessionContent`

--- a/lex-parser/tests/compile_fail/definition_rejects_session.rs
+++ b/lex-parser/tests/compile_fail/definition_rejects_session.rs
@@ -1,0 +1,8 @@
+use lex_parser::lex::ast::elements::typed_content::SessionContent;
+use lex_parser::lex::ast::{Definition, Session, TextContent};
+
+fn main() {
+    let subject = TextContent::from_string("Term".to_string(), None);
+    let session = Session::with_title("Nested".to_string());
+    let _definition = Definition::new(subject, vec![SessionContent::Session(session)]);
+}

--- a/lex-parser/tests/compile_fail/definition_rejects_session.stderr
+++ b/lex-parser/tests/compile_fail/definition_rejects_session.stderr
@@ -1,0 +1,5 @@
+error[E0308]: mismatched types
+ --> tests/compile_fail/definition_rejects_session.rs:7:53
+  |
+7 |     let _definition = Definition::new(subject, vec![SessionContent::Session(session)]);
+  |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `ContentElement`, found `SessionContent`


### PR DESCRIPTION
## Summary
- finish Step 5-7 of #228 by making every AST constructor/container API typed-only
- remove runtime/deprecated shims (, , *_from_text) and update parser+builders
- add compile-fail tests plus docs/architecture/type-safe-containers.md and crate README documenting the policy system

## Testing
- cargo fmt --all
- cargo check
- TRYBUILD=overwrite cargo test -p lex-parser --test compile_fail
- cargo nextest run --no-fail-fast

Closes #228
Closes #229
Closes #230
Closes #231
Closes #232
Closes #233
Closes #234
Closes #235