### PR TITLE
refactor(parser): run inline parsing before assembly

### DIFF
--- a/docs/dev/guides/fast-track.lex
+++ b/docs/dev/guides/fast-track.lex
@@ -49,19 +49,19 @@ This is a high level overview of how the Lex parser is designed.
 	- Produces the root Session tree that represents document content
 
 
-	4. Document Assembly (part of STRING_TO_AST)
+	4. Inline Parsing (ParseInlines stage)
+		Session → Session
+	- Runs immediately after building while annotations are still content items
+	- Parses TextContent nodes for inline elements (bold, italic, references, etc.)
+	- Uses declarative engine with formal start/end tokens
+
+
+	5. Document Assembly (part of STRING_TO_AST)
 		Session → Document → Document
 	- Wraps the built Session tree in a Document node
 	- Attaches annotations from content to AST nodes as metadata
 	- Calculates "human understanding" distance for ambiguous cases
 	- Post-parsing transformations on the complete AST
-
-
-	5. Inline Parsing (ParseInlines stage)
-		Document → Document
-	- Parses TextContent nodes for inline elements (bold, italic, references, etc.)
-	- Uses declarative engine with formal start/end tokens
-	- Much simpler than block parsing (no structural elements)
 
 
 	Standard pipelines:

--- a/docs/dev/guides/on-all-of-lex.lex
+++ b/docs/dev/guides/on-all-of-lex.lex
@@ -222,17 +222,17 @@ These conclude the description of the grammar and syntax. With that in mind, we 
         At this stage we create the root Session tree; the Document wrapper will be attached during the assembling stage. 
 
 
-	5.4 Document assembly
+	5.4 Inline Parsing
 
-		We start with the root session tree from the builder and wrap it in the Document node. With the full document in place, annotations—which are metadata—are attached to AST nodes so they can be very targeted.  Only with the document assembled can we attach annotations to their correct target nodes.[10]
-		This is harder than it seems. Keeping Lex ethos of not enforcing structure, this needs to deal with several ambiguous cases, including some complex logic for calculating "human understanding" distance between elements[12].
-
-	5.5 Inline Parsing
-
-		Finally, with the full and correctly annotated document, we will parse the TextContent nodes for inline elements. This parsing is much simpler, as it has formal start/end tokens as has no structural elements.
+		With the root session in place—but before annotations are attached—we parse the TextContent nodes for inline elements. This parsing is much simpler, as it has formal start/end tokens and has no structural elements.
 
 		Inline parsing is done by a declarative engine that will process each element declaration.[11] For some , this is a flat transformation (i.e. it only wraps up the text into a node, as in bold or italic). Others are more involved, as in references, in which the engine will execute a callback with the text content and return a node. 
 		This solves elegantly the fact that most inlines are simple and very much the same structure, while allowing for more complex ones to handle their specific needs. 
+
+	5.5 Document assembly
+
+		We start with the inline-parsed session tree from the builder and wrap it in the Document node. With the full document in place, annotations—which are metadata—are attached to AST nodes so they can be very targeted.  Only with the document assembled can we attach annotations to their correct target nodes.[10]
+		This is harder than it seems. Keeping Lex ethos of not enforcing structure, this needs to deal with several ambiguous cases, including some complex logic for calculating "human understanding" distance between elements[12].
 
 
 6. Structure, Children, Indentation and the AST

--- a/lex-parser/src/lex/inlines.rs
+++ b/lex-parser/src/lex/inlines.rs
@@ -4,9 +4,9 @@
 //!     (formatting, code, math). Later stages layer references and citations on top of the
 //!     same building blocks.
 //!
-//!     Finally, with the full and correctly annotated document, we will parse the TextContent
-//!     nodes for inline elements. This parsing is much simpler than block parsing, as it has
-//!     formal start/end tokens and has no structural elements.
+//!     Immediately after building (before annotations are attached in the assembly stage),
+//!     we parse the TextContent nodes for inline elements. This parsing is much simpler than
+//!     block parsing, as it has formal start/end tokens and has no structural elements.
 //!
 //!     Inline parsing is done by a declarative engine that will process each element declaration.
 //!     For some, this is a flat transformation (i.e. it only wraps up the text into a node, as

--- a/lex-parser/src/lex/parsing.rs
+++ b/lex-parser/src/lex/parsing.rs
@@ -4,8 +4,8 @@
 //!         1. Lexing: Tokenization of source text. See [lexing](crate::lex::lexing) module.
 //!         2. Analysis: Syntactic analysis to produce IR nodes. See [engine](engine) module.
 //!         3. Building: Construction of AST from IR nodes. See [building](crate::lex::building) module.
-//!         4. Assembling: Post-parsing transformations. See [assembling](crate::lex::assembling) module.
-//!         5. Inline Parsing: Parse inline elements in text content. See [inlines](crate::lex::inlines) module.
+//!         4. Inline Parsing: Parse inline elements in text content. See [inlines](crate::lex::inlines) module.
+//!         5. Assembling: Post-parsing transformations. See [assembling](crate::lex::assembling) module.
 //!
 //! Parsing End To End
 //!
@@ -41,7 +41,12 @@
 //!             At this stage we create the root session node; it will be attached to the
 //!             [`Document`] during assembling.
 //!
-//!         Document Assembly (5.4):
+//!         Inline Parsing (5.4):
+//!             Before assembling the document (while annotations are still part of the content
+//!             tree), we parse the TextContent nodes for inline elements. This parsing is much
+//!             simpler, as it has formal start/end tokens and has no structural elements.
+//!
+//!         Document Assembly (5.5):
 //!             The assembling stage wraps the root session into a document node and performs
 //!             metadata attachment. Annotations, which are metadata, are always attached to AST
 //!             nodes, so they can be very targeted. Only with the full document in place we can
@@ -49,11 +54,6 @@
 //!             Keeping Lex ethos of not enforcing structure, this needs to deal with several
 //!             ambiguous cases, including some complex logic for calculating "human
 //!             understanding" distance between elements.
-//!
-//!         Inline Parsing (5.5):
-//!             Finally, with the full and correctly annotated document, we will parse the
-//!             TextContent nodes for inline elements. This parsing is much simpler, as it has
-//!             formal start/end tokens and has no structural elements.
 //!
 //! Terminology
 //!

--- a/lex-parser/src/lex/testing.rs
+++ b/lex-parser/src/lex/testing.rs
@@ -249,6 +249,7 @@ pub fn parse_without_annotation_attachment(
 ) -> Result<crate::lex::ast::Document, String> {
     use crate::lex::assembling::AttachRoot;
     use crate::lex::parsing::engine::parse_from_flat_tokens;
+    use crate::lex::transforms::stages::ParseInlines;
     use crate::lex::transforms::standard::LEXING;
     use crate::lex::transforms::Runnable;
 
@@ -259,6 +260,7 @@ pub fn parse_without_annotation_attachment(
     };
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
     let root = parse_from_flat_tokens(tokens, &source).map_err(|e| e.to_string())?;
+    let root = ParseInlines::new().run(root).map_err(|e| e.to_string())?;
     // Assemble the root session into a Document but skip metadata attachment
     AttachRoot::new().run(root).map_err(|e| e.to_string())
 }

--- a/lex-parser/src/lex/transforms/stages/inline_parsing.rs
+++ b/lex-parser/src/lex/transforms/stages/inline_parsing.rs
@@ -1,6 +1,6 @@
 use crate::lex::ast::{
-    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Session, TextContent,
-    TextLine, Verbatim,
+    Annotation, ContentItem, Definition, List, ListItem, Paragraph, Session, TextContent, TextLine,
+    Verbatim,
 };
 use crate::lex::transforms::{Runnable, TransformError};
 
@@ -19,9 +19,9 @@ impl Default for ParseInlines {
     }
 }
 
-impl Runnable<Document, Document> for ParseInlines {
-    fn run(&self, mut input: Document) -> Result<Document, TransformError> {
-        InlineProcessor.process_document(&mut input);
+impl Runnable<Session, Session> for ParseInlines {
+    fn run(&self, mut input: Session) -> Result<Session, TransformError> {
+        InlineProcessor.process_session(&mut input);
         Ok(input)
     }
 }
@@ -29,13 +29,6 @@ impl Runnable<Document, Document> for ParseInlines {
 struct InlineProcessor;
 
 impl InlineProcessor {
-    fn process_document(&self, document: &mut Document) {
-        for annotation in &mut document.annotations {
-            self.process_annotation(annotation);
-        }
-        self.process_session(&mut document.root);
-    }
-
     fn process_session(&self, session: &mut Session) {
         self.process_text_content(&mut session.title);
         for annotation in &mut session.annotations {

--- a/lex-parser/src/lex/transforms/standard.rs
+++ b/lex-parser/src/lex/transforms/standard.rs
@@ -122,14 +122,14 @@ pub static STRING_TO_AST: Lazy<AstTransform> =
                     message: e.to_string(),
                 })?;
 
+            // Parse inline elements before assembly
+            let root = ParseInlines::new().run(root)?;
+
             // Attach root session to a document
             let mut doc = AttachRoot::new().run(root)?;
 
             // Attach annotations as metadata
             doc = AttachAnnotations::new().run(doc)?;
-
-            // Parse inline elements across all TextContent nodes
-            doc = ParseInlines::new().run(doc)?;
 
             Ok(doc)
         })


### PR DESCRIPTION
## Summary
- move the inline parsing transform immediately after AST building so text nodes are parsed before annotations get attached
- update testing/helpers and the standard transform pipeline to use the Session→Session inline stage
- refresh docs/guides to describe the new pipeline ordering

## Testing
- cargo test -p lex-parser
