### PR TITLE
  Handle session separators via boundaries and clarify grammar

### DIFF
--- a/docs/dev/guides/on-all-of-lex.lex
+++ b/docs/dev/guides/on-all-of-lex.lex
@@ -286,14 +286,14 @@ These conclude the description of the grammar and syntax. With that in mind, we 
 
 	Table: Nested Elements Structure and Parsing:
 
-		| Element     | Prec. Blank | Head                | Blank     | Content  | Tail          	|
-		|-------------|-------------|---------------------|-----------|----------|------------------|
-		| Session     | Yes         | ParagraphLine       | Yes       | Yes      | dedent        	|
-		| Definition  | Optional    | SubjectLine         | No        | Yes      | dedent        	|
-		| Verbatim    | Optional    | SubjectLine         | Optional  | Optional | dedent+ DataLine |
-		| Annotation  | Optional    | AnnotationStartLine | Yes       | Yes      | AnnotationEnd 	|
-		| List        | Optional    | ListLine            | No        | Yes      | No               | 
-		|-------------------------------------------------------------------------------------------|
+		| Element     | Separator Before Head | Head                | Blank (head→content) | Content  | Tail          	|
+		|-------------|-----------------------|---------------------|----------------------|----------|------------------|
+		| Session     | Blank or boundary     | ParagraphLine       | Yes                  | Yes      | dedent        	|
+		| Definition  | Optional blank        | SubjectLine         | No                   | Yes      | dedent        	|
+		| Verbatim    | Optional blank        | SubjectLine         | Optional             | Optional | dedent+ DataLine |
+		| Annotation  | Optional blank        | AnnotationStartLine | Yes                  | Yes      | AnnotationEnd 	|
+		| List        | Optional blank        | ListLine            | No                   | Yes      | No               | 
+		|-------------------------------------------------------------------------------------------------------------|
 
     Table: Flat Elements Structure and Parsing:	
 
@@ -318,7 +318,7 @@ These conclude the description of the grammar and syntax. With that in mind, we 
 	
 
 	There are a couple of interesting things to note here. The first is that all container elements, salvo for Verbatim blocks are terminated by a dedent. That it, you don't know where they ended, you just know that something else started.
-	Sessions are unique in that the head must be enclosed by blank lines. The reason this is significant is that it makes for a lot of complication in specific scenarios. Conside this:
+	Sessions remain special because the title must be followed by a blank line before content, but the separator *before* the title can be either a blank-line in the current container or simply the boundary after a previous child. Blank lines stay with the container where they appear; they are not hoisted out of children. A boundary (dedent) therefore also counts as a separator when starting a new session sibling. Consider:
 
 	1. I'm the outter session.
 
@@ -327,7 +327,7 @@ These conclude the description of the grammar and syntax. With that in mind, we 
 			I'm just a pargraph.
     :: lex
 
-	Consider the parsing of the middle session. As it's the very first element of the session, the preceding blank line is part of it's parent session. It can see the following blank line before the pargraph just fine, as it belongs to it. But the first blank line is out of it's reach.
+	Consider the parsing of the middle session. As it's the very first element of the session, the preceding blank line is part of it's parent session. It can see the following blank line before the pargraph just fine, as it belongs to it. But the first blank line is out of it's reach. The parser therefore treats either a visible blank line *or* the boundary after the previous child as a valid separator before a new session, keeping blank-line ownership intact while still parsing correctly across container edges.
 
 	The obvious solultion is to imperatively walk the tree up and check if the parent session has a preceding blank line. This works but this makes the grammar context sensitive, and now things are way more complicated, good by simple regular langauge parser.
 

--- a/docs/specs/v1/elements/session/session-13-blankline-issue.lex
+++ b/docs/specs/v1/elements/session/session-13-blankline-issue.lex
@@ -1,0 +1,11 @@
+# Session blank line ownership issue {{paragraph}}
+
+Definition: {{definition}}
+    Within a definition we include a nested list to force trailing blanks to stay inside the container. {{paragraph}}
+
+    - Item one {{list-item}}
+    - Item two {{list-item}}
+
+1. Next session {{session}}
+
+    Content after the disputed blank line. {{paragraph}}

--- a/docs/specs/v1/grammar-core.lex
+++ b/docs/specs/v1/grammar-core.lex
@@ -203,6 +203,11 @@ Grammar for lex
     <session> = <session-title-line> <blank-line> <indent> <session-content>
     <session-content> = (<paragraph> | <list> | <session>)+
 
+    Notes on separators and ownership:
+    - A blank line between the title and the indented content is REQUIRED (disambiguates from definitions).
+    - A session may start at document/container start, after a blank-line group, or immediately after a just-closed child (a boundary). Blank lines stay in the container where they appear; dedent boundaries also act as separators for starting the next session sibling.
+    - Content can include nested sessions, definitions, lists, and paragraphs.
+
     <verbatim-block> = <subject-line> <blank-line>? <verbatim-content>? <closing-annotation>
     <subject-line> = <text-span>+ <colon> <line-break>
     <verbatim-content> = <indent> <raw-text-line>+ <dedent>

--- a/docs/specs/v1/grammar-line.lex
+++ b/docs/specs/v1/grammar-line.lex
@@ -28,7 +28,9 @@ Line Token Grammar for lex
 
         <blank-line> = (<whitespace> | <indentation>)+ <line-break>
         Only whitespace (spaces, tabs, indentation tokens) plus the terminating
-        newline. Resets dialog detection state.
+        newline. Resets dialog detection state. Blank lines remain in the
+        container where they appear; they are not hoisted across indentation
+        boundaries.
 
     3.2. <annotation-end-line>
 

--- a/lex-parser/src/lex/parsing/parser.rs
+++ b/lex-parser/src/lex/parsing/parser.rs
@@ -157,7 +157,7 @@ impl GrammarMatcher {
                                 trailing_blank_range,
                             }
                         }
-                        "session_no_blank" => {
+                        "session" => {
                             // Allow session_no_blank in these cases:
                             // 1. At document start (is_first_item=true), OR
                             // 2. At container start when sessions are allowed (start_idx=0 && allow_sessions=true), OR

--- a/lex-parser/src/lex/parsing/parser.rs
+++ b/lex-parser/src/lex/parsing/parser.rs
@@ -39,6 +39,7 @@ impl GrammarMatcher {
         allow_sessions: bool,
         is_first_item: bool,
         has_preceding_blank: bool,
+        has_preceding_boundary: bool,
         prev_was_session: bool,
     ) -> Option<(PatternMatch, Range<usize>)> {
         if start_idx >= tokens.len() {
@@ -156,30 +157,13 @@ impl GrammarMatcher {
                                 trailing_blank_range,
                             }
                         }
-                        "session_with_blank" => {
-                            let prefix_blank_count = caps
-                                .name("prefix_blank")
-                                .map(|m| Self::count_consumed_tokens(m.as_str()))
-                                .unwrap_or(0);
-                            let blank_str = caps.name("blank").unwrap().as_str();
-                            let blank_count = Self::count_consumed_tokens(blank_str);
-                            let preceding_blank_range = if prefix_blank_count > 0 {
-                                Some(start_idx..start_idx + prefix_blank_count)
-                            } else {
-                                None
-                            };
-                            PatternMatch::Session {
-                                subject_idx: prefix_blank_count,
-                                content_idx: prefix_blank_count + 1 + blank_count,
-                                preceding_blank_range,
-                            }
-                        }
                         "session_no_blank" => {
                             // Allow session_no_blank in these cases:
                             // 1. At document start (is_first_item=true), OR
                             // 2. At container start when sessions are allowed (start_idx=0 && allow_sessions=true), OR
                             // 3. After a BlankLineGroup when sessions are allowed (has_preceding_blank && allow_sessions)
                             // 4. Immediately after another session (prev_was_session && allow_sessions)
+                            // 5. Immediately after a container that just closed (has_preceding_boundary && allow_sessions)
                             // This prevents Sessions inside Definitions while allowing legitimate session sequences.
                             if !allow_sessions {
                                 continue; // Definitions and other containers don't allow sessions
@@ -187,6 +171,7 @@ impl GrammarMatcher {
                             if !(is_first_item
                                 || start_idx == 0
                                 || has_preceding_blank
+                                || has_preceding_boundary
                                 || prev_was_session)
                             {
                                 continue; // Sessions need a separator or another session before them
@@ -417,14 +402,17 @@ fn parse_with_declarative_grammar_internal(
     let mut idx = 0;
 
     while idx < tokens.len() {
-        let (has_preceding_blank, prev_was_session) = if let Some(last_node) = items.last() {
-            (
-                matches!(last_node.node_type, NodeType::BlankLineGroup),
-                matches!(last_node.node_type, NodeType::Session),
-            )
-        } else {
-            (false, false)
-        };
+        let (has_preceding_blank, has_preceding_boundary, prev_was_session) =
+            if let Some(last_node) = items.last() {
+                (
+                    matches!(last_node.node_type, NodeType::BlankLineGroup),
+                    // A node with children indicates we just closed a container; this counts as a boundary.
+                    !last_node.children.is_empty(),
+                    matches!(last_node.node_type, NodeType::Session),
+                )
+            } else {
+                (false, false, false)
+            };
 
         let is_first_item = idx == 0 && is_doc_start;
         if let Some((pattern, range)) = GrammarMatcher::try_match(
@@ -433,6 +421,7 @@ fn parse_with_declarative_grammar_internal(
             allow_sessions,
             is_first_item,
             has_preceding_blank,
+            has_preceding_boundary,
             prev_was_session,
         ) {
             let mut pending_nodes = Vec::new();
@@ -466,9 +455,7 @@ fn parse_with_declarative_grammar_internal(
                     parse_with_declarative_grammar_internal(children, src, is_session, false)
                 },
             )?;
-            let (item, mut trailing_blanks) = split_trailing_blank_groups(item);
             pending_nodes.push(item);
-            pending_nodes.append(&mut trailing_blanks);
 
             if let PatternMatch::List {
                 trailing_blank_range: Some(blank_range),
@@ -486,25 +473,4 @@ fn parse_with_declarative_grammar_internal(
     }
 
     Ok(items)
-}
-
-/// Detach trailing blank-line groups from a node so separators bubble up to the parent level.
-fn split_trailing_blank_groups(mut node: ParseNode) -> (ParseNode, Vec<ParseNode>) {
-    if matches!(node.node_type, NodeType::BlankLineGroup) {
-        return (node, Vec::new());
-    }
-
-    let mut trailing = Vec::new();
-    while node
-        .children
-        .last()
-        .map(|child| matches!(child.node_type, NodeType::BlankLineGroup))
-        .unwrap_or(false)
-    {
-        if let Some(blank) = node.children.pop() {
-            trailing.push(blank);
-        }
-    }
-    trailing.reverse();
-    (node, trailing)
 }

--- a/lex-parser/src/lex/parsing/parser/grammar.rs
+++ b/lex-parser/src/lex/parsing/parser/grammar.rs
@@ -11,11 +11,10 @@
 //! 3. annotation_single - single-line annotation only
 //! 4. list_no_blank - 2+ list items without preceding blank (inside containers)
 //! 5. list - requires preceding blank line + 2+ list items (at root level)
-//! 6. session_with_blank - requires preceding blank + subject + blank + indent
-//! 7. definition - requires subject + immediate indent
-//! 8. session_no_blank - requires subject + blank + indent (at container start)
-//! 9. paragraph - any content-line or sequence thereof
-//! 10. blank_line_group - one or more consecutive blank lines
+//! 6. definition - requires subject + immediate indent
+//! 7. session_no_blank - requires subject + blank + indent (at container start or after separator)
+//! 8. paragraph - any content-line or sequence thereof
+//! 9. blank_line_group - one or more consecutive blank lines
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -60,11 +59,6 @@ pub(super) const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
     (
         "list",
         r"^(?P<blank><blank-line>+)(?P<items>((<list-line>|<subject-or-list-item-line>)(<container>)?){2,})(?P<trailing_blank><blank-line>)?",
-    ),
-    // Session with preceding blank line (for sessions inside containers)
-    (
-        "session_with_blank",
-        r"^(?P<prefix_blank><blank-line>+)(?P<subject><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank><blank-line>+)(?P<content><container>)",
     ),
     // Definition: <subject-line>|<subject-or-list-item-line>|<paragraph-line><container>
     (

--- a/lex-parser/src/lex/parsing/parser/grammar.rs
+++ b/lex-parser/src/lex/parsing/parser/grammar.rs
@@ -12,7 +12,7 @@
 //! 4. list_no_blank - 2+ list items without preceding blank (inside containers)
 //! 5. list - requires preceding blank line + 2+ list items (at root level)
 //! 6. definition - requires subject + immediate indent
-//! 7. session_no_blank - requires subject + blank + indent (at container start or after separator)
+//! 7. session - requires subject + blank + indent (at container start or after separator)
 //! 8. paragraph - any content-line or sequence thereof
 //! 9. blank_line_group - one or more consecutive blank lines
 
@@ -65,9 +65,9 @@ pub(super) const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
         "definition",
         r"^(?P<subject><subject-line>|<subject-or-list-item-line>|<paragraph-line>)(?P<content><container>)",
     ),
-    // Session without preceding blank line (for sessions at container start)
+    // Session (requires subject + blank + indented content, allowed at start or after separator)
     (
-        "session_no_blank",
+        "session",
         r"^(?P<subject><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank><blank-line>+)(?P<content><container>)",
     ),
     // Paragraph: <content-line>+

--- a/lex-parser/tests/snapshots/parser_kitchensink__parser_kitchensink_snapshot.snap
+++ b/lex-parser/tests/snapshots/parser_kitchensink__parser_kitchensink_snapshot.snap
@@ -1,8 +1,9 @@
 ---
 source: lex-parser/tests/parser_kitchensink.rs
+assertion_line: 16
 expression: snapshot
 ---
-Document with 16 root items:
+Document with 12 root items:
 
 [0] Paragraph with 1 line(s):   [0] TextLine: Kitchensink Test Document {{paragraph}}
 [1] BlankLineGroup with 1 line(s)
@@ -12,17 +13,17 @@ Document with 16 root items:
   [0] TextLine: This is a two-lined paragraph.
   [1] TextLine: First, a simple _definition_ at the root level. {{paragraph}}
 [5] BlankLineGroup with 1 line(s)
-[6] Definition with 3 item(s):
+[6] Definition with 5 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This definition contains a paragraph and a `list` to test mixed content at the top level. {{definition}}
   [1] BlankLineGroup with 1 line(s)
   [2] List with 2 item(s):
     [0] List item with 0 content item(s):
     [1] List item with 0 content item(s):
-[7] BlankLineGroup with 1 line(s)
+  [3] BlankLineGroup with 1 line(s)
+  [4] BlankLineGroup with 1 line(s)
+[7] Paragraph with 1 line(s):   [0] TextLine: This is a marker annotation at the root level, attached to the definition above.
 [8] BlankLineGroup with 1 line(s)
-[9] Paragraph with 1 line(s):   [0] TextLine: This is a marker annotation at the root level, attached to the definition above.
-[10] BlankLineGroup with 1 line(s)
-[11] Session with 9 item(s):
+[9] Session with 9 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session acts as the main container for testing nested structures. It starts with a simple paragraph. {{paragraph}}
   [1] BlankLineGroup with 1 line(s)
   [2] List with 2 item(s):
@@ -33,14 +34,14 @@ Document with 16 root items:
   [5] Session with 5 item(s):
     [0] Paragraph with 1 line(s):       [0] TextLine: This is a second-level session containing a definition and a list with nested content. {{paragraph}}
     [1] BlankLineGroup with 1 line(s)
-    [2] Definition with 3 item(s):
+    [2] Definition with 4 item(s):
       [0] Paragraph with 1 line(s):         [0] TextLine: This definition is inside a nested session and contains a list. {{definition}}
       [1] BlankLineGroup with 1 line(s)
       [2] List with 2 item(s):
         [0] List item with 0 content item(s):
         [1] List item with 0 content item(s):
-    [3] BlankLineGroup with 1 line(s)
-    [4] List with 2 item(s):
+      [3] BlankLineGroup with 1 line(s)
+    [3] List with 2 item(s):
       [0] List item with 3 content item(s):
         [0] Paragraph with 1 line(s):           [0] TextLine: This list item contains a nested paragraph. {{paragraph}}
         [1] BlankLineGroup with 1 line(s)
@@ -48,13 +49,13 @@ Document with 16 root items:
           [0] List item with 0 content item(s):
           [1] List item with 0 content item(s):
       [1] List item with 0 content item(s):
-  [6] BlankLineGroup with 1 line(s)
-  [7] Paragraph with 1 line(s):     [0] TextLine: A paragraph back at the first level of nesting. {{paragraph}}
-  [8] VerbatimBlock with 72 content char(s)
-[12] BlankLineGroup with 1 line(s)
-[13] Session with 3 item(s):
+    [4] BlankLineGroup with 1 line(s)
+  [6] Paragraph with 1 line(s):     [0] TextLine: A paragraph back at the first level of nesting. {{paragraph}}
+  [7] VerbatimBlock with 72 content char(s)
+  [8] BlankLineGroup with 1 line(s)
+[10] Session with 4 item(s):
   [0] Paragraph with 1 line(s):     [0] TextLine: This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}
   [1] BlankLineGroup with 1 line(s)
   [2] VerbatimBlock with 0 content char(s)
-[14] BlankLineGroup with 1 line(s)
-[15] Paragraph with 1 line(s):   [0] TextLine: Final paragraph at the end of the document. {{paragraph}}
+  [3] BlankLineGroup with 1 line(s)
+[11] Paragraph with 1 line(s):   [0] TextLine: Final paragraph at the end of the document. {{paragraph}}


### PR DESCRIPTION
  - Keep blank lines owned by their containers while allowing sessions to start after either a blank-line
  group or a boundary (dedent), eliminating the old session_with_blank rule and renaming the remaining
  session pattern to session.
  - Add a focused fixture for the blank-line boundary case and refresh the kitchensink snapshot to match
  the new ownership model.
  - Update grammar docs and the overview guide to explain separator rules (blank vs boundary) and the non-
  hoisting behavior of blank lines.

  Tests: cargo test -p lex-parser -- --nocapture

  Closes #266.