### PR TITLE
Slit parser code into multiple files

### DIFF
--- a/lex-parser/src/lex/parsing/parser.rs
+++ b/lex-parser/src/lex/parsing/parser.rs
@@ -7,108 +7,20 @@
 //! 4. Recursively descends into containers when building AST
 //! 5. No imperative pattern matching - grammar is data, not code
 //!
-//! The grammar parse order (from grammar.lex §4.7):
-//! 1. verbatim-block (requires closing annotation - try first for disambiguation)
-//! 2. annotation_block (block with container between start and end markers)
-//! 3. annotation_single (single-line annotation only)
-//! 4. list (requires preceding blank line + 2+ list items)
-//! 5. definition (requires subject + immediate indent)
-//! 6. session (requires subject + blank line + indent)
-//! 7. paragraph (any content-line or sequence thereof)
-//! 8. blank_line_group (one or more consecutive blank lines)
+//! The grammar patterns and AST building logic have been extracted to separate modules:
+//! - `grammar.rs` - Pattern definitions and matching order
+//! - `builder.rs` - AST node construction from matched patterns
 
-use crate::lex::parsing::ir::{NodeType, ParseNode};
-use crate::lex::token::{LineContainer, LineToken, LineType, Token};
-use once_cell::sync::Lazy;
+use crate::lex::parsing::ir::ParseNode;
+use crate::lex::token::{LineContainer, LineType};
 use regex::Regex;
 use std::ops::Range;
 
-/// Lazy-compiled regex for extracting list items from the list group capture
-static LIST_ITEM_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(<list-line>|<subject-or-list-item-line>)(<container>)?").unwrap());
+mod builder;
+mod grammar;
 
-/// Grammar patterns as regex rules with names and patterns
-/// Order matters: patterns are tried in declaration order for correct disambiguation
-const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
-    // Annotation (multi-line with markers): <annotation-start-line><container><annotation-end-line>
-    (
-        "annotation_block_with_end",
-        r"^(?P<start><annotation-start-line>)(?P<content><container>)(?P<end><annotation-end-line>)",
-    ),
-    // Annotation (multi-line without end marker): <annotation-start-line><container>
-    (
-        "annotation_block",
-        r"^(?P<start><annotation-start-line>)(?P<content><container>)",
-    ),
-    // Annotation (single-line): <annotation-start-line><content>
-    ("annotation_single", r"^(?P<start><annotation-start-line>)"),
-    // List without preceding blank line (for lists inside containers)
-    (
-        "list_no_blank",
-        r"^(?P<items>((<list-line>|<subject-or-list-item-line>)(<container>)?){2,})(?P<trailing_blank><blank-line>)?",
-    ),
-    // List with preceding blank line (for lists at root level)
-    (
-        "list",
-        r"^(?P<blank><blank-line>+)(?P<items>((<list-line>|<subject-or-list-item-line>)(<container>)?){2,})(?P<trailing_blank><blank-line>)?",
-    ),
-    // Session: <content-line><blank-line><container>
-    (
-        "session",
-        r"^(?P<subject><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank><blank-line>+)(?P<content><container>)",
-    ),
-    // Definition: <subject-line>|<subject-or-list-item-line>|<paragraph-line><container>
-    (
-        "definition",
-        r"^(?P<subject><subject-line>|<subject-or-list-item-line>|<paragraph-line>)(?P<content><container>)",
-    ),
-    // Paragraph: <content-line>+
-    (
-        "paragraph",
-        r"^(?P<lines>(<paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>|<dialog-line>)+)",
-    ),
-    // Blank lines: <blank-line-group>
-    ("blank_line_group", r"^(?P<lines>(<blank-line>)+)"),
-];
-
-/// Represents the result of pattern matching at one level
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct VerbatimGroupMatch {
-    pub subject_idx: usize,
-    pub content_idx: Option<usize>,
-}
-
-enum PatternMatch {
-    /// Verbatim block: one or more subject/content pairs followed by closing annotation
-    VerbatimBlock {
-        groups: Vec<VerbatimGroupMatch>,
-        closing_idx: usize,
-    },
-    /// Annotation block: start + container + end
-    AnnotationBlock {
-        start_idx: usize,
-        content_idx: usize,
-    },
-    /// Annotation single: just start line
-    AnnotationSingle { start_idx: usize },
-    /// List: preceding blank line + 2+ consecutive list items
-    List { items: Vec<(usize, Option<usize>)> },
-    /// Definition: subject + immediate indent + content
-    Definition {
-        subject_idx: usize,
-        content_idx: usize,
-    },
-    /// Session: subject + blank line + indent + content
-    Session {
-        subject_idx: usize,
-        content_idx: usize,
-    },
-    /// Paragraph: one or more consecutive non-blank, non-special lines
-    Paragraph { start_idx: usize, end_idx: usize },
-    /// Blank line group: one or more consecutive blank lines
-    BlankLineGroup,
-}
+use builder::{convert_pattern_to_node, PatternMatch, VerbatimGroupMatch};
+use grammar::{GRAMMAR_PATTERNS, LIST_ITEM_REGEX};
 
 /// Pattern matcher for declarative grammar using regex-based matching
 pub struct GrammarMatcher;
@@ -129,6 +41,7 @@ impl GrammarMatcher {
             return None;
         }
 
+        // Try verbatim block first (requires special imperative matching logic)
         if let Some(result) = Self::match_verbatim_block(tokens, start_idx) {
             return Some(result);
         }
@@ -247,12 +160,20 @@ impl GrammarMatcher {
         }
     }
 
-    /// Count how many tokens are represented in a grammar string
-    /// Each token type in angle brackets represents one token
+    /// Count how many tokens are represented in a grammar string.
+    /// Each token type in angle brackets represents one token.
     fn count_consumed_tokens(grammar_str: &str) -> usize {
         grammar_str.matches('<').count()
     }
 
+    /// Match verbatim blocks using imperative logic.
+    ///
+    /// Verbatim blocks require special handling because they consist of:
+    /// 1. One or more subject/content pairs (subject line + optional container)
+    /// 2. A closing annotation marker (:: ... ::)
+    ///
+    /// This cannot be easily expressed as a single regex pattern due to the
+    /// variable number of groups and the need to track indices for each group.
     fn match_verbatim_block(
         tokens: &[LineContainer],
         start_idx: usize,
@@ -294,6 +215,7 @@ impl GrammarMatcher {
                 _ => return None,
             };
 
+            // Skip blank lines after subject
             while current < len {
                 if let LineContainer::Token(line) = &tokens[current] {
                     if line.line_type == BlankLine {
@@ -304,6 +226,7 @@ impl GrammarMatcher {
                 break;
             }
 
+            // Optional content container
             let mut content_idx = None;
             if current < len && matches!(tokens[current], LineContainer::Container { .. }) {
                 content_idx = Some(current);
@@ -315,6 +238,7 @@ impl GrammarMatcher {
                 content_idx,
             });
 
+            // Skip blank lines after content
             while current < len {
                 if let LineContainer::Token(line) = &tokens[current] {
                     if line.line_type == BlankLine {
@@ -325,6 +249,7 @@ impl GrammarMatcher {
                 break;
             }
 
+            // Check for closing annotation or another subject
             if current < len {
                 if let LineContainer::Token(line) = &tokens[current] {
                     if matches!(line.line_type, AnnotationStartLine | AnnotationEndLine) {
@@ -349,7 +274,10 @@ impl GrammarMatcher {
     }
 }
 
-/// Main recursive descent parser using the declarative grammar
+/// Main recursive descent parser using the declarative grammar.
+///
+/// This is the entry point for parsing a sequence of tokens at any level.
+/// It iteratively tries to match patterns and recursively descends into containers.
 pub fn parse_with_declarative_grammar(
     tokens: Vec<LineContainer>,
     source: &str,
@@ -361,8 +289,14 @@ pub fn parse_with_declarative_grammar(
         if let Some((pattern, range)) = GrammarMatcher::try_match(&tokens, idx) {
             // Skip blank line groups (they're structural, not content)
             if !matches!(pattern, PatternMatch::BlankLineGroup) {
-                // Convert pattern to ContentItem
-                let item = convert_pattern_to_item(&tokens, &pattern, range.start, source)?;
+                // Convert pattern to ParseNode
+                let item = convert_pattern_to_node(
+                    &tokens,
+                    &pattern,
+                    range.start,
+                    source,
+                    &|children, src| parse_with_declarative_grammar(children, src),
+                )?;
                 items.push(item);
             }
             idx = range.end;
@@ -372,338 +306,4 @@ pub fn parse_with_declarative_grammar(
     }
 
     Ok(items)
-}
-
-/// Convert a matched pattern to a ContentItem
-///
-/// pattern_offset: the index where the pattern starts in the tokens array
-/// (used to convert relative indices in the pattern to absolute indices)
-fn convert_pattern_to_item(
-    tokens: &[LineContainer],
-    pattern: &PatternMatch,
-    pattern_offset: usize,
-    source: &str,
-) -> Result<ParseNode, String> {
-    match pattern {
-        PatternMatch::VerbatimBlock {
-            groups,
-            closing_idx,
-        } => {
-            let mut child_nodes = Vec::new();
-
-            for group in groups {
-                let subject_token = extract_line_token(&tokens[group.subject_idx])?;
-                let subject_tokens: Vec<_> = subject_token
-                    .source_tokens
-                    .clone()
-                    .into_iter()
-                    .zip(subject_token.token_spans.clone())
-                    .filter(|(token, _)| {
-                        !matches!(
-                            token,
-                            crate::lex::lexing::Token::Colon
-                                | crate::lex::lexing::Token::BlankLine(_)
-                        )
-                    })
-                    .collect();
-
-                let mut content_tokens = Vec::new();
-                if let Some(content_idx_val) = group.content_idx {
-                    if let Some(container) = tokens.get(content_idx_val) {
-                        let mut line_tokens = Vec::new();
-                        collect_line_tokens(container, &mut line_tokens);
-                        for line_token in line_tokens {
-                            content_tokens.extend(
-                                line_token
-                                    .source_tokens
-                                    .into_iter()
-                                    .zip(line_token.token_spans.into_iter()),
-                            );
-                        }
-                    }
-                }
-
-                child_nodes.push(ParseNode::new(
-                    NodeType::VerbatimBlockkSubject,
-                    subject_tokens,
-                    vec![],
-                ));
-                child_nodes.push(ParseNode::new(
-                    NodeType::VerbatimBlockkContent,
-                    content_tokens,
-                    vec![],
-                ));
-            }
-
-            let closing_token = extract_line_token(&tokens[*closing_idx])?;
-            let (header_tokens, closing_children) =
-                extract_annotation_single_content(closing_token);
-            child_nodes.push(ParseNode::new(
-                NodeType::VerbatimBlockkClosing,
-                header_tokens,
-                closing_children,
-            ));
-
-            Ok(ParseNode::new(NodeType::VerbatimBlock, vec![], child_nodes))
-        }
-        PatternMatch::AnnotationBlock {
-            start_idx,
-            content_idx,
-        } => {
-            let start_token = extract_line_token(&tokens[pattern_offset + start_idx])?;
-
-            // Extract header tokens using shared helper function
-            let header_tokens = extract_annotation_header_tokens(start_token);
-
-            // Extract content from container using shared helper function
-            // This ensures block forms use the same content extraction path
-            // Note: content_idx is relative to pattern_offset, so we need to add it
-            let children =
-                extract_annotation_block_content(tokens, pattern_offset + content_idx, source)?;
-
-            Ok(ParseNode::new(
-                NodeType::Annotation,
-                header_tokens,
-                children,
-            ))
-        }
-        PatternMatch::AnnotationSingle { start_idx } => {
-            let start_token = extract_line_token(&tokens[pattern_offset + start_idx])?;
-
-            // Extract header tokens and content using shared helper function
-            // This ensures single-line form uses the same extraction logic as block forms
-            let (header_tokens, children) = extract_annotation_single_content(start_token);
-
-            Ok(ParseNode::new(
-                NodeType::Annotation,
-                header_tokens,
-                children,
-            ))
-        }
-        PatternMatch::List { items } => {
-            let mut list_items = Vec::new();
-
-            for (item_idx, content_idx) in items {
-                let item_token = extract_line_token(&tokens[pattern_offset + item_idx])?;
-
-                let children = if let Some(content_idx_val) = content_idx {
-                    if let Some(LineContainer::Container { children, .. }) =
-                        tokens.get(pattern_offset + content_idx_val)
-                    {
-                        parse_with_declarative_grammar(children.clone(), source)?
-                    } else {
-                        Vec::new()
-                    }
-                } else {
-                    Vec::new()
-                };
-                let list_item = ParseNode::new(
-                    NodeType::ListItem,
-                    item_token
-                        .source_tokens
-                        .clone()
-                        .into_iter()
-                        .zip(item_token.token_spans.clone())
-                        .collect(),
-                    children,
-                );
-                list_items.push(list_item);
-            }
-
-            Ok(ParseNode::new(NodeType::List, vec![], list_items))
-        }
-        PatternMatch::Definition {
-            subject_idx,
-            content_idx,
-        } => {
-            let subject_token = extract_line_token(&tokens[pattern_offset + subject_idx])?;
-
-            let children = if let Some(LineContainer::Container { children, .. }) =
-                tokens.get(pattern_offset + content_idx)
-            {
-                parse_with_declarative_grammar(children.clone(), source)?
-            } else {
-                Vec::new()
-            };
-
-            // Filter out Colon, Whitespace, and BlankLine tokens from definition subject
-            // Definition subject should only contain the text before the colon
-            let subject_tokens: Vec<_> = subject_token
-                .source_tokens
-                .clone()
-                .into_iter()
-                .zip(subject_token.token_spans.clone())
-                .filter(|(token, _)| {
-                    !matches!(
-                        token,
-                        crate::lex::lexing::Token::Colon
-                            | crate::lex::lexing::Token::Whitespace
-                            | crate::lex::lexing::Token::BlankLine(_)
-                    )
-                })
-                .collect();
-
-            Ok(ParseNode::new(
-                NodeType::Definition,
-                subject_tokens,
-                children,
-            ))
-        }
-        PatternMatch::Session {
-            subject_idx,
-            content_idx,
-        } => {
-            let subject_token = extract_line_token(&tokens[pattern_offset + subject_idx])?;
-            let mut content_children = vec![];
-            if let Some(LineContainer::Container { children, .. }) =
-                tokens.get(pattern_offset + content_idx)
-            {
-                content_children = parse_with_declarative_grammar(children.clone(), source)?;
-            }
-
-            // Filter out trailing Whitespace and BlankLine tokens from session label
-            let subject_tokens: Vec<_> = subject_token
-                .source_tokens
-                .clone()
-                .into_iter()
-                .zip(subject_token.token_spans.clone())
-                .filter(|(token, _)| {
-                    !matches!(
-                        token,
-                        crate::lex::lexing::Token::Whitespace
-                            | crate::lex::lexing::Token::BlankLine(_)
-                    )
-                })
-                .collect();
-
-            Ok(ParseNode::new(
-                NodeType::Session,
-                subject_tokens,
-                content_children,
-            ))
-        }
-        PatternMatch::Paragraph { start_idx, end_idx } => {
-            let paragraph_tokens: Vec<LineToken> = ((pattern_offset + start_idx)
-                ..=(pattern_offset + end_idx))
-                .filter_map(|idx| extract_line_token(&tokens[idx]).ok().cloned())
-                .collect();
-            let mut all_tokens = Vec::new();
-            for line in paragraph_tokens {
-                all_tokens.extend(
-                    line.source_tokens
-                        .into_iter()
-                        .zip(line.token_spans.into_iter()),
-                );
-            }
-            Ok(ParseNode::new(NodeType::Paragraph, all_tokens, vec![]))
-        }
-        PatternMatch::BlankLineGroup => {
-            // BlankLineGroups should have been filtered out in parse_with_declarative_grammar
-            // If we reach here, something went wrong
-            Err("Internal error: BlankLineGroup reached convert_pattern_to_item".to_string())
-        }
-    }
-}
-
-/// Helper to extract a LineToken from a LineContainerToken
-fn extract_line_token(token: &LineContainer) -> Result<&LineToken, String> {
-    match token {
-        LineContainer::Token(t) => Ok(t),
-        _ => Err("Expected LineToken, found Container".to_string()),
-    }
-}
-
-/// Recursively gather all LineTokens contained within a LineContainer tree.
-///
-/// The tokenizer already encodes indentation structure via nested
-/// `LineContainer::Container` nodes, so verbatim content that spans multiple
-/// indentation levels needs to be flattened before we hand the tokens to the
-/// shared AST builders. We keep every nested line (including those that contain
-/// inline `::` markers) so verbatim blocks rely on dedent boundaries instead of
-/// mistaking inline markers for closing annotations.
-fn collect_line_tokens(container: &LineContainer, out: &mut Vec<LineToken>) {
-    match container {
-        LineContainer::Token(token) => out.push(token.clone()),
-        LineContainer::Container { children } => {
-            for child in children {
-                collect_line_tokens(child, out);
-            }
-        }
-    }
-}
-
-/// Extract header tokens from an annotation start line.
-/// Header tokens are all tokens between the two :: markers (excluding the markers themselves).
-fn extract_annotation_header_tokens(
-    start_token: &LineToken,
-) -> Vec<(Token, std::ops::Range<usize>)> {
-    start_token
-        .source_tokens
-        .clone()
-        .into_iter()
-        .zip(start_token.token_spans.clone())
-        .filter(|(token, _)| !matches!(token, Token::LexMarker))
-        .collect()
-}
-
-/// Extract content from an annotation single-line form.
-/// Returns (header_tokens, content_children) where content_children is either empty
-/// or contains a single Paragraph node with the inline content.
-fn extract_annotation_single_content(
-    start_token: &LineToken,
-) -> (Vec<(Token, std::ops::Range<usize>)>, Vec<ParseNode>) {
-    let all_tokens = start_token
-        .source_tokens
-        .clone()
-        .into_iter()
-        .zip(start_token.token_spans.clone())
-        .collect::<Vec<_>>();
-
-    let mut lex_marker_count = 0;
-    let mut content_started = false;
-    let mut header_tokens = Vec::new();
-    let mut content_tokens = Vec::new();
-
-    for (token, span) in all_tokens {
-        if token == Token::LexMarker {
-            lex_marker_count += 1;
-            if lex_marker_count == 2 {
-                content_started = true;
-            }
-            // Don't include LexMarker tokens in header_tokens
-            continue;
-        }
-
-        if !content_started {
-            // Collect tokens between the two :: markers (excluding the markers themselves)
-            header_tokens.push((token, span));
-        } else {
-            // Collect tokens after the second :: marker
-            content_tokens.push((token, span));
-        }
-    }
-
-    // If there's content after the header, create a paragraph for it
-    // This ensures single-line form content goes through the same structure as block forms
-    let children = if !content_tokens.is_empty() {
-        vec![ParseNode::new(NodeType::Paragraph, content_tokens, vec![])]
-    } else {
-        vec![]
-    };
-
-    (header_tokens, children)
-}
-
-/// Extract content from an annotation block form.
-/// Returns the parsed children from the container, or empty vector if no container.
-fn extract_annotation_block_content(
-    tokens: &[LineContainer],
-    content_idx: usize,
-    source: &str,
-) -> Result<Vec<ParseNode>, String> {
-    if let Some(LineContainer::Container { children, .. }) = tokens.get(content_idx) {
-        parse_with_declarative_grammar(children.clone(), source)
-    } else {
-        Ok(vec![])
-    }
 }

--- a/lex-parser/src/lex/parsing/parser/builder.rs
+++ b/lex-parser/src/lex/parsing/parser/builder.rs
@@ -1,0 +1,451 @@
+//! AST Node Builder
+//!
+//! This module converts matched grammar patterns into ParseNode AST structures.
+//! It handles the extraction of tokens from LineContainers and the recursive
+//! descent into nested containers.
+
+use crate::lex::parsing::ir::{NodeType, ParseNode};
+use crate::lex::token::{LineContainer, LineToken, Token};
+use std::ops::Range;
+
+/// Type alias for the recursive parser function callback
+type ParserFn = dyn Fn(Vec<LineContainer>, &str) -> Result<Vec<ParseNode>, String>;
+
+/// Represents the result of pattern matching
+#[derive(Debug, Clone)]
+pub(super) enum PatternMatch {
+    /// Verbatim block: one or more subject/content pairs followed by closing annotation
+    VerbatimBlock {
+        groups: Vec<VerbatimGroupMatch>,
+        closing_idx: usize,
+    },
+    /// Annotation block: start + container + end
+    AnnotationBlock {
+        start_idx: usize,
+        content_idx: usize,
+    },
+    /// Annotation single: just start line
+    AnnotationSingle { start_idx: usize },
+    /// List: preceding blank line + 2+ consecutive list items
+    List { items: Vec<(usize, Option<usize>)> },
+    /// Definition: subject + immediate indent + content
+    Definition {
+        subject_idx: usize,
+        content_idx: usize,
+    },
+    /// Session: subject + blank line + indent + content
+    Session {
+        subject_idx: usize,
+        content_idx: usize,
+    },
+    /// Paragraph: one or more consecutive non-blank, non-special lines
+    Paragraph { start_idx: usize, end_idx: usize },
+    /// Blank line group: one or more consecutive blank lines
+    BlankLineGroup,
+}
+
+/// Represents a matched verbatim group (subject + optional content)
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct VerbatimGroupMatch {
+    pub subject_idx: usize,
+    pub content_idx: Option<usize>,
+}
+
+/// Convert a matched pattern to a ParseNode.
+///
+/// # Arguments
+///
+/// * `tokens` - The full token array
+/// * `pattern` - The matched pattern with relative indices
+/// * `pattern_offset` - Index where the pattern starts (converts relative to absolute indices)
+/// * `source` - Original source text
+/// * `parse_children` - Function to recursively parse nested containers
+pub(super) fn convert_pattern_to_node(
+    tokens: &[LineContainer],
+    pattern: &PatternMatch,
+    pattern_offset: usize,
+    source: &str,
+    parse_children: &ParserFn,
+) -> Result<ParseNode, String> {
+    match pattern {
+        PatternMatch::VerbatimBlock {
+            groups,
+            closing_idx,
+        } => build_verbatim_block(tokens, groups, *closing_idx),
+        PatternMatch::AnnotationBlock {
+            start_idx,
+            content_idx,
+        } => build_annotation_block(
+            tokens,
+            pattern_offset + start_idx,
+            pattern_offset + content_idx,
+            source,
+            parse_children,
+        ),
+        PatternMatch::AnnotationSingle { start_idx } => {
+            build_annotation_single(tokens, pattern_offset + start_idx)
+        }
+        PatternMatch::List { items } => {
+            build_list(tokens, items, pattern_offset, source, parse_children)
+        }
+        PatternMatch::Definition {
+            subject_idx,
+            content_idx,
+        } => build_definition(
+            tokens,
+            pattern_offset + subject_idx,
+            pattern_offset + content_idx,
+            source,
+            parse_children,
+        ),
+        PatternMatch::Session {
+            subject_idx,
+            content_idx,
+        } => build_session(
+            tokens,
+            pattern_offset + subject_idx,
+            pattern_offset + content_idx,
+            source,
+            parse_children,
+        ),
+        PatternMatch::Paragraph { start_idx, end_idx } => {
+            build_paragraph(tokens, pattern_offset + start_idx, pattern_offset + end_idx)
+        }
+        PatternMatch::BlankLineGroup => {
+            Err("Internal error: BlankLineGroup reached convert_pattern_to_node".to_string())
+        }
+    }
+}
+
+/// Build a verbatim block node from matched groups
+fn build_verbatim_block(
+    tokens: &[LineContainer],
+    groups: &[VerbatimGroupMatch],
+    closing_idx: usize,
+) -> Result<ParseNode, String> {
+    let mut child_nodes = Vec::new();
+
+    for group in groups {
+        let subject_token = extract_line_token(&tokens[group.subject_idx])?;
+        let subject_tokens: Vec<_> = subject_token
+            .source_tokens
+            .clone()
+            .into_iter()
+            .zip(subject_token.token_spans.clone())
+            .filter(|(token, _)| {
+                !matches!(
+                    token,
+                    crate::lex::lexing::Token::Colon | crate::lex::lexing::Token::BlankLine(_)
+                )
+            })
+            .collect();
+
+        let mut content_tokens = Vec::new();
+        if let Some(content_idx_val) = group.content_idx {
+            if let Some(container) = tokens.get(content_idx_val) {
+                let mut line_tokens = Vec::new();
+                collect_line_tokens(container, &mut line_tokens);
+                for line_token in line_tokens {
+                    content_tokens.extend(
+                        line_token
+                            .source_tokens
+                            .into_iter()
+                            .zip(line_token.token_spans.into_iter()),
+                    );
+                }
+            }
+        }
+
+        child_nodes.push(ParseNode::new(
+            NodeType::VerbatimBlockkSubject,
+            subject_tokens,
+            vec![],
+        ));
+        child_nodes.push(ParseNode::new(
+            NodeType::VerbatimBlockkContent,
+            content_tokens,
+            vec![],
+        ));
+    }
+
+    let closing_token = extract_line_token(&tokens[closing_idx])?;
+    let (header_tokens, closing_children) = extract_annotation_single_content(closing_token);
+    child_nodes.push(ParseNode::new(
+        NodeType::VerbatimBlockkClosing,
+        header_tokens,
+        closing_children,
+    ));
+
+    Ok(ParseNode::new(NodeType::VerbatimBlock, vec![], child_nodes))
+}
+
+/// Build an annotation block node
+fn build_annotation_block(
+    tokens: &[LineContainer],
+    start_idx: usize,
+    content_idx: usize,
+    source: &str,
+    parse_children: &ParserFn,
+) -> Result<ParseNode, String> {
+    let start_token = extract_line_token(&tokens[start_idx])?;
+    let header_tokens = extract_annotation_header_tokens(start_token);
+
+    let children = if let Some(LineContainer::Container { children, .. }) = tokens.get(content_idx)
+    {
+        parse_children(children.clone(), source)?
+    } else {
+        vec![]
+    };
+
+    Ok(ParseNode::new(
+        NodeType::Annotation,
+        header_tokens,
+        children,
+    ))
+}
+
+/// Build an annotation single-line node
+fn build_annotation_single(
+    tokens: &[LineContainer],
+    start_idx: usize,
+) -> Result<ParseNode, String> {
+    let start_token = extract_line_token(&tokens[start_idx])?;
+    let (header_tokens, children) = extract_annotation_single_content(start_token);
+
+    Ok(ParseNode::new(
+        NodeType::Annotation,
+        header_tokens,
+        children,
+    ))
+}
+
+/// Build a list node with list items
+fn build_list(
+    tokens: &[LineContainer],
+    items: &[(usize, Option<usize>)],
+    pattern_offset: usize,
+    source: &str,
+    parse_children: &ParserFn,
+) -> Result<ParseNode, String> {
+    let mut list_items = Vec::new();
+
+    for (item_idx, content_idx) in items {
+        let item_token = extract_line_token(&tokens[pattern_offset + item_idx])?;
+
+        let children = if let Some(content_idx_val) = content_idx {
+            if let Some(LineContainer::Container { children, .. }) =
+                tokens.get(pattern_offset + content_idx_val)
+            {
+                parse_children(children.clone(), source)?
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+
+        let list_item = ParseNode::new(
+            NodeType::ListItem,
+            item_token
+                .source_tokens
+                .clone()
+                .into_iter()
+                .zip(item_token.token_spans.clone())
+                .collect(),
+            children,
+        );
+        list_items.push(list_item);
+    }
+
+    Ok(ParseNode::new(NodeType::List, vec![], list_items))
+}
+
+/// Build a definition node
+fn build_definition(
+    tokens: &[LineContainer],
+    subject_idx: usize,
+    content_idx: usize,
+    source: &str,
+    parse_children: &ParserFn,
+) -> Result<ParseNode, String> {
+    let subject_token = extract_line_token(&tokens[subject_idx])?;
+
+    let children = if let Some(LineContainer::Container { children, .. }) = tokens.get(content_idx)
+    {
+        parse_children(children.clone(), source)?
+    } else {
+        Vec::new()
+    };
+
+    // Filter out Colon, Whitespace, and BlankLine tokens from definition subject
+    let subject_tokens: Vec<_> = subject_token
+        .source_tokens
+        .clone()
+        .into_iter()
+        .zip(subject_token.token_spans.clone())
+        .filter(|(token, _)| {
+            !matches!(
+                token,
+                crate::lex::lexing::Token::Colon
+                    | crate::lex::lexing::Token::Whitespace
+                    | crate::lex::lexing::Token::BlankLine(_)
+            )
+        })
+        .collect();
+
+    Ok(ParseNode::new(
+        NodeType::Definition,
+        subject_tokens,
+        children,
+    ))
+}
+
+/// Build a session node
+fn build_session(
+    tokens: &[LineContainer],
+    subject_idx: usize,
+    content_idx: usize,
+    source: &str,
+    parse_children: &ParserFn,
+) -> Result<ParseNode, String> {
+    let subject_token = extract_line_token(&tokens[subject_idx])?;
+
+    let content_children =
+        if let Some(LineContainer::Container { children, .. }) = tokens.get(content_idx) {
+            parse_children(children.clone(), source)?
+        } else {
+            vec![]
+        };
+
+    // Filter out trailing Whitespace and BlankLine tokens from session label
+    let subject_tokens: Vec<_> = subject_token
+        .source_tokens
+        .clone()
+        .into_iter()
+        .zip(subject_token.token_spans.clone())
+        .filter(|(token, _)| {
+            !matches!(
+                token,
+                crate::lex::lexing::Token::Whitespace | crate::lex::lexing::Token::BlankLine(_)
+            )
+        })
+        .collect();
+
+    Ok(ParseNode::new(
+        NodeType::Session,
+        subject_tokens,
+        content_children,
+    ))
+}
+
+/// Build a paragraph node
+fn build_paragraph(
+    tokens: &[LineContainer],
+    start_idx: usize,
+    end_idx: usize,
+) -> Result<ParseNode, String> {
+    let paragraph_tokens: Vec<LineToken> = (start_idx..=end_idx)
+        .filter_map(|idx| extract_line_token(&tokens[idx]).ok().cloned())
+        .collect();
+
+    let mut all_tokens = Vec::new();
+    for line in paragraph_tokens {
+        all_tokens.extend(
+            line.source_tokens
+                .into_iter()
+                .zip(line.token_spans.into_iter()),
+        );
+    }
+
+    Ok(ParseNode::new(NodeType::Paragraph, all_tokens, vec![]))
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Extract a LineToken from a LineContainer
+fn extract_line_token(token: &LineContainer) -> Result<&LineToken, String> {
+    match token {
+        LineContainer::Token(t) => Ok(t),
+        _ => Err("Expected LineToken, found Container".to_string()),
+    }
+}
+
+/// Recursively gather all LineTokens contained within a LineContainer tree.
+///
+/// The tokenizer already encodes indentation structure via nested
+/// `LineContainer::Container` nodes, so verbatim content that spans multiple
+/// indentation levels needs to be flattened before we hand the tokens to the
+/// shared AST builders. We keep every nested line (including those that contain
+/// inline `::` markers) so verbatim blocks rely on dedent boundaries instead of
+/// mistaking inline markers for closing annotations.
+fn collect_line_tokens(container: &LineContainer, out: &mut Vec<LineToken>) {
+    match container {
+        LineContainer::Token(token) => out.push(token.clone()),
+        LineContainer::Container { children } => {
+            for child in children {
+                collect_line_tokens(child, out);
+            }
+        }
+    }
+}
+
+/// Extract header tokens from an annotation start line.
+/// Header tokens are all tokens between the two :: markers (excluding the markers themselves).
+fn extract_annotation_header_tokens(
+    start_token: &LineToken,
+) -> Vec<(Token, std::ops::Range<usize>)> {
+    start_token
+        .source_tokens
+        .clone()
+        .into_iter()
+        .zip(start_token.token_spans.clone())
+        .filter(|(token, _)| !matches!(token, Token::LexMarker))
+        .collect()
+}
+
+/// Extract content from an annotation single-line form.
+/// Returns (header_tokens, content_children) where content_children is either empty
+/// or contains a single Paragraph node with the inline content.
+fn extract_annotation_single_content(
+    start_token: &LineToken,
+) -> (Vec<(Token, Range<usize>)>, Vec<ParseNode>) {
+    let all_tokens = start_token
+        .source_tokens
+        .clone()
+        .into_iter()
+        .zip(start_token.token_spans.clone())
+        .collect::<Vec<_>>();
+
+    let mut lex_marker_count = 0;
+    let mut content_started = false;
+    let mut header_tokens = Vec::new();
+    let mut content_tokens = Vec::new();
+
+    for (token, span) in all_tokens {
+        if token == Token::LexMarker {
+            lex_marker_count += 1;
+            if lex_marker_count == 2 {
+                content_started = true;
+            }
+            continue;
+        }
+
+        if !content_started {
+            header_tokens.push((token, span));
+        } else {
+            content_tokens.push((token, span));
+        }
+    }
+
+    // If there's content after the header, create a paragraph for it
+    let children = if !content_tokens.is_empty() {
+        vec![ParseNode::new(NodeType::Paragraph, content_tokens, vec![])]
+    } else {
+        vec![]
+    };
+
+    (header_tokens, children)
+}

--- a/lex-parser/src/lex/parsing/parser/grammar.rs
+++ b/lex-parser/src/lex/parsing/parser/grammar.rs
@@ -1,0 +1,79 @@
+//! Grammar Pattern Definitions
+//!
+//! This module defines the declarative grammar patterns used by the parser.
+//! Patterns are defined as regex rules and are tried in declaration order
+//! for correct disambiguation according to the grammar specification.
+//!
+//! # Grammar Parse Order (from grammar.lex §4.7)
+//!
+//! 1. verbatim-block - requires closing annotation, tried first for disambiguation
+//! 2. annotation_block - block with container between start and end markers
+//! 3. annotation_single - single-line annotation only
+//! 4. list - requires preceding blank line + 2+ list items (or no blank inside containers)
+//! 5. definition - requires subject + immediate indent
+//! 6. session - requires subject + blank line + indent
+//! 7. paragraph - any content-line or sequence thereof
+//! 8. blank_line_group - one or more consecutive blank lines
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Lazy-compiled regex for extracting list items from the list group capture.
+///
+/// This regex identifies individual list items and their optional nested containers
+/// within the matched list pattern.
+pub(super) static LIST_ITEM_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(<list-line>|<subject-or-list-item-line>)(<container>)?").unwrap());
+
+/// Grammar patterns as regex rules with names and patterns.
+///
+/// **Order matters**: patterns are tried in declaration order for correct disambiguation.
+/// Each pattern is a tuple of (pattern_name, regex_pattern_string).
+///
+/// # Pattern Structure
+///
+/// - Named capture groups (e.g., `(?P<start>...)`) allow extracting specific parts
+/// - Token types in angle brackets (e.g., `<annotation-start-line>`) match grammar symbols
+/// - `<container>` represents a nested indented block
+/// - Quantifiers like `+` (one or more) and `{2,}` (two or more) enforce grammar rules
+pub(super) const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
+    // Annotation (multi-line with markers): <annotation-start-line><container><annotation-end-line>
+    (
+        "annotation_block_with_end",
+        r"^(?P<start><annotation-start-line>)(?P<content><container>)(?P<end><annotation-end-line>)",
+    ),
+    // Annotation (multi-line without end marker): <annotation-start-line><container>
+    (
+        "annotation_block",
+        r"^(?P<start><annotation-start-line>)(?P<content><container>)",
+    ),
+    // Annotation (single-line): <annotation-start-line><content>
+    ("annotation_single", r"^(?P<start><annotation-start-line>)"),
+    // List without preceding blank line (for lists inside containers)
+    (
+        "list_no_blank",
+        r"^(?P<items>((<list-line>|<subject-or-list-item-line>)(<container>)?){2,})(?P<trailing_blank><blank-line>)?",
+    ),
+    // List with preceding blank line (for lists at root level)
+    (
+        "list",
+        r"^(?P<blank><blank-line>+)(?P<items>((<list-line>|<subject-or-list-item-line>)(<container>)?){2,})(?P<trailing_blank><blank-line>)?",
+    ),
+    // Session: <content-line><blank-line><container>
+    (
+        "session",
+        r"^(?P<subject><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank><blank-line>+)(?P<content><container>)",
+    ),
+    // Definition: <subject-line>|<subject-or-list-item-line>|<paragraph-line><container>
+    (
+        "definition",
+        r"^(?P<subject><subject-line>|<subject-or-list-item-line>|<paragraph-line>)(?P<content><container>)",
+    ),
+    // Paragraph: <content-line>+
+    (
+        "paragraph",
+        r"^(?P<lines>(<paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>|<dialog-line>)+)",
+    ),
+    // Blank lines: <blank-line-group>
+    ("blank_line_group", r"^(?P<lines>(<blank-line>)+)"),
+];


### PR DESCRIPTION
Split parser.rs (710 LOC) into focused modules for better maintainability:

- parser/grammar.rs: Declarative grammar pattern constants and regex rules
- parser/builder.rs: AST node construction logic from matched patterns
- parser.rs: Core pattern matching engine (reduced to 307 LOC)

This separation improves code visibility and follows the same architectural
pattern established in the extraction module refactoring.

For now we will not pursue a more granular parser function split. While two
functions are 100 line strong , their logic is straight forward and splitting
them would likely result in harder to read code.
