### PR TITLE
Feature: Verbatim mode Full Width

### DIFF
--- a/docs/dev/proposals/fullwidth.lex
+++ b/docs/dev/proposals/fullwidth.lex
@@ -1,120 +1,80 @@
-Fullwidth Verbatim Blocks
+# Fullwidth Verbatim Blocks
 
+## 1. Introduction
 
-1. Introduction
-	Verbatim blocks embed non-lex content within a document, following the general indentation structure of lex, which means the block's content is +1 indented from the block's subject line.
+Verbatim blocks embed non-lex content within a document. Typically, the block's content must be indented one level deeper than its subject line.
 
-	This is a Verbatim block:
+**Inflow (Standard) Verbatim block:**
+```lex
+    Subject:
+        |<- content wall starts here (+1 indent)
+        def hello():
+            print("hello")
+:: lex ::
+```
 
-        |<- content wall starts here
-        |<- characters to the left are illegal (they are the indentation wall , not part of the content)
-		def hello():
-			print("hello")
-    :: text ::
+## 2. Rationale
 
+For wide content like tables, especially when nested deep in a document, the columns lost to indentation can harm readability. To address this, a "fullwidth" mode is proposed, allowing content to start at a fixed, absolute column close to the left margin, independent of the block's own indentation level.
 
-2. Rationale
+## 3. Conceptual Model & Syntax
 
-    For some wider contents, such as tables, when the block is already deep in the document, the columns lost to the indentation wall can hinder the readability of the content. For this reason, verbatim blocks have a fullwidth mode, in which the content starts at the FULLWIDTH_INDENT, which is by default absolute 2 [1]. 
+-   **Inflow Mode (Default):** The content's indentation "wall" is at `+1` level from the subject line.
+-   **Fullwidth Mode:** The content's indentation "wall" is at a fixed absolute column: `FULLWIDTH_INDENT` (column 2, index 1).
 
-3. Conceptual Model
+True to Lex's ethos, there is no explicit syntax. The mode is **inferred** by the position of the first non-whitespace character of the *first content line*.
 
-	From both a parsing and a code perspective we define a fullwidth block as one having the indentation wall at column absolute one, whereas the regular block (henceforth called inflow) has the wall at +1 indentation level from the block itself.
+-   If it starts at `FULLWIDTH_INDENT`, the block is **Fullwidth**.
+-   Otherwise, the block is **Inflow**.
 
-	That change aside, the internal code should behave the same. For example: 
-  | Mode   | Block Start Index | Content Start Index |
-  | ------ | ------------------| ------------------- |
-  | Inflow 		| 4            | 8              	 |
-  | Fullwidth	| 1            | 2              	 |
-	:: table ::
+Once the mode is set for a block, the wall is fixed. All subsequent content lines must start at or after the wall.
 
-   The example above shows a full width block with the content starting at column 2, and the block starting at column 5. Note that both the blocks start line (the subject line) and the end line (the closing annotation) are at the same indentation level as the content they are attached to.
+## 4. Revised Implementation Plan
 
-4. Syntax 
+This revised plan is simpler and more robust than the original. It moves the core logic from the lexer to the parser and builder, which are the layers responsible for understanding block structure and context.
 
-	True to Lex's ethos, there is no explicit syntax for fullwidth blocks. The block's type is inferred from the position of the first content line character's position. Note that , for example the first line being FULLWIDTH_INDENT will make that a fullwidth block. The logic for verbatim content is that contend is indented at the wall level or greater. Full width blocks, being the same rule, behaver the same way, and as such any content starting at FULLWIDTH_INDENT +1 is valid, with the empty spaces between the wall and the first char being part of the content itself, as before.
+### Phase 1: Keep the Lexer Simple and Stateless
 
-	The opposite is not true. If the first content line is indentation +1 , no other content lines can be to the left of the wall, regardless of it being at FULLWIDTH_INDENT or not.
-   
- 
-5. Implementation Plan
+-   **No Lexer Changes:** The lexing pipeline (`line_classification.rs`, `semantic_indentation.rs`, etc.) will **not** be modified.
+-   It will have no special knowledge of verbatim blocks. Content lines within a verbatim block will be treated as standard `ParagraphLine`s or `BlankLine`s.
+-   The `semantic_indentation` mapper will correctly emit `Dedent` tokens for fullwidth lines, but this is expected and will be handled by the parser.
 
-	This implementation avoids changes to the low-level tokenizer in favor of centralizing the detection logic within the more context-aware mappers of the lexing pipeline. This approach keeps the initial tokenization simple and robust.
+### Phase 2: Enhance the Parser (Core Logic)
 
+The `linebased` parser is context-aware and is the correct place to identify the full boundary of a verbatim block.
 
-	5.0 Prep work: 
+-   **Modify `declarative_grammar.rs`:**
+    -   The pattern for a verbatim block will be updated. Instead of looking for a `SubjectLine` followed by an indented `<container>`, it will be modified to find a `SubjectLine` followed by a sequence of *any* line tokens, ending when it finds a closing `AnnotationLine` at the **same indentation level** as the subject.
+    -   This change makes the parser responsible for finding the block's boundaries, without relying on the `tree_builder` to have pre-nested the content in a container (which it can't do for fullwidth content).
+    -   The parser will then pass the raw, flat list of content `LineToken`s to the building stage.
 
-		Before starting the code, be sure to add Lex sample files for this feature to : docs/specs/v1/elements/verbatim, using the guidelines as in docs/dev/guides/on-lexplore.lex, including: 
-			- Isolated Elements: files for tests.
-            - Simple ensambles (can be with only sessions, paragraphs) so that you can test the bblocks at different levels of nesting.
-			- More complicated ensables with more eelements, the block being the last in a level that is about to be dedented and so on
+### Phase 3: Centralize Logic in the Builder
 
-			- When all is working add one instance of the block in the kitchensink document.
+The `building` stage is the ideal place for the feature-specific logic of mode detection and wall calculation.
 
-	5.1. Phase 1: No Lexer/Token Changes
+-   **Update the AST (`verbatim.rs`):**
+    -   Introduce a public enum: `VerbatimBlockMode { Inflow, Fullwidth }`.
+    -   Add a `mode: VerbatimBlockMode` field to the `VerbatimBlock` struct.
 
-		- Keep `tokens_core.rs` unchanged. Do not introduce a special `<fullwidth>` token. The initial `logos`-based tokenizer will continue to see all leading whitespace as standard `Whitespace` tokens. This maintains the simplicity and context-free nature of the foundational lexing layer.
+-   **Update the Extraction Layer (`extraction/verbatim.rs`):**
+    -   The `extract_verbatim_block_data` function will be the primary site for the new logic. It will now receive the flat list of content `LineToken`s from the parser.
+    -   **Mode Detection:** It will inspect the *first content line token*. It will calculate the column of its first non-whitespace character.
+        -   If `column == FULLWIDTH_INDENT` (index 1), the mode is set to `Fullwidth`.
+        -   Otherwise, the mode is set to `Inflow`.
+    -   **Wall Calculation:** Based on the detected mode, it will calculate the `indentation_wall`.
+        -   If `mode` is `Fullwidth`, `indentation_wall = FULLWIDTH_INDENT`.
+        -   If `mode` is `Inflow`, `indentation_wall = subject_line.indent_level + 1`.
+    -   The rest of the function's logic (stripping the wall from each line) will operate on the correctly calculated `indentation_wall`.
 
-	5.2. Phase 2: Enhance Pipeline Mappers (Core Logic)
+-   **Update the Builder (`ast_nodes.rs`):**
+    -   The `verbatim_block_node` function will be updated to accept the `VerbatimBlockMode` from the extraction layer and populate the new `mode` field in the final AST node.
 
-		The primary challenge is to prevent fullwidth content lines from triggering premature `Dedent` events in the `semantic_indentation` mapper. We will achieve this by identifying potential verbatim blocks and re-classifying their content lines *before* they reach the indentation mapper.
+### Phase 4: Testing
 
-		5.2.1. Enhance `line_type_classification.rs`:
-			- Modify this mapper to become stateful. When it encounters a `SubjectLine`, it will begin buffering subsequent lines.
-			- It will continue to buffer lines until it finds a matching `AnnotationLine` at the same indentation level as the initial `SubjectLine`.
-			- Once this complete `Subject -> ... -> Closing Annotation` pattern is confirmed, it will re-classify all the buffered lines:
-				- The first line remains a `SubjectLine`.
-				- The last line remains an `AnnotationLine`.
-				- All lines in between are re-tagged with a new `LineType`: `VerbatimContentLine`.
-			- The mapper will then flush this sequence of re-tagged lines to the next stage of the pipeline.
+-   Add new `.lex` sample files to `docs/specs/v1/elements/verbatim/` to test the fullwidth feature at various nesting levels.
+-   Add unit tests for the mode detection and wall calculation logic in the extraction layer to test it in isolation.
+-   Ensure existing verbatim block tests continue to pass.
 
-		5.2.2. Enhance `semantic_indentation.rs`:
-			- Modify this mapper to recognize the new `VerbatimContentLine` `LineType`.
-			- When it encounters a line of this type, it will completely bypass its standard indentation logic. It will not check the line's indentation level against the stack and will not emit any `Indent` or `Dedent` events. It will simply pass the `VerbatimContentLine` through untouched.
-			- This step effectively "protects" the fullwidth content from breaking the block structure, solving the core problem.
+## 5. NOTES
 
-	5.3. Phase 3: Update AST and Extraction Layer
-
-		This layer is responsible for interpreting the stream of `VerbatimContentLine`s and determining the block's mode and indentation wall.
-
-		5.3.1. Update the AST (`verbatim.rs`):
-			- Introduce a public enum to represent the block's mode:
-					pub enum VerbatimBlockMode {
-						Inflow,
-						Fullwidth,
-					}
-				:: rust ::
-			- Add a `mode` field to the `VerbatimBlock` struct: `pub mode: VerbatimBlockMode`.
-
-		5.3.2. Update the Extraction Layer (`extraction.rs`):
-			- The `extract_verbatim_block_data` function will be the primary site for mode detection.
-			- It will receive the list of `VerbatimContentLine`s from the parser.
-			- Mode Detection Logic: It will inspect the column of the first non-whitespace character of the *first content line*.
-				- If `first_content_line.start_column == FULLWIDTH_INDENT` (e.g., column 2, which is index 1), the mode is set to `Fullwidth`.
-				- Otherwise, the mode is set to `Inflow`.
-			- Wall Calculation: Based on the detected mode, it will calculate the `indentation_wall`:
-				- If `mode` is `Fullwidth`, `indentation_wall = FULLWIDTH_INDENT`.
-				- If `mode` is `Inflow`, `indentation_wall = subject_line.indent_level + 1` (using the existing logic).
-			- The rest of the function's logic, which strips the wall and creates `VerbatimLine`s, will remain unchanged, as it will operate on the correctly calculated `indentation_wall`. This fulfills the goal of having the internal logic behave identically for both modes.
-
-	5.4. Phase 4: Update the Builder
-
-		- Modify `ast_nodes.rs`: The `verbatim_block_node` function will be updated to accept the `VerbatimBlockMode` from the extraction layer. It will then use this to populate the new `mode` field when constructing the final `VerbatimBlock` AST node.
-
-	5.5. Phase 5: Testing
-
-		- Add new `.lex` sample files to `docs/specs/v1/elements/verbatim/` to specifically test the fullwidth feature.
-		- Include test cases for content positioned exactly at the fullwidth wall, content indented beyond the wall, and mixed-indentation content.
-		- Add a test case to verify that a block starting with a `+1` indent line but containing subsequent lines at the `FULLWIDTH_INDENT` is correctly parsed as an `Inflow` block and that the out-of-place lines are handled correctly (likely resulting in a parsing error or being truncated, as per the spec).
-		- Add unit tests for the mode detection and wall calculation logic within the extraction layer.
-
-6. NOTES
-
-	1. Full Width Indent  
-
-		The FULLWIDTH_INDENT being the second column (col 1 for 0 zero based indexing), that is absolute one. It's easier, in this spec to use base 1 indexing, but do note that the actual implementation uses zero based indexing.
-
-		The reason for this is that: 
-			- Were it to start at col 1, there would be no way to differentiate a inner content's annotation mark like line from the actual verbatim block end line without escaping , which is antethical to the goal of lex to be a simple and forgiving language.
-		- Logically then anything from column two onwards are good candadiates, and the sorter the better.
-		- However, tests shows that col 2 is not a good candidate, because it's too close to the indentation wall, and people often mistake it for an error. Hence position 2 makes is more obvioius to be a deliberate choice.
+1.  **Full Width Indent:** `FULLWIDTH_INDENT` is column 2 (0-based index 1). This provides a clear visual offset from the margin and avoids ambiguity with closing annotation markers (`::`) which could appear at column 1.

--- a/docs/specs/v1/elements/verbatim/verbatim-14-fullwidth.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim-14-fullwidth.lex
@@ -1,0 +1,6 @@
+Fullwidth Table Example:
+ Header | Value | Notes
+ -------+-------+------
+ Alpha  | 10    | baseline
+Beta   | 25    | extended range
+:: table summary="export" :: Minimal fullwidth block for wide tables

--- a/docs/specs/v1/elements/verbatim/verbatim-16-fullwidth-nested.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim-16-fullwidth-nested.lex
@@ -1,0 +1,10 @@
+This paragraph comes before the fullwidth block.
+
+Fullwidth Table at Root:
+ ID | Name      | Status
+ ---+-----------+--------
+ 01 | Alice     | Active
+ 02 | Bob       | Pending
+:: data ::
+
+This paragraph comes after the fullwidth block.

--- a/docs/specs/v1/elements/verbatim/verbatim.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim.lex
@@ -59,6 +59,24 @@ The Indentation Wall
 		- Content can contain :: markers (they're ignored if indented)
 		- Clean detection of closing annotation
 
+Fullwidth Mode
+
+	When indentation steals too much horizontal space, content can drop to a
+	fixed, absolute wall at column 2 (zero-based index 1). The parser detects
+	this automatically when the first non-blank content line starts at that
+	column.
+
+		- The closing annotation stays aligned with the subject, so existing
+		  readers still see the same structure.
+		- All content lines share the same wall regardless of how deeply the block
+		  is nested.
+		- Blank lines and any indentation beyond the wall remain untouched after
+		  extraction.
+
+	Example:
+		- docs/specs/v1/elements/verbatim/verbatim-14-fullwidth.lex - Flat table
+		  whose rows start near the left margin
+
 Content Preservation
 
 	Everything between subject and closing annotation is preserved exactly:

--- a/lex-parser/src/lex/building/ast_nodes.rs
+++ b/lex-parser/src/lex/building/ast_nodes.rs
@@ -29,7 +29,7 @@
 //! conversion happens here using `byte_range_to_ast_range()`.
 
 use super::extraction::{
-    AnnotationData, DefinitionData, ListItemData, ParagraphData, SessionData, VerbatimBlockkData,
+    AnnotationData, DefinitionData, ListItemData, ParagraphData, SessionData, VerbatimBlockData,
     VerbatimGroupData,
 };
 use super::location::{
@@ -302,33 +302,28 @@ pub(super) fn annotation_node(
 ///
 /// A VerbatimBlock ContentItem
 pub(super) fn verbatim_block_node(
-    data: VerbatimBlockkData,
+    data: VerbatimBlockData,
     closing_annotation: Annotation,
     source: &str,
 ) -> ContentItem {
     if data.groups.is_empty() {
         panic!("Verbatim blocks must contain at least one subject/content pair");
     }
-
+    let mode = data.mode;
     let mut data_groups = data.groups.into_iter();
     let (first_subject, first_children, mut location_sources) =
         build_verbatim_group(data_groups.next().unwrap(), source);
-
     let mut additional_groups: Vec<VerbatimGroupItem> = Vec::new();
-
     for group_data in data_groups {
         let (subject, children, mut group_locations) = build_verbatim_group(group_data, source);
         location_sources.append(&mut group_locations);
         additional_groups.push(VerbatimGroupItem::new(subject, children));
     }
-
     location_sources.push(closing_annotation.location.clone());
     let location = compute_location_from_locations(&location_sources);
-
-    let verbatim_block = Verbatim::new(first_subject, first_children, closing_annotation)
+    let verbatim_block = Verbatim::new(first_subject, first_children, closing_annotation, mode)
         .with_additional_groups(additional_groups)
         .at(location);
-
     ContentItem::VerbatimBlock(Box::new(verbatim_block))
 }
 

--- a/lex-parser/src/lex/building/extraction.rs
+++ b/lex-parser/src/lex/building/extraction.rs
@@ -44,7 +44,6 @@ pub(super) use definition::{extract_definition_data, DefinitionData};
 pub(super) use list_item::{extract_list_item_data, ListItemData};
 pub(super) use paragraph::{extract_paragraph_data, ParagraphData};
 pub(super) use session::{extract_session_data, SessionData};
-pub(super) use verbatim::{extract_verbatim_block_data, VerbatimBlockkData, VerbatimGroupData};
+pub(super) use verbatim::{extract_verbatim_block_data, VerbatimBlockData, VerbatimGroupData};
 
 // Re-export VerbatimGroupTokenLines as public for use in ast_tree.rs
-pub use verbatim::VerbatimGroupTokenLines;

--- a/lex-parser/src/lex/building/extraction/verbatim.rs
+++ b/lex-parser/src/lex/building/extraction/verbatim.rs
@@ -361,7 +361,12 @@ mod tests {
     fn detects_fullwidth_mode_and_trims_wall() {
         let mut builder = SourceBuilder::new();
         let subject = subject_line(&mut builder, 0, "Fullwidth Example");
-        let content = content_line(&mut builder, 1, "Header | Value | Notes");
+        // Content at FULLWIDTH_INDENT_COLUMN triggers fullwidth mode
+        let content = content_line(
+            &mut builder,
+            FULLWIDTH_INDENT_COLUMN,
+            "Header | Value | Notes",
+        );
 
         let data = extract_verbatim_block_data(&subject, &[content], &builder.text);
 
@@ -375,11 +380,16 @@ mod tests {
     #[test]
     fn splits_groups_and_strips_inflow_wall() {
         let mut builder = SourceBuilder::new();
-        let subject = subject_line(&mut builder, 1, "Snippet");
-        let line1 = content_line(&mut builder, 8, "line one");
-        let line2 = content_line(&mut builder, 8, "line two");
-        let second_subject = subject_line(&mut builder, 1, "Another block");
-        let line3 = content_line(&mut builder, 8, "inner body");
+        let subject_indent_level = 1;
+        let subject = subject_line(&mut builder, subject_indent_level, "Snippet");
+        // Inflow mode: content indented relative to subject (subject_column + INFLOW_INDENT_STEP_COLUMNS)
+        // Subject at indent level 1 = column 4 (1 * 4 spaces)
+        // Content wall = 4 + 4 = column 8
+        let inflow_content_column = (subject_indent_level * 4) + INFLOW_INDENT_STEP_COLUMNS;
+        let line1 = content_line(&mut builder, inflow_content_column, "line one");
+        let line2 = content_line(&mut builder, inflow_content_column, "line two");
+        let second_subject = subject_line(&mut builder, subject_indent_level, "Another block");
+        let line3 = content_line(&mut builder, inflow_content_column, "inner body");
 
         let content = vec![line1, line2, second_subject.clone(), line3];
         let data = extract_verbatim_block_data(&subject, &content, &builder.text);

--- a/lex-parser/src/lex/building/extraction/verbatim.rs
+++ b/lex-parser/src/lex/building/extraction/verbatim.rs
@@ -1,18 +1,12 @@
 //! Verbatim Block Data Extraction
-//!
-//! Extracts primitive data (text, byte ranges) from normalized token vectors
-//! for building Verbatim AST nodes. Handles indentation wall stripping.
-
+use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+use crate::lex::token::line::{LineToken, LineType};
 use crate::lex::token::normalization::utilities::{compute_bounding_box, extract_text};
 use crate::lex::token::Token;
 use std::ops::Range as ByteRange;
 
-/// Token buckets for a single verbatim subject/content pair prior to extraction.
-#[derive(Debug, Clone)]
-pub struct VerbatimGroupTokenLines {
-    pub subject_tokens: Vec<(Token, ByteRange<usize>)>,
-    pub content_token_lines: Vec<Vec<(Token, ByteRange<usize>)>>,
-}
+const FULLWIDTH_INDENT_COLUMN: usize = 1; // Zero-based column index
+const INFLOW_INDENT_STEP_COLUMNS: usize = 4;
 
 /// Extracted data for an individual verbatim group item.
 #[derive(Debug, Clone)]
@@ -23,118 +17,101 @@ pub(in crate::lex::building) struct VerbatimGroupData {
 }
 
 /// Extracted data for building a VerbatimBlock AST node.
-///
-/// Contains the ordered verbatim groups with indentation wall already stripped.
 #[derive(Debug, Clone)]
-pub(in crate::lex::building) struct VerbatimBlockkData {
+pub(in crate::lex::building) struct VerbatimBlockData {
     pub groups: Vec<VerbatimGroupData>,
+    pub mode: VerbatimBlockMode,
 }
 
-/// Calculate the indentation wall from content token lines.
-///
-/// The "wall" is the minimum indentation level across all content lines.
-/// This is determined by counting leading Indent tokens.
-///
-/// # Arguments
-///
-/// * `content_token_lines` - Token vectors for each content line
-///
-/// # Returns
-///
-/// The number of Indent tokens to strip from each line (the wall depth)
-fn calculate_indentation_wall(content_token_lines: &[Vec<(Token, ByteRange<usize>)>]) -> usize {
-    if content_token_lines.is_empty() {
-        return 0;
-    }
-
-    content_token_lines
-        .iter()
-        .map(|tokens| {
-            // Count leading Indent tokens
-            tokens
-                .iter()
-                .take_while(|(token, _)| matches!(token, Token::Indent(_) | Token::Indentation))
-                .count()
-        })
-        .min()
-        .unwrap_or(0)
-}
-
-/// Strip indentation wall from a line of tokens.
-///
-/// Removes the first `wall_depth` Indent/Indentation tokens from the line.
-///
-/// # Arguments
-///
-/// * `tokens` - Token vector for one line
-/// * `wall_depth` - Number of leading Indent tokens to remove
-///
-/// # Returns
-///
-/// Token vector with wall stripped
-fn strip_indentation_wall(
-    tokens: Vec<(Token, ByteRange<usize>)>,
-    wall_depth: usize,
-) -> Vec<(Token, ByteRange<usize>)> {
-    let mut skipped = 0;
-    tokens
-        .into_iter()
-        .skip_while(|(token, _)| {
-            if skipped < wall_depth && matches!(token, Token::Indent(_) | Token::Indentation) {
-                skipped += 1;
-                true
-            } else {
-                false
-            }
-        })
-        .collect()
-}
-
-/// Extract verbatim block data from grouped subject/content tokens.
-///
-/// Applies indentation wall stripping per group so nested verbatim blocks share
-/// identical extracted content regardless of indentation depth.
 pub(in crate::lex::building) fn extract_verbatim_block_data(
-    groups: Vec<VerbatimGroupTokenLines>,
+    subject_line: &LineToken,
+    content_lines: &[LineToken],
     source: &str,
-) -> VerbatimBlockkData {
-    let groups = groups
+) -> VerbatimBlockData {
+    let mode = detect_mode(content_lines, source);
+    let subject_column = first_visual_column(subject_line, source).unwrap_or(0);
+    let wall_column = match mode {
+        VerbatimBlockMode::Fullwidth => FULLWIDTH_INDENT_COLUMN,
+        VerbatimBlockMode::Inflow => subject_column + INFLOW_INDENT_STEP_COLUMNS,
+    };
+
+    let groups = split_groups(subject_line, content_lines, subject_column, source)
         .into_iter()
-        .map(|group| extract_verbatim_group(group, source))
+        .map(|(subject, lines)| extract_group(subject, lines, wall_column, source))
         .collect();
 
-    VerbatimBlockkData { groups }
+    VerbatimBlockData { groups, mode }
 }
 
-fn extract_verbatim_group(
-    VerbatimGroupTokenLines {
-        subject_tokens,
-        mut content_token_lines,
-    }: VerbatimGroupTokenLines,
+fn detect_mode(content_lines: &[LineToken], source: &str) -> VerbatimBlockMode {
+    for line in content_lines {
+        if is_effectively_blank(line) {
+            continue;
+        }
+        if let Some(column) = first_visual_column(line, source) {
+            if column == FULLWIDTH_INDENT_COLUMN {
+                return VerbatimBlockMode::Fullwidth;
+            } else {
+                break;
+            }
+        }
+    }
+    VerbatimBlockMode::Inflow
+}
+
+fn split_groups(
+    first_subject: &LineToken,
+    content_lines: &[LineToken],
+    base_subject_column: usize,
+    source: &str,
+) -> Vec<(LineToken, Vec<LineToken>)> {
+    let mut groups = Vec::new();
+    let mut current_subject = first_subject.clone();
+    let mut current_content: Vec<LineToken> = Vec::new();
+
+    for line in content_lines {
+        if line.line_type == LineType::BlankLine
+            && is_effectively_blank(line)
+            && current_content.is_empty()
+        {
+            continue;
+        }
+        if is_new_group_subject(line, base_subject_column, source) {
+            groups.push((current_subject, current_content));
+            current_subject = line.clone();
+            current_content = Vec::new();
+        } else {
+            current_content.push(line.clone());
+        }
+    }
+
+    groups.push((current_subject, current_content));
+    groups
+}
+
+fn extract_group(
+    subject_line: LineToken,
+    content_lines: Vec<LineToken>,
+    wall_column: usize,
     source: &str,
 ) -> VerbatimGroupData {
-    let subject_byte_range = compute_bounding_box(&subject_tokens);
+    let subject_pairs: Vec<_> = subject_line
+        .source_token_pairs()
+        .into_iter()
+        .filter(|(token, _)| !matches!(token, Token::Colon | Token::BlankLine(_)))
+        .collect();
+    let subject_byte_range = if subject_pairs.is_empty() {
+        0..0
+    } else {
+        compute_bounding_box(&subject_pairs)
+    };
     let subject_text = extract_text(subject_byte_range.clone(), source)
         .trim()
         .to_string();
 
-    let wall_depth = calculate_indentation_wall(&content_token_lines);
-    content_token_lines = content_token_lines
+    let content_lines: Vec<(String, ByteRange<usize>)> = content_lines
         .into_iter()
-        .map(|tokens| strip_indentation_wall(tokens, wall_depth))
-        .collect();
-
-    let content_lines: Vec<(String, ByteRange<usize>)> = content_token_lines
-        .into_iter()
-        .map(|tokens| {
-            if tokens.is_empty() {
-                (String::new(), 0..0)
-            } else {
-                let byte_range = compute_bounding_box(&tokens);
-                let line_text = extract_text(byte_range.clone(), source);
-                (line_text, byte_range)
-            }
-        })
+        .map(|line| extract_content_line(line, wall_column, source))
         .collect();
 
     VerbatimGroupData {
@@ -144,57 +121,208 @@ fn extract_verbatim_group(
     }
 }
 
+fn extract_content_line(
+    line: LineToken,
+    wall_column: usize,
+    source: &str,
+) -> (String, ByteRange<usize>) {
+    let bounds = line_bounds(&line);
+    if bounds.is_none() {
+        return (String::new(), 0..0);
+    }
+    let (line_start, line_end) = bounds.unwrap();
+    let trimmed_end = trim_trailing_newline(source, line_start, line_end);
+    if trimmed_end <= line_start {
+        return (String::new(), line_start..line_start);
+    }
+
+    let start_offset = advance_to_wall(source, line_start, trimmed_end, wall_column);
+    if start_offset >= trimmed_end {
+        return (String::new(), trimmed_end..trimmed_end);
+    }
+
+    let text = source[start_offset..trimmed_end].to_string();
+    (text, start_offset..trimmed_end)
+}
+
+fn is_effectively_blank(line: &LineToken) -> bool {
+    line.source_tokens.iter().all(|token| token.is_whitespace())
+}
+
+fn is_new_group_subject(line: &LineToken, base_column: usize, source: &str) -> bool {
+    if !matches!(
+        line.line_type,
+        LineType::SubjectLine | LineType::SubjectOrListItemLine
+    ) {
+        return false;
+    }
+    first_visual_column(line, source) == Some(base_column)
+}
+
+fn first_visual_column(line: &LineToken, source: &str) -> Option<usize> {
+    line.source_token_pairs()
+        .into_iter()
+        .find(|(token, _)| !token.is_whitespace())
+        .map(|(_, range)| visual_column_at(range.start, source))
+}
+
+fn visual_column_at(offset: usize, source: &str) -> usize {
+    let line_start = source[..offset].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+    let mut column = 0;
+    let mut idx = line_start;
+    while idx < offset {
+        let ch = source[idx..].chars().next().unwrap();
+        if ch == '\r' {
+            idx += 1;
+            continue;
+        }
+        if ch.is_whitespace() {
+            column += whitespace_width(ch);
+        } else {
+            column += 1;
+        }
+        idx += ch.len_utf8();
+    }
+    column
+}
+
+fn line_bounds(line: &LineToken) -> Option<(usize, usize)> {
+    let pairs = line.source_token_pairs();
+    if pairs.is_empty() {
+        None
+    } else {
+        let range = compute_bounding_box(&pairs);
+        Some((range.start, range.end))
+    }
+}
+
+fn trim_trailing_newline(source: &str, start: usize, mut end: usize) -> usize {
+    while end > start {
+        let byte = source.as_bytes()[end - 1];
+        if byte == b'\n' || byte == b'\r' {
+            end -= 1;
+        } else {
+            break;
+        }
+    }
+    end
+}
+
+fn advance_to_wall(source: &str, start: usize, end: usize, wall_column: usize) -> usize {
+    let mut column = 0;
+    let mut offset = start;
+    while offset < end && column < wall_column {
+        let ch = source[offset..].chars().next().unwrap();
+        if !ch.is_whitespace() {
+            break;
+        }
+        column += whitespace_width(ch);
+        offset += ch.len_utf8();
+    }
+    offset.min(end)
+}
+
+fn whitespace_width(ch: char) -> usize {
+    match ch {
+        '\t' => INFLOW_INDENT_STEP_COLUMNS,
+        _ => 1,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lex::token::Token;
 
-    #[test]
-    fn test_calculate_indentation_wall() {
-        // Two lines, one with 1 indent, one with 2 indents -> wall is 1
-        let lines = vec![
-            vec![(Token::Indentation, 0..4), (Token::Text("a".into()), 4..5)],
-            vec![
-                (Token::Indentation, 0..4),
-                (Token::Indentation, 4..8),
-                (Token::Text("b".into()), 8..9),
-            ],
-        ];
+    struct SourceBuilder {
+        text: String,
+    }
 
-        let wall = calculate_indentation_wall(&lines);
-        assert_eq!(wall, 1);
+    impl SourceBuilder {
+        fn new() -> Self {
+            Self {
+                text: String::new(),
+            }
+        }
+
+        fn push(&mut self, fragment: &str) -> ByteRange<usize> {
+            let start = self.text.len();
+            self.text.push_str(fragment);
+            start..self.text.len()
+        }
+    }
+
+    fn line_token(line_type: LineType, parts: Vec<(Token, ByteRange<usize>)>) -> LineToken {
+        let (tokens, spans): (Vec<_>, Vec<_>) = parts.into_iter().unzip();
+        LineToken {
+            source_tokens: tokens,
+            token_spans: spans,
+            line_type,
+        }
+    }
+
+    fn subject_line(builder: &mut SourceBuilder, indent_levels: usize, label: &str) -> LineToken {
+        let mut parts = Vec::new();
+        for _ in 0..indent_levels {
+            let range = builder.push("    ");
+            parts.push((Token::Indentation, range));
+        }
+        let range = builder.push(label);
+        parts.push((Token::Text(label.to_string()), range));
+        let range = builder.push(":");
+        parts.push((Token::Colon, range));
+        let range = builder.push("\n");
+        parts.push((Token::BlankLine(Some("\n".to_string())), range));
+        line_token(LineType::SubjectLine, parts)
+    }
+
+    fn content_line(builder: &mut SourceBuilder, indent_spaces: usize, text: &str) -> LineToken {
+        let mut parts = Vec::new();
+        for _ in 0..indent_spaces {
+            let range = builder.push(" ");
+            parts.push((Token::Whitespace, range));
+        }
+        if !text.is_empty() {
+            let range = builder.push(text);
+            parts.push((Token::Text(text.to_string()), range));
+        }
+        let range = builder.push("\n");
+        parts.push((Token::BlankLine(Some("\n".to_string())), range));
+        line_token(LineType::ParagraphLine, parts)
     }
 
     #[test]
-    fn test_extract_verbatim_block_data_strips_wall() {
-        let source = "Code:\n    line1\n        line2";
+    fn detects_fullwidth_mode_and_trims_wall() {
+        let mut builder = SourceBuilder::new();
+        let subject = subject_line(&mut builder, 0, "Fullwidth Example");
+        let content = content_line(&mut builder, 1, "Header | Value | Notes");
 
-        let subject_tokens = vec![(Token::Text("Code".to_string()), 0..4)];
+        let data = extract_verbatim_block_data(&subject, &[content], &builder.text);
 
-        let content_lines = vec![
-            vec![
-                (Token::Indentation, 6..10),
-                (Token::Text("line1".to_string()), 10..15),
-            ],
-            vec![
-                (Token::Indentation, 16..20),
-                (Token::Indentation, 20..24),
-                (Token::Text("line2".to_string()), 24..29),
-            ],
-        ];
-
-        let group = VerbatimGroupTokenLines {
-            subject_tokens,
-            content_token_lines: content_lines,
-        };
-
-        let data = extract_verbatim_block_data(vec![group], source);
-
+        assert_eq!(data.mode, VerbatimBlockMode::Fullwidth);
         assert_eq!(data.groups.len(), 1);
-        assert_eq!(data.groups[0].subject_text, "Code");
-        // Wall of 1 indent should be stripped from both lines
-        // So line1 has no indent, line2 has 1 indent left
-        assert_eq!(data.groups[0].content_lines.len(), 2);
-        assert_eq!(data.groups[0].content_lines[0].0, "line1");
-        assert_eq!(data.groups[0].content_lines[1].0, "    line2");
+        assert_eq!(data.groups[0].content_lines.len(), 1);
+        assert_eq!(data.groups[0].content_lines[0].0, "Header | Value | Notes");
+        assert!(data.groups[0].content_lines[0].1.start < data.groups[0].content_lines[0].1.end);
+    }
+
+    #[test]
+    fn splits_groups_and_strips_inflow_wall() {
+        let mut builder = SourceBuilder::new();
+        let subject = subject_line(&mut builder, 1, "Snippet");
+        let line1 = content_line(&mut builder, 8, "line one");
+        let line2 = content_line(&mut builder, 8, "line two");
+        let second_subject = subject_line(&mut builder, 1, "Another block");
+        let line3 = content_line(&mut builder, 8, "inner body");
+
+        let content = vec![line1, line2, second_subject.clone(), line3];
+        let data = extract_verbatim_block_data(&subject, &content, &builder.text);
+
+        assert_eq!(data.mode, VerbatimBlockMode::Inflow);
+        assert_eq!(data.groups.len(), 2);
+        assert_eq!(data.groups[0].subject_text, "Snippet");
+        assert_eq!(data.groups[0].content_lines[0].0, "line one");
+        assert_eq!(data.groups[1].subject_text, "Another block");
+        assert_eq!(data.groups[1].content_lines[0].0, "inner body");
     }
 }

--- a/lex-parser/src/lex/building/extraction/verbatim.rs
+++ b/lex-parser/src/lex/building/extraction/verbatim.rs
@@ -252,10 +252,29 @@ fn extract_content_line(
     (text, start_offset..trimmed_end)
 }
 
+/// Check if a line is effectively blank (contains only whitespace tokens).
+///
+/// Used to distinguish truly blank lines from those that might have content.
+/// This helps with proper handling of inter-group spacing in verbatim blocks.
 fn is_effectively_blank(line: &LineToken) -> bool {
     line.source_tokens.iter().all(|token| token.is_whitespace())
 }
 
+/// Determine if a line is a new group subject at the specified column.
+///
+/// A line qualifies as a new group subject if:
+/// 1. It has a subject line type (SubjectLine or SubjectOrListItemLine)
+/// 2. Its first non-whitespace content starts at exactly `base_column`
+///
+/// # Arguments
+///
+/// * `line` - The line token to check
+/// * `base_column` - The column where group subjects must start
+/// * `source` - Original source text for column calculation
+///
+/// # Returns
+///
+/// `true` if this line starts a new verbatim group, `false` otherwise
 fn is_new_group_subject(line: &LineToken, base_column: usize, source: &str) -> bool {
     if !matches!(
         line.line_type,
@@ -266,6 +285,19 @@ fn is_new_group_subject(line: &LineToken, base_column: usize, source: &str) -> b
     first_visual_column(line, source) == Some(base_column)
 }
 
+/// Find the visual column of the first non-whitespace token in a line.
+///
+/// Visual columns account for tab expansion (tabs count as 4 columns each).
+/// Returns `None` if the line contains only whitespace.
+///
+/// # Arguments
+///
+/// * `line` - The line token to analyze
+/// * `source` - Original source text for column calculation
+///
+/// # Returns
+///
+/// The visual column (0-indexed) where the first content appears, or `None` for blank lines
 fn first_visual_column(line: &LineToken, source: &str) -> Option<usize> {
     line.source_token_pairs()
         .into_iter()

--- a/lex-parser/src/lex/parsing/ir.rs
+++ b/lex-parser/src/lex/parsing/ir.rs
@@ -5,6 +5,7 @@
 //! without coupling the parser to the AST building logic.
 
 use crate::lex::lexing::Token;
+use crate::lex::token::LineToken;
 use std::ops::Range;
 
 /// Type alias for token with location
@@ -21,9 +22,16 @@ pub enum NodeType {
     Definition,
     Annotation,
     VerbatimBlock,
-    VerbatimBlockkSubject,
-    VerbatimBlockkContent,
-    VerbatimBlockkClosing,
+}
+
+/// Additional payload carried by specific parse nodes.
+#[derive(Debug, Clone)]
+pub enum ParseNodePayload {
+    /// Raw line tokens needed to build a verbatim block (subject + content lines)
+    VerbatimBlock {
+        subject: LineToken,
+        content_lines: Vec<LineToken>,
+    },
 }
 
 /// A node in the parse tree.
@@ -32,6 +40,7 @@ pub struct ParseNode {
     pub node_type: NodeType,
     pub tokens: Vec<TokenLocation>,
     pub children: Vec<ParseNode>,
+    pub payload: Option<ParseNodePayload>,
 }
 
 impl ParseNode {
@@ -41,6 +50,13 @@ impl ParseNode {
             node_type,
             tokens,
             children,
+            payload: None,
         }
+    }
+
+    /// Attach a payload to this node.
+    pub fn with_payload(mut self, payload: ParseNodePayload) -> Self {
+        self.payload = Some(payload);
+        self
     }
 }

--- a/lex-parser/src/lex/parsing/parser/builder/builders/mod.rs
+++ b/lex-parser/src/lex/parsing/parser/builder/builders/mod.rs
@@ -19,4 +19,3 @@ pub(in crate::lex::parsing::parser::builder) use list::build_list;
 pub(in crate::lex::parsing::parser::builder) use paragraph::build_paragraph;
 pub(in crate::lex::parsing::parser::builder) use session::build_session;
 pub(in crate::lex::parsing::parser::builder) use verbatim::build_verbatim_block;
-pub(in crate::lex::parsing::parser) use verbatim::VerbatimGroupMatch;

--- a/lex-parser/src/lex/parsing/parser/builder/builders/verbatim.rs
+++ b/lex-parser/src/lex/parsing/parser/builder/builders/verbatim.rs
@@ -3,75 +3,35 @@
 //! Handles construction of verbatim block nodes from matched patterns.
 
 use super::helpers::{collect_line_tokens, extract_annotation_single_content, extract_line_token};
-use crate::lex::parsing::ir::{NodeType, ParseNode};
+use crate::lex::parsing::ir::{NodeType, ParseNode, ParseNodePayload};
 use crate::lex::token::LineContainer;
+use std::ops::Range;
 
-/// Represents a matched verbatim group (subject + optional content)
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub(in crate::lex::parsing::parser) struct VerbatimGroupMatch {
-    pub subject_idx: usize,
-    pub content_idx: Option<usize>,
-}
-
-/// Build a verbatim block node from matched groups
+/// Build a verbatim block node from a subject, arbitrary content lines, and a closing annotation.
 pub(in crate::lex::parsing::parser::builder) fn build_verbatim_block(
     tokens: &[LineContainer],
-    groups: &[VerbatimGroupMatch],
+    subject_idx: usize,
+    content_range: Range<usize>,
     closing_idx: usize,
 ) -> Result<ParseNode, String> {
-    let mut child_nodes = Vec::new();
+    let subject_token = extract_line_token(&tokens[subject_idx])?.clone();
 
-    for group in groups {
-        let subject_token = extract_line_token(&tokens[group.subject_idx])?;
-        let subject_tokens: Vec<_> = subject_token
-            .source_tokens
-            .clone()
-            .into_iter()
-            .zip(subject_token.token_spans.clone())
-            .filter(|(token, _)| {
-                !matches!(
-                    token,
-                    crate::lex::lexing::Token::Colon | crate::lex::lexing::Token::BlankLine(_)
-                )
-            })
-            .collect();
-
-        let mut content_tokens = Vec::new();
-        if let Some(content_idx_val) = group.content_idx {
-            if let Some(container) = tokens.get(content_idx_val) {
-                let mut line_tokens = Vec::new();
-                collect_line_tokens(container, &mut line_tokens);
-                for line_token in line_tokens {
-                    content_tokens.extend(
-                        line_token
-                            .source_tokens
-                            .into_iter()
-                            .zip(line_token.token_spans.into_iter()),
-                    );
-                }
-            }
+    let mut content_lines = Vec::new();
+    for idx in content_range {
+        if let Some(container) = tokens.get(idx) {
+            collect_line_tokens(container, &mut content_lines);
         }
-
-        child_nodes.push(ParseNode::new(
-            NodeType::VerbatimBlockkSubject,
-            subject_tokens,
-            vec![],
-        ));
-        child_nodes.push(ParseNode::new(
-            NodeType::VerbatimBlockkContent,
-            content_tokens,
-            vec![],
-        ));
     }
 
     let closing_token = extract_line_token(&tokens[closing_idx])?;
     let (header_tokens, closing_children) = extract_annotation_single_content(closing_token);
-    child_nodes.push(ParseNode::new(
-        NodeType::VerbatimBlockkClosing,
-        header_tokens,
-        closing_children,
-    ));
+    let closing_node = ParseNode::new(NodeType::Annotation, header_tokens, closing_children);
 
-    Ok(ParseNode::new(NodeType::VerbatimBlock, vec![], child_nodes))
+    let verbatim_node = ParseNode::new(NodeType::VerbatimBlock, vec![], vec![closing_node])
+        .with_payload(ParseNodePayload::VerbatimBlock {
+            subject: subject_token,
+            content_lines,
+        });
+
+    Ok(verbatim_node)
 }

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/verbatim.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/verbatim.rs
@@ -1,6 +1,7 @@
 //! Verbatim block assertions
 
 use crate::lex::ast::elements::container::VerbatimContainer;
+use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
 use crate::lex::ast::{ContentItem, TextContent, Verbatim};
 
 pub struct VerbatimBlockkAssertion<'a> {
@@ -45,6 +46,15 @@ impl<'a> VerbatimBlockkAssertion<'a> {
             actual, expected,
             "{}: Expected closing annotation label to be '{}', but got '{}'",
             self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn mode(self, expected: VerbatimBlockMode) -> Self {
+        assert_eq!(
+            self.verbatim_block.mode, expected,
+            "{}: Expected verbatim block mode {:?}, got {:?}",
+            self.context, expected, self.verbatim_block.mode
         );
         self
     }

--- a/lex-parser/src/lex/token/normalization/utilities.rs
+++ b/lex-parser/src/lex/token/normalization/utilities.rs
@@ -124,6 +124,34 @@ pub fn extract_text(range: ByteRange<usize>, source: &str) -> String {
     source[range].to_string()
 }
 
+/// Compute the 0-indexed column number for a given byte offset in the source string.
+///
+/// # Arguments
+///
+/// * `offset` - The byte offset to get the column for
+/// * `source` - The original source string
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let source = "hello\n world";
+/// // 'w' is at byte offset 6
+/// let col = compute_column(6, source);
+/// assert_eq!(col, 1);
+/// ```
+pub fn compute_column(offset: usize, source: &str) -> usize {
+    let mut last_newline = 0;
+    for (i, c) in source.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if c == '\n' {
+            last_newline = i + 1;
+        }
+    }
+    offset - last_newline
+}
+
 /// High-level convenience: extract text directly from tokens.
 ///
 /// This combines `compute_bounding_box` and `extract_text` for convenience.

--- a/lex-parser/tests/elements_verbatim.rs
+++ b/lex-parser/tests/elements_verbatim.rs
@@ -331,6 +331,36 @@ fn test_verbatim_14_fullwidth_table() {
 }
 
 #[test]
+fn test_verbatim_16_fullwidth_at_root() {
+    // verbatim-16-fullwidth-nested.lex: Fullwidth verbatim at root level
+    // Demonstrates fullwidth mode works correctly with other root-level elements
+    let doc = Lexplore::verbatim(16).parse();
+
+    assert_ast(&doc).item_count(3); // para before, verbatim, para after
+
+    // First: paragraph before
+    assert_ast(&doc).item(0, |item| {
+        item.assert_paragraph().text_contains("comes before");
+    });
+
+    // Second: fullwidth verbatim at root level
+    assert_ast(&doc).item(1, |item| {
+        item.assert_verbatim_block()
+            .subject("Fullwidth Table at Root")
+            .mode(VerbatimBlockMode::Fullwidth)
+            .closing_label("data")
+            .line_count(4) // table rows
+            .content_contains("ID | Name")
+            .content_contains("Alice");
+    });
+
+    // Third: paragraph after verbatim
+    assert_ast(&doc).item(2, |item| {
+        item.assert_paragraph().text_contains("comes after");
+    });
+}
+
+#[test]
 fn test_verbatim_11_group_sequences() {
     // verbatim-11-group-shell.lex: Multiple subject/content pairs sharing an annotation
     let doc = Lexplore::verbatim(11).parse();

--- a/lex-parser/tests/elements_verbatim.rs
+++ b/lex-parser/tests/elements_verbatim.rs
@@ -6,6 +6,7 @@
 //! - Test isolated elements (one element per test)
 //! - Verify content and structure, not just counts
 
+use lex_parser::lex::ast::elements::verbatim::VerbatimBlockMode;
 use lex_parser::lex::ast::AstNode;
 use lex_parser::lex::testing::assert_ast;
 use lex_parser::lex::testing::lexplore::Lexplore;
@@ -311,6 +312,21 @@ fn test_verbatim_13_group_spades() {
         item.assert_paragraph().text_contains(
             "Note that verbatim blocks conetents can have any number of blank lines",
         );
+    });
+}
+
+#[test]
+fn test_verbatim_14_fullwidth_table() {
+    // verbatim-14-fullwidth.lex: Fullwidth block starting near the left margin
+    let doc = Lexplore::verbatim(14).parse();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_verbatim_block()
+            .subject("Fullwidth Table Example")
+            .mode(VerbatimBlockMode::Fullwidth)
+            .line_count(4)
+            .content_contains("Header | Value | Notes")
+            .content_contains("Beta   | 25    | extended range");
     });
 }
 


### PR DESCRIPTION
# feat(verbatim): add fullwidth verbatim mode

## Summary
- shift verbatim group detection from indentation containers to parser payloads, so we can infer a block’s mode (inflow vs. fullwidth) based on the first content line’s visual column while preserving the existing AST shape
- plumb a `VerbatimBlockMode` field through extraction → AST nodes, trim trailing colons from subject text, and fix grouping logic so subjects at mixed indentation still form groups
- document the new behavior, add a `verbatim-14-fullwidth.lex` fixture, and extend tests/assertions to cover both inflow and fullwidth blocks

## Testing
- `cargo test --test elements_verbatim`
- `cargo test`
