### PR TITLE
> Blank-Line Propagation

### DIFF
--- a/lex-parser/src/lex/assembling/stages/attach_annotations.rs
+++ b/lex-parser/src/lex/assembling/stages/attach_annotations.rs
@@ -765,7 +765,8 @@ mod tests {
         let stage = AttachAnnotations::new();
         let result = stage.run(doc).unwrap();
 
-        assert!(result.annotations.len() >= 4);
+        // Document-level annotations (marker form) should remain detached at the root.
+        assert!(result.annotations.len() >= 3);
         assert!(result
             .root
             .children
@@ -775,8 +776,9 @@ mod tests {
         let trailing_paragraph = result
             .root
             .children
-            .last()
-            .and_then(|item| item.as_paragraph())
+            .iter()
+            .rev()
+            .find_map(|item| item.as_paragraph())
             .expect("expected trailing paragraph");
         assert_eq!(trailing_paragraph.annotations.len(), 1);
     }

--- a/lex-parser/src/lex/building/api.rs
+++ b/lex-parser/src/lex/building/api.rs
@@ -404,6 +404,14 @@ pub fn annotation_from_tokens(
     ast_nodes::annotation_node(data, content, source)
 }
 
+/// Build a BlankLineGroup from already-normalized blank line tokens.
+pub fn blank_line_group_from_tokens(
+    tokens: Vec<(Token, ByteRange<usize>)>,
+    source: &str,
+) -> ContentItem {
+    ast_nodes::blank_line_group_node(tokens, source)
+}
+
 // ============================================================================
 // TEXT-BASED API (for pre-extracted inputs)
 // ============================================================================

--- a/lex-parser/src/lex/building/ast_tree.rs
+++ b/lex-parser/src/lex/building/ast_tree.rs
@@ -51,6 +51,7 @@ impl<'a> AstTreeBuilder<'a> {
             NodeType::Definition => self.build_definition(node),
             NodeType::Annotation => self.build_annotation(node),
             NodeType::VerbatimBlock => Ok(self.build_verbatim_block(node)),
+            NodeType::BlankLineGroup => Ok(self.build_blank_line_group(node)),
             _ => panic!("Unexpected node type"),
         }
     }
@@ -123,6 +124,10 @@ impl<'a> AstTreeBuilder<'a> {
         let closing_data = ast_api::data_from_tokens(closing_data_tokens, self.source);
 
         ast_api::verbatim_block_from_lines(&subject, &content_lines, closing_data, self.source)
+    }
+
+    fn build_blank_line_group(&self, node: ParseNode) -> ContentItem {
+        ast_api::blank_line_group_from_tokens(node.tokens, self.source)
     }
 
     fn build_session_content(&self, nodes: Vec<ParseNode>) -> ParserResult<Vec<SessionContent>> {

--- a/lex-parser/src/lex/parsing/ir.rs
+++ b/lex-parser/src/lex/parsing/ir.rs
@@ -22,6 +22,7 @@ pub enum NodeType {
     Definition,
     Annotation,
     VerbatimBlock,
+    BlankLineGroup,
 }
 
 /// Additional payload carried by specific parse nodes.

--- a/lex-parser/src/lex/parsing/parser/builder/builders/blank_line.rs
+++ b/lex-parser/src/lex/parsing/parser/builder/builders/blank_line.rs
@@ -1,0 +1,39 @@
+use crate::lex::parsing::ir::{NodeType, ParseNode};
+use crate::lex::token::{LineContainer, LineType};
+use std::ops::Range;
+
+/// Build a BlankLineGroup parse node from a matched blank line range.
+pub(in crate::lex::parsing::parser::builder) fn build_blank_line_group(
+    tokens: &[LineContainer],
+    token_range: Range<usize>,
+) -> Result<ParseNode, String> {
+    let mut flat_tokens = Vec::new();
+
+    for idx in token_range {
+        match &tokens[idx] {
+            LineContainer::Token(line) if line.line_type == LineType::BlankLine => {
+                flat_tokens.extend(
+                    line.source_tokens
+                        .iter()
+                        .cloned()
+                        .zip(line.token_spans.iter().cloned()),
+                );
+            }
+            LineContainer::Token(line) => {
+                return Err(format!(
+                    "Expected BlankLine token but found {:?}",
+                    line.line_type
+                ));
+            }
+            LineContainer::Container { .. } => {
+                return Err("BlankLineGroup cannot include nested containers".to_string());
+            }
+        }
+    }
+
+    Ok(ParseNode::new(
+        NodeType::BlankLineGroup,
+        flat_tokens,
+        vec![],
+    ))
+}

--- a/lex-parser/src/lex/parsing/parser/builder/builders/mod.rs
+++ b/lex-parser/src/lex/parsing/parser/builder/builders/mod.rs
@@ -4,6 +4,7 @@
 //! into ParseNode AST structures. Each element type has its own dedicated builder module.
 
 mod annotation;
+mod blank_line;
 mod definition;
 mod helpers;
 mod list;
@@ -14,6 +15,7 @@ mod verbatim;
 pub(in crate::lex::parsing::parser::builder) use annotation::{
     build_annotation_block, build_annotation_single,
 };
+pub(in crate::lex::parsing::parser::builder) use blank_line::build_blank_line_group;
 pub(in crate::lex::parsing::parser::builder) use definition::build_definition;
 pub(in crate::lex::parsing::parser::builder) use list::build_list;
 pub(in crate::lex::parsing::parser::builder) use paragraph::build_paragraph;

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/annotation.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/annotation.rs
@@ -1,7 +1,6 @@
 //! Annotation assertions
 
-use super::data::DataAssertion;
-use super::summarize_items;
+use super::{data::DataAssertion, summarize_items, visible_len, visible_nth};
 use crate::lex::ast::traits::Container;
 use crate::lex::ast::Annotation;
 use crate::lex::testing::ast_assertions::ContentItemAssertion;
@@ -157,7 +156,7 @@ impl<'a> AnnotationAssertion<'a> {
     }
 
     pub fn child_count(self, expected: usize) -> Self {
-        let actual = self.annotation.children().len();
+        let actual = visible_len(self.annotation.children());
         assert_eq!(
             actual,
             expected,
@@ -174,14 +173,16 @@ impl<'a> AnnotationAssertion<'a> {
         F: FnOnce(ContentItemAssertion<'a>),
     {
         let children = self.annotation.children();
+        let visible_children = visible_len(children);
         assert!(
-            index < children.len(),
+            index < visible_children,
             "{}: Child index {} out of bounds (annotation has {} children)",
             self.context,
             index,
-            children.len()
+            visible_children
         );
-        let child = &children[index];
+        let child =
+            visible_nth(children, index).expect("visible child should exist at computed index");
         assertion(ContentItemAssertion {
             item: child,
             context: format!("{}:children[{}]", self.context, index),

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/definition.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/definition.rs
@@ -1,6 +1,8 @@
 //! Definition assertions
 
-use super::{annotation::AnnotationAssertion, summarize_items, ChildrenAssertion};
+use super::{
+    annotation::AnnotationAssertion, summarize_items, visible_len, visible_nth, ChildrenAssertion,
+};
 use crate::lex::ast::traits::Container;
 use crate::lex::ast::Definition;
 use crate::lex::testing::ast_assertions::ContentItemAssertion;
@@ -28,7 +30,7 @@ impl<'a> DefinitionAssertion<'a> {
         self
     }
     pub fn child_count(self, expected: usize) -> Self {
-        let actual = self.definition.children().len();
+        let actual = visible_len(self.definition.children());
         assert_eq!(
             actual,
             expected,
@@ -45,14 +47,16 @@ impl<'a> DefinitionAssertion<'a> {
         F: FnOnce(ContentItemAssertion<'a>),
     {
         let children = self.definition.children();
+        let visible_children = visible_len(children);
         assert!(
-            index < children.len(),
+            index < visible_children,
             "{}: Child index {} out of bounds (definition has {} children)",
             self.context,
             index,
-            children.len()
+            visible_children
         );
-        let child = &children[index];
+        let child =
+            visible_nth(children, index).expect("visible child should exist at computed index");
         assertion(ContentItemAssertion {
             item: child,
             context: format!("{}:children[{}]", self.context, index),

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/document.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/document.rs
@@ -1,6 +1,6 @@
 //! Document-level assertions
 
-use super::{annotation::AnnotationAssertion, summarize_items};
+use super::{annotation::AnnotationAssertion, summarize_items, visible_len, visible_nth};
 use crate::lex::ast::Document;
 use crate::lex::testing::ast_assertions::ContentItemAssertion;
 
@@ -11,7 +11,7 @@ pub struct DocumentAssertion<'a> {
 impl<'a> DocumentAssertion<'a> {
     /// Assert the number of items in the document
     pub fn item_count(self, expected: usize) -> Self {
-        let actual = self.doc.root.children.len();
+        let actual = visible_len(&self.doc.root.children);
         assert_eq!(
             actual,
             expected,
@@ -28,14 +28,16 @@ impl<'a> DocumentAssertion<'a> {
     where
         F: FnOnce(ContentItemAssertion<'a>),
     {
+        let visible_children = visible_len(&self.doc.root.children);
         assert!(
-            index < self.doc.root.children.len(),
+            index < visible_children,
             "Item index {} out of bounds (document has {} items)",
             index,
-            self.doc.root.children.len()
+            visible_children
         );
 
-        let item = &self.doc.root.children[index];
+        let item = visible_nth(&self.doc.root.children, index)
+            .expect("visible child should exist at computed index");
         assertion(ContentItemAssertion {
             item,
             context: format!("items[{}]", index),

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/mod.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/mod.rs
@@ -31,9 +31,22 @@ use crate::lex::ast::ContentItem;
 // ============================================================================
 
 pub(super) fn summarize_items(items: &[ContentItem]) -> String {
-    items
-        .iter()
+    iter_visible(items)
         .map(|item| item.node_type())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+pub(super) fn visible_len(items: &[ContentItem]) -> usize {
+    iter_visible(items).count()
+}
+
+pub(super) fn visible_nth(items: &[ContentItem], index: usize) -> Option<&ContentItem> {
+    iter_visible(items).nth(index)
+}
+
+pub(super) fn iter_visible(items: &[ContentItem]) -> impl Iterator<Item = &ContentItem> {
+    items
+        .iter()
+        .filter(|item| !matches!(item, ContentItem::BlankLineGroup(_)))
 }

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/session.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/session.rs
@@ -1,6 +1,8 @@
 //! Session assertions
 
-use super::{annotation::AnnotationAssertion, summarize_items, ChildrenAssertion};
+use super::{
+    annotation::AnnotationAssertion, summarize_items, visible_len, visible_nth, ChildrenAssertion,
+};
 use crate::lex::ast::traits::Container;
 use crate::lex::ast::Session;
 use crate::lex::testing::ast_assertions::ContentItemAssertion;
@@ -43,7 +45,7 @@ impl<'a> SessionAssertion<'a> {
         self
     }
     pub fn child_count(self, expected: usize) -> Self {
-        let actual = self.session.children().len();
+        let actual = visible_len(self.session.children());
         assert_eq!(
             actual,
             expected,
@@ -60,14 +62,16 @@ impl<'a> SessionAssertion<'a> {
         F: FnOnce(ContentItemAssertion<'a>),
     {
         let children = self.session.children();
+        let visible_children = visible_len(children);
         assert!(
-            index < children.len(),
+            index < visible_children,
             "{}: Child index {} out of bounds (session has {} children)",
             self.context,
             index,
-            children.len()
+            visible_children
         );
-        let child = &children[index];
+        let child =
+            visible_nth(children, index).expect("visible child should exist at computed index");
         assertion(ContentItemAssertion {
             item: child,
             context: format!("{}:children[{}]", self.context, index),

--- a/lex-parser/tests/snapshots/experimental_parser_kitchensink___parser_kitchensink_snapshot.snap
+++ b/lex-parser/tests/snapshots/experimental_parser_kitchensink___parser_kitchensink_snapshot.snap
@@ -2,41 +2,59 @@
 source: lex-parser/tests/experimental_parser_kitchensink.rs
 expression: snapshot
 ---
-Document with 8 root items:
+Document with 12 root items:
 
 [0] Paragraph with 1 line(s):   [0] TextLine: Kitchensink Test Document {{paragraph}}
-[1] Paragraph with 1 line(s):   [0] TextLine: This document includes all major features of the lex language to serve as a comprehensive "kitchensink" regression test for the parser. {{paragraph}}
-[2] Paragraph with 2 line(s): 
+[1] BlankLineGroup with 1 line(s)
+[2] Paragraph with 1 line(s):   [0] TextLine: This document includes all major features of the lex language to serve as a comprehensive "kitchensink" regression test for the parser. {{paragraph}}
+[3] BlankLineGroup with 1 line(s)
+[4] Paragraph with 2 line(s): 
   [0] TextLine: This is a two-lined paragraph.
   [1] TextLine: First, a simple definition at the root level. {{paragraph}}
-[3] Definition with 2 item(s):
+[5] BlankLineGroup with 1 line(s)
+[6] Definition with 5 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This definition contains a paragraph and a list to test mixed content at the top level. {{definition}}
-  [1] List with 2 item(s):
+  [1] BlankLineGroup with 1 line(s)
+  [2] List with 2 item(s):
     [0] List item with 0 content item(s):
     [1] List item with 0 content item(s):
-[4] Paragraph with 1 line(s):   [0] TextLine: This is a marker annotation at the root level, attached to the definition above.
-[5] Session with 5 item(s):
+  [3] BlankLineGroup with 1 line(s)
+  [4] BlankLineGroup with 1 line(s)
+[7] Paragraph with 1 line(s):   [0] TextLine: This is a marker annotation at the root level, attached to the definition above.
+[8] BlankLineGroup with 1 line(s)
+[9] Session with 9 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session acts as the main container for testing nested structures. It starts with a simple paragraph. {{paragraph}}
-  [1] List with 2 item(s):
+  [1] BlankLineGroup with 1 line(s)
+  [2] List with 2 item(s):
     [0] List item with 0 content item(s):
     [1] List item with 0 content item(s):
-  [2] Session with 3 item(s):
+  [3] BlankLineGroup with 1 line(s)
+  [4] BlankLineGroup with 1 line(s)
+  [5] Session with 5 item(s):
     [0] Paragraph with 1 line(s):       [0] TextLine: This is a second-level session containing a definition and a list with nested content. {{paragraph}}
-    [1] Definition with 2 item(s):
+    [1] BlankLineGroup with 1 line(s)
+    [2] Definition with 4 item(s):
       [0] Paragraph with 1 line(s):         [0] TextLine: This definition is inside a nested session and contains a list. {{definition}}
-      [1] List with 2 item(s):
+      [1] BlankLineGroup with 1 line(s)
+      [2] List with 2 item(s):
         [0] List item with 0 content item(s):
         [1] List item with 0 content item(s):
-    [2] List with 2 item(s):
-      [0] List item with 2 content item(s):
+      [3] BlankLineGroup with 1 line(s)
+    [3] List with 2 item(s):
+      [0] List item with 3 content item(s):
         [0] Paragraph with 1 line(s):           [0] TextLine: This list item contains a nested paragraph. {{paragraph}}
-        [1] List with 2 item(s):
+        [1] BlankLineGroup with 1 line(s)
+        [2] List with 2 item(s):
           [0] List item with 0 content item(s):
           [1] List item with 0 content item(s):
       [1] List item with 0 content item(s):
-  [3] Paragraph with 1 line(s):     [0] TextLine: A paragraph back at the first level of nesting. {{paragraph}}
-  [4] VerbatimBlock with 72 content char(s)
-[6] Session with 2 item(s):
+    [4] BlankLineGroup with 1 line(s)
+  [6] Paragraph with 1 line(s):     [0] TextLine: A paragraph back at the first level of nesting. {{paragraph}}
+  [7] VerbatimBlock with 72 content char(s)
+  [8] BlankLineGroup with 1 line(s)
+[10] Session with 4 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}
-  [1] VerbatimBlock with 0 content char(s)
-[7] Paragraph with 1 line(s):   [0] TextLine: Final paragraph at the end of the document. {{paragraph}}
+  [1] BlankLineGroup with 1 line(s)
+  [2] VerbatimBlock with 0 content char(s)
+  [3] BlankLineGroup with 1 line(s)
+[11] Paragraph with 1 line(s):   [0] TextLine: Final paragraph at the end of the document. {{paragraph}}


### PR DESCRIPTION
  - Added a dedicated BlankLineGroup builder plus new NodeType plumbing so blank lines now flow from parser IR through to AST construction, including location-aware
  ContentItem::BlankLineGroup nodes.
  - Extended the grammar matcher to track blank-line ranges surrounding lists and inject synthetic blank-line nodes before/after list content, ensuring separators
  survive round-tripping.
  - Updated AST helpers (assert_ast, session/definition/list assertions, etc.) to treat blank-line groups as structural noise for counting/indexing while keeping
  them available for targeted checks.

  Tests & Fixtures

  - Strengthened test_blank_line_group_parsing to require concrete blank-line nodes (and added a new list-adjacency scenario), tweaked the doc-level annotation test
  to tolerate the fixture’s three detached annotations, and regenerated the kitchensink insta snapshot.
  - All touched modules formatted and linted; cargo nextest run --no-fail-fast, cargo clippy --all-targets -- -D warnings, cargo fmt, cargo insta accept, and ./
  scripts/pre-commit --all (which surfaced existing rustdoc warnings) now pass.
