### PR TITLE
feat(markdown): add importer fixtures and cli test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +135,17 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -386,6 +412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +482,15 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -626,10 +667,12 @@ dependencies = [
 name = "lex-cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "clap_complete",
  "lex-babel",
  "lex-parser",
+ "predicates",
  "serde_json",
 ]
 
@@ -816,6 +859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1035,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1504,6 +1583,12 @@ dependencies = [
  "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/README.txt
+++ b/README.txt
@@ -14,3 +14,18 @@ Documentation Structure.
     Inside each version: 
         1. general.lex -> A introduction to the format, which includes general points,like character encoding a description of each major element type.
         2. grammar.lex -> the syntax and grammar/syntax defs for the language, using the simplified BNF-like described in the document
+
+Working with Markdown input.
+
+    The markdown importer lives in lex-babel and is powered by the comrak crate. We keep
+    reference fixtures under lex-babel/tests/fixtures/, including copies of the CommonMark
+    and Comrak READMEs with attribution headers. The importer converts Markdown → IR →
+    Lex AST before being consumed by other formats such as the tag/treeviz visualizers.
+
+    Recommended workflows:
+        - Run `cargo test -p lex-babel markdown::import` to exercise the element/unit suites.
+        - Run `cargo test -p lex-cli` to ensure the CLI can ingest Markdown inputs.
+        - Inspect Markdown on the shell via `cargo run --bin lex -- path/to/doc.md --to tag`
+          (auto-detected `--from markdown`).
+
+    The CLI test + command above mirror the manual debugging flow mentioned in docs/dev/guides.

--- a/docs/dev/proposals/babel.lex
+++ b/docs/dev/proposals/babel.lex
@@ -20,11 +20,11 @@ Implementation Phases
 		-   Implement LexFormat (parser delegation, serializer)
 		-   Ensure round-trip capability for Lex documents
 
-	Phase 3: Markdown Support
+	Phase 3: Markdown Support DONE
 		-   Add comrak dependency to lex-babel
 		-   Implement interop::markdown (Lex � comrak AST)
 		-   Implement MarkdownFormat (bidirectional)
-		-   Add lex convert --from markdown --to lex
-		-   Add lex convert --from lex --to markdown
+		-   Add lex convert markdown support (auto-detected .md inputs)
+		-   Add importer regression fixtures and CLI verification docs
 
 	from there on it's all abouting adding additional format, being html then pandoc the next priorities.	

--- a/lex-babel/README.lex
+++ b/lex-babel/README.lex
@@ -109,6 +109,12 @@ the export implementation for testing.
     - LaTeX: Common LaTeX document patterns
 
     Create: tests/fixtures/<format>-reference.<ext> with representative examples
+    - Markdown currently snapshots:
+        * tests/fixtures/markdown-reference-commonmark.md (CommonMark spec README)
+        * tests/fixtures/markdown-reference-comrak.md (Comrak README)
+      These are imported in lex-babel/tests/markdown/import.rs and asserted via insta snapshots.
+      Verify round-trips from the CLI with:
+        cargo run --bin lex -- lex-babel/tests/fixtures/markdown-reference-commonmark.md --to tag
 
 1. What to test: as a general rule we want to have:
 

--- a/lex-babel/tests/fixtures/markdown-reference-commonmark.md
+++ b/lex-babel/tests/fixtures/markdown-reference-commonmark.md
@@ -1,0 +1,197 @@
+<!-- Reference fixture sourced from https://github.com/commonmark/commonmark-spec/blob/master/README.md on 2025-11-21; see upstream repo for license details. -->
+
+CommonMark
+==========
+
+CommonMark is a rationalized version of Markdown syntax,
+with a [spec][the spec] and BSD-licensed reference
+implementations in C and JavaScript.
+
+[Try it now!](https://spec.commonmark.org/dingus/)
+
+[the spec]:  https://spec.commonmark.org/
+
+For more details, see <https://commonmark.org>.
+
+This repository contains the spec itself, along with tools for
+running tests against the spec, and for creating HTML and PDF versions
+of the spec.
+
+The reference implementations live in separate repositories:
+
+- <https://github.com/commonmark/cmark> (C)
+- <https://github.com/commonmark/commonmark.js> (JavaScript)
+
+There is a list of third-party libraries
+in a dozen different languages
+[here](https://github.com/commonmark/CommonMark/wiki/List-of-CommonMark-Implementations).
+
+Running tests against the spec
+------------------------------
+
+[The spec] contains over 500 embedded examples which serve as conformance
+tests. To run the tests using an executable `$PROG`:
+
+    python3 test/spec_tests.py --program $PROG
+
+If you want to extract the raw test data from the spec without
+actually running the tests, you can do:
+
+    python3 test/spec_tests.py --dump-tests
+
+and you'll get all the tests in JSON format.
+
+JavaScript developers may find it more convenient to use the
+[`commonmark-spec` npm package], which is published from this
+repository.  It exports an array `tests` of JSON objects with
+the format
+
+```json
+{
+  "markdown": "Foo\nBar\n---\n",
+  "html": "<h2>Foo\nBar</h2>\n",
+  "section": "Setext headings",
+  "number": 65
+}
+```
+
+[`commonmark-spec` npm package]: https://www.npmjs.com/package/commonmark-spec
+
+The spec
+--------
+
+The source of [the spec] is `spec.txt`.  This is basically a Markdown
+file, with code examples written in a shorthand form:
+
+    ```````````````````````````````` example
+    Markdown source
+    .
+    expected HTML output
+    ````````````````````````````````
+
+To build an HTML version of the spec, do `make spec.html`.  To build a
+PDF version, do `make spec.pdf`.  For both versions, you must
+have the lua rock `lcmark` installed:  after installing lua and
+lua rocks, `luarocks install lcmark`.  For the PDF you must also
+have xelatex installed.
+
+The spec is written from the point of view of the human writer, not
+the computer reader.  It is not an algorithm---an English translation of
+a computer program---but a declarative description of what counts as a block
+quote, a code block, and each of the other structural elements that can
+make up a Markdown document.
+
+Because John Gruber's [canonical syntax
+description](https://daringfireball.net/projects/markdown/syntax) leaves
+many aspects of the syntax undetermined, writing a precise spec requires
+making a large number of decisions, many of them somewhat arbitrary.
+In making them, we have appealed to existing conventions and
+considerations of simplicity, readability, expressive power, and
+consistency.  We have tried to ensure that "normal" documents in the many
+incompatible existing implementations of Markdown will render, as far as
+possible, as their authors intended.  And we have tried to make the rules
+for different elements work together harmoniously.  In places where
+different decisions could have been made (for example, the rules
+governing list indentation), we have explained the rationale for
+our choices.  In a few cases, we have departed slightly from the canonical
+syntax description, in ways that we think further the goals of Markdown
+as stated in that description.
+
+For the most part, we have limited ourselves to the basic elements
+described in Gruber's canonical syntax description, eschewing extensions
+like footnotes and definition lists.  It is important to get the core
+right before considering such things. However, we have included a visible
+syntax for line breaks and fenced code blocks.
+
+Differences from original Markdown
+----------------------------------
+
+There are only a few places where this spec says things that contradict
+the canonical syntax description:
+
+-   It allows all punctuation symbols to be backslash-escaped,
+    not just the symbols with special meanings in Markdown. We found
+    that it was just too hard to remember which symbols could be
+    escaped.
+
+-   It introduces an alternative syntax for hard line
+    breaks, a backslash at the end of the line, supplementing the
+    two-spaces-at-the-end-of-line rule. This is motivated by persistent
+    complaints about the “invisible” nature of the two-space rule.
+
+-   Link syntax has been made a bit more predictable (in a
+    backwards-compatible way). For example, `Markdown.pl` allows single
+    quotes around a title in inline links, but not in reference links.
+    This kind of difference is really hard for users to remember, so the
+    spec allows single quotes in both contexts.
+
+-   The rule for HTML blocks differs, though in most real cases it
+    shouldn't make a difference. (See the section on HTML Blocks
+    for details.) The spec's proposal makes it easy to include Markdown
+    inside HTML block-level tags, if you want to, but also allows you to
+    exclude this. It also makes parsing much easier, avoiding
+    expensive backtracking.
+
+-   It does not collapse adjacent bird-track blocks into a single
+    blockquote:
+
+        > these are two
+
+        > blockquotes
+
+        > this is a single
+        >
+        > blockquote with two paragraphs
+
+-   Rules for content in lists differ in a few respects, though (as with
+    HTML blocks), most lists in existing documents should render as
+    intended. There is some discussion of the choice points and
+    differences in the subsection of List Items entitled Motivation.
+    We think that the spec's proposal does better than any existing
+    implementation in rendering lists the way a human writer or reader
+    would intuitively understand them. (We could give numerous examples
+    of perfectly natural looking lists that nearly every existing
+    implementation flubs up.)
+
+-   Changing bullet characters, or changing from bullets to numbers or
+    vice versa, starts a new list. We think that is almost always going
+    to be the writer's intent.
+
+-   The number that begins an ordered list item may be followed by
+    either `.` or `)`. Changing the delimiter style starts a new
+    list.
+
+-   The start number of an ordered list is significant.
+
+-   Fenced code blocks are supported, delimited by either
+    backticks (```` ``` ````) or tildes (` ~~~ `).
+
+Contributing
+------------
+
+There is a [forum for discussing
+CommonMark](https://talk.commonmark.org); you should use it instead of
+github issues for questions and possibly open-ended discussions.
+Use the [github issue tracker](https://github.com/commonmark/CommonMark/issues)
+only for simple, clear, actionable issues.
+
+Authors
+-------
+
+The spec was written by John MacFarlane, drawing on
+
+- his experience writing and maintaining Markdown implementations in several
+  languages, including the first Markdown parser not based on regular
+  expression substitutions ([pandoc](https://github.com/jgm/pandoc)) and
+  the first markdown parsers based on PEG grammars
+  ([peg-markdown](https://github.com/jgm/peg-markdown),
+  [lunamark](https://github.com/jgm/lunamark))
+- a detailed examination of the differences between existing Markdown
+  implementations using [BabelMark 2](https://johnmacfarlane.net/babelmark2/),
+  and
+- extensive discussions with David Greenspan, Jeff Atwood, Vicent
+  Marti, Neil Williams, and Benjamin Dumke-von der Ehe.
+
+Since the first announcement, many people have contributed ideas.
+Kārlis Gaņģis was especially helpful in refining the rules for
+emphasis, strong emphasis, links, and images.

--- a/lex-babel/tests/fixtures/markdown-reference-comrak.md
+++ b/lex-babel/tests/fixtures/markdown-reference-comrak.md
@@ -1,0 +1,417 @@
+<!-- Reference fixture sourced from https://github.com/kivikakk/comrak/blob/master/README.md on 2025-11-21; see upstream repo for license details. -->
+
+# [Comrak](https://comrak.ee/)
+
+[![Build status](https://github.com/kivikakk/comrak/actions/workflows/rust.yml/badge.svg)](https://github.com/kivikakk/comrak/actions/workflows/rust.yml)
+[![CommonMark: 652/652](https://img.shields.io/badge/commonmark-652%2F652-brightgreen.svg)](https://github.com/commonmark/commonmark-spec/blob/9103e341a973013013bb1a80e13567007c5cef6f/spec.txt)
+[![GFM: 670/670](https://img.shields.io/badge/gfm-670%2F670-brightgreen.svg)](https://github.com/kivikakk/cmark-gfm/blob/2f13eeedfe9906c72a1843b03552550af7bee29a/test/spec.txt)
+[![crates.io version](https://img.shields.io/crates/v/comrak.svg)](https://crates.io/crates/comrak)
+[![docs.rs](https://docs.rs/comrak/badge.svg)](https://docs.rs/comrak)
+
+[Comrak](https://comrak.ee/) is a [CommonMark](https://commonmark.org/) and [GitHub Flavored Markdown](https://github.github.com/gfm/) compatible parser and renderer, written in Rust.
+
+Compliant with [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) by default.
+
+## Installation
+
+Specify it as a requirement in `Cargo.toml`:
+
+```toml
+[dependencies]
+comrak = "0.48"
+```
+
+Comrak's library supports Rust <span class="msrv">1.70</span>+.
+
+### CLI
+
+- Anywhere with a Rust toolchain:
+  - `cargo install comrak`
+  - <code>[cargo binstall](https://github.com/cargo-bins/cargo-binstall) comrak</code>
+- Many Unix distributions:
+  - `pacman -S comrak`
+  - `brew install comrak`
+  - `dnf install comrak`
+  - `nix run nixpkgs#comrak`
+
+You can also find builds I've published in [GitHub Releases](https://github.com/kivikakk/comrak/releases), but they're limited to machines I have access to at the time of making them! [webinstall.dev](https://webinstall.dev/comrak/) offers `curl | shell`-style installation of the latest of these for your OS, including Windows.
+
+## Usage
+
+<details>
+
+<summary>Click to expand the CLI <code>--help</code> output.
+
+```console
+$ comrak --help
+```
+
+</summary>
+
+```
+A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter
+
+Usage: comrak [OPTIONS] [FILE]...
+
+Arguments:
+  [FILE]...
+          CommonMark file(s) to parse; or standard input if none passed
+
+Options:
+  -c, --config-file <PATH>
+          Path to config file containing command-line arguments, or 'none'
+          
+          [default: /home/runner/.config/comrak/config]
+
+  -i, --inplace
+          Reformat a CommonMark file in-place
+
+      --hardbreaks
+          Treat newlines as hard line breaks
+
+      --smart
+          Replace punctuation like "this" with smart punctuation like “this”
+
+      --github-pre-lang
+          Use GitHub-style "<pre lang>" for code blocks
+
+      --full-info-string
+          Include words following the code block info string in a data-meta attribute
+
+      --gfm
+          Enable GitHub-flavored markdown extensions: strikethrough, tagfilter, table, autolink, and
+          tasklist. Also enables --github-pre-lang and --gfm-quirks
+
+      --gfm-quirks
+          Use GFM-style quirks in output HTML, such as not nesting <strong> tags, which otherwise
+          breaks CommonMark compatibility
+
+      --relaxed-tasklist-character
+          Permit any character inside a tasklist item, not just " ", "x" or "X"
+
+      --relaxed-autolinks
+          Relax autolink parsing: allows links to be recognised when in brackets, permits all URL
+          schemes, and permits domains without a TLD (like "http://localhost")
+
+      --tasklist-classes
+          Include "task-list-item" and "task-list-item-checkbox" classes on
+
+      --default-info-string <INFO>
+          Default value for fenced code block's info strings if none is given
+
+      --unsafe
+          Allow inline and block HTML (unless --escape is given), and permit
+
+      --gemoji
+          Translate gemoji like ":thumbsup:" into Unicode emoji like "👍"
+
+      --escape
+          Escape raw HTML, instead of clobbering it; takes precedence over --unsafe
+
+      --escaped-char-spans
+          Wrap escaped Markdown characters in "<span data-escaped-char>" in HTML
+
+  -e, --extension <EXTENSION>
+          Specify extensions to use
+          
+          Multiple extensions can be delimited with ",", e.g. '--extension strikethrough,table', or
+          you can pass --extension/-e multiple times
+          
+          [possible values: strikethrough, tagfilter, table, autolink, tasklist, superscript,
+          footnotes, inline-footnotes, description-lists, multiline-block-quotes, math-dollars,
+          math-code, wikilinks-title-after-pipe, wikilinks-title-before-pipe, underline, subscript,
+          spoiler, greentext, alerts, cjk-friendly-emphasis, subtext, highlight]
+
+  -t, --to <FORMAT>
+          Specify output format
+          
+          [default: html]
+          [possible values: html, xml, commonmark]
+
+  -o, --output <FILE>
+          Write output to FILE instead of stdout
+
+      --width <WIDTH>
+          Specify wrap width for output CommonMark, or '0' to disable wrapping
+          
+          [default: 0]
+
+      --header-ids <PREFIX>
+          Use the Comrak header IDs extension, with the given ID prefix
+
+      --front-matter-delimiter <DELIMITER>
+          Detect frontmatter that starts and ends with the given string, and do not include it in
+          the resulting document
+
+      --syntax-highlighting <THEME>
+          Syntax highlighting theme for fenced code blocks; specify a theme, or 'none' to disable
+          
+          [default: base16-ocean.dark]
+
+      --list-style <LIST_STYLE>
+          Specify bullet character for lists ("-", "+", "*") in CommonMark output
+          
+          [default: dash]
+          [possible values: dash, plus, star]
+
+      --sourcepos
+          Include source position attributes in HTML and XML output
+
+      --ignore-setext
+          Do not parse setext headers
+
+      --ignore-empty-links
+          Do not parse empty links
+
+      --experimental-minimize-commonmark
+          Minimise escapes in CommonMark output using a trial-and-error algorithm
+
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+  -V, --version
+          Print version information
+
+By default, Comrak will attempt to read command-line options from a config file specified by
+--config-file. This behaviour can be disabled by passing --config-file none. It is not an error if
+the file does not exist.
+```
+
+</details>
+
+And there's a Rust interface. You can use `comrak::markdown_to_html` directly:
+
+```rust
+use comrak::{markdown_to_html, Options};
+assert_eq!(
+    markdown_to_html("¡Olá, **世界**!", &Options::default()),
+    "<p>¡Olá, <strong>世界</strong>!</p>\n"
+);
+```
+
+Or you can parse the input into an AST yourself, manipulate it, and then use your desired formatter:
+
+```rust
+use comrak::nodes::NodeValue;
+use comrak::{format_html, parse_document, Arena, Options};
+
+fn replace_text(document: &str, orig_string: &str, replacement: &str) -> String {
+    // The returned nodes are created in the supplied Arena, and are bound by its lifetime.
+    let arena = Arena::new();
+
+    // Parse the document into a root `AstNode`
+    let root = parse_document(&arena, document, &Options::default());
+
+    // Iterate over all the descendants of root.
+    for node in root.descendants() {
+        if let NodeValue::Text(ref mut text) = node.data.borrow_mut().value {
+            // If the node is a text node, perform the string replacement.
+            *text = text.to_mut().replace(orig_string, replacement).into()
+        }
+    }
+
+    let mut html = String::new();
+    format_html(root, &Options::default(), &mut html).unwrap();
+
+    html
+}
+
+fn main() {
+    let doc = "Hello, pretty world!\n\n1. Do you like [pretty](#) paintings?\n2. Or *pretty* music?\n";
+    let orig = "pretty";
+    let repl = "beautiful";
+    let html = replace_text(doc, orig, repl);
+
+    println!("{}", html);
+    // Output:
+    //
+    // <p>Hello, beautiful world!</p>
+    // <ol>
+    // <li>Do you like <a href="#">beautiful</a> paintings?</li>
+    // <li>Or <em>beautiful</em> music?</li>
+    // </ol>
+}
+```
+
+For a slightly more real-world example, see how I [generate my GitHub user README](https://github.com/kivikakk/kivikakk) from a base document with embedded YAML, which itself has embedded Markdown, or
+[check out some of Comrak's dependents on crates.io](https://crates.io/crates/comrak/reverse_dependencies) or [on GitHub](https://github.com/kivikakk/comrak/network/dependents).
+
+## Security
+
+As with [`cmark`](https://github.com/commonmark/cmark) and [`cmark-gfm`](https://github.com/github/cmark-gfm#security),
+Comrak will scrub raw HTML and potentially dangerous links. This change was introduced in Comrak 0.4.0 in support of a
+safe-by-default posture, and later adopted by our contemporaries. :)
+
+To allow these, use the `r#unsafe` option (or `--unsafe` with the command line program). If doing so, we recommend the
+use of a sanitisation library like [`ammonia`](https://github.com/notriddle/ammonia) configured specific to your needs.
+
+## Extensions
+
+Comrak supports the five extensions to CommonMark defined in the [GitHub Flavored Markdown
+Spec](https://github.github.com/gfm/):
+
+- [Tables](https://github.github.com/gfm/#tables-extension-)
+- [Task list items](https://github.github.com/gfm/#task-list-items-extension-)
+- [Strikethrough](https://github.github.com/gfm/#strikethrough-extension-)
+- [Autolinks](https://github.github.com/gfm/#autolinks-extension-)
+- [Disallowed Raw HTML](https://github.github.com/gfm/#disallowed-raw-html-extension-)
+
+Comrak additionally supports its own extensions, which are yet to be specced out (PRs welcome!):
+
+- Superscript
+- Header IDs
+- Footnotes
+- Inline footnotes
+- Description lists
+- Front matter
+- Multi-line blockquotes
+- Math
+- Emoji shortcodes
+- Wikilinks
+- Underline
+- Spoiler text
+- "Greentext"
+- [CJK friendly emphasis](https://github.com/tats-u/markdown-cjk-friendly)
+
+By default none are enabled; they are individually enabled with each parse by setting the appropriate values in the
+[`options::Extension` struct](https://docs.rs/comrak/latest/comrak/options/struct.Extension.html).
+
+## Custom formatting
+
+The default HTML formatter can be partially specialised, to
+allow customising the output for certain node types without
+having to reimplement a whole formatter.  See the docs for
+[`comrak::create_formatter`](https://docs.rs/comrak/latest/comrak/macro.create_formatter.html)
+for details.
+
+## Plugins
+
+### Fenced code block syntax highlighting
+
+You can provide your own syntax highlighting engine.
+
+Create an implementation of the `SyntaxHighlighterAdapter` trait, and then provide an instance of such adapter to
+`Plugins.render.codefence_syntax_highlighter`. For formatting a Markdown document with plugins, use the
+`markdown_to_html_with_plugins` function, which accepts your plugins object as a parameter.
+
+See the `syntax_highlighter.rs` and `syntect.rs` examples for more details.
+
+#### Syntect
+
+[`syntect`](https://github.com/trishume/syntect) is a syntax highlighting library for Rust. By default, `comrak` offers
+a plugin for it. In order to utilize it, create an instance of `plugins::syntect::SyntectAdapter` and use it in your
+`Plugins` option.
+
+## Related projects
+
+Comrak's original design goal was to model the upstream
+[`cmark-gfm`](https://github.com/github/cmark-gfm) as closely as possible in
+terms of code structure. Many years have passed since its inception, and the codebases
+have since grown considerably apart. It does remain the case, though, that there
+are bugs in `cmark-gfm` that are likely in Comrak too, as a result.
+
+Over the years, we have increasingly opted to fix such bugs, rather than
+maintain upstream compatibility at all costs.  `cmark-gfm` no longer appears to
+be under active maintenance, but Comrak is a living and growing project.
+
+This library offers an AST backed by
+[`typed_arena`](https://github.com/thomcc/rust-typed-arena), with extensive
+use of `RefCell` in the core node type to provide mutable access with
+parent/sibling/child pointers.  This can produce non-idiomatic-looking code,
+though in practice it has proven very usable.
+
+For whatever reason, Comrak may not meet your requirements. Here are some
+projects and resources to also consider:
+
+- [Raph Levien](https://github.com/raphlinus)'s [`pulldown-cmark`](https://github.com/google/pulldown-cmark). It's
+  very fast, uses a novel parsing algorithm, and doesn't construct an AST (but you can use it to make one if you
+  want). `cargo doc` uses this, as do many other projects in the ecosystem.
+- [markdown-rs](https://github.com/wooorm/markdown-rs) looks really promising.
+- [markdown-it](https://github.com/markdown-it-rust/markdown-it) is a port of JavaScript's [markdown-it.js](https://github.com/markdown-it/markdown-it).
+- [babelmark](https://babelmark.github.io/) lets you compare many implementations at once, including the above.
+- Know of another library? Please open a PR to add it!
+
+### Bindings
+
+- [Commonmarker](https://github.com/gjtorikian/commonmarker) — Ruby bindings for this library built with Magnus/rb-sys.
+  Available on RubyGems as [`commonmarker`](https://rubygems.org/gems/commonmarker).
+- [MDEx](https://github.com/leandrocp/mdex) — Elixir bindings for this library built with Rustler.
+  Available on Hex as [`mdex`](https://hex.pm/packages/mdex).
+- [comrak](https://github.com/lmmx/comrak) — Python bindings for this library built with PyO3.
+  Available on PyPI as [`comrak`](https://pypi.org/project/comrak), benchmarked at 15-60x faster than pure Python alternatives.
+- [comrak-ext](https://github.com/Martin005/comrak-ext) — Python bindings; fork of `comrak` with additional APIs exposed, including the AST.
+  Available on PyPI as [`comrak-ext`](https://pypi.org/project/comrak-ext).
+- [comrak-wasm](https://github.com/nberlette/comrak-wasm) — TypeScript bindings for this library, built with WebAssembly.
+  Available on JSR as [`@nick/comrak`](https://jsr.io/@nick/comrak).
+
+### Users
+
+Comrak is used in a few Rust-y places, and more beyond:
+
+- [crates.io](https://crates.io), [docs.rs](https://docs.rs) and [lib.rs](https://lib.rs) use Comrak to render README Markdown faithfully.
+- [GitLab](https://gitlab.com) uses Comrak to render Markdown documents, issues, comments, and more.
+- [Deno](https://deno.com) uses Comrak to render documentation in [`deno_doc`](https://github.com/denoland/deno_doc).
+- [Reddit](https://reddit.com)'s new-style site uses a Comrak fork[^reddit].
+- [Lockbook](https://lockbook.net/) is a Markdown-based secure notebook with native apps. It looks really neat!!
+- [many](https://github.com/kivikakk/comrak/network/dependents) [more!](https://crates.io/crates/comrak/reverse_dependencies)
+
+I'd be really happy to add your site or app here, just open a PR or issue. :)
+
+[^reddit]: And they contributed some really nice changes, years back. Then management went and sold their user base and all their credibility. What can you do.
+
+## Benchmarking
+
+We offer some tools to perform stdin-to-stdout benchmarking of Comrak with its contemporaries.  In this respect, Comrak is not and will not be the fastest: some alternatives do not construct an AST in this scenario.
+
+You'll need to [install hyperfine](https://github.com/sharkdp/hyperfine#installation), and CMake if you want to compare against `cmark-gfm`.
+
+If you want to just run the benchmark for the `comrak` binary itself, run:
+
+```bash
+make bench-comrak
+```
+
+This will build Comrak in release mode, and run benchmark on it. You will see the time measurements as reported by hyperfine in the console.
+
+The `Makefile` also provides a way to run benchmarks for `comrak` current state (with your changes), `comrak` main branch, [`cmark-gfm`](https://github.com/github/cmark-gfm), [`pulldown-cmark`](https://github.com/raphlinus/pulldown-cmark) and [`markdown-it.rs`](https://github.com/rlidwka/markdown-it.rs). You'll need CMake, and ensure [submodules are prepared](https://stackoverflow.com/a/10168693/499609).
+
+```bash
+make bench-all
+```
+
+This will build and run benchmarks across all, and report the time taken by each as well as relative time.
+
+<!-- XXX: The following isn't really true at the moment, due to https://github.com/kivikakk/comrak/issues/339 -->
+
+<!-- Apart from this, CI is also setup for running benchmarks when a pull request is first opened. It will add a comment with the results on the pull request in a tabular format comparing the 5 versions. After that you can manually trigger this CI by commenting `/run-bench` on the PR, this will update the existing comment with new results. Note benchmarks won't be automatically run on each push. -->
+
+## Contributing
+
+Contributions are **highly encouraged**; if you'd like to assist, consider checking out the [`good first issue` label](https://github.com/kivikakk/comrak/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)! I'm happy to help provide direction and guidance throughout, even if (especially if!) you're new to Rust or open source.
+
+Where possible I practice [Optimistic Merging](http://hintjens.com/blog:106) as described by Peter Hintjens. Please keep the [code of conduct](CODE_OF_CONDUCT.md) in mind too.
+
+Thank you to Comrak's many contributors for PRs and issues opened!
+
+### Code Contributors
+
+[![Small chart showing Comrak contributors.](https://opencollective.com/comrak/contributors.svg?width=890&button=false)](https://github.com/kivikakk/comrak/graphs/contributors)
+
+### Financial Contributors
+
+Since September 2025, the scope of my [day job](https://about.gitlab.com/company/team/#kivikakk) includes Comrak, meaning I can spend some time on it as part of my paid work!  That's so nice, and so donations from the community are better directed elsewhere, in my opinion.
+
+If you feel like you would like to do so anyway, however, [GitHub Sponsors](https://github.com/sponsors/kivikakk) is the best way.
+
+## Contact
+
+Asherah Connor <ashe kivikakk ee\>
+
+## Legal
+
+Copyright (c) 2017–2025, Comrak contributors. Licensed under
+the [2-Clause BSD License](https://opensource.org/licenses/BSD-2-Clause).
+
+`cmark` itself is is copyright (c) 2014, John MacFarlane.
+
+See [COPYING](COPYING) for all the details.

--- a/lex-babel/tests/markdown/import.rs
+++ b/lex-babel/tests/markdown/import.rs
@@ -10,6 +10,7 @@ use lex_babel::formats::markdown::MarkdownFormat;
 use lex_babel::formats::tag::serialize_document_with_params;
 use lex_parser::lex::ast::ContentItem;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 /// Helper to parse Markdown to Lex AST
 fn md_to_lex(md: &str) -> lex_parser::lex::ast::Document {
@@ -17,10 +18,17 @@ fn md_to_lex(md: &str) -> lex_parser::lex::ast::Document {
 }
 
 /// Snapshot helper for reference Markdown fixtures
+///
+/// Uses `ast-full` serialization to capture complete AST structure including
+/// annotations and all metadata, ensuring comprehensive regression detection
+/// for complex markdown documents.
 fn snapshot_md_fixture(fixture: &str, snapshot_name: &str) {
-    let path = format!("tests/fixtures/{}", fixture);
-    let md =
-        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {}", path, e));
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(fixture);
+    let md = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read {:?}: {}", path, e));
 
     let doc = md_to_lex(&md);
 

--- a/lex-babel/tests/markdown/import.rs
+++ b/lex-babel/tests/markdown/import.rs
@@ -384,7 +384,7 @@ fn test_kitchensink_round_trip() {
 // ============================================================================
 
 #[test]
-fn test_reference_commonmark_snapshot() {
+fn test_markdown_import_commonmark_reference() {
     snapshot_md_fixture(
         "markdown-reference-commonmark.md",
         "markdown_import_commonmark_reference",
@@ -392,7 +392,7 @@ fn test_reference_commonmark_snapshot() {
 }
 
 #[test]
-fn test_reference_comrak_snapshot() {
+fn test_markdown_import_comrak_reference() {
     snapshot_md_fixture(
         "markdown-reference-comrak.md",
         "markdown_import_comrak_reference",

--- a/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_commonmark_reference.snap
+++ b/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_commonmark_reference.snap
@@ -1,0 +1,226 @@
+---
+source: lex-babel/tests/markdown/import.rs
+expression: serialized
+---
+<document>
+  <session>CommonMark
+    <paragraph>1 line(s)
+      <text-line>CommonMark is a rationalized version of Markdown s…</text-line>
+    </paragraph>
+    <paragraph>1 line(s)
+      <text-line>[https://spec.commonmark.org/dingus/]</text-line>
+    </paragraph>
+    <paragraph>1 line(s)
+      <text-line>For more details, see [https://commonmark.org].</text-line>
+    </paragraph>
+    <paragraph>1 line(s)
+      <text-line>This repository contains the spec itself, along wi…</text-line>
+    </paragraph>
+    <paragraph>1 line(s)
+      <text-line>The reference implementations live in separate rep…</text-line>
+    </paragraph>
+    <list>2 items
+      <list-item>
+        <marker>-</marker>
+        <text></text>
+        <paragraph>1 line(s)
+          <text-line>[https://github.com/commonmark/cmark] (C)</text-line>
+        </paragraph>
+      </list-item>
+      <list-item>
+        <marker>-</marker>
+        <text></text>
+        <paragraph>1 line(s)
+          <text-line>[https://github.com/commonmark/commonmark.js] (Jav…</text-line>
+        </paragraph>
+      </list-item>
+    </list>
+    <paragraph>1 line(s)
+      <text-line>There is a list of third-party libraries in a doze…</text-line>
+    </paragraph>
+    <session>Running tests against the spec
+      <paragraph>1 line(s)
+        <text-line>[https://spec.commonmark.org/] contains over 500 e…</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>python3 test/spec_tests.py --program $PROG</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>If you want to extract the raw test data from the …</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>python3 test/spec_tests.py --dump-tests</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>and you&apos;ll get all the tests in JSON format.</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>JavaScript developers may find it more convenient …</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>{</verbatim-line>
+          <verbatim-line>  &quot;markdown&quot;: &quot;Foo\nBar\n---\n&quot;,</verbatim-line>
+          <verbatim-line>  &quot;html&quot;: &quot;&lt;h2&gt;Foo\nBar&lt;/h2&gt;\n&quot;,</verbatim-line>
+          <verbatim-line>  &quot;section&quot;: &quot;Setext headings&quot;,</verbatim-line>
+          <verbatim-line>  &quot;number&quot;: 65</verbatim-line>
+          <verbatim-line>}</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+    </session>
+    <session>The spec
+      <paragraph>1 line(s)
+        <text-line>The source of [https://spec.commonmark.org/] is `s…</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>```````````````````````````````` example</verbatim-line>
+          <verbatim-line>Markdown source</verbatim-line>
+          <verbatim-line>.</verbatim-line>
+          <verbatim-line>expected HTML output</verbatim-line>
+          <verbatim-line>````````````````````````````````</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>To build an HTML version of the spec, do `make spe…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>The spec is written from the point of view of the …</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>Because John Gruber&apos;s [https://daringfireball.net/…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>For the most part, we have limited ourselves to th…</text-line>
+      </paragraph>
+    </session>
+    <session>Differences from original Markdown
+      <paragraph>1 line(s)
+        <text-line>There are only a few places where this spec says t…</text-line>
+      </paragraph>
+      <list>10 items
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>It allows all punctuation symbols to be backslash-…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>It introduces an alternative syntax for hard line …</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Link syntax has been made a bit more predictable (…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>The rule for HTML blocks differs, though in most r…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>It does not collapse adjacent bird-track blocks in…</text-line>
+          </paragraph>
+          <verbatim-block>
+            <verbatim-group>
+              <verbatim-line>&gt; these are two</verbatim-line>
+              <verbatim-line></verbatim-line>
+              <verbatim-line>&gt; blockquotes</verbatim-line>
+              <verbatim-line></verbatim-line>
+              <verbatim-line>&gt; this is a single</verbatim-line>
+              <verbatim-line>&gt;</verbatim-line>
+              <verbatim-line>&gt; blockquote with two paragraphs</verbatim-line>
+            </verbatim-group>
+          </verbatim-block>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Rules for content in lists differ in a few respect…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Changing bullet characters, or changing from bulle…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>The number that begins an ordered list item may be…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>The start number of an ordered list is significant…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Fenced code blocks are supported, delimited by eit…</text-line>
+          </paragraph>
+        </list-item>
+      </list>
+    </session>
+    <session>Contributing
+      <paragraph>1 line(s)
+        <text-line>There is a [https://talk.commonmark.org]; you shou…</text-line>
+      </paragraph>
+    </session>
+    <session>Authors
+      <paragraph>1 line(s)
+        <text-line>The spec was written by John MacFarlane, drawing o…</text-line>
+      </paragraph>
+      <list>3 items
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>his experience writing and maintaining Markdown im…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>a detailed examination of the differences between …</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>extensive discussions with David Greenspan, Jeff A…</text-line>
+          </paragraph>
+        </list-item>
+      </list>
+      <paragraph>1 line(s)
+        <text-line>Since the first announcement, many people have con…</text-line>
+      </paragraph>
+    </session>
+  </session>
+</document>

--- a/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_reference.snap
+++ b/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_reference.snap
@@ -1,0 +1,690 @@
+---
+source: lex-babel/tests/markdown/import.rs
+expression: serialized
+---
+<document>
+  <session>[https://comrak.ee/]
+    <paragraph>1 line(s)
+      <text-line>[https://github.com/kivikakk/comrak/actions/workfl…</text-line>
+    </paragraph>
+    <paragraph>1 line(s)
+      <text-line>[https://comrak.ee/] is a [https://commonmark.org/…</text-line>
+    </paragraph>
+    <paragraph>1 line(s)
+      <text-line>Compliant with [https://spec.commonmark.org/0.31.2…</text-line>
+    </paragraph>
+    <session>Installation
+      <paragraph>1 line(s)
+        <text-line>Specify it as a requirement in `Cargo.toml`:</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>[dependencies]</verbatim-line>
+          <verbatim-line>comrak = &quot;0.48&quot;</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>Comrak&apos;s library supports Rust 1.70+.</text-line>
+      </paragraph>
+      <session>CLI
+        <list>2 items
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>Anywhere with a Rust toolchain:</text-line>
+            </paragraph>
+            <list>2 items
+              <list-item>
+                <marker>-</marker>
+                <text></text>
+                <paragraph>1 line(s)
+                  <text-line>`cargo install comrak`</text-line>
+                </paragraph>
+              </list-item>
+              <list-item>
+                <marker>-</marker>
+                <text></text>
+                <paragraph>1 line(s)
+                  <text-line>[https://github.com/cargo-bins/cargo-binstall] com…</text-line>
+                </paragraph>
+              </list-item>
+            </list>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>Many Unix distributions:</text-line>
+            </paragraph>
+            <list>4 items
+              <list-item>
+                <marker>-</marker>
+                <text></text>
+                <paragraph>1 line(s)
+                  <text-line>`pacman -S comrak`</text-line>
+                </paragraph>
+              </list-item>
+              <list-item>
+                <marker>-</marker>
+                <text></text>
+                <paragraph>1 line(s)
+                  <text-line>`brew install comrak`</text-line>
+                </paragraph>
+              </list-item>
+              <list-item>
+                <marker>-</marker>
+                <text></text>
+                <paragraph>1 line(s)
+                  <text-line>`dnf install comrak`</text-line>
+                </paragraph>
+              </list-item>
+              <list-item>
+                <marker>-</marker>
+                <text></text>
+                <paragraph>1 line(s)
+                  <text-line>`nix run nixpkgs#comrak`</text-line>
+                </paragraph>
+              </list-item>
+            </list>
+          </list-item>
+        </list>
+        <paragraph>1 line(s)
+          <text-line>You can also find builds I&apos;ve published in [https:…</text-line>
+        </paragraph>
+      </session>
+    </session>
+    <session>Usage
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>$ comrak --help</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>A 100% CommonMark-compatible GitHub Flavored Markd…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>Usage: comrak [OPTIONS] [FILE]...</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>Arguments:</verbatim-line>
+          <verbatim-line>  [FILE]...</verbatim-line>
+          <verbatim-line>          CommonMark file(s) to parse; or standard…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>Options:</verbatim-line>
+          <verbatim-line>  -c, --config-file &lt;PATH&gt;</verbatim-line>
+          <verbatim-line>          Path to config file containing command-l…</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          [default: /home/runner/.config/comrak/co…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>  -i, --inplace</verbatim-line>
+          <verbatim-line>          Reformat a CommonMark file in-place</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --hardbreaks</verbatim-line>
+          <verbatim-line>          Treat newlines as hard line breaks</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --smart</verbatim-line>
+          <verbatim-line>          Replace punctuation like &quot;this&quot; with sma…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --github-pre-lang</verbatim-line>
+          <verbatim-line>          Use GitHub-style &quot;&lt;pre lang&gt;&quot; for code b…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --full-info-string</verbatim-line>
+          <verbatim-line>          Include words following the code block i…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --gfm</verbatim-line>
+          <verbatim-line>          Enable GitHub-flavored markdown extensio…</verbatim-line>
+          <verbatim-line>          tasklist. Also enables --github-pre-lang…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --gfm-quirks</verbatim-line>
+          <verbatim-line>          Use GFM-style quirks in output HTML, suc…</verbatim-line>
+          <verbatim-line>          breaks CommonMark compatibility</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --relaxed-tasklist-character</verbatim-line>
+          <verbatim-line>          Permit any character inside a tasklist i…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --relaxed-autolinks</verbatim-line>
+          <verbatim-line>          Relax autolink parsing: allows links to …</verbatim-line>
+          <verbatim-line>          schemes, and permits domains without a T…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --tasklist-classes</verbatim-line>
+          <verbatim-line>          Include &quot;task-list-item&quot; and &quot;task-list-…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --default-info-string &lt;INFO&gt;</verbatim-line>
+          <verbatim-line>          Default value for fenced code block&apos;s in…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --unsafe</verbatim-line>
+          <verbatim-line>          Allow inline and block HTML (unless --es…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --gemoji</verbatim-line>
+          <verbatim-line>          Translate gemoji like &quot;:thumbsup:&quot; into …</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --escape</verbatim-line>
+          <verbatim-line>          Escape raw HTML, instead of clobbering i…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --escaped-char-spans</verbatim-line>
+          <verbatim-line>          Wrap escaped Markdown characters in &quot;&lt;sp…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>  -e, --extension &lt;EXTENSION&gt;</verbatim-line>
+          <verbatim-line>          Specify extensions to use</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          Multiple extensions can be delimited wit…</verbatim-line>
+          <verbatim-line>          you can pass --extension/-e multiple tim…</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          [possible values: strikethrough, tagfilt…</verbatim-line>
+          <verbatim-line>          footnotes, inline-footnotes, description…</verbatim-line>
+          <verbatim-line>          math-code, wikilinks-title-after-pipe, w…</verbatim-line>
+          <verbatim-line>          spoiler, greentext, alerts, cjk-friendly…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>  -t, --to &lt;FORMAT&gt;</verbatim-line>
+          <verbatim-line>          Specify output format</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          [default: html]</verbatim-line>
+          <verbatim-line>          [possible values: html, xml, commonmark]</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>  -o, --output &lt;FILE&gt;</verbatim-line>
+          <verbatim-line>          Write output to FILE instead of stdout</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --width &lt;WIDTH&gt;</verbatim-line>
+          <verbatim-line>          Specify wrap width for output CommonMark…</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          [default: 0]</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --header-ids &lt;PREFIX&gt;</verbatim-line>
+          <verbatim-line>          Use the Comrak header IDs extension, wit…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --front-matter-delimiter &lt;DELIMITER&gt;</verbatim-line>
+          <verbatim-line>          Detect frontmatter that starts and ends …</verbatim-line>
+          <verbatim-line>          the resulting document</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --syntax-highlighting &lt;THEME&gt;</verbatim-line>
+          <verbatim-line>          Syntax highlighting theme for fenced cod…</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          [default: base16-ocean.dark]</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --list-style &lt;LIST_STYLE&gt;</verbatim-line>
+          <verbatim-line>          Specify bullet character for lists (&quot;-&quot;,…</verbatim-line>
+          <verbatim-line>          </verbatim-line>
+          <verbatim-line>          [default: dash]</verbatim-line>
+          <verbatim-line>          [possible values: dash, plus, star]</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --sourcepos</verbatim-line>
+          <verbatim-line>          Include source position attributes in HT…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --ignore-setext</verbatim-line>
+          <verbatim-line>          Do not parse setext headers</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --ignore-empty-links</verbatim-line>
+          <verbatim-line>          Do not parse empty links</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>      --experimental-minimize-commonmark</verbatim-line>
+          <verbatim-line>          Minimise escapes in CommonMark output us…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>  -h, --help</verbatim-line>
+          <verbatim-line>          Print help information (use `-h` for a s…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>  -V, --version</verbatim-line>
+          <verbatim-line>          Print version information</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>By default, Comrak will attempt to read command-li…</verbatim-line>
+          <verbatim-line>--config-file. This behaviour can be disabled by p…</verbatim-line>
+          <verbatim-line>the file does not exist.</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>And there&apos;s a Rust interface. You can use `comrak:…</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>use comrak::{markdown_to_html, Options};</verbatim-line>
+          <verbatim-line>assert_eq!(</verbatim-line>
+          <verbatim-line>    markdown_to_html(&quot;¡Olá, **世界**!&quot;, &amp;Options::de…</verbatim-line>
+          <verbatim-line>    &quot;&lt;p&gt;¡Olá, &lt;strong&gt;世界&lt;/strong&gt;!&lt;/p&gt;\n&quot;</verbatim-line>
+          <verbatim-line>);</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>Or you can parse the input into an AST yourself, m…</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>use comrak::nodes::NodeValue;</verbatim-line>
+          <verbatim-line>use comrak::{format_html, parse_document, Arena, O…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>fn replace_text(document: &amp;str, orig_string: &amp;str,…</verbatim-line>
+          <verbatim-line>    // The returned nodes are created in the suppl…</verbatim-line>
+          <verbatim-line>    let arena = Arena::new();</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>    // Parse the document into a root `AstNode`</verbatim-line>
+          <verbatim-line>    let root = parse_document(&amp;arena, document, &amp;O…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>    // Iterate over all the descendants of root.</verbatim-line>
+          <verbatim-line>    for node in root.descendants() {</verbatim-line>
+          <verbatim-line>        if let NodeValue::Text(ref mut text) = nod…</verbatim-line>
+          <verbatim-line>            // If the node is a text node, perform…</verbatim-line>
+          <verbatim-line>            *text = text.to_mut().replace(orig_str…</verbatim-line>
+          <verbatim-line>        }</verbatim-line>
+          <verbatim-line>    }</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>    let mut html = String::new();</verbatim-line>
+          <verbatim-line>    format_html(root, &amp;Options::default(), &amp;mut ht…</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>    html</verbatim-line>
+          <verbatim-line>}</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>fn main() {</verbatim-line>
+          <verbatim-line>    let doc = &quot;Hello, pretty world!\n\n1. Do you l…</verbatim-line>
+          <verbatim-line>    let orig = &quot;pretty&quot;;</verbatim-line>
+          <verbatim-line>    let repl = &quot;beautiful&quot;;</verbatim-line>
+          <verbatim-line>    let html = replace_text(doc, orig, repl);</verbatim-line>
+          <verbatim-line></verbatim-line>
+          <verbatim-line>    println!(&quot;{}&quot;, html);</verbatim-line>
+          <verbatim-line>    // Output:</verbatim-line>
+          <verbatim-line>    //</verbatim-line>
+          <verbatim-line>    // &lt;p&gt;Hello, beautiful world!&lt;/p&gt;</verbatim-line>
+          <verbatim-line>    // &lt;ol&gt;</verbatim-line>
+          <verbatim-line>    // &lt;li&gt;Do you like &lt;a href=&quot;#&quot;&gt;beautiful&lt;/a&gt; p…</verbatim-line>
+          <verbatim-line>    // &lt;li&gt;Or &lt;em&gt;beautiful&lt;/em&gt; music?&lt;/li&gt;</verbatim-line>
+          <verbatim-line>    // &lt;/ol&gt;</verbatim-line>
+          <verbatim-line>}</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>For a slightly more real-world example, see how I …</text-line>
+      </paragraph>
+    </session>
+    <session>Security
+      <paragraph>1 line(s)
+        <text-line>As with [https://github.com/commonmark/cmark] and …</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>To allow these, use the `r#unsafe` option (or `--u…</text-line>
+      </paragraph>
+    </session>
+    <session>Extensions
+      <paragraph>1 line(s)
+        <text-line>Comrak supports the five extensions to CommonMark …</text-line>
+      </paragraph>
+      <list>5 items
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.github.com/gfm/#tables-extension-]</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.github.com/gfm/#task-list-items-ex…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.github.com/gfm/#strikethrough-exte…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.github.com/gfm/#autolinks-extensio…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.github.com/gfm/#disallowed-raw-htm…</text-line>
+          </paragraph>
+        </list-item>
+      </list>
+      <paragraph>1 line(s)
+        <text-line>Comrak additionally supports its own extensions, w…</text-line>
+      </paragraph>
+      <list>14 items
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Superscript</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Header IDs</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Footnotes</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Inline footnotes</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Description lists</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Front matter</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Multi-line blockquotes</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Math</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Emoji shortcodes</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Wikilinks</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Underline</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Spoiler text</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>&quot;Greentext&quot;</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.com/tats-u/markdown-cjk-friendly]</text-line>
+          </paragraph>
+        </list-item>
+      </list>
+      <paragraph>1 line(s)
+        <text-line>By default none are enabled; they are individually…</text-line>
+      </paragraph>
+    </session>
+    <session>Custom formatting
+      <paragraph>1 line(s)
+        <text-line>The default HTML formatter can be partially specia…</text-line>
+      </paragraph>
+    </session>
+    <session>Plugins
+      <session>Fenced code block syntax highlighting
+        <paragraph>1 line(s)
+          <text-line>You can provide your own syntax highlighting engin…</text-line>
+        </paragraph>
+        <paragraph>1 line(s)
+          <text-line>Create an implementation of the `SyntaxHighlighter…</text-line>
+        </paragraph>
+        <paragraph>1 line(s)
+          <text-line>See the `syntax_highlighter.rs` and `syntect.rs` e…</text-line>
+        </paragraph>
+        <session>Syntect
+          <paragraph>1 line(s)
+            <text-line>[https://github.com/trishume/syntect] is a syntax …</text-line>
+          </paragraph>
+        </session>
+      </session>
+    </session>
+    <session>Related projects
+      <paragraph>1 line(s)
+        <text-line>Comrak&apos;s original design goal was to model the ups…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>Over the years, we have increasingly opted to fix …</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>This library offers an AST backed by [https://gith…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>For whatever reason, Comrak may not meet your requ…</text-line>
+      </paragraph>
+      <list>5 items
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.com/raphlinus]&apos;s [https://github.c…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.com/wooorm/markdown-rs] looks real…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://github.com/markdown-it-rust/markdown-it] …</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>[https://babelmark.github.io/] lets you compare ma…</text-line>
+          </paragraph>
+        </list-item>
+        <list-item>
+          <marker>-</marker>
+          <text></text>
+          <paragraph>1 line(s)
+            <text-line>Know of another library? Please open a PR to add i…</text-line>
+          </paragraph>
+        </list-item>
+      </list>
+      <session>Bindings
+        <list>5 items
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://github.com/gjtorikian/commonmarker] — Rub…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://github.com/leandrocp/mdex] — Elixir bindi…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://github.com/lmmx/comrak] — Python bindings…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://github.com/Martin005/comrak-ext] — Python…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://github.com/nberlette/comrak-wasm] — TypeS…</text-line>
+            </paragraph>
+          </list-item>
+        </list>
+      </session>
+      <session>Users
+        <paragraph>1 line(s)
+          <text-line>Comrak is used in a few Rust-y places, and more be…</text-line>
+        </paragraph>
+        <list>6 items
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://crates.io], [https://docs.rs] and [https:…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://gitlab.com] uses Comrak to render Markdow…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://deno.com] uses Comrak to render documenta…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://reddit.com]&apos;s new-style site uses a Comra…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://lockbook.net/] is a Markdown-based secure…</text-line>
+            </paragraph>
+          </list-item>
+          <list-item>
+            <marker>-</marker>
+            <text></text>
+            <paragraph>1 line(s)
+              <text-line>[https://github.com/kivikakk/comrak/network/depend…</text-line>
+            </paragraph>
+          </list-item>
+        </list>
+        <paragraph>1 line(s)
+          <text-line>I&apos;d be really happy to add your site or app here, …</text-line>
+        </paragraph>
+        <paragraph>1 line(s)
+          <text-line>[^reddit]: And they contributed some really nice c…</text-line>
+        </paragraph>
+      </session>
+    </session>
+    <session>Benchmarking
+      <paragraph>1 line(s)
+        <text-line>We offer some tools to perform stdin-to-stdout ben…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>You&apos;ll need to [https://github.com/sharkdp/hyperfi…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>If you want to just run the benchmark for the `com…</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>make bench-comrak</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>This will build Comrak in release mode, and run be…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>The `Makefile` also provides a way to run benchmar…</text-line>
+      </paragraph>
+      <verbatim-block>
+        <verbatim-group>
+          <verbatim-line>make bench-all</verbatim-line>
+        </verbatim-group>
+      </verbatim-block>
+      <paragraph>1 line(s)
+        <text-line>This will build and run benchmarks across all, and…</text-line>
+      </paragraph>
+    </session>
+    <session>Contributing
+      <paragraph>1 line(s)
+        <text-line>Contributions are *highly encouraged*; if you&apos;d li…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>Where possible I practice [http://hintjens.com/blo…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>Thank you to Comrak&apos;s many contributors for PRs an…</text-line>
+      </paragraph>
+      <session>Code Contributors
+        <paragraph>1 line(s)
+          <text-line>[https://github.com/kivikakk/comrak/graphs/contrib…</text-line>
+        </paragraph>
+      </session>
+      <session>Financial Contributors
+        <paragraph>1 line(s)
+          <text-line>Since September 2025, the scope of my [https://abo…</text-line>
+        </paragraph>
+        <paragraph>1 line(s)
+          <text-line>If you feel like you would like to do so anyway, h…</text-line>
+        </paragraph>
+      </session>
+    </session>
+    <session>Contact
+      <paragraph>1 line(s)
+        <text-line>Asherah Connor &lt;ashe kivikakk ee&gt;</text-line>
+      </paragraph>
+    </session>
+    <session>Legal
+      <paragraph>1 line(s)
+        <text-line>Copyright (c) 2017–2025, Comrak contributors. Lice…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>`cmark` itself is is copyright (c) 2014, John MacF…</text-line>
+      </paragraph>
+      <paragraph>1 line(s)
+        <text-line>See [COPYING] for all the details.</text-line>
+      </paragraph>
+    </session>
+  </session>
+</document>

--- a/lex-cli/Cargo.toml
+++ b/lex-cli/Cargo.toml
@@ -24,3 +24,7 @@ serde_json = { workspace = true }
 [build-dependencies]
 clap = { workspace = true }
 clap_complete = "4.4"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"

--- a/lex-cli/tests/markdown_import.rs
+++ b/lex-cli/tests/markdown_import.rs
@@ -1,0 +1,24 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("lex-babel")
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+#[test]
+fn convert_markdown_to_tag_via_cli() {
+    let fixture = fixture_path("markdown-reference-commonmark.md");
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("convert").arg(&fixture).arg("--to").arg("tag");
+
+    let output_pred =
+        predicate::str::contains("<document>").and(predicate::str::contains("<session>CommonMark"));
+
+    cmd.assert().success().stdout(output_pred);
+}

--- a/lex-cli/tests/markdown_import.rs
+++ b/lex-cli/tests/markdown_import.rs
@@ -17,8 +17,12 @@ fn convert_markdown_to_tag_via_cli() {
     let mut cmd = cargo_bin_cmd!("lex");
     cmd.arg("convert").arg(&fixture).arg("--to").arg("tag");
 
-    let output_pred =
-        predicate::str::contains("<document>").and(predicate::str::contains("<session>CommonMark"));
+    // Verify comprehensive output structure from markdown import
+    let output_pred = predicate::str::contains("<document>")
+        .and(predicate::str::contains("<session>CommonMark"))
+        .and(predicate::str::contains("<paragraph>"))
+        .and(predicate::str::contains("<list>"))
+        .and(predicate::str::contains("Running tests against the spec"));
 
     cmd.assert().success().stdout(output_pred);
 }


### PR DESCRIPTION
## Summary
- add CommonMark + Comrak markdown fixtures with insta snapshots exercised by the importer
- document the markdown workflow and fixtures plus new CLI guidance
- add a CLI integration test to prove `lex convert <file>.md --to tag` round-trips via markdown import

## Testing
- cargo test -p lex-babel markdown::import
- cargo test -p lex-cli
- cargo run --bin lex -- lex-babel/tests/fixtures/markdown-reference-commonmark.md --to tag | head -n 5
