### PR TITLE
fix: preserve leading blank lines in verbatim blocks

### DIFF
--- a/docs/specs/v1/elements/verbatim/verbatim-15-inflow-leading-blank.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim-15-inflow-leading-blank.lex
@@ -1,0 +1,5 @@
+Inflow Leading Blank:
+    
+    echo "first"
+    echo "second"
+:: shell

--- a/docs/specs/v1/elements/verbatim/verbatim-17-fullwidth-leading-blank.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim-17-fullwidth-leading-blank.lex
@@ -1,0 +1,5 @@
+Fullwidth Leading Blank:
+
+ Header | Value
+ Data   | More
+:: table

--- a/docs/specs/v1/elements/verbatim/verbatim.lex
+++ b/docs/specs/v1/elements/verbatim/verbatim.lex
@@ -84,6 +84,7 @@ Content Preservation
 		- All whitespace (spaces, blank lines)
 		- Special characters (no escaping needed)
 		- Indentation beyond the wall (part of content)
+		- Leading blank lines after the subject stay in the payload
 
 	Example:
 		Code:

--- a/lex-parser/src/lex/building/extraction/verbatim.rs
+++ b/lex-parser/src/lex/building/extraction/verbatim.rs
@@ -135,8 +135,6 @@ fn detect_mode(content_lines: &[LineToken], source: &str) -> VerbatimBlockMode {
 ///
 /// 1. Start with the first subject and empty content accumulator
 /// 2. For each content line:
-///    - Skip leading blank lines before any content is accumulated (these belong
-///      to the previous group or are inter-group spacing)
 ///    - If the line is a subject at `base_subject_column`, it starts a new group:
 ///      push the accumulated (subject, content) pair and start fresh
 ///    - Otherwise, add the line to the current group's content
@@ -145,8 +143,8 @@ fn detect_mode(content_lines: &[LineToken], source: &str) -> VerbatimBlockMode {
 /// # Invariants
 ///
 /// - All group subjects must be at the same indentation level (`base_subject_column`)
-/// - Blank lines between groups (before any content) are skipped
-/// - Blank lines within a group's content are preserved
+/// - Blank lines between groups stay attached to the previous group's content
+/// - Leading blank lines after a subject are preserved as part of that group's content
 /// - Returns at least one group (the first subject with possibly empty content)
 ///
 /// # Arguments
@@ -170,15 +168,6 @@ fn split_groups(
     let mut current_content: Vec<LineToken> = Vec::new();
 
     for line in content_lines {
-        // Skip blank lines that appear before any content is accumulated.
-        // These are inter-group spacing and don't belong to the current group.
-        if line.line_type == LineType::BlankLine
-            && is_effectively_blank(line)
-            && current_content.is_empty()
-        {
-            continue;
-        }
-
         // Check if this line starts a new group (subject at base indentation).
         if is_new_group_subject(line, base_subject_column, source) {
             // Save the current group and start a new one

--- a/lex-parser/src/lex/testing/ast_assertions/assertions/verbatim.rs
+++ b/lex-parser/src/lex/testing/ast_assertions/assertions/verbatim.rs
@@ -69,6 +69,34 @@ impl<'a> VerbatimBlockkAssertion<'a> {
         );
         self
     }
+
+    pub fn line_eq(self, index: usize, expected: &str) -> Self {
+        let line = self.verbatim_block.children.get(index).unwrap_or_else(|| {
+            panic!(
+                "{}: Verbatim line index {} out of bounds ({} lines)",
+                self.context,
+                index,
+                self.verbatim_block.children.len()
+            )
+        });
+
+        match line {
+            ContentItem::VerbatimLine(line) => {
+                let actual = line.content.as_string();
+                assert_eq!(
+                    actual, expected,
+                    "{}: Expected verbatim line {} to be '{}', but got '{}'",
+                    self.context, index, expected, actual
+                );
+            }
+            other => panic!(
+                "{}: Expected verbatim line at index {}, found {:?}",
+                self.context, index, other
+            ),
+        }
+
+        self
+    }
     pub fn has_closing_parameter_with_value(self, key: &str, value: &str) -> Self {
         let found = self
             .verbatim_block
@@ -182,6 +210,34 @@ impl<'a> VerbatimGroupAssertion<'a> {
             "{}: Expected verbatim group to have {} lines, but got {}",
             self.context, expected, actual
         );
+        self
+    }
+
+    pub fn line_eq(self, index: usize, expected: &str) -> Self {
+        let line = self.children.get(index).unwrap_or_else(|| {
+            panic!(
+                "{}: Verbatim group line index {} out of bounds ({} lines)",
+                self.context,
+                index,
+                self.children.len()
+            )
+        });
+
+        match line {
+            ContentItem::VerbatimLine(line) => {
+                let actual = line.content.as_string();
+                assert_eq!(
+                    actual, expected,
+                    "{}: Expected verbatim group line {} to be '{}', but got '{}'",
+                    self.context, index, expected, actual
+                );
+            }
+            other => panic!(
+                "{}: Expected verbatim line at index {}, found {:?}",
+                self.context, index, other
+            ),
+        }
+
         self
     }
 


### PR DESCRIPTION
## Summary
- preserve leading blank lines inside verbatim blocks in both inflow and fullwidth modes
- add fixtures/tests for leading-blank verbatim content and strengthen assertions to check exact lines
- document preservation guarantee in the verbatim spec

## Testing
- cargo test -p lex-parser --test elements_verbatim
- cargo test -p lex-parser
- ./scripts/pre-commit --all

Closes #276.
