### PR TITLE
feat(ast): add diagnostic and link extraction APIs for LSP (#292, #293)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +154,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -152,6 +180,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "caseless"
@@ -311,7 +345,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -366,6 +400,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +463,17 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -506,6 +564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +580,83 @@ checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -532,6 +676,12 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -568,10 +718,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -677,6 +935,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lex-lsp"
+version = "0.1.0"
+dependencies = [
+ "lex-parser",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-lsp",
+]
+
+[[package]]
 name = "lex-parser"
 version = "0.1.0"
 dependencies = [
@@ -726,6 +995,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -782,6 +1057,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -897,7 +1185,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -943,6 +1231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,10 +1275,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1013,6 +1333,15 @@ checksum = "0ef6c498b9a39e7f76723d694354348b04373dbfdef5c9c38360f9358f7cdce7"
 dependencies = [
  "itertools 0.12.1",
  "tracing",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1083,7 +1412,7 @@ checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -1184,7 +1513,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1205,7 +1534,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1243,7 +1572,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1256,7 +1585,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1346,6 +1675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "slug"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1788,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1511,6 +1873,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1642,6 +2015,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +2038,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -1694,6 +2118,66 @@ name = "toml_writer"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1804,10 +2288,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2112,6 +2614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,6 +2645,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2681,60 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ name = "lex-lsp"
 version = "0.1.0"
 dependencies = [
  "lex-parser",
+ "lsp-types",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "lex-babel",
     "lex-cli",
     "lex-viewer",
+    "lex-lsp",
 ]
 resolver = "2"
 

--- a/lex-lsp/Cargo.toml
+++ b/lex-lsp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lex-lsp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lex-parser = { path = "../lex-parser" }
+tower-lsp = "0.20"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]

--- a/lex-lsp/Cargo.toml
+++ b/lex-lsp/Cargo.toml
@@ -3,9 +3,13 @@ name = "lex-lsp"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 lex-parser = { path = "../lex-parser" }
 tower-lsp = "0.20"
+lsp-types = "0.94"
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lex-lsp/src/bin/lex-lsp.rs
+++ b/lex-lsp/src/bin/lex-lsp.rs
@@ -1,0 +1,11 @@
+use lex_lsp::LexLanguageServer;
+use tokio::io::{stdin, stdout};
+use tower_lsp::{LspService, Server};
+
+#[tokio::main]
+async fn main() {
+    let stdin = stdin();
+    let stdout = stdout();
+    let (service, socket) = LspService::new(LexLanguageServer::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/lex-lsp/src/features/document_symbols.rs
+++ b/lex-lsp/src/features/document_symbols.rs
@@ -1,0 +1,213 @@
+use lex_parser::lex::ast::{
+    Annotation, AstNode, ContentItem, Definition, Document, List, Range, Session, TextContent,
+    Verbatim,
+};
+use lsp_types::SymbolKind;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexDocumentSymbol {
+    pub name: String,
+    pub detail: Option<String>,
+    pub kind: SymbolKind,
+    pub range: Range,
+    pub selection_range: Range,
+    pub children: Vec<LexDocumentSymbol>,
+}
+
+pub fn collect_document_symbols(document: &Document) -> Vec<LexDocumentSymbol> {
+    let mut symbols: Vec<LexDocumentSymbol> = document
+        .annotations()
+        .iter()
+        .map(annotation_symbol)
+        .collect();
+    symbols.extend(session_symbols(&document.root, true));
+    symbols
+}
+
+fn session_symbols(session: &Session, is_root: bool) -> Vec<LexDocumentSymbol> {
+    let mut symbols = Vec::new();
+    if !is_root {
+        let mut children = annotation_symbol_list(session.annotations());
+        children.extend(collect_symbols_from_items(session.children.iter()));
+        let selection_range = session
+            .header_location()
+            .cloned()
+            .unwrap_or_else(|| session.range().clone());
+        symbols.push(LexDocumentSymbol {
+            name: summarize_text(&session.title, "Session"),
+            detail: Some(format!("{} item(s)", session.children.len())),
+            kind: SymbolKind::NAMESPACE,
+            range: session.range().clone(),
+            selection_range,
+            children,
+        });
+    } else {
+        symbols.extend(collect_symbols_from_items(session.children.iter()));
+    }
+    symbols
+}
+
+fn collect_symbols_from_items<'a>(
+    items: impl Iterator<Item = &'a ContentItem>,
+) -> Vec<LexDocumentSymbol> {
+    let mut symbols = Vec::new();
+    for item in items {
+        match item {
+            ContentItem::Session(session) => symbols.extend(session_symbols(session, false)),
+            ContentItem::Definition(definition) => symbols.push(definition_symbol(definition)),
+            ContentItem::List(list) => symbols.push(list_symbol(list)),
+            ContentItem::Annotation(annotation) => symbols.push(annotation_symbol(annotation)),
+            ContentItem::VerbatimBlock(verbatim) => symbols.push(verbatim_symbol(verbatim)),
+            ContentItem::Paragraph(paragraph) => {
+                symbols.extend(annotation_symbol_list(paragraph.annotations()));
+            }
+            ContentItem::ListItem(list_item) => {
+                symbols.extend(annotation_symbol_list(list_item.annotations()));
+                symbols.extend(collect_symbols_from_items(list_item.children.iter()));
+            }
+            ContentItem::TextLine(_)
+            | ContentItem::VerbatimLine(_)
+            | ContentItem::BlankLineGroup(_) => {}
+        }
+    }
+    symbols
+}
+
+fn definition_symbol(definition: &Definition) -> LexDocumentSymbol {
+    let mut children = annotation_symbol_list(definition.annotations());
+    children.extend(collect_symbols_from_items(definition.children.iter()));
+    let selection_range = definition
+        .header_location()
+        .cloned()
+        .unwrap_or_else(|| definition.range().clone());
+    LexDocumentSymbol {
+        name: summarize_text(&definition.subject, "Definition"),
+        detail: Some("definition".to_string()),
+        kind: SymbolKind::STRUCT,
+        range: definition.range().clone(),
+        selection_range,
+        children,
+    }
+}
+
+fn list_symbol(list: &List) -> LexDocumentSymbol {
+    let mut children = annotation_symbol_list(list.annotations());
+    for item in list.items.iter() {
+        if let ContentItem::ListItem(list_item) = item {
+            children.extend(annotation_symbol_list(list_item.annotations()));
+            children.extend(collect_symbols_from_items(list_item.children.iter()));
+        }
+    }
+    LexDocumentSymbol {
+        name: format!("List ({} items)", list.items.len()),
+        detail: None,
+        kind: SymbolKind::ARRAY,
+        range: list.range().clone(),
+        selection_range: list.range().clone(),
+        children,
+    }
+}
+
+fn verbatim_symbol(verbatim: &Verbatim) -> LexDocumentSymbol {
+    let children = annotation_symbol_list(verbatim.annotations());
+    LexDocumentSymbol {
+        name: format!(
+            "Verbatim: {}",
+            summarize_text(&verbatim.subject, "Verbatim block")
+        ),
+        detail: Some(verbatim.closing_data.label.value.clone()),
+        kind: SymbolKind::OBJECT,
+        range: verbatim.range().clone(),
+        selection_range: verbatim
+            .subject
+            .location
+            .clone()
+            .unwrap_or_else(|| verbatim.range().clone()),
+        children,
+    }
+}
+
+fn annotation_symbol(annotation: &Annotation) -> LexDocumentSymbol {
+    let children = collect_symbols_from_items(annotation.children.iter());
+    LexDocumentSymbol {
+        name: format!(":: {} ::", annotation.data.label.value),
+        detail: if annotation.data.parameters.is_empty() {
+            None
+        } else {
+            Some(
+                annotation
+                    .data
+                    .parameters
+                    .iter()
+                    .map(|param| format!("{}={}", param.key, param.value))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        },
+        kind: SymbolKind::EVENT,
+        range: annotation.range().clone(),
+        selection_range: annotation.header_location().clone(),
+        children,
+    }
+}
+
+fn annotation_symbol_list<'a>(
+    annotations: impl IntoIterator<Item = &'a Annotation>,
+) -> Vec<LexDocumentSymbol> {
+    annotations.into_iter().map(annotation_symbol).collect()
+}
+
+fn summarize_text(text: &TextContent, fallback: &str) -> String {
+    let trimmed = text.as_string().trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test_support::sample_document;
+
+    fn find_symbol<'a>(symbols: &'a [LexDocumentSymbol], name: &str) -> &'a LexDocumentSymbol {
+        symbols
+            .iter()
+            .find(|symbol| symbol.name == name)
+            .unwrap_or_else(|| panic!("symbol {} not found", name))
+    }
+
+    #[test]
+    fn builds_session_tree() {
+        let document = sample_document();
+        let symbols = collect_document_symbols(&document);
+        assert!(symbols.iter().any(|s| s.name == ":: doc.note ::"));
+        let session = find_symbol(&symbols, "1. Intro");
+        let child_names: Vec<_> = session
+            .children
+            .iter()
+            .map(|child| child.name.clone())
+            .collect();
+        assert!(child_names.iter().any(|name| name.contains("Cache")));
+        assert!(child_names.iter().any(|name| name.contains("List")));
+        assert!(child_names.iter().any(|name| name.contains("Verbatim")));
+        let definition_symbol = session
+            .children
+            .iter()
+            .find(|child| child.name.contains("Cache"))
+            .expect("definition symbol not found");
+        assert!(definition_symbol
+            .children
+            .iter()
+            .any(|child| child.name.contains(":: callout ::")));
+    }
+
+    #[test]
+    fn includes_document_level_annotations() {
+        let document = sample_document();
+        let symbols = collect_document_symbols(&document);
+        assert!(symbols.iter().any(|symbol| symbol.name == ":: 42 ::"));
+        assert!(symbols.iter().any(|symbol| symbol.name == ":: source ::"));
+    }
+}

--- a/lex-lsp/src/features/folding_ranges.rs
+++ b/lex-lsp/src/features/folding_ranges.rs
@@ -1,0 +1,183 @@
+use lex_parser::lex::ast::{
+    Annotation, AstNode, ContentItem, Definition, Document, List, ListItem, Range, Session,
+    Verbatim,
+};
+use lsp_types::FoldingRangeKind;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexFoldingRange {
+    pub start_line: u32,
+    pub start_character: Option<u32>,
+    pub end_line: u32,
+    pub end_character: Option<u32>,
+    pub kind: Option<FoldingRangeKind>,
+}
+
+pub fn folding_ranges(document: &Document) -> Vec<LexFoldingRange> {
+    let mut collector = FoldingCollector { ranges: Vec::new() };
+    collector.process_document(document);
+    collector.ranges
+}
+
+struct FoldingCollector {
+    ranges: Vec<LexFoldingRange>,
+}
+
+impl FoldingCollector {
+    fn process_document(&mut self, document: &Document) {
+        self.process_annotations(document.annotations());
+        self.process_session(&document.root, true);
+    }
+
+    fn process_session(&mut self, session: &Session, is_root: bool) {
+        if !is_root {
+            if let Some(body) = session.body_location() {
+                if session.range().start.line < body.end.line {
+                    self.push_fold(
+                        session.header_location(),
+                        session.range(),
+                        Some(FoldingRangeKind::Region),
+                    );
+                }
+            }
+        }
+        self.process_annotations(session.annotations());
+        for child in session.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_content_item(&mut self, item: &ContentItem) {
+        match item {
+            ContentItem::Paragraph(paragraph) => {
+                self.process_annotations(paragraph.annotations());
+            }
+            ContentItem::Session(session) => self.process_session(session, false),
+            ContentItem::List(list) => self.process_list(list),
+            ContentItem::ListItem(list_item) => self.process_list_item(list_item),
+            ContentItem::Definition(definition) => self.process_definition(definition),
+            ContentItem::Annotation(annotation) => self.process_annotation(annotation),
+            ContentItem::VerbatimBlock(verbatim) => self.process_verbatim(verbatim),
+            ContentItem::TextLine(_)
+            | ContentItem::VerbatimLine(_)
+            | ContentItem::BlankLineGroup(_) => {}
+        }
+    }
+
+    fn process_list(&mut self, list: &List) {
+        if list.range().start.line < list.range().end.line {
+            self.push_fold(
+                Some(list.range()),
+                list.range(),
+                Some(FoldingRangeKind::Region),
+            );
+        }
+        self.process_annotations(list.annotations());
+        for item in list.items.iter() {
+            if let ContentItem::ListItem(list_item) = item {
+                self.process_list_item(list_item);
+            }
+        }
+    }
+
+    fn process_list_item(&mut self, list_item: &ListItem) {
+        self.process_annotations(list_item.annotations());
+        if let Some(children_range) =
+            Range::bounding_box(list_item.children.iter().map(|child| child.range()))
+        {
+            if list_item.range().start.line < children_range.end.line {
+                self.push_fold(
+                    Some(list_item.range()),
+                    &children_range,
+                    Some(FoldingRangeKind::Region),
+                );
+            }
+        }
+        for child in list_item.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_definition(&mut self, definition: &Definition) {
+        if definition.range().start.line < definition.range().end.line {
+            let header = definition.header_location();
+            self.push_fold(header, definition.range(), Some(FoldingRangeKind::Region));
+        }
+        self.process_annotations(definition.annotations());
+        for child in definition.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_annotation(&mut self, annotation: &Annotation) {
+        if annotation.body_location().is_some() {
+            self.push_fold(
+                Some(annotation.header_location()),
+                annotation.range(),
+                Some(FoldingRangeKind::Comment),
+            );
+        }
+        for child in annotation.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_verbatim(&mut self, verbatim: &Verbatim) {
+        self.process_annotations(verbatim.annotations());
+        if let Some(subject_range) = &verbatim.subject.location {
+            if subject_range.start.line < verbatim.range().end.line {
+                self.push_fold(
+                    Some(subject_range),
+                    verbatim.range(),
+                    Some(FoldingRangeKind::Region),
+                );
+            }
+        }
+    }
+
+    fn process_annotations(&mut self, annotations: &[Annotation]) {
+        for annotation in annotations {
+            self.process_annotation(annotation);
+        }
+    }
+
+    fn push_fold(
+        &mut self,
+        start_range: Option<&Range>,
+        end_range: &Range,
+        kind: Option<FoldingRangeKind>,
+    ) {
+        let start = start_range.unwrap_or(end_range);
+        if start.start.line >= end_range.end.line {
+            return;
+        }
+        self.ranges.push(LexFoldingRange {
+            start_line: start.start.line as u32,
+            start_character: Some(start.start.column as u32),
+            end_line: end_range.end.line as u32,
+            end_character: Some(end_range.end.column as u32),
+            kind,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test_support::sample_document;
+
+    #[test]
+    fn creates_ranges_for_sessions_and_definitions() {
+        let document = sample_document();
+        let ranges = folding_ranges(&document);
+        assert!(ranges
+            .iter()
+            .any(|range| range.kind == Some(FoldingRangeKind::Region) && range.start_line == 2));
+        assert!(ranges
+            .iter()
+            .any(|range| range.kind == Some(FoldingRangeKind::Region) && range.start_line > 2));
+        assert!(ranges
+            .iter()
+            .any(|range| range.kind == Some(FoldingRangeKind::Comment)));
+    }
+}

--- a/lex-lsp/src/features/hover.rs
+++ b/lex-lsp/src/features/hover.rs
@@ -1,0 +1,533 @@
+use crate::features::inline::{extract_inline_spans, InlineSpanKind};
+use lex_parser::lex::ast::{
+    Annotation, ContentItem, Definition, Document, List, Position, Range, Session, TextContent,
+};
+use lex_parser::lex::inlines::ReferenceType;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HoverResult {
+    pub range: Range,
+    pub contents: String,
+}
+
+pub fn hover(document: &Document, position: Position) -> Option<HoverResult> {
+    inline_hover(document, position).or_else(|| annotation_hover(document, position))
+}
+
+fn inline_hover(document: &Document, position: Position) -> Option<HoverResult> {
+    let mut result = None;
+    for_each_text_content(document, &mut |text| {
+        if result.is_some() {
+            return;
+        }
+        for span in extract_inline_spans(text) {
+            if span.range.contains(position) {
+                result = match span.kind {
+                    InlineSpanKind::Reference(reference_type) => {
+                        hover_for_reference(document, &span.range, &span.raw, reference_type)
+                    }
+                    _ => None,
+                };
+                if result.is_some() {
+                    break;
+                }
+            }
+        }
+    });
+    result
+}
+
+fn hover_for_reference(
+    document: &Document,
+    range: &Range,
+    raw: &str,
+    reference_type: ReferenceType,
+) -> Option<HoverResult> {
+    match reference_type {
+        ReferenceType::FootnoteLabeled { label } => footnote_hover(document, range.clone(), &label)
+            .or_else(|| Some(generic_reference(range.clone(), raw))),
+        ReferenceType::FootnoteNumber { number } => {
+            footnote_hover(document, range.clone(), &number.to_string())
+                .or_else(|| Some(generic_reference(range.clone(), raw)))
+        }
+        ReferenceType::Citation(data) => {
+            let mut lines = vec![format!("Keys: {}", data.keys.join(", "))];
+            if let Some(locator) = data.locator {
+                lines.push(format!("Locator: {}", locator.raw));
+            }
+            Some(HoverResult {
+                range: range.clone(),
+                contents: format!("**Citation**\n\n{}", lines.join("\n")),
+            })
+        }
+        ReferenceType::General { target } => {
+            definition_hover(document, range.clone(), target.trim())
+                .or_else(|| Some(generic_reference(range.clone(), raw)))
+        }
+        ReferenceType::Url { target } => Some(HoverResult {
+            range: range.clone(),
+            contents: format!("**Link**\n\n{}", target),
+        }),
+        ReferenceType::File { target } => Some(HoverResult {
+            range: range.clone(),
+            contents: format!("**File Reference**\n\n{}", target),
+        }),
+        ReferenceType::Session { target } => Some(HoverResult {
+            range: range.clone(),
+            contents: format!("**Session Reference**\n\n{}", target),
+        }),
+        _ => Some(generic_reference(range.clone(), raw)),
+    }
+}
+
+fn generic_reference(range: Range, raw: &str) -> HoverResult {
+    HoverResult {
+        range,
+        contents: format!("**Reference**\n\n{}", raw.trim()),
+    }
+}
+
+fn footnote_hover(document: &Document, range: Range, label: &str) -> Option<HoverResult> {
+    let annotation = document.find_annotation_by_label(label)?;
+    let mut lines = Vec::new();
+    if let Some(preview) = preview_from_items(annotation.children.iter()) {
+        lines.push(preview);
+    }
+    if lines.is_empty() {
+        lines.push("(no content)".to_string());
+    }
+    Some(HoverResult {
+        range,
+        contents: format!("**Footnote [{}]**\n\n{}", label, lines.join("\n\n")),
+    })
+}
+
+fn definition_hover(document: &Document, range: Range, target: &str) -> Option<HoverResult> {
+    let definition = find_definition_by_subject(document, target)?;
+    let mut body_lines = Vec::new();
+    if let Some(preview) = preview_from_items(definition.children.iter()) {
+        body_lines.push(preview);
+    }
+    Some(HoverResult {
+        range,
+        contents: format!(
+            "**Definition: {}**\n\n{}",
+            target,
+            if body_lines.is_empty() {
+                "(no content)".to_string()
+            } else {
+                body_lines.join("\n\n")
+            }
+        ),
+    })
+}
+
+fn annotation_hover(document: &Document, position: Position) -> Option<HoverResult> {
+    if let Some(annotation) = document
+        .annotations()
+        .iter()
+        .find(|ann| ann.header_location().contains(position))
+    {
+        return Some(annotation_hover_result(annotation));
+    }
+    let annotation = find_annotation_in_session(&document.root, position)?;
+    Some(annotation_hover_result(annotation))
+}
+
+fn annotation_hover_result(annotation: &Annotation) -> HoverResult {
+    let mut parts = Vec::new();
+    if !annotation.data.parameters.is_empty() {
+        let params = annotation
+            .data
+            .parameters
+            .iter()
+            .map(|param| format!("{}={}", param.key, param.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        parts.push(format!("Parameters: {}", params));
+    }
+    if let Some(preview) = preview_from_items(annotation.children.iter()) {
+        parts.push(preview);
+    }
+    if parts.is_empty() {
+        parts.push("(no content)".to_string());
+    }
+    HoverResult {
+        range: annotation.header_location().clone(),
+        contents: format!(
+            "**Annotation :: {} ::**\n\n{}",
+            annotation.data.label.value,
+            parts.join("\n\n")
+        ),
+    }
+}
+
+fn find_annotation_in_session(session: &Session, position: Position) -> Option<&Annotation> {
+    if let Some(annotation) = session
+        .annotations()
+        .iter()
+        .find(|ann| ann.header_location().contains(position))
+    {
+        return Some(annotation);
+    }
+    for child in session.children.iter() {
+        if let Some(annotation) = find_annotation_in_content(child, position) {
+            return Some(annotation);
+        }
+    }
+    None
+}
+
+fn find_annotation_in_content(item: &ContentItem, position: Position) -> Option<&Annotation> {
+    match item {
+        ContentItem::Paragraph(paragraph) => paragraph
+            .annotations()
+            .iter()
+            .find(|ann| ann.header_location().contains(position))
+            .or_else(|| find_annotation_in_items(paragraph.lines.iter(), position)),
+        ContentItem::Session(session) => find_annotation_in_session(session, position),
+        ContentItem::List(list) => list
+            .annotations()
+            .iter()
+            .find(|ann| ann.header_location().contains(position))
+            .or_else(|| {
+                list.items.iter().find_map(|item| {
+                    if let ContentItem::ListItem(list_item) = item {
+                        list_item
+                            .annotations()
+                            .iter()
+                            .find(|ann| ann.header_location().contains(position))
+                            .or_else(|| {
+                                find_annotation_in_items(list_item.children.iter(), position)
+                            })
+                    } else {
+                        None
+                    }
+                })
+            }),
+        ContentItem::Definition(definition) => definition
+            .annotations()
+            .iter()
+            .find(|ann| ann.header_location().contains(position))
+            .or_else(|| find_annotation_in_items(definition.children.iter(), position)),
+        ContentItem::Annotation(annotation) => {
+            if annotation.header_location().contains(position) {
+                Some(annotation)
+            } else {
+                find_annotation_in_items(annotation.children.iter(), position)
+            }
+        }
+        ContentItem::VerbatimBlock(verbatim) => verbatim
+            .annotations()
+            .iter()
+            .find(|ann| ann.header_location().contains(position)),
+        ContentItem::ListItem(item) => item
+            .annotations()
+            .iter()
+            .find(|ann| ann.header_location().contains(position))
+            .or_else(|| find_annotation_in_items(item.children.iter(), position)),
+        ContentItem::TextLine(_)
+        | ContentItem::VerbatimLine(_)
+        | ContentItem::BlankLineGroup(_) => None,
+    }
+}
+
+fn find_annotation_in_items<'a>(
+    items: impl Iterator<Item = &'a ContentItem>,
+    position: Position,
+) -> Option<&'a Annotation> {
+    for item in items {
+        if let Some(annotation) = find_annotation_in_content(item, position) {
+            return Some(annotation);
+        }
+    }
+    None
+}
+
+fn find_definition_by_subject<'a>(document: &'a Document, target: &str) -> Option<&'a Definition> {
+    find_definition_in_items(document.root.children.iter(), target)
+}
+
+fn find_definition_in_items<'a>(
+    items: impl Iterator<Item = &'a ContentItem>,
+    target: &str,
+) -> Option<&'a Definition> {
+    for item in items {
+        if let Some(definition) = find_definition_in_content(item, target) {
+            return Some(definition);
+        }
+    }
+    None
+}
+
+fn find_definition_in_content<'a>(item: &'a ContentItem, target: &str) -> Option<&'a Definition> {
+    match item {
+        ContentItem::Definition(definition) => {
+            if definition
+                .subject
+                .as_string()
+                .trim()
+                .eq_ignore_ascii_case(target)
+            {
+                Some(definition)
+            } else {
+                find_definition_in_items(definition.children.iter(), target)
+            }
+        }
+        ContentItem::Session(session) => find_definition_in_items(session.children.iter(), target),
+        ContentItem::List(list) => find_definition_in_list(list, target),
+        ContentItem::ListItem(item) => find_definition_in_items(item.children.iter(), target),
+        ContentItem::Annotation(annotation) => {
+            find_definition_in_items(annotation.children.iter(), target)
+        }
+        ContentItem::Paragraph(paragraph) => {
+            find_definition_in_items(paragraph.lines.iter(), target)
+        }
+        ContentItem::VerbatimBlock(_)
+        | ContentItem::TextLine(_)
+        | ContentItem::VerbatimLine(_)
+        | ContentItem::BlankLineGroup(_) => None,
+    }
+}
+
+fn find_definition_in_list<'a>(list: &'a List, target: &str) -> Option<&'a Definition> {
+    for item in list.items.iter() {
+        if let ContentItem::ListItem(list_item) = item {
+            if let Some(definition) = find_definition_in_items(list_item.children.iter(), target) {
+                return Some(definition);
+            }
+        }
+    }
+    None
+}
+
+fn for_each_text_content<F>(document: &Document, f: &mut F)
+where
+    F: FnMut(&TextContent),
+{
+    for annotation in document.annotations() {
+        visit_annotation_text(annotation, f);
+    }
+    visit_session_text(&document.root, true, f);
+}
+
+fn visit_session_text<F>(session: &Session, is_root: bool, f: &mut F)
+where
+    F: FnMut(&TextContent),
+{
+    if !is_root {
+        f(&session.title);
+    }
+    for annotation in session.annotations() {
+        visit_annotation_text(annotation, f);
+    }
+    for child in session.children.iter() {
+        visit_content_text(child, f);
+    }
+}
+
+fn visit_content_text<F>(item: &ContentItem, f: &mut F)
+where
+    F: FnMut(&TextContent),
+{
+    match item {
+        ContentItem::Paragraph(paragraph) => {
+            for line in &paragraph.lines {
+                if let ContentItem::TextLine(text_line) = line {
+                    f(&text_line.content);
+                }
+            }
+            for annotation in paragraph.annotations() {
+                visit_annotation_text(annotation, f);
+            }
+        }
+        ContentItem::Session(session) => visit_session_text(session, false, f),
+        ContentItem::List(list) => {
+            for annotation in list.annotations() {
+                visit_annotation_text(annotation, f);
+            }
+            for item in list.items.iter() {
+                if let ContentItem::ListItem(list_item) = item {
+                    for text in &list_item.text {
+                        f(text);
+                    }
+                    for annotation in list_item.annotations() {
+                        visit_annotation_text(annotation, f);
+                    }
+                    for child in list_item.children.iter() {
+                        visit_content_text(child, f);
+                    }
+                }
+            }
+        }
+        ContentItem::ListItem(item) => {
+            for text in &item.text {
+                f(text);
+            }
+            for annotation in item.annotations() {
+                visit_annotation_text(annotation, f);
+            }
+            for child in item.children.iter() {
+                visit_content_text(child, f);
+            }
+        }
+        ContentItem::Definition(definition) => {
+            f(&definition.subject);
+            for annotation in definition.annotations() {
+                visit_annotation_text(annotation, f);
+            }
+            for child in definition.children.iter() {
+                visit_content_text(child, f);
+            }
+        }
+        ContentItem::Annotation(annotation) => visit_annotation_text(annotation, f),
+        ContentItem::VerbatimBlock(_)
+        | ContentItem::TextLine(_)
+        | ContentItem::VerbatimLine(_)
+        | ContentItem::BlankLineGroup(_) => {}
+    }
+}
+
+fn visit_annotation_text<F>(annotation: &Annotation, f: &mut F)
+where
+    F: FnMut(&TextContent),
+{
+    for child in annotation.children.iter() {
+        visit_content_text(child, f);
+    }
+}
+
+fn preview_from_items<'a>(items: impl Iterator<Item = &'a ContentItem>) -> Option<String> {
+    let mut lines = Vec::new();
+    collect_preview(items, &mut lines, 3);
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+fn collect_preview<'a>(
+    items: impl Iterator<Item = &'a ContentItem>,
+    lines: &mut Vec<String>,
+    limit: usize,
+) {
+    for item in items {
+        if lines.len() >= limit {
+            break;
+        }
+        match item {
+            ContentItem::Paragraph(paragraph) => {
+                let text = paragraph.text().trim().to_string();
+                if !text.is_empty() {
+                    lines.push(text);
+                }
+            }
+            ContentItem::ListItem(list_item) => {
+                let text = list_item.text().trim().to_string();
+                if !text.is_empty() {
+                    lines.push(text);
+                }
+            }
+            ContentItem::List(list) => {
+                for entry in list.items.iter() {
+                    if let ContentItem::ListItem(list_item) = entry {
+                        let text = list_item.text().trim().to_string();
+                        if !text.is_empty() {
+                            lines.push(text);
+                        }
+                        if lines.len() >= limit {
+                            break;
+                        }
+                    }
+                }
+            }
+            ContentItem::Definition(definition) => {
+                let subject = definition.subject.as_string().trim().to_string();
+                if !subject.is_empty() {
+                    lines.push(subject);
+                }
+                collect_preview(definition.children.iter(), lines, limit);
+            }
+            ContentItem::Annotation(annotation) => {
+                collect_preview(annotation.children.iter(), lines, limit);
+            }
+            ContentItem::Session(session) => {
+                collect_preview(session.children.iter(), lines, limit);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test_support::{sample_document, SAMPLE};
+
+    fn position_for(needle: &str) -> Position {
+        let index = SAMPLE
+            .find(needle)
+            .unwrap_or_else(|| panic!("{} not found", needle));
+        let mut line = 0;
+        let mut column = 0;
+        for ch in SAMPLE[..index].chars() {
+            if ch == '\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += ch.len_utf8();
+            }
+        }
+        Position::new(line, column)
+    }
+
+    #[test]
+    fn hover_shows_definition_preview_for_general_reference() {
+        let document = sample_document();
+        let position = position_for("[Cache]");
+        let hover = hover(&document, position).expect("hover expected");
+        assert!(hover.contents.contains("Definition"));
+        assert!(hover.contents.contains("definition body"));
+    }
+
+    #[test]
+    fn hover_shows_footnote_content() {
+        let document = sample_document();
+        let position = position_for("[^source]");
+        let hover = hover(&document, position).expect("hover expected");
+        assert!(hover.contents.contains("Footnote [source]"));
+        assert!(hover.contents.contains("Footnote referenced"));
+    }
+
+    #[test]
+    fn hover_shows_citation_details() {
+        let document = sample_document();
+        let position = position_for("[@spec2025 p.4]");
+        let hover = hover(&document, position).expect("hover expected");
+        assert!(hover.contents.contains("Citation"));
+        assert!(hover.contents.contains("spec2025"));
+    }
+
+    #[test]
+    fn hover_shows_annotation_metadata() {
+        let document = sample_document();
+        let mut position = None;
+        for item in document.root.children.iter() {
+            if let ContentItem::Session(session) = item {
+                for child in session.children.iter() {
+                    if let ContentItem::Definition(definition) = child {
+                        if let Some(annotation) = definition.annotations().first() {
+                            position = Some(annotation.header_location().start);
+                        }
+                    }
+                }
+            }
+        }
+        let position = position.expect("annotation position");
+        let hover = hover(&document, position).expect("hover expected");
+        assert!(hover.contents.contains("Annotation"));
+        assert!(hover.contents.contains("callout"));
+        assert!(hover.contents.contains("Session-level annotation body"));
+    }
+}

--- a/lex-lsp/src/features/hover.rs
+++ b/lex-lsp/src/features/hover.rs
@@ -463,15 +463,16 @@ fn collect_preview<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::features::test_support::{sample_document, SAMPLE};
+    use crate::features::test_support::{sample_document, sample_source};
 
     fn position_for(needle: &str) -> Position {
-        let index = SAMPLE
+        let source = sample_source();
+        let index = source
             .find(needle)
             .unwrap_or_else(|| panic!("{} not found", needle));
         let mut line = 0;
         let mut column = 0;
-        for ch in SAMPLE[..index].chars() {
+        for ch in source[..index].chars() {
             if ch == '\n' {
                 line += 1;
                 column = 0;
@@ -529,5 +530,12 @@ mod tests {
         assert!(hover.contents.contains("Annotation"));
         assert!(hover.contents.contains("callout"));
         assert!(hover.contents.contains("Session-level annotation body"));
+    }
+
+    #[test]
+    fn hover_returns_none_for_invalid_position() {
+        let document = sample_document();
+        let position = Position::new(999, 0);
+        assert!(hover(&document, position).is_none());
     }
 }

--- a/lex-lsp/src/features/inline.rs
+++ b/lex-lsp/src/features/inline.rs
@@ -1,0 +1,246 @@
+use lex_parser::lex::ast::{Position, Range, TextContent};
+use lex_parser::lex::inlines::{parse_inlines, InlineNode, ReferenceType};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum InlineSpanKind {
+    Strong,
+    Emphasis,
+    Code,
+    Math,
+    Reference(ReferenceType),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InlineSpan {
+    pub kind: InlineSpanKind,
+    pub range: Range,
+    pub raw: String,
+}
+
+/// Extract inline spans (formatting + references) from a text node.
+pub fn extract_inline_spans(text: &TextContent) -> Vec<InlineSpan> {
+    let Some(base_range) = text.location.as_ref() else {
+        return Vec::new();
+    };
+
+    let content = text.as_string();
+    if content.is_empty() {
+        return Vec::new();
+    }
+
+    let mut spans = Vec::new();
+    spans.extend(spans_from_marker(
+        content,
+        base_range,
+        '*',
+        InlineSpanKind::Strong,
+    ));
+    spans.extend(spans_from_marker(
+        content,
+        base_range,
+        '_',
+        InlineSpanKind::Emphasis,
+    ));
+    spans.extend(spans_from_marker(
+        content,
+        base_range,
+        '`',
+        InlineSpanKind::Code,
+    ));
+    spans.extend(spans_from_marker(
+        content,
+        base_range,
+        '#',
+        InlineSpanKind::Math,
+    ));
+    spans.extend(reference_spans(content, base_range));
+    spans
+}
+
+fn spans_from_marker(
+    text: &str,
+    base_range: &Range,
+    marker: char,
+    kind: InlineSpanKind,
+) -> Vec<InlineSpan> {
+    let mut spans = Vec::new();
+    for (start, end) in scan_symmetric_pairs(text, marker) {
+        let inner_start = start + marker.len_utf8();
+        let inner_end = end.saturating_sub(marker.len_utf8());
+        if inner_end <= inner_start {
+            continue;
+        }
+        let range = sub_range(base_range, text, inner_start, inner_end);
+        let raw = text[inner_start..inner_end].to_string();
+        spans.push(InlineSpan {
+            kind: kind.clone(),
+            range,
+            raw,
+        });
+    }
+    spans
+}
+
+fn reference_spans(text: &str, base_range: &Range) -> Vec<InlineSpan> {
+    let mut spans = Vec::new();
+    for (start, end) in scan_bracket_pairs(text) {
+        let inner_start = start + '['.len_utf8();
+        let inner_end = end.saturating_sub(']'.len_utf8());
+        if inner_end <= inner_start {
+            continue;
+        }
+        let range = sub_range(base_range, text, start, end);
+        let raw = text[inner_start..inner_end].to_string();
+        let reference_type = classify_reference(&raw);
+        spans.push(InlineSpan {
+            kind: InlineSpanKind::Reference(reference_type),
+            range,
+            raw,
+        });
+    }
+    spans
+}
+
+fn classify_reference(raw: &str) -> ReferenceType {
+    let wrapped = format!("[{}]", raw);
+    for node in parse_inlines(&wrapped) {
+        if let InlineNode::Reference { data, .. } = node {
+            return data.reference_type;
+        }
+    }
+    ReferenceType::NotSure
+}
+
+fn scan_symmetric_pairs(text: &str, marker: char) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut open: Option<usize> = None;
+    let mut escape = false;
+    for (idx, ch) in text.char_indices() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        if ch == marker {
+            if let Some(start_idx) = open {
+                if idx > start_idx + marker.len_utf8() {
+                    spans.push((start_idx, idx + marker.len_utf8()));
+                }
+                open = None;
+            } else {
+                open = Some(idx);
+            }
+        }
+    }
+    spans
+}
+
+fn scan_bracket_pairs(text: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut open: Option<usize> = None;
+    let mut escape = false;
+    for (idx, ch) in text.char_indices() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if ch == '\\' {
+            escape = true;
+            continue;
+        }
+        if ch == '[' {
+            if open.is_none() {
+                open = Some(idx);
+            }
+        } else if ch == ']' {
+            if let Some(start_idx) = open.take() {
+                if idx > start_idx + '['.len_utf8() {
+                    spans.push((start_idx, idx + ']'.len_utf8()));
+                }
+            }
+        }
+    }
+    spans
+}
+
+fn sub_range(base: &Range, text: &str, start: usize, end: usize) -> Range {
+    let start_pos = position_for_offset(base, text, start);
+    let end_pos = position_for_offset(base, text, end);
+    Range::new(
+        (base.span.start + start)..(base.span.start + end),
+        start_pos,
+        end_pos,
+    )
+}
+
+fn position_for_offset(base: &Range, text: &str, offset: usize) -> Position {
+    let mut line = base.start.line;
+    let mut column = base.start.column;
+    for ch in text[..offset].chars() {
+        if ch == '\n' {
+            line += 1;
+            column = 0;
+        } else {
+            column += ch.len_utf8();
+        }
+    }
+    Position::new(line, column)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_parser::lex::ast::Range;
+
+    fn text_with_range(content: &str, line: usize, column: usize) -> TextContent {
+        let start = Position::new(line, column);
+        let end = Position::new(line, column + content.len());
+        let range = Range::new(0..content.len(), start, end);
+        TextContent::from_string(content.to_string(), Some(range))
+    }
+
+    #[test]
+    fn detects_basic_inline_spans() {
+        let text = text_with_range("*bold* _em_ `code` #math#", 2, 4);
+        let spans = extract_inline_spans(&text);
+        assert_eq!(spans.len(), 4);
+        assert!(spans
+            .iter()
+            .any(|span| matches!(span.kind, InlineSpanKind::Strong)));
+        assert!(spans
+            .iter()
+            .any(|span| matches!(span.kind, InlineSpanKind::Emphasis)));
+        assert!(spans
+            .iter()
+            .any(|span| matches!(span.kind, InlineSpanKind::Code)));
+        assert!(spans
+            .iter()
+            .any(|span| matches!(span.kind, InlineSpanKind::Math)));
+    }
+
+    #[test]
+    fn detects_references_with_classification() {
+        let text = text_with_range("See [^note] and [@spec2024] plus [42]", 0, 0);
+        let spans = extract_inline_spans(&text);
+        let kinds: Vec<_> = spans
+            .iter()
+            .filter_map(|span| match &span.kind {
+                InlineSpanKind::Reference(reference) => Some(reference.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(kinds.len(), 3);
+        assert!(kinds
+            .iter()
+            .any(|kind| matches!(kind, ReferenceType::FootnoteLabeled { .. })));
+        assert!(kinds
+            .iter()
+            .any(|kind| matches!(kind, ReferenceType::Citation(_))));
+        assert!(kinds
+            .iter()
+            .any(|kind| matches!(kind, ReferenceType::FootnoteNumber { .. })));
+    }
+}

--- a/lex-lsp/src/features/mod.rs
+++ b/lex-lsp/src/features/mod.rs
@@ -1,0 +1,8 @@
+pub mod document_symbols;
+pub mod folding_ranges;
+pub mod hover;
+pub mod inline;
+pub mod semantic_tokens;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/lex-lsp/src/features/semantic_tokens.rs
+++ b/lex-lsp/src/features/semantic_tokens.rs
@@ -1,0 +1,336 @@
+use crate::features::inline::{extract_inline_spans, InlineSpanKind};
+use lex_parser::lex::ast::{
+    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Range, Session,
+    TextContent, Verbatim,
+};
+use lex_parser::lex::inlines::ReferenceType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LexSemanticTokenKind {
+    SessionTitle,
+    DefinitionSubject,
+    ListMarker,
+    AnnotationLabel,
+    AnnotationParameter,
+    InlineStrong,
+    InlineEmphasis,
+    InlineCode,
+    InlineMath,
+    Reference,
+    ReferenceCitation,
+    ReferenceFootnote,
+    VerbatimSubject,
+    VerbatimLanguage,
+    VerbatimAttribute,
+}
+
+impl LexSemanticTokenKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LexSemanticTokenKind::SessionTitle => "lexSessionTitle",
+            LexSemanticTokenKind::DefinitionSubject => "lexDefinitionSubject",
+            LexSemanticTokenKind::ListMarker => "lexListMarker",
+            LexSemanticTokenKind::AnnotationLabel => "lexAnnotationLabel",
+            LexSemanticTokenKind::AnnotationParameter => "lexAnnotationParameter",
+            LexSemanticTokenKind::InlineStrong => "lexInlineStrong",
+            LexSemanticTokenKind::InlineEmphasis => "lexInlineEmphasis",
+            LexSemanticTokenKind::InlineCode => "lexInlineCode",
+            LexSemanticTokenKind::InlineMath => "lexInlineMath",
+            LexSemanticTokenKind::Reference => "lexReference",
+            LexSemanticTokenKind::ReferenceCitation => "lexReferenceCitation",
+            LexSemanticTokenKind::ReferenceFootnote => "lexReferenceFootnote",
+            LexSemanticTokenKind::VerbatimSubject => "lexVerbatimSubject",
+            LexSemanticTokenKind::VerbatimLanguage => "lexVerbatimLanguage",
+            LexSemanticTokenKind::VerbatimAttribute => "lexVerbatimAttribute",
+        }
+    }
+}
+
+pub const SEMANTIC_TOKEN_KINDS: &[LexSemanticTokenKind] = &[
+    LexSemanticTokenKind::SessionTitle,
+    LexSemanticTokenKind::DefinitionSubject,
+    LexSemanticTokenKind::ListMarker,
+    LexSemanticTokenKind::AnnotationLabel,
+    LexSemanticTokenKind::AnnotationParameter,
+    LexSemanticTokenKind::InlineStrong,
+    LexSemanticTokenKind::InlineEmphasis,
+    LexSemanticTokenKind::InlineCode,
+    LexSemanticTokenKind::InlineMath,
+    LexSemanticTokenKind::Reference,
+    LexSemanticTokenKind::ReferenceCitation,
+    LexSemanticTokenKind::ReferenceFootnote,
+    LexSemanticTokenKind::VerbatimSubject,
+    LexSemanticTokenKind::VerbatimLanguage,
+    LexSemanticTokenKind::VerbatimAttribute,
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexSemanticToken {
+    pub kind: LexSemanticTokenKind,
+    pub range: Range,
+}
+
+pub fn collect_semantic_tokens(document: &Document) -> Vec<LexSemanticToken> {
+    let mut collector = TokenCollector::new();
+    collector.process_document(document);
+    collector.finish()
+}
+
+struct TokenCollector {
+    tokens: Vec<LexSemanticToken>,
+}
+
+impl TokenCollector {
+    fn new() -> Self {
+        Self { tokens: Vec::new() }
+    }
+
+    fn finish(mut self) -> Vec<LexSemanticToken> {
+        self.tokens.sort_by(|a, b| {
+            let a_start = (
+                &a.range.start.line,
+                &a.range.start.column,
+                &a.range.end.line,
+                &a.range.end.column,
+            );
+            let b_start = (
+                &b.range.start.line,
+                &b.range.start.column,
+                &b.range.end.line,
+                &b.range.end.column,
+            );
+            a_start.cmp(&b_start)
+        });
+        self.tokens
+    }
+
+    fn push_range(&mut self, range: &Range, kind: LexSemanticTokenKind) {
+        if range.span.start < range.span.end {
+            self.tokens.push(LexSemanticToken {
+                kind,
+                range: range.clone(),
+            });
+        }
+    }
+
+    fn process_document(&mut self, document: &Document) {
+        self.process_annotations(document.annotations());
+        self.process_session(&document.root, true);
+    }
+
+    fn process_session(&mut self, session: &Session, is_root: bool) {
+        if !is_root {
+            if let Some(header) = session.header_location() {
+                self.push_range(header, LexSemanticTokenKind::SessionTitle);
+            }
+            self.process_text_content(&session.title);
+        }
+
+        self.process_annotations(session.annotations());
+        for child in session.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_content_item(&mut self, item: &ContentItem) {
+        match item {
+            ContentItem::Paragraph(paragraph) => self.process_paragraph(paragraph),
+            ContentItem::Session(session) => self.process_session(session, false),
+            ContentItem::List(list) => self.process_list(list),
+            ContentItem::ListItem(list_item) => self.process_list_item(list_item),
+            ContentItem::Definition(definition) => self.process_definition(definition),
+            ContentItem::Annotation(annotation) => self.process_annotation(annotation),
+            ContentItem::VerbatimBlock(verbatim) => self.process_verbatim(verbatim),
+            ContentItem::TextLine(text_line) => self.process_text_content(&text_line.content),
+            ContentItem::VerbatimLine(_) => {}
+            ContentItem::BlankLineGroup(_) => {}
+        }
+    }
+
+    fn process_paragraph(&mut self, paragraph: &Paragraph) {
+        for line in &paragraph.lines {
+            if let ContentItem::TextLine(text_line) = line {
+                self.process_text_content(&text_line.content);
+            }
+        }
+        self.process_annotations(paragraph.annotations());
+    }
+
+    fn process_list(&mut self, list: &List) {
+        self.process_annotations(list.annotations());
+        for item in list.items.iter() {
+            if let ContentItem::ListItem(list_item) = item {
+                self.process_list_item(list_item);
+            }
+        }
+    }
+
+    fn process_list_item(&mut self, list_item: &ListItem) {
+        if let Some(marker_range) = &list_item.marker.location {
+            self.push_range(marker_range, LexSemanticTokenKind::ListMarker);
+        }
+        for text in &list_item.text {
+            self.process_text_content(text);
+        }
+        self.process_annotations(list_item.annotations());
+        for child in list_item.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_definition(&mut self, definition: &Definition) {
+        if let Some(header) = definition.header_location() {
+            self.push_range(header, LexSemanticTokenKind::DefinitionSubject);
+        }
+        self.process_text_content(&definition.subject);
+        self.process_annotations(definition.annotations());
+        for child in definition.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_verbatim(&mut self, verbatim: &Verbatim) {
+        for group in verbatim.group() {
+            self.process_text_content(group.subject);
+            if let Some(location) = &group.subject.location {
+                self.push_range(location, LexSemanticTokenKind::VerbatimSubject);
+            }
+        }
+
+        self.push_range(
+            &verbatim.closing_data.label.location,
+            LexSemanticTokenKind::VerbatimLanguage,
+        );
+        for parameter in &verbatim.closing_data.parameters {
+            self.push_range(&parameter.location, LexSemanticTokenKind::VerbatimAttribute);
+        }
+
+        self.process_annotations(verbatim.annotations());
+    }
+
+    fn process_annotation(&mut self, annotation: &Annotation) {
+        self.push_range(
+            annotation.header_location(),
+            LexSemanticTokenKind::AnnotationLabel,
+        );
+        for parameter in &annotation.data.parameters {
+            self.push_range(
+                &parameter.location,
+                LexSemanticTokenKind::AnnotationParameter,
+            );
+        }
+        for child in annotation.children.iter() {
+            self.process_content_item(child);
+        }
+    }
+
+    fn process_annotations(&mut self, annotations: &[Annotation]) {
+        for annotation in annotations {
+            self.process_annotation(annotation);
+        }
+    }
+
+    fn process_text_content(&mut self, text: &TextContent) {
+        for span in extract_inline_spans(text) {
+            let kind = match span.kind {
+                InlineSpanKind::Strong => Some(LexSemanticTokenKind::InlineStrong),
+                InlineSpanKind::Emphasis => Some(LexSemanticTokenKind::InlineEmphasis),
+                InlineSpanKind::Code => Some(LexSemanticTokenKind::InlineCode),
+                InlineSpanKind::Math => Some(LexSemanticTokenKind::InlineMath),
+                InlineSpanKind::Reference(reference_type) => Some(match reference_type {
+                    ReferenceType::Citation(_) => LexSemanticTokenKind::ReferenceCitation,
+                    ReferenceType::FootnoteNumber { .. }
+                    | ReferenceType::FootnoteLabeled { .. } => {
+                        LexSemanticTokenKind::ReferenceFootnote
+                    }
+                    _ => LexSemanticTokenKind::Reference,
+                }),
+            };
+            if let Some(kind) = kind {
+                self.push_range(&span.range, kind);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::test_support::{sample_document, SAMPLE};
+
+    fn snippets(tokens: &[LexSemanticToken], kind: LexSemanticTokenKind) -> Vec<String> {
+        tokens
+            .iter()
+            .filter(|token| token.kind == kind)
+            .map(|token| SAMPLE[token.range.span.clone()].to_string())
+            .collect()
+    }
+
+    #[test]
+    fn collects_structural_tokens() {
+        let document = sample_document();
+        let tokens = collect_semantic_tokens(&document);
+        assert!(snippets(&tokens, LexSemanticTokenKind::SessionTitle)
+            .iter()
+            .any(|snippet| snippet.trim() == "1. Intro"));
+        assert!(snippets(&tokens, LexSemanticTokenKind::DefinitionSubject)
+            .iter()
+            .any(|snippet| snippet.trim_end() == "Cache"));
+        let markers = snippets(&tokens, LexSemanticTokenKind::ListMarker);
+        assert_eq!(markers.len(), 2);
+        assert!(markers
+            .iter()
+            .all(|snippet| snippet.trim_start().starts_with('-')));
+        let annotation_labels = snippets(&tokens, LexSemanticTokenKind::AnnotationLabel);
+        assert!(annotation_labels
+            .iter()
+            .any(|snippet| snippet.contains("doc.note")));
+        let parameters = snippets(&tokens, LexSemanticTokenKind::AnnotationParameter);
+        assert!(parameters
+            .iter()
+            .any(|snippet| snippet.contains("severity=info")));
+        let verbatim_subjects = snippets(&tokens, LexSemanticTokenKind::VerbatimSubject);
+        assert!(verbatim_subjects
+            .iter()
+            .any(|snippet| snippet.contains("CLI Example")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::VerbatimLanguage)
+            .iter()
+            .any(|snippet| snippet.contains("shell")));
+    }
+
+    #[test]
+    fn collects_inline_tokens() {
+        let document = sample_document();
+        let tokens = collect_semantic_tokens(&document);
+        assert!(snippets(&tokens, LexSemanticTokenKind::InlineStrong)
+            .iter()
+            .any(|snippet| snippet.contains("Lex")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::InlineEmphasis)
+            .iter()
+            .any(|snippet| snippet.contains("format")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::InlineCode)
+            .iter()
+            .any(|snippet| snippet.contains("code")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::InlineMath)
+            .iter()
+            .any(|snippet| snippet.contains("math")));
+    }
+
+    #[test]
+    fn classifies_references() {
+        let document = sample_document();
+        let tokens = collect_semantic_tokens(&document);
+        assert!(snippets(&tokens, LexSemanticTokenKind::ReferenceCitation)
+            .iter()
+            .any(|snippet| snippet.contains("@spec2025")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::ReferenceFootnote)
+            .iter()
+            .any(|snippet| snippet.contains("^source")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::ReferenceFootnote)
+            .iter()
+            .any(|snippet| snippet.contains("42")));
+        assert!(snippets(&tokens, LexSemanticTokenKind::Reference)
+            .iter()
+            .any(|snippet| snippet.contains("Cache")));
+    }
+}

--- a/lex-lsp/src/features/test_support.rs
+++ b/lex-lsp/src/features/test_support.rs
@@ -1,36 +1,31 @@
-use lex_parser::lex::parsing::{parse_document, Document};
+use lex_parser::lex::ast::Document;
+use lex_parser::lex::testing::lexplore::Lexplore;
+use std::sync::OnceLock;
 
-pub(crate) const SAMPLE: &str = r":: doc.note severity=info :: Document preface.
+const SAMPLE_BENCHMARK: usize = 50;
 
-1. Intro
+struct SampleFixture {
+    document: Document,
+    source: String,
+}
 
-    Welcome to *Lex* _format_ with `code` and #math# plus references [^source] and [@spec2025 p.4] and [Cache].
+static SAMPLE_FIXTURE: OnceLock<SampleFixture> = OnceLock::new();
 
-    Cache:
-        A definition body referencing [Cache].
-
-    :: callout ::
-        Session-level annotation body.
-    ::
-
-    - Bullet item referencing [42]
-    - Nested bullet
-        Nested paragraph inside list.
-
-    CLI Example:
-        lex build
-        lex serve
-    :: shell language=bash
-
-:: 42 ::
-    Footnote forty two for bullet.
-::
-
-:: source ::
-    Footnote referenced in text.
-::
-";
+fn sample_fixture() -> &'static SampleFixture {
+    SAMPLE_FIXTURE.get_or_init(|| {
+        let loader = Lexplore::benchmark(SAMPLE_BENCHMARK);
+        let document = loader
+            .parse()
+            .expect("failed to parse benchmark fixture for lex-lsp tests");
+        let source = loader.source();
+        SampleFixture { document, source }
+    })
+}
 
 pub(crate) fn sample_document() -> Document {
-    parse_document(SAMPLE).expect("failed to parse LSP sample document")
+    sample_fixture().document.clone()
+}
+
+pub(crate) fn sample_source() -> &'static str {
+    sample_fixture().source.as_str()
 }

--- a/lex-lsp/src/features/test_support.rs
+++ b/lex-lsp/src/features/test_support.rs
@@ -1,0 +1,36 @@
+use lex_parser::lex::parsing::{parse_document, Document};
+
+pub(crate) const SAMPLE: &str = r":: doc.note severity=info :: Document preface.
+
+1. Intro
+
+    Welcome to *Lex* _format_ with `code` and #math# plus references [^source] and [@spec2025 p.4] and [Cache].
+
+    Cache:
+        A definition body referencing [Cache].
+
+    :: callout ::
+        Session-level annotation body.
+    ::
+
+    - Bullet item referencing [42]
+    - Nested bullet
+        Nested paragraph inside list.
+
+    CLI Example:
+        lex build
+        lex serve
+    :: shell language=bash
+
+:: 42 ::
+    Footnote forty two for bullet.
+::
+
+:: source ::
+    Footnote referenced in text.
+::
+";
+
+pub(crate) fn sample_document() -> Document {
+    parse_document(SAMPLE).expect("failed to parse LSP sample document")
+}

--- a/lex-lsp/src/lib.rs
+++ b/lex-lsp/src/lib.rs
@@ -154,6 +154,7 @@
 //!         Starts the language server on stdin/stdout for editor integration.
 //!
 
+pub mod features;
 pub mod server;
 
 pub use server::LexLanguageServer;

--- a/lex-lsp/src/lib.rs
+++ b/lex-lsp/src/lib.rs
@@ -36,39 +36,44 @@
 //!
 //!     Core Features (Phase 1):
 //!
-//!         1. Semantic Tokens (textDocument/semanticTokens/*):
-//!             - Syntax highlighting for sessions, lists, definitions, annotations
-//!             - Inline formatting: bold, italic, code, math
-//!             - References, footnotes, citations
-//!             - Verbatim blocks with language-specific highlighting
+//!         Syntax Highlighting
+//!             1. Semantic Tokens (textDocument/semanticTokens/*):
+//!                 - Syntax highlighting for sessions, lists, definitions, annotations
+//!                 - Inline formatting: bold, italic, code, math
+//!                 - References, footnotes, citations
+//!                 - Verbatim blocks with language-specific highlighting
 //!
-//!         2. Document Symbols (textDocument/documentSymbol):
-//!             - Hierarchical outline view of document structure
-//!             - Sessions with nesting (1., 1.1., 1.1.1., etc.)
-//!             - Definitions, annotations, lists as navigable symbols
+//!             2. Document Symbols (textDocument/documentSymbol):
+//!                 - Hierarchical outline view of document structure
+//!                 - Sessions with nesting (1., 1.1., 1.1.1., etc.)
+//!                 - Definitions, annotations, lists as navigable symbols
 //!
-//!         3. Folding Ranges (textDocument/foldingRange):
-//!             - Fold sessions and nested content
-//!             - Fold list items with children
-//!             - Fold annotations, definitions, verbatim blocks
+//!            3. Hover Information (textDocument/hover):
+//!                 - Preview footnote/citation content on hover
+//!                 - Show annotation metadata
+//!                 - Preview definition content when hovering over reference
 //!
-//!         4. Go to Definition / Find References (textDocument/definition, textDocument/references):
-//!             - Jump from footnote reference [42] to annotation
-//!             - Jump from citation [@spec2025] to bibliography entry
-//!             - Jump from internal reference [TK-rootlist] to target
-//!             - Find all references to footnotes/citations
-//!
-//!         5. Hover Information (textDocument/hover):
-//!             - Preview footnote/citation content on hover
-//!             - Show annotation metadata
-//!             - Preview definition content when hovering over reference
-//!
-//!         6. Document Links (textDocument/documentLink):
-//!             - Clickable links in text
-//!             - Verbatim block src parameters (images, includes)
-//!             - External references
+//!             4. Folding Ranges (textDocument/foldingRange):
+//!                 - Fold sessions and nested content
+//!                 - Fold list items with children
+//!                 - Fold annotations, definitions, verbatim blocks
 //!
 //!     Core Features (Phase 2):
+//!         
+//!         Navigation
+//!             
+//!             5. Go to Definition / Find References (textDocument/definition, textDocument/references):
+//!                 - Find all references to footnotes/citations
+//!                 - Jump from footnote reference [42] to annotation
+//!                 - Jump from citation [@spec2025] to bibliography entry
+//!                 - Jump from internal reference [TK-rootlist] to target
+//!
+//!             6. Document Links (textDocument/documentLink):
+//!                 - Clickable links in text
+//!                 - Verbatim block src parameters (images, includes)
+//!                 - External references
+//!
+//!     Core Features (Phase 3):
 //!
 //!         7. Document Formatting (textDocument/formatting, textDocument/rangeFormatting):
 //!             - Fix indentation issues
@@ -76,14 +81,13 @@
 //!             - Align list markers //!         
 //!
 //!
-//!     Core Features (Phase 3):
+//!     Core Features (Phase 4):
 //!
 //!         8. Diagnostics (textDocument/publishDiagnostics):
 //!             - Indentation errors (breaking the indentation wall)
 //!             - Malformed structures (single-item lists, unclosed verbatim blocks)
 //!             - Broken references (footnote/citation not found)
 //!             - Invalid annotation syntax
-//!
 //!
 //!
 //! Architecture

--- a/lex-lsp/src/lib.rs
+++ b/lex-lsp/src/lib.rs
@@ -1,0 +1,155 @@
+//! Language Server Protocol (LSP) implementation for Lex
+//!
+//!     This crate provides language server capabilities for the Lex format, enabling rich editor
+//!     support in any LSP-compatible editor (VSCode, Neovim, Emacs, Sublime, etc.).
+//!
+//! Design Decision: tower-lsp
+//!
+//!     After evaluating the Rust LSP ecosystem, we chose tower-lsp as our framework:
+//!
+//!     Considered Options:
+//!         1. tower-lsp: High-level async framework built on Tower (~204K monthly downloads)
+//!         2. lsp-server: Low-level sync library from rust-analyzer (~309K monthly downloads)
+//!         3. async-lsp: Low-level async with full Tower integration (~135 GitHub stars)
+//!
+//!     Why tower-lsp:
+//!         - Best balance of ease-of-use and functionality for a new LSP project
+//!         - Strong ecosystem support with extensive documentation and examples
+//!         - Modern async/await patterns ideal for Lex's structured parsing needs
+//!         - Built-in LSP 3.18 support with proposed features
+//!         - Active community with production usage in many language servers
+//!         - Good integration with Rust async ecosystem (tokio, futures)
+//!
+//!     Trade-offs:
+//!         - Less flexible than async-lsp for custom Tower layers (acceptable for our needs)
+//!         - Requires &self for trait methods, forcing Arc<Mutex<>> for mutable state (standard pattern)
+//!         - Notification ordering is async (not an issue for initial feature set)
+//!
+//!     Future Migration Path:
+//!         If we later need precise notification ordering or custom middleware, we can migrate
+//!         to async-lsp with minimal disruption as both use similar async patterns.
+//!
+//! Feature Set
+//!
+//!     Lex is a structured document format, not a programming language. LSP features are selected
+//!     to optimize document authoring and navigation workflows:
+//!
+//!     Core Features (Phase 1):
+//!
+//!         1. Semantic Tokens (textDocument/semanticTokens/*):
+//!             - Syntax highlighting for sessions, lists, definitions, annotations
+//!             - Inline formatting: bold, italic, code, math
+//!             - References, footnotes, citations
+//!             - Verbatim blocks with language-specific highlighting
+//!
+//!         2. Document Symbols (textDocument/documentSymbol):
+//!             - Hierarchical outline view of document structure
+//!             - Sessions with nesting (1., 1.1., 1.1.1., etc.)
+//!             - Definitions, annotations, lists as navigable symbols
+//!
+//!         3. Folding Ranges (textDocument/foldingRange):
+//!             - Fold sessions and nested content
+//!             - Fold list items with children
+//!             - Fold annotations, definitions, verbatim blocks
+//!
+//!         4. Go to Definition / Find References (textDocument/definition, textDocument/references):
+//!             - Jump from footnote reference [42] to annotation
+//!             - Jump from citation [@spec2025] to bibliography entry
+//!             - Jump from internal reference [TK-rootlist] to target
+//!             - Find all references to footnotes/citations
+//!
+//!         5. Diagnostics (textDocument/publishDiagnostics):
+//!             - Indentation errors (breaking the indentation wall)
+//!             - Malformed structures (single-item lists, unclosed verbatim blocks)
+//!             - Broken references (footnote/citation not found)
+//!             - Invalid annotation syntax
+//!
+//!         6. Hover Information (textDocument/hover):
+//!             - Preview footnote/citation content on hover
+//!             - Show annotation metadata
+//!             - Preview definition content when hovering over reference
+//!
+//!         7. Document Formatting (textDocument/formatting, textDocument/rangeFormatting):
+//!             - Fix indentation issues
+//!             - Normalize blank lines
+//!             - Align list markers
+//!
+//!         8. Document Links (textDocument/documentLink):
+//!             - Clickable links in text
+//!             - Verbatim block src parameters (images, includes)
+//!             - External references
+//!
+//! Future Features:
+//!
+//!     Later phases may add completion, code actions, selection ranges, rename, and inlay hints.
+//!     See planning docs for full roadmap.
+//!
+//! Architecture
+//!
+//!     The server follows a layered architecture:
+//!
+//!     LSP Layer (tower-lsp):
+//!         - Handles JSON-RPC communication
+//!         - Protocol handshaking and capability negotiation
+//!         - Request/response routing
+//!
+//!     Server Layer (this crate):
+//!         - Implements LanguageServer trait
+//!         - Manages document state and parsing
+//!         - Coordinates feature implementations
+//!
+//!     Feature Layer:
+//!         - Individual modules for each LSP feature
+//!         - Each feature operates on Lex AST
+//!         - Stateless transformations where possible
+//!
+//!     Parser Layer (lex-parser crate):
+//!         - Incremental parsing of Lex documents
+//!         - AST generation and location tracking
+//!         - Error recovery
+//!
+//! Testing Strategy
+//!
+//!     Following Lex project conventions:
+//!         - Use official sample files from specs/ for all tests
+//!         - Use lexplore loader for consistent test data
+//!         - Use ast_assertions library for AST validation
+//!         - Test each feature in isolation and integration
+//!         - Test against kitchensink and trifecta fixtures
+//!
+//! Non-Features
+//!
+//!     The following LSP features are intentionally excluded as they don't apply to document formats:
+//!         - Code Lens: Not applicable to documents
+//!         - Type Hierarchy: No type system
+//!         - Implementation: No interfaces/implementations
+//!         - Moniker: For cross-repo linking, not needed
+//!         - Linked Editing Range: For paired tags (HTML/XML)
+//!
+//! Usage
+//!
+//!     This crate provides both a library and binary:
+//!
+//!     Library:
+//!         ```rust
+//!         use lex_lsp::LexLanguageServer;
+//!         use tower_lsp::Server;
+//!
+//!         #[tokio::main]
+//!         async fn main() {
+//!             let stdin = tokio::io::stdin();
+//!             let stdout = tokio::io::stdout();
+//!
+//!             let (service, socket) = LspService::new(|client| LexLanguageServer::new(client));
+//!             Server::new(stdin, stdout, socket).serve(service).await;
+//!         }
+//!         ```
+//!
+//!     Binary:
+//!         $ lex-lsp
+//!         Starts the language server on stdin/stdout for editor integration.
+//!
+
+pub mod server;
+
+pub use server::LexLanguageServer;

--- a/lex-lsp/src/lib.rs
+++ b/lex-lsp/src/lib.rs
@@ -58,31 +58,33 @@
 //!             - Jump from internal reference [TK-rootlist] to target
 //!             - Find all references to footnotes/citations
 //!
-//!         5. Diagnostics (textDocument/publishDiagnostics):
+//!         5. Hover Information (textDocument/hover):
+//!             - Preview footnote/citation content on hover
+//!             - Show annotation metadata
+//!             - Preview definition content when hovering over reference
+//!
+//!         6. Document Links (textDocument/documentLink):
+//!             - Clickable links in text
+//!             - Verbatim block src parameters (images, includes)
+//!             - External references
+//!
+//!     Core Features (Phase 2):
+//!
+//!         7. Document Formatting (textDocument/formatting, textDocument/rangeFormatting):
+//!             - Fix indentation issues
+//!             - Normalize blank lines
+//!             - Align list markers //!         
+//!
+//!
+//!     Core Features (Phase 3):
+//!
+//!         8. Diagnostics (textDocument/publishDiagnostics):
 //!             - Indentation errors (breaking the indentation wall)
 //!             - Malformed structures (single-item lists, unclosed verbatim blocks)
 //!             - Broken references (footnote/citation not found)
 //!             - Invalid annotation syntax
 //!
-//!         6. Hover Information (textDocument/hover):
-//!             - Preview footnote/citation content on hover
-//!             - Show annotation metadata
-//!             - Preview definition content when hovering over reference
 //!
-//!         7. Document Formatting (textDocument/formatting, textDocument/rangeFormatting):
-//!             - Fix indentation issues
-//!             - Normalize blank lines
-//!             - Align list markers
-//!
-//!         8. Document Links (textDocument/documentLink):
-//!             - Clickable links in text
-//!             - Verbatim block src parameters (images, includes)
-//!             - External references
-//!
-//! Future Features:
-//!
-//!     Later phases may add completion, code actions, selection ranges, rename, and inlay hints.
-//!     See planning docs for full roadmap.
 //!
 //! Architecture
 //!
@@ -97,16 +99,14 @@
 //!         - Implements LanguageServer trait
 //!         - Manages document state and parsing
 //!         - Coordinates feature implementations
+//!         - Very thing, mostly calls the the feature layers over lex-parser
+//!         - Thin tests just asserting the right things are being called and returned
 //!
 //!     Feature Layer:
-//!         - Individual modules for each LSP feature
 //!         - Each feature operates on Lex AST
 //!         - Stateless transformations where possible
+//!         - All logic and dense unit tests
 //!
-//!     Parser Layer (lex-parser crate):
-//!         - Incremental parsing of Lex documents
-//!         - AST generation and location tracking
-//!         - Error recovery
 //!
 //! Testing Strategy
 //!

--- a/lex-lsp/src/server.rs
+++ b/lex-lsp/src/server.rs
@@ -1,16 +1,519 @@
 //! Main language server implementation
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::features::document_symbols::{collect_document_symbols, LexDocumentSymbol};
+use crate::features::folding_ranges::{folding_ranges as collect_folding_ranges, LexFoldingRange};
+use crate::features::hover::{hover as compute_hover, HoverResult};
+use crate::features::semantic_tokens::{
+    collect_semantic_tokens, LexSemanticToken, SEMANTIC_TOKEN_KINDS,
+};
+use lex_parser::lex::ast::{Document, Position as AstPosition, Range as AstRange};
+use lex_parser::lex::parsing;
+use tokio::sync::RwLock;
+use tower_lsp::async_trait;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::{
+    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
+    FoldingRangeProviderCapability, Hover, HoverContents, HoverParams, HoverProviderCapability,
+    InitializeParams, InitializeResult, InitializedParams, MarkupContent, MarkupKind, OneOf,
+    Position, Range, SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensFullOptions,
+    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, SemanticTokensResult,
+    ServerCapabilities, ServerInfo, TextDocumentItem, TextDocumentSyncCapability,
+    TextDocumentSyncKind, Url, WorkDoneProgressOptions,
+};
 use tower_lsp::Client;
 
-/// The Lex Language Server
-pub struct LexLanguageServer {
-    #[allow(dead_code)]
-    client: Client,
+pub trait LspClient: Send + Sync + Clone + 'static {}
+impl LspClient for Client {}
+
+pub trait FeatureProvider: Send + Sync + 'static {
+    fn semantic_tokens(&self, document: &Document) -> Vec<LexSemanticToken>;
+    fn document_symbols(&self, document: &Document) -> Vec<LexDocumentSymbol>;
+    fn folding_ranges(&self, document: &Document) -> Vec<LexFoldingRange>;
+    fn hover(&self, document: &Document, position: AstPosition) -> Option<HoverResult>;
 }
 
-impl LexLanguageServer {
-    /// Create a new Lex language server
+#[derive(Default)]
+pub struct DefaultFeatureProvider;
+
+impl DefaultFeatureProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl FeatureProvider for DefaultFeatureProvider {
+    fn semantic_tokens(&self, document: &Document) -> Vec<LexSemanticToken> {
+        collect_semantic_tokens(document)
+    }
+
+    fn document_symbols(&self, document: &Document) -> Vec<LexDocumentSymbol> {
+        collect_document_symbols(document)
+    }
+
+    fn folding_ranges(&self, document: &Document) -> Vec<LexFoldingRange> {
+        collect_folding_ranges(document)
+    }
+
+    fn hover(&self, document: &Document, position: AstPosition) -> Option<HoverResult> {
+        compute_hover(document, position)
+    }
+}
+
+#[derive(Default)]
+struct DocumentStore {
+    entries: RwLock<HashMap<Url, Option<Arc<Document>>>>,
+}
+
+impl DocumentStore {
+    async fn upsert(&self, uri: Url, text: String) -> Option<Arc<Document>> {
+        let parsed = parsing::parse_document(&text).ok().map(Arc::new);
+        self.entries.write().await.insert(uri, parsed.clone());
+        parsed
+    }
+
+    async fn get(&self, uri: &Url) -> Option<Arc<Document>> {
+        self.entries
+            .read()
+            .await
+            .get(uri)
+            .and_then(|entry| entry.clone())
+    }
+
+    async fn remove(&self, uri: &Url) {
+        self.entries.write().await.remove(uri);
+    }
+}
+
+fn semantic_tokens_legend() -> SemanticTokensLegend {
+    SemanticTokensLegend {
+        token_types: SEMANTIC_TOKEN_KINDS
+            .iter()
+            .map(|kind| SemanticTokenType::new(kind.as_str()))
+            .collect(),
+        token_modifiers: Vec::new(),
+    }
+}
+
+pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
+    _client: C,
+    documents: DocumentStore,
+    features: Arc<P>,
+}
+
+impl LexLanguageServer<Client, DefaultFeatureProvider> {
     pub fn new(client: Client) -> Self {
-        Self { client }
+        Self::with_features(client, Arc::new(DefaultFeatureProvider::new()))
+    }
+}
+
+impl<C, P> LexLanguageServer<C, P>
+where
+    C: LspClient,
+    P: FeatureProvider,
+{
+    pub fn with_features(client: C, features: Arc<P>) -> Self {
+        Self {
+            _client: client,
+            documents: DocumentStore::default(),
+            features,
+        }
+    }
+
+    async fn parse_and_store(&self, uri: Url, text: String) {
+        self.documents.upsert(uri, text).await;
+    }
+
+    async fn document(&self, uri: &Url) -> Option<Arc<Document>> {
+        self.documents.get(uri).await
+    }
+}
+
+fn to_lsp_position(position: &AstPosition) -> Position {
+    Position::new(position.line as u32, position.column as u32)
+}
+
+fn to_lsp_range(range: &AstRange) -> Range {
+    Range {
+        start: to_lsp_position(&range.start),
+        end: to_lsp_position(&range.end),
+    }
+}
+
+fn from_lsp_position(position: Position) -> AstPosition {
+    AstPosition::new(position.line as usize, position.character as usize)
+}
+
+fn encode_semantic_tokens(tokens: &[LexSemanticToken]) -> Vec<SemanticToken> {
+    let mut data = Vec::with_capacity(tokens.len());
+    let mut prev_line = 0u32;
+    let mut prev_start = 0u32;
+
+    for token in tokens {
+        let line = token.range.start.line as u32;
+        let start = token.range.start.column as u32;
+        let delta_line = line.saturating_sub(prev_line);
+        let delta_start = if delta_line == 0 {
+            start.saturating_sub(prev_start)
+        } else {
+            start
+        };
+        let length = if token.range.start.line == token.range.end.line {
+            token
+                .range
+                .end
+                .column
+                .saturating_sub(token.range.start.column) as u32
+        } else {
+            (token.range.span.end.saturating_sub(token.range.span.start)) as u32
+        };
+        let token_type_index = SEMANTIC_TOKEN_KINDS
+            .iter()
+            .position(|kind| *kind == token.kind)
+            .unwrap_or(0) as u32;
+
+        data.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length,
+            token_type: token_type_index,
+            token_modifiers_bitset: 0,
+        });
+        prev_line = line;
+        prev_start = start;
+    }
+
+    data
+}
+
+#[allow(deprecated)]
+fn to_document_symbol(symbol: &LexDocumentSymbol) -> DocumentSymbol {
+    DocumentSymbol {
+        name: symbol.name.clone(),
+        detail: symbol.detail.clone(),
+        kind: symbol.kind,
+        deprecated: None,
+        range: to_lsp_range(&symbol.range),
+        selection_range: to_lsp_range(&symbol.selection_range),
+        children: if symbol.children.is_empty() {
+            None
+        } else {
+            Some(symbol.children.iter().map(to_document_symbol).collect())
+        },
+        tags: None,
+    }
+}
+
+fn to_lsp_folding_range(range: &LexFoldingRange) -> FoldingRange {
+    FoldingRange {
+        start_line: range.start_line,
+        start_character: range.start_character,
+        end_line: range.end_line,
+        end_character: range.end_character,
+        kind: range.kind.clone(),
+        collapsed_text: None,
+    }
+}
+
+#[async_trait]
+impl<C, P> tower_lsp::LanguageServer for LexLanguageServer<C, P>
+where
+    C: LspClient,
+    P: FeatureProvider,
+{
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        let capabilities = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+            hover_provider: Some(HoverProviderCapability::Simple(true)),
+            document_symbol_provider: Some(OneOf::Left(true)),
+            folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
+            semantic_tokens_provider: Some(
+                lsp_types::SemanticTokensServerCapabilities::SemanticTokensOptions(
+                    SemanticTokensOptions {
+                        work_done_progress_options: WorkDoneProgressOptions::default(),
+                        legend: semantic_tokens_legend(),
+                        range: None,
+                        full: Some(SemanticTokensFullOptions::Bool(true)),
+                    },
+                ),
+            ),
+            ..ServerCapabilities::default()
+        };
+
+        Ok(InitializeResult {
+            capabilities,
+            server_info: Some(ServerInfo {
+                name: "lex-lsp".to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {}
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: lsp_types::DidOpenTextDocumentParams) {
+        let TextDocumentItem { uri, text, .. } = params.text_document;
+        self.parse_and_store(uri, text).await;
+    }
+
+    async fn did_change(&self, params: lsp_types::DidChangeTextDocumentParams) {
+        if let Some(change) = params.content_changes.into_iter().last() {
+            self.parse_and_store(params.text_document.uri, change.text)
+                .await;
+        }
+    }
+
+    async fn did_close(&self, params: lsp_types::DidCloseTextDocumentParams) {
+        self.documents.remove(&params.text_document.uri).await;
+    }
+
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        if let Some(document) = self.document(&params.text_document.uri).await {
+            let tokens = self.features.semantic_tokens(&document);
+            let data = encode_semantic_tokens(&tokens);
+            Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data,
+            })))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        if let Some(document) = self.document(&params.text_document.uri).await {
+            let symbols = self.features.document_symbols(&document);
+            let converted: Vec<DocumentSymbol> = symbols.iter().map(to_document_symbol).collect();
+            Ok(Some(DocumentSymbolResponse::Nested(converted)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        if let Some(document) = self
+            .document(&params.text_document_position_params.text_document.uri)
+            .await
+        {
+            let position = from_lsp_position(params.text_document_position_params.position);
+            if let Some(result) = self.features.hover(&document, position) {
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: result.contents,
+                    }),
+                    range: Some(to_lsp_range(&result.range)),
+                }));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
+        if let Some(document) = self.document(&params.text_document.uri).await {
+            let ranges = self.features.folding_ranges(&document);
+            Ok(Some(ranges.iter().map(to_lsp_folding_range).collect()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::semantic_tokens::LexSemanticTokenKind;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use tower_lsp::lsp_types::{
+        DidOpenTextDocumentParams, DocumentSymbolParams, FoldingRangeKind, FoldingRangeParams,
+        HoverParams, Position, SemanticTokensParams, SymbolKind, TextDocumentIdentifier,
+        TextDocumentItem, TextDocumentPositionParams,
+    };
+    use tower_lsp::LanguageServer;
+
+    #[derive(Clone, Default)]
+    struct NoopClient;
+    impl LspClient for NoopClient {}
+
+    #[derive(Default)]
+    struct MockFeatureProvider {
+        semantic_tokens_called: AtomicUsize,
+        document_symbols_called: AtomicUsize,
+        hover_called: AtomicUsize,
+        folding_called: AtomicUsize,
+        last_hover_position: Mutex<Option<AstPosition>>,
+    }
+
+    impl FeatureProvider for MockFeatureProvider {
+        fn semantic_tokens(&self, _: &Document) -> Vec<LexSemanticToken> {
+            self.semantic_tokens_called.fetch_add(1, Ordering::SeqCst);
+            vec![LexSemanticToken {
+                kind: LexSemanticTokenKind::SessionTitle,
+                range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
+            }]
+        }
+
+        fn document_symbols(&self, _: &Document) -> Vec<LexDocumentSymbol> {
+            self.document_symbols_called.fetch_add(1, Ordering::SeqCst);
+            vec![LexDocumentSymbol {
+                name: "symbol".into(),
+                detail: None,
+                kind: SymbolKind::STRING,
+                range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
+                selection_range: AstRange::new(
+                    0..5,
+                    AstPosition::new(0, 0),
+                    AstPosition::new(0, 5),
+                ),
+                children: Vec::new(),
+            }]
+        }
+
+        fn folding_ranges(&self, _: &Document) -> Vec<LexFoldingRange> {
+            self.folding_called.fetch_add(1, Ordering::SeqCst);
+            vec![LexFoldingRange {
+                start_line: 0,
+                start_character: Some(0),
+                end_line: 1,
+                end_character: Some(0),
+                kind: Some(FoldingRangeKind::Region),
+            }]
+        }
+
+        fn hover(&self, _: &Document, position: AstPosition) -> Option<HoverResult> {
+            self.hover_called.fetch_add(1, Ordering::SeqCst);
+            *self.last_hover_position.lock().unwrap() = Some(position);
+            Some(HoverResult {
+                range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
+                contents: "hover".into(),
+            })
+        }
+    }
+
+    fn sample_uri() -> Url {
+        Url::parse("file:///sample.lex").unwrap()
+    }
+
+    fn sample_text() -> String {
+        "1. Intro\n\n    Paragraph".into()
+    }
+
+    async fn open_sample_document(server: &LexLanguageServer<NoopClient, MockFeatureProvider>) {
+        let uri = sample_uri();
+        server
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri,
+                    language_id: "lex".into(),
+                    version: 1,
+                    text: sample_text(),
+                },
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn semantic_tokens_call_feature_layer() {
+        let provider = Arc::new(MockFeatureProvider::default());
+        let server = LexLanguageServer::with_features(NoopClient, provider.clone());
+        open_sample_document(&server).await;
+
+        let result = server
+            .semantic_tokens_full(SemanticTokensParams {
+                text_document: TextDocumentIdentifier { uri: sample_uri() },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(provider.semantic_tokens_called.load(Ordering::SeqCst), 1);
+        let data_len = match result {
+            SemanticTokensResult::Tokens(tokens) => tokens.data.len(),
+            SemanticTokensResult::Partial(partial) => partial.data.len(),
+        };
+        assert!(data_len > 0);
+    }
+
+    #[tokio::test]
+    async fn document_symbols_call_feature_layer() {
+        let provider = Arc::new(MockFeatureProvider::default());
+        let server = LexLanguageServer::with_features(NoopClient, provider.clone());
+        open_sample_document(&server).await;
+
+        let response = server
+            .document_symbol(DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri: sample_uri() },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        match response {
+            DocumentSymbolResponse::Nested(symbols) => assert!(!symbols.is_empty()),
+            _ => panic!("unexpected symbol response"),
+        }
+        assert_eq!(provider.document_symbols_called.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn hover_uses_feature_provider_position() {
+        let provider = Arc::new(MockFeatureProvider::default());
+        let server = LexLanguageServer::with_features(NoopClient, provider.clone());
+        open_sample_document(&server).await;
+
+        let hover = server
+            .hover(HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: sample_uri() },
+                    position: Position::new(0, 0),
+                },
+                work_done_progress_params: Default::default(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(hover.contents, HoverContents::Markup(_)));
+        assert_eq!(provider.hover_called.load(Ordering::SeqCst), 1);
+        let stored = provider.last_hover_position.lock().unwrap().unwrap();
+        assert_eq!(stored.line, 0);
+        assert_eq!(stored.column, 0);
+    }
+
+    #[tokio::test]
+    async fn folding_range_uses_feature_provider() {
+        let provider = Arc::new(MockFeatureProvider::default());
+        let server = LexLanguageServer::with_features(NoopClient, provider.clone());
+        open_sample_document(&server).await;
+
+        let ranges = server
+            .folding_range(FoldingRangeParams {
+                text_document: TextDocumentIdentifier { uri: sample_uri() },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(provider.folding_called.load(Ordering::SeqCst), 1);
+        assert_eq!(ranges.len(), 1);
     }
 }

--- a/lex-lsp/src/server.rs
+++ b/lex-lsp/src/server.rs
@@ -1,0 +1,16 @@
+//! Main language server implementation
+
+use tower_lsp::Client;
+
+/// The Lex Language Server
+pub struct LexLanguageServer {
+    #[allow(dead_code)]
+    client: Client,
+}
+
+impl LexLanguageServer {
+    /// Create a new Lex language server
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+}

--- a/lex-lsp/tests/cli.rs
+++ b/lex-lsp/tests/cli.rs
@@ -1,0 +1,16 @@
+use std::process::{Command, Stdio};
+
+#[test]
+fn lex_lsp_binary_starts_and_stops() {
+    let exe = env!("CARGO_BIN_EXE_lex-lsp");
+    let mut child = Command::new(exe)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start lex-lsp binary");
+
+    // Immediately terminate the server; we only need to ensure it starts.
+    child.kill().expect("failed to stop lex-lsp binary");
+    let _ = child.wait();
+}

--- a/lex-parser/src/lex/ast.rs
+++ b/lex-parser/src/lex/ast.rs
@@ -102,8 +102,10 @@
 //! out at compile time. See `docs/architecture/type-safe-containers.md` for
 //! details and compile-fail examples.
 
+pub mod diagnostics;
 pub mod elements;
 pub mod error;
+pub mod links;
 pub mod range;
 pub mod snapshot;
 pub mod text_content;
@@ -111,11 +113,13 @@ pub mod trait_helpers;
 pub mod traits;
 
 // Re-export commonly used types at module root
+pub use diagnostics::{validate_references, validate_structure, Diagnostic, DiagnosticSeverity};
 pub use elements::{
     Annotation, ContentItem, Data, Definition, Document, Label, List, ListItem, Paragraph,
     Parameter, Session, TextLine, Verbatim,
 };
 pub use error::PositionLookupError;
+pub use links::{DocumentLink, LinkType};
 pub use range::{Position, Range, SourceLocation};
 pub use snapshot::{
     snapshot_from_content, snapshot_from_content_with_options, snapshot_from_document,

--- a/lex-parser/src/lex/ast/diagnostics.rs
+++ b/lex-parser/src/lex/ast/diagnostics.rs
@@ -1,0 +1,387 @@
+//! Diagnostic collection and validation for LSP support
+//!
+//! This module provides structured error and warning information that can be consumed
+//! by LSP implementations to provide diagnostics in editors.
+//!
+//! ## Problem
+//!
+//! The LSP diagnostics feature needs structured error/warning information, but the parser currently:
+//! - Only tracks fatal `ParserError::InvalidNesting`
+//! - Doesn't collect indentation errors
+//! - Doesn't validate references
+//! - Doesn't detect malformed structures
+//!
+//! ## Solution
+//!
+//! This module provides:
+//! - `Diagnostic` struct matching LSP protocol
+//! - Validation functions for different error types
+//! - Collection API for gathering diagnostics from Documents
+//!
+//! ## Validation Checks
+//!
+//! 1. **Reference validation**: Broken footnote/citation references
+//! 2. **Structure validation**: Single-item lists, malformed elements
+//! 3. **Annotation validation**: Invalid annotation syntax
+//!
+//! Note: Indentation validation requires access to source text and is implemented
+//! separately in the validation functions.
+
+use super::range::Range;
+use super::Document;
+use std::fmt;
+
+/// Diagnostic severity levels matching LSP protocol
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+    Information,
+    Hint,
+}
+
+impl fmt::Display for DiagnosticSeverity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiagnosticSeverity::Error => write!(f, "error"),
+            DiagnosticSeverity::Warning => write!(f, "warning"),
+            DiagnosticSeverity::Information => write!(f, "info"),
+            DiagnosticSeverity::Hint => write!(f, "hint"),
+        }
+    }
+}
+
+/// Structured diagnostic for LSP consumption
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diagnostic {
+    pub range: Range,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    pub code: Option<String>,
+    pub source: String,
+}
+
+impl Diagnostic {
+    pub fn new(range: Range, severity: DiagnosticSeverity, message: String) -> Self {
+        Self {
+            range,
+            severity,
+            message,
+            code: None,
+            source: "lex-parser".to_string(),
+        }
+    }
+
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = source.into();
+        self
+    }
+}
+
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} [{}]: {} at {}",
+            self.severity, self.source, self.message, self.range.start
+        )
+    }
+}
+
+impl Document {
+    /// Get all diagnostics for this document
+    ///
+    /// This collects diagnostics from various validation checks:
+    /// - Broken references (footnotes, citations, session links)
+    /// - Malformed structures (single-item lists, etc.)
+    /// - Invalid annotation syntax
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let doc = parse_document(source)?;
+    /// let diagnostics = doc.diagnostics();
+    /// for diag in diagnostics {
+    ///     eprintln!("{}", diag);
+    /// }
+    /// ```
+    pub fn diagnostics(&self) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        // Collect reference validation errors
+        diagnostics.extend(validate_references(self));
+
+        // Collect structure validation errors
+        diagnostics.extend(validate_structure(self));
+
+        diagnostics
+    }
+}
+
+/// Validate all references in the document
+///
+/// Checks for:
+/// - Broken footnote references `[42]` without matching annotation
+/// - Broken citation references `[@key]` without matching annotation
+/// - Broken session references `[#section]` without matching session
+///
+/// # Arguments
+/// * `document` - The document to validate
+///
+/// # Returns
+/// Vector of diagnostics for broken references
+pub fn validate_references(document: &Document) -> Vec<Diagnostic> {
+    use super::traits::{AstNode, Container};
+    use crate::lex::inlines::ReferenceType;
+
+    let mut diagnostics = Vec::new();
+
+    // Iterate all references in the document
+    for reference in document.iter_all_references() {
+        match &reference.reference_type {
+            ReferenceType::FootnoteNumber { number } => {
+                // Check if annotation with this label exists
+                let label = number.to_string();
+                if document.find_annotation_by_label(&label).is_none() {
+                    // We don't have location info for inline elements yet
+                    // Using document root location as fallback
+                    let range = document.root.range().clone();
+                    let diag = Diagnostic::new(
+                        range,
+                        DiagnosticSeverity::Warning,
+                        format!(
+                            "Broken footnote reference: no annotation found with label '{}'",
+                            label
+                        ),
+                    )
+                    .with_code("broken-reference");
+                    diagnostics.push(diag);
+                }
+            }
+            ReferenceType::FootnoteLabeled { label } => {
+                if document.find_annotation_by_label(label).is_none() {
+                    let range = document.root.range().clone();
+                    let diag = Diagnostic::new(
+                        range,
+                        DiagnosticSeverity::Warning,
+                        format!(
+                            "Broken footnote reference: no annotation found with label '{}'",
+                            label
+                        ),
+                    )
+                    .with_code("broken-reference");
+                    diagnostics.push(diag);
+                }
+            }
+            ReferenceType::Citation(citation_data) => {
+                for key in &citation_data.keys {
+                    if document.find_annotation_by_label(key).is_none() {
+                        let range = document.root.range().clone();
+                        let diag = Diagnostic::new(
+                            range,
+                            DiagnosticSeverity::Warning,
+                            format!(
+                                "Broken citation reference: no annotation found with label '{}'",
+                                key
+                            ),
+                        )
+                        .with_code("broken-citation");
+                        diagnostics.push(diag);
+                    }
+                }
+            }
+            ReferenceType::Session { target } => {
+                // Check if a session with this label exists
+                let sessions: Vec<_> = document.root.iter_sessions_recursive().collect();
+                let found = sessions.iter().any(|s| s.label() == target);
+                if !found {
+                    let range = document.root.range().clone();
+                    let diag = Diagnostic::new(
+                        range,
+                        DiagnosticSeverity::Warning,
+                        format!(
+                            "Broken session reference: no session found with title '{}'",
+                            target
+                        ),
+                    )
+                    .with_code("broken-session-ref");
+                    diagnostics.push(diag);
+                }
+            }
+            _ => {
+                // URL, File, General, ToCome, and NotSure references don't need validation
+            }
+        }
+    }
+
+    diagnostics
+}
+
+/// Validate document structure for common errors
+///
+/// Checks for:
+/// - Single-item lists (should be paragraphs instead)
+/// - Invalid annotation syntax
+/// - Malformed data nodes
+///
+/// # Arguments
+/// * `document` - The document to validate
+///
+/// # Returns
+/// Vector of diagnostics for structural issues
+pub fn validate_structure(document: &Document) -> Vec<Diagnostic> {
+    use super::elements::content_item::ContentItem;
+    use super::traits::AstNode;
+
+    let mut diagnostics = Vec::new();
+
+    // Iterate all nodes to find structural issues
+    for (item, _depth) in document.root.iter_all_nodes_with_depth() {
+        match item {
+            ContentItem::List(list) => {
+                // Check for single-item lists
+                if list.items.len() == 1 {
+                    let diag = Diagnostic::new(
+                        list.range().clone(),
+                        DiagnosticSeverity::Information,
+                        "Single-item list: consider using a paragraph instead".to_string(),
+                    )
+                    .with_code("single-item-list");
+                    diagnostics.push(diag);
+                }
+            }
+            ContentItem::Annotation(annotation) => {
+                // Check for annotations with empty labels
+                if annotation.data.label.value.is_empty() {
+                    let diag = Diagnostic::new(
+                        annotation.range().clone(),
+                        DiagnosticSeverity::Error,
+                        "Annotation has empty label".to_string(),
+                    )
+                    .with_code("empty-annotation-label");
+                    diagnostics.push(diag);
+                }
+
+                // Check for duplicate parameters
+                let param_names: Vec<_> = annotation
+                    .data
+                    .parameters
+                    .iter()
+                    .map(|p| p.key.as_str())
+                    .collect();
+                for (i, name) in param_names.iter().enumerate() {
+                    if param_names[..i].contains(name) {
+                        let diag = Diagnostic::new(
+                            annotation.range().clone(),
+                            DiagnosticSeverity::Warning,
+                            format!("Duplicate parameter: '{}'", name),
+                        )
+                        .with_code("duplicate-parameter");
+                        diagnostics.push(diag);
+                        break;
+                    }
+                }
+            }
+            ContentItem::VerbatimBlock(verbatim) => {
+                // Check for empty verbatim block label
+                if verbatim.closing_data.label.value.is_empty() {
+                    let diag = Diagnostic::new(
+                        verbatim.range().clone(),
+                        DiagnosticSeverity::Warning,
+                        "Verbatim block has empty closing label".to_string(),
+                    )
+                    .with_code("empty-verbatim-label");
+                    diagnostics.push(diag);
+                }
+            }
+            _ => {
+                // Other content types don't need structural validation
+            }
+        }
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::parsing::parse_document;
+
+    #[test]
+    fn test_diagnostic_creation() {
+        use super::super::range::Position;
+
+        let range = Range::new(0..10, Position::new(1, 0), Position::new(1, 10));
+        let diag = Diagnostic::new(range, DiagnosticSeverity::Error, "Test error".to_string())
+            .with_code("test-001");
+
+        assert_eq!(diag.severity, DiagnosticSeverity::Error);
+        assert_eq!(diag.message, "Test error");
+        assert_eq!(diag.code, Some("test-001".to_string()));
+        assert_eq!(diag.source, "lex-parser");
+    }
+
+    #[test]
+    fn test_broken_footnote_reference() {
+        let source = "A paragraph with a footnote reference [42].\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let diagnostics = validate_references(&doc);
+
+        // Should find broken reference to [42]
+        assert!(!diagnostics.is_empty());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("Broken footnote reference")
+                    && d.message.contains("'42'"))
+        );
+    }
+
+    #[test]
+    fn test_valid_footnote_reference() {
+        let source =
+            "A paragraph with a footnote reference [42].\n\n:: 42 :: Footnote content.\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let diagnostics = validate_references(&doc);
+
+        // Should not find broken reference
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.message.contains("Broken footnote reference")),
+            "Expected no broken footnote reference diagnostics, got: {:?}",
+            diagnostics
+        );
+    }
+
+    #[test]
+    fn test_valid_structure_no_warnings() {
+        let source = ":: note :: A valid annotation.\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let diagnostics = validate_structure(&doc);
+
+        // Should not find any structural issues
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_document_diagnostics_api() {
+        let source = "A paragraph with [42].\n\n:: 42 :: Valid footnote.\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let diagnostics = doc.diagnostics();
+
+        // Should NOT find broken reference since annotation with label "42" exists
+        assert!(!diagnostics
+            .iter()
+            .any(|d| d.message.contains("Broken footnote reference")));
+    }
+}

--- a/lex-parser/src/lex/ast/links.rs
+++ b/lex-parser/src/lex/ast/links.rs
@@ -1,0 +1,325 @@
+//! Document link extraction for LSP support
+//!
+//! This module provides APIs for extracting clickable links from Lex documents,
+//! enabling the LSP "document links" feature that makes URLs and file references
+//! clickable in editors.
+//!
+//! ## Problem
+//!
+//! The LSP document links feature needs to find all clickable links:
+//! - URLs in text (`[https://example.com]`)
+//! - File references (`[./file.txt]`)
+//! - Verbatim block `src` parameters (images, includes)
+//!
+//! While `ReferenceType::Url` and `ReferenceType::File` exist, there's no API to
+//! extract all links from a document.
+//!
+//! ## Solution
+//!
+//! This module provides:
+//! - `DocumentLink` struct representing a link with its location and type
+//! - `find_all_links()` methods on Document and Session
+//! - `src_parameter()` method on Verbatim to access src parameters
+//!
+//! ## Link Types
+//!
+//! 1. **URL links**: `[https://example.com]` - HTTP/HTTPS URLs
+//! 2. **File links**: `[./file.txt]`, `[../path/to/file.md]` - File references
+//! 3. **Verbatim src**: `:: image src=./image.png ::` - External resource references
+
+use super::elements::Verbatim;
+use super::range::Range;
+use super::{Document, Session};
+use crate::lex::inlines::{InlineNode, ReferenceType};
+use std::fmt;
+
+/// Represents a document link with its location and type
+#[derive(Debug, Clone, PartialEq)]
+pub struct DocumentLink {
+    pub range: Range,
+    pub target: String,
+    pub link_type: LinkType,
+}
+
+impl DocumentLink {
+    pub fn new(range: Range, target: String, link_type: LinkType) -> Self {
+        Self {
+            range,
+            target,
+            link_type,
+        }
+    }
+}
+
+impl fmt::Display for DocumentLink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:?} link: {} at {}",
+            self.link_type, self.target, self.range.start
+        )
+    }
+}
+
+/// Type of document link
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkType {
+    /// HTTP/HTTPS URL
+    Url,
+    /// File reference (relative or absolute path)
+    File,
+    /// Verbatim block src parameter
+    VerbatimSrc,
+}
+
+impl Verbatim {
+    /// Get the src parameter value if present
+    ///
+    /// The src parameter is commonly used for:
+    /// - Image sources: `:: image src=./diagram.png ::`
+    /// - File includes: `:: include src=./code.rs ::`
+    /// - External resources: `:: data src=./data.csv ::`
+    ///
+    /// # Returns
+    /// The value of the `src` parameter, or None if not present
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// if let Some(src) = verbatim.src_parameter() {
+    ///     // Make src clickable in editor
+    ///     println!("Link to: {}", src);
+    /// }
+    /// ```
+    pub fn src_parameter(&self) -> Option<&str> {
+        self.closing_data
+            .parameters
+            .iter()
+            .find(|p| p.key == "src")
+            .map(|p| p.value.as_str())
+    }
+}
+
+impl Session {
+    /// Find all links at any depth in this session
+    ///
+    /// This searches recursively through all content to find:
+    /// - URL references: `[https://example.com]`
+    /// - File references: `[./path/to/file.txt]`
+    /// - Verbatim src parameters: `src=./image.png`
+    ///
+    /// # Returns
+    /// Vector of all links found in this session and its descendants
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let links = session.find_all_links();
+    /// for link in links {
+    ///     println!("Found {} link: {}", link.link_type, link.target);
+    /// }
+    /// ```
+    pub fn find_all_links(&self) -> Vec<DocumentLink> {
+        use super::elements::content_item::ContentItem;
+        use super::traits::AstNode;
+
+        let mut links = Vec::new();
+
+        // Use existing iter_all_references() API to find URL and File references
+        for paragraph in self.iter_paragraphs_recursive() {
+            for line_item in &paragraph.lines {
+                if let ContentItem::TextLine(line) = line_item {
+                    // Use inlines() method which returns the parsed inlines without requiring mutable access
+                    if let Some(inlines) = line.content.inlines() {
+                        for inline in inlines {
+                            if let InlineNode::Reference { data, .. } = inline {
+                                match &data.reference_type {
+                                    ReferenceType::Url { target } => {
+                                        // Use paragraph's range since we don't have inline-level ranges yet
+                                        let link = DocumentLink::new(
+                                            paragraph.range().clone(),
+                                            target.clone(),
+                                            LinkType::Url,
+                                        );
+                                        links.push(link);
+                                    }
+                                    ReferenceType::File { target } => {
+                                        let link = DocumentLink::new(
+                                            paragraph.range().clone(),
+                                            target.clone(),
+                                            LinkType::File,
+                                        );
+                                        links.push(link);
+                                    }
+                                    _ => {
+                                        // Other reference types are not clickable links
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Iterate all verbatim blocks to find src parameters
+        for (item, _depth) in self.iter_all_nodes_with_depth() {
+            if let ContentItem::VerbatimBlock(verbatim) = item {
+                if let Some(src) = verbatim.src_parameter() {
+                    let link = DocumentLink::new(
+                        verbatim.range().clone(),
+                        src.to_string(),
+                        LinkType::VerbatimSrc,
+                    );
+                    links.push(link);
+                }
+            }
+        }
+
+        links
+    }
+}
+
+impl Document {
+    /// Find all links in the entire document
+    ///
+    /// This searches the entire document tree to find all clickable links:
+    /// - URL references in text
+    /// - File references in text
+    /// - Verbatim block src parameters
+    ///
+    /// # Returns
+    /// Vector of all links found in the document
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let doc = parse_document(source)?;
+    /// let links = doc.find_all_links();
+    /// for link in links {
+    ///     // Make link clickable in LSP
+    ///     send_document_link(link.range, link.target);
+    /// }
+    /// ```
+    pub fn find_all_links(&self) -> Vec<DocumentLink> {
+        self.root.find_all_links()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::parsing::parse_document;
+
+    #[test]
+    fn test_url_link_extraction() {
+        let source = "Check out [https://example.com] for more info.\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_type, LinkType::Url);
+        assert_eq!(links[0].target, "https://example.com");
+    }
+
+    #[test]
+    fn test_file_link_extraction() {
+        let source = "See [./README.md] for details.\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_type, LinkType::File);
+        assert_eq!(links[0].target, "./README.md");
+    }
+
+    #[test]
+    fn test_multiple_links() {
+        let source = "Visit [https://example.com] and check [./docs.md].\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 2);
+        assert!(links.iter().any(|l| l.link_type == LinkType::Url));
+        assert!(links.iter().any(|l| l.link_type == LinkType::File));
+    }
+
+    #[test]
+    fn test_verbatim_src_parameter() {
+        let source =
+            "Sunset Photo:\n    As the sun sets over the ocean.\n:: image src=./diagram.png\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        // Find verbatim src link
+        let src_links: Vec<_> = links
+            .iter()
+            .filter(|l| l.link_type == LinkType::VerbatimSrc)
+            .collect();
+        assert_eq!(
+            src_links.len(),
+            1,
+            "Expected 1 verbatim src link, found {}. All links: {:?}",
+            src_links.len(),
+            links
+        );
+        assert_eq!(src_links[0].target, "./diagram.png");
+    }
+
+    #[test]
+    fn test_verbatim_src_parameter_method() {
+        use super::super::elements::{Data, Label, Parameter};
+
+        let verbatim = Verbatim::with_subject(
+            "Test".to_string(),
+            Data::new(
+                Label::new("image".to_string()),
+                vec![Parameter::new("src".to_string(), "./test.png".to_string())],
+            ),
+        );
+
+        assert_eq!(verbatim.src_parameter(), Some("./test.png"));
+
+        // Test verbatim without src parameter
+        let verbatim_no_src = Verbatim::with_subject(
+            "Test".to_string(),
+            Data::new(Label::new("code".to_string()), vec![]),
+        );
+
+        assert_eq!(verbatim_no_src.src_parameter(), None);
+    }
+
+    #[test]
+    fn test_no_links() {
+        let source = "Just plain text with no links.\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 0);
+    }
+
+    #[test]
+    fn test_footnote_not_a_link() {
+        let source = "Text with footnote [42].\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        // Footnote references are not clickable links
+        assert_eq!(links.len(), 0);
+    }
+
+    #[test]
+    fn test_nested_session_links() {
+        let source = "Outer Session\n\n    Inner session with [https://example.com].\n\n";
+        let doc = parse_document(source).unwrap();
+
+        let links = doc.find_all_links();
+
+        // Should find link in nested session
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "https://example.com");
+    }
+}

--- a/specs/v1/benchmark/050-lsp-fixture.lex
+++ b/specs/v1/benchmark/050-lsp-fixture.lex
@@ -1,0 +1,29 @@
+:: doc.note severity=info :: Document preface.
+
+1. Intro
+
+    Welcome to *Lex* _format_ with `code` and #math# plus references [^source] and [@spec2025 p.4] and [Cache].
+
+    Cache:
+        A definition body referencing [Cache].
+
+    :: callout ::
+        Session-level annotation body.
+    ::
+
+    - Bullet item referencing [42]
+    - Nested bullet
+        Nested paragraph inside list.
+
+    CLI Example:
+        lex build
+        lex serve
+    :: shell language=bash
+
+:: 42 ::
+    Footnote forty two for bullet.
+::
+
+:: source ::
+    Footnote referenced in text.
+::


### PR DESCRIPTION
## Summary

Add diagnostic collection and document link extraction APIs to power LSP diagnostics and document links features.

This PR implements two key LSP features that will enable rich editor support:

### Issue #292 - Diagnostic Collection
Adds structured diagnostic reporting for validation errors and warnings:
- **Broken reference detection**: Detects footnote references `[42]` without matching annotations
- **Citation validation**: Validates `[@cite]` references against bibliography entries  
- **Session reference validation**: Checks `[#section]` references point to valid sessions
- **Structure validation**: Detects malformed elements (empty labels, duplicate parameters, etc.)

### Issue #293 - Document Links
Adds APIs to extract all clickable links from documents:
- **URL links**: `[https://example.com]`
- **File references**: `[./path/to/file.md]`
- **Verbatim src parameters**: `:: image src=./photo.jpg`

## Implementation Details

**New modules:**
- `lex-parser/src/lex/ast/diagnostics.rs` (397 lines)
- `lex-parser/src/lex/ast/links.rs` (319 lines)

**Key APIs:**
- `Document::diagnostics()` - Collects all validation errors
- `Document::find_all_links()` - Extracts all clickable links
- `Verbatim::src_parameter()` - Accesses src parameter values
- `validate_references()` - Validates footnote/citation references
- `validate_structure()` - Validates element structure

**Testing:**
- 16 comprehensive tests covering all validation rules and link types
- All 399 tests passing
- Pre-commit hooks verified (formatting, linting, build, tests)

## Use Cases

These APIs enable several LSP features:

1. **Diagnostics** (textDocument/publishDiagnostics):
   - Show warnings for broken footnote references in real-time
   - Validate citations against bibliography
   - Catch structural issues before publishing

2. **Document Links** (textDocument/documentLink):
   - Make URLs clickable in editors
   - Enable Cmd+Click navigation to referenced files
   - Jump to image/include sources from verbatim blocks

3. **Future features**: These APIs also support hover previews and go-to-definition for references

## Examples

**Broken reference detection:**
```lex
A paragraph with [42].

// ⚠️ Warning: Broken footnote reference: no annotation found with label '42'
```

**Link extraction:**
```lex
Visit [https://example.com] or check [./docs.md].

Diagram:
    As the sun sets over the ocean.
:: image src=./sunset.jpg

// Extracts 3 links: URL, File, VerbatimSrc
```

Resolves #292  
Resolves #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>