### PR TITLE
refactor(parser): attach document during assembling

### DIFF
--- a/docs/dev/guides/fast-track.lex
+++ b/docs/dev/guides/fast-track.lex
@@ -42,15 +42,16 @@ This is a high level overview of how the Lex parser is designed.
 
 
 	3. AST Building (part of STRING_TO_AST)
-		ParseNode → Document
+		ParseNode → Session (root tree)
 	- Walks IR tree creating final AST nodes
 	- Unrolls source tokens so AST nodes have access to token values
 	- Translates byte ranges to AST Location objects (line:column positions)
-	- Creates Document node with root Session
+	- Produces the root Session tree that represents document content
 
 
 	4. Document Assembly (part of STRING_TO_AST)
-		Document → Document
+		Session → Document → Document
+	- Wraps the built Session tree in a Document node
 	- Attaches annotations from content to AST nodes as metadata
 	- Calculates "human understanding" distance for ambiguous cases
 	- Post-parsing transformations on the complete AST
@@ -115,7 +116,7 @@ This is a high level overview of how the Lex parser is designed.
 
 5. AST Structure
 
-	Document is the root node, containing:
+	Document is the root node constructed during assembling, containing:
 	- Root Session: The content tree (sessions can nest arbitrarily)
 	- Annotations: Document-level metadata
 

--- a/docs/dev/guides/on-all-of-lex.lex
+++ b/docs/dev/guides/on-all-of-lex.lex
@@ -219,12 +219,12 @@ These conclude the description of the grammar and syntax. With that in mind, we 
 			1. We unroll source tokens so that ast nodes have acccess to token values .
 			2. The location from tokens is used to calculate the location for the the ast node.
             3. The location is transformed from  byte range to a dual byte range + line:column position.
-        At this stage we create the Document node, it's root session node and the ast will be attached to it. 
+        At this stage we create the root Session tree; the Document wrapper will be attached during the assembling stage. 
 
 
 	5.4 Document assembly
 
-		We do have a document ast node, but it's not yet complete. Annotations, which are metadata, are always attached to AST nodes, so they can be very targeted.  Only with the full document in place we can attach annotations to their correct target nodes.[10]
+		We start with the root session tree from the builder and wrap it in the Document node. With the full document in place, annotations—which are metadata—are attached to AST nodes so they can be very targeted.  Only with the document assembled can we attach annotations to their correct target nodes.[10]
 		This is harder than it seems. Keeping Lex ethos of not enforcing structure, this needs to deal with several ambiguous cases, including some complex logic for calculating "human understanding" distance between elements[12].
 
 	5.5 Inline Parsing

--- a/lex-parser/src/lex/assembling.rs
+++ b/lex-parser/src/lex/assembling.rs
@@ -4,9 +4,10 @@
 //!     post-parsing transformations. Unlike the parsing stage which converts tokens to AST,
 //!     assembling stages operate on the AST itself.
 //!
-//!     We do have a document ast node, but it's not yet complete. Annotations, which are
-//!     metadata, are always attached to AST nodes, so they can be very targeted. Only with
-//!     the full document in place we can attach annotations to their correct target nodes.
+//!     The builder returns the root session tree, so assembling first wraps it in a
+//!     [`Document`](crate::lex::ast::Document). Annotations, which are metadata, are always
+//!     attached to AST nodes so they can be very targeted. Only with the full document in
+//!     place can we attach annotations to their correct target nodes.
 //!
 //!     This is harder than it seems. Keeping Lex ethos of not enforcing structure, this needs
 //!     to deal with several ambiguous cases, including some complex logic for calculating

--- a/lex-parser/src/lex/assembling.rs
+++ b/lex-parser/src/lex/assembling.rs
@@ -14,9 +14,10 @@
 //!
 //! Current stages:
 //!
+//!     - `attach_root`: Wraps the built session tree in a [`Document`].
 //!     - `attach_annotations`: Attaches annotations from content to AST nodes as metadata.
 //!       See [attach_annotations](stages::attach_annotations) for details.
 
 pub mod stages;
 
-pub use stages::AttachAnnotations;
+pub use stages::{AttachAnnotations, AttachRoot};

--- a/lex-parser/src/lex/assembling/stages.rs
+++ b/lex-parser/src/lex/assembling/stages.rs
@@ -4,5 +4,7 @@
 //! Each stage implements the `Runnable` trait.
 
 pub mod attach_annotations;
+pub mod attach_root;
 
 pub use attach_annotations::AttachAnnotations;
+pub use attach_root::AttachRoot;

--- a/lex-parser/src/lex/assembling/stages/attach_root.rs
+++ b/lex-parser/src/lex/assembling/stages/attach_root.rs
@@ -1,0 +1,29 @@
+//! Document attachment stage
+//!
+//! This stage receives the fully built root session tree from the building phase
+//! and attaches it to a `Document` node. Downstream assembling steps (like
+//! annotation attachment) can then operate on the complete document structure.
+
+use crate::lex::ast::{Document, Session};
+use crate::lex::transforms::{Runnable, TransformError};
+
+/// Attach the root session returned by the builder to a `Document` node.
+pub struct AttachRoot;
+
+impl AttachRoot {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AttachRoot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Runnable<Session, Document> for AttachRoot {
+    fn run(&self, root: Session) -> Result<Document, TransformError> {
+        Ok(Document::from_root(root))
+    }
+}

--- a/lex-parser/src/lex/ast/elements/document.rs
+++ b/lex-parser/src/lex/ast/elements/document.rs
@@ -65,6 +65,14 @@ impl Document {
         }
     }
 
+    /// Construct a document from an existing root session.
+    pub fn from_root(root: Session) -> Self {
+        Self {
+            annotations: Vec::new(),
+            root,
+        }
+    }
+
     pub fn with_annotations_and_content(
         annotations: Vec<Annotation>,
         content: Vec<ContentItem>,

--- a/lex-parser/src/lex/building.rs
+++ b/lex-parser/src/lex/building.rs
@@ -8,8 +8,8 @@
 //!         3. The location is transformed from byte range to a dual byte range + line:column
 //!            position.
 //!
-//!     At this stage we create the Document node, its root session node and the ast will be
-//!     attached to it.
+//!     At this stage we create the root session tree, which will later be attached to the
+//!     [`Document`](crate::lex::ast::Document) during assembling.
 //!
 //! Three-Layer Architecture
 //!

--- a/lex-parser/src/lex/parsing.rs
+++ b/lex-parser/src/lex/parsing.rs
@@ -38,16 +38,17 @@
 //!                 2. The location from tokens is used to calculate the location for the ast node.
 //!                 3. The location is transformed from byte range to a dual byte range + line:column
 //!                    position.
-//!             At this stage we create the Document node, its root session node and the ast will
-//!             be attached to it.
+//!             At this stage we create the root session node; it will be attached to the
+//!             [`Document`] during assembling.
 //!
 //!         Document Assembly (5.4):
-//!             We do have a document ast node, but it's not yet complete. Annotations, which are
-//!             metadata, are always attached to AST nodes, so they can be very targeted. Only
-//!             with the full document in place we can attach annotations to their correct target
-//!             nodes. This is harder than it seems. Keeping Lex ethos of not enforcing structure,
-//!             this needs to deal with several ambiguous cases, including some complex logic for
-//!             calculating "human understanding" distance between elements.
+//!             The assembling stage wraps the root session into a document node and performs
+//!             metadata attachment. Annotations, which are metadata, are always attached to AST
+//!             nodes, so they can be very targeted. Only with the full document in place we can
+//!             attach annotations to their correct target nodes. This is harder than it seems.
+//!             Keeping Lex ethos of not enforcing structure, this needs to deal with several
+//!             ambiguous cases, including some complex logic for calculating "human
+//!             understanding" distance between elements.
 //!
 //!         Inline Parsing (5.5):
 //!             Finally, with the full and correctly annotated document, we will parse the

--- a/lex-parser/src/lex/parsing.rs
+++ b/lex-parser/src/lex/parsing.rs
@@ -91,7 +91,8 @@ type ProcessResult = Result<Document, String>;
 /// This is the primary entry point for processing lex documents. It performs:
 /// 1. Lexing: Tokenizes the source text
 /// 2. Analysis: Performs syntactic analysis to produce IR nodes
-/// 3. Building: Constructs the final AST from IR nodes
+/// 3. Building: Constructs the root session tree from IR nodes (assembling wraps it in a
+///    `Document` and attaches metadata)
 ///
 /// # Arguments
 ///

--- a/lex-parser/src/lex/testing.rs
+++ b/lex-parser/src/lex/testing.rs
@@ -247,8 +247,10 @@ pub fn workspace_path(relative_path: &str) -> std::path::PathBuf {
 pub fn parse_without_annotation_attachment(
     source: &str,
 ) -> Result<crate::lex::ast::Document, String> {
+    use crate::lex::assembling::AttachRoot;
     use crate::lex::parsing::engine::parse_from_flat_tokens;
     use crate::lex::transforms::standard::LEXING;
+    use crate::lex::transforms::Runnable;
 
     let source = if !source.is_empty() && !source.ends_with('\n') {
         format!("{}\n", source)
@@ -256,5 +258,6 @@ pub fn parse_without_annotation_attachment(
         source.to_string()
     };
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
-    parse_from_flat_tokens(tokens, &source).map_err(|e| e.to_string())
+    let root = parse_from_flat_tokens(tokens, &source).map_err(|e| e.to_string())?;
+    AttachRoot::new().run(root).map_err(|e| e.to_string())
 }

--- a/lex-parser/src/lex/testing.rs
+++ b/lex-parser/src/lex/testing.rs
@@ -259,5 +259,6 @@ pub fn parse_without_annotation_attachment(
     };
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
     let root = parse_from_flat_tokens(tokens, &source).map_err(|e| e.to_string())?;
+    // Assemble the root session into a Document but skip metadata attachment
     AttachRoot::new().run(root).map_err(|e| e.to_string())
 }

--- a/lex-parser/tests/parameter_proptest.rs
+++ b/lex-parser/tests/parameter_proptest.rs
@@ -6,10 +6,12 @@
 //! - Parameters are separated by commas only (not whitespace)
 //! - Whitespace around parameters is ignored
 
+use lex_parser::lex::assembling::AttachRoot;
 use lex_parser::lex::parsing::engine::parse_from_flat_tokens;
 use lex_parser::lex::parsing::{parse_document, ContentItem, Document};
 use lex_parser::lex::testing::assert_ast;
 use lex_parser::lex::transforms::standard::LEXING;
+use lex_parser::lex::transforms::Runnable;
 use proptest::prelude::*;
 
 fn parse_annotation_without_attachment(source: &str) -> Result<Document, String> {
@@ -19,7 +21,8 @@ fn parse_annotation_without_attachment(source: &str) -> Result<Document, String>
         source.to_string()
     };
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
-    parse_from_flat_tokens(tokens, &source)
+    let root = parse_from_flat_tokens(tokens, &source)?;
+    AttachRoot::new().run(root).map_err(|e| e.to_string())
 }
 
 /// Generate valid parameter keys


### PR DESCRIPTION
## Summary
- move Document construction out of the builder so it only returns the root session tree
- add an assembling stage that wraps the built tree in a Document before further assembly
- update parsing helpers/tests to use the new attachment stage

## Testing
- cargo test -p lex-parser
