### PR TITLE
feat(editors/nvim): Phase 0 - Neovim plugin setup with LSP integration

### DIFF
--- a/editors/nvim/README.md
+++ b/editors/nvim/README.md
@@ -1,0 +1,71 @@
+# Lex Neovim Plugin
+
+This directory contains the Neovim plugin for the Lex language, providing LSP integration, syntax highlighting, and symbol support.
+
+## Setup
+
+### Prerequisites
+
+- Neovim >= 0.9.0
+- `lex-lsp` binary in your PATH (or configured explicitly)
+
+### Minimal Configuration
+
+The plugin requires a minimal Neovim setup with LSP support. We use a LazyVim-style configuration that includes:
+
+- LSP client capabilities
+- Treesitter for syntax highlighting
+- Basic LSP UI components
+
+#### Bootstrap Config
+
+The plugin can be tested headlessly using a minimal config located in `config/init.lua`. This config:
+
+1. Sets up lazy.nvim package manager
+2. Installs necessary LSP dependencies
+3. Registers the Lex LSP server
+4. Configures file type detection for `.lex` files
+
+To use this config for testing:
+
+```bash
+# Run Neovim with isolated config
+NVIM_APPNAME=lex-test nvim -u config/init.lua
+```
+
+### Headless Testing
+
+The plugin includes headless tests that can run without a UI:
+
+```bash
+# Run all headless tests
+./test/run_headless.sh
+```
+
+## Development
+
+The plugin follows standard Neovim plugin structure:
+
+```
+editors/nvim/
+├── README.md           # This file
+├── config/             # Minimal test configurations
+│   └── init.lua        # Bootstrap config for testing
+├── lua/
+│   └── lex/            # Plugin code
+│       └── init.lua    # Main plugin entry point
+├── ftdetect/           # Filetype detection
+│   └── lex.lua
+└── test/               # Headless tests
+    └── run_headless.sh
+```
+
+## Features
+
+- [x] Filetype detection for `.lex` files
+- [x] LSP server integration
+- [ ] Hover documentation
+- [ ] Go to definition
+- [ ] Symbol search
+- [ ] Semantic token highlighting
+- [ ] Diagnostics

--- a/editors/nvim/config/init.lua
+++ b/editors/nvim/config/init.lua
@@ -1,0 +1,102 @@
+-- Minimal Neovim config for testing Lex plugin
+-- This config can be used headlessly: nvim -u config/init.lua --headless
+
+-- Add the plugin directory to the runtime path
+local plugin_dir = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":p:h:h")
+vim.opt.rtp:prepend(plugin_dir)
+
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Minimal settings
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- Setup lazy.nvim with minimal plugins for LSP support
+require("lazy").setup({
+  -- LSP config
+  {
+    "neovim/nvim-lspconfig",
+    dependencies = {
+      -- Mason for managing LSP servers (optional, we'll use lex-lsp directly)
+      "williamboman/mason.nvim",
+      "williamboman/mason-lspconfig.nvim",
+    },
+    config = function()
+      -- Setup Mason (optional)
+      require("mason").setup()
+      require("mason-lspconfig").setup()
+
+      -- Setup LSP capabilities
+      local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+      -- Register the Lex LSP server
+      local lspconfig = require("lspconfig")
+      local configs = require("lspconfig.configs")
+
+      -- Check if lex LSP config already exists
+      if not configs.lex_lsp then
+        configs.lex_lsp = {
+          default_config = {
+            cmd = { "lex-lsp" },
+            filetypes = { "lex" },
+            root_dir = function(fname)
+              return lspconfig.util.find_git_ancestor(fname) or vim.fn.getcwd()
+            end,
+            settings = {},
+          },
+        }
+      end
+
+      -- Start the LSP server for .lex files
+      lspconfig.lex_lsp.setup({
+        capabilities = capabilities,
+        on_attach = function(client, bufnr)
+          -- Enable completion triggered by <c-x><c-o>
+          vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+          -- Buffer-local keymaps
+          local bufopts = { noremap = true, silent = true, buffer = bufnr }
+          vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
+          vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
+          vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
+          vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
+          vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, bufopts)
+          vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, bufopts)
+        end,
+      })
+    end,
+  },
+
+  -- Treesitter for syntax highlighting (optional for now)
+  {
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
+    config = function()
+      require("nvim-treesitter.configs").setup({
+        ensure_installed = {}, -- We'll add lex parser later
+        highlight = {
+          enable = true,
+        },
+      })
+    end,
+  },
+})
+
+-- Filetype detection for .lex files
+vim.filetype.add({
+  extension = {
+    lex = "lex",
+  },
+})

--- a/editors/nvim/ftdetect/lex.lua
+++ b/editors/nvim/ftdetect/lex.lua
@@ -1,0 +1,7 @@
+-- Filetype detection for .lex files
+vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+  pattern = "*.lex",
+  callback = function()
+    vim.bo.filetype = "lex"
+  end,
+})

--- a/editors/nvim/lua/lex/init.lua
+++ b/editors/nvim/lua/lex/init.lua
@@ -1,0 +1,57 @@
+-- Lex Neovim plugin
+-- Main entry point for the Lex language plugin
+
+local M = {}
+
+-- Plugin version
+M.version = "0.1.0"
+
+-- Setup function called by lazy.nvim or manual setup
+function M.setup(opts)
+  opts = opts or {}
+
+  -- Register .lex filetype
+  vim.filetype.add({
+    extension = {
+      lex = "lex",
+    },
+  })
+
+  -- Setup LSP if lspconfig is available
+  local ok, lspconfig = pcall(require, "lspconfig")
+  if ok then
+    local configs = require("lspconfig.configs")
+
+    -- Register lex-lsp server config if not already registered
+    if not configs.lex_lsp then
+      configs.lex_lsp = {
+        default_config = {
+          cmd = opts.cmd or { "lex-lsp" },
+          filetypes = { "lex" },
+          root_dir = function(fname)
+            return lspconfig.util.find_git_ancestor(fname) or vim.fn.getcwd()
+          end,
+          settings = opts.settings or {},
+        },
+      }
+    end
+
+    -- Auto-start LSP for .lex files
+    lspconfig.lex_lsp.setup(opts.lsp_config or {})
+  end
+
+  -- Setup autocommands for .lex files
+  local augroup = vim.api.nvim_create_augroup("LexPlugin", { clear = true })
+
+  vim.api.nvim_create_autocmd("FileType", {
+    group = augroup,
+    pattern = "lex",
+    callback = function()
+      -- Set buffer-local options for .lex files
+      vim.bo.commentstring = "# %s"
+      vim.bo.comments = ":#"
+    end,
+  })
+end
+
+return M

--- a/editors/nvim/test/fixtures/example.lex
+++ b/editors/nvim/test/fixtures/example.lex
@@ -1,0 +1,19 @@
+# Example .lex file for testing
+
+section: introduction
+  @tag: example
+
+  This is a test document for the Lex language.
+  We use it to verify LSP functionality.
+
+section: features
+  @tag: lsp
+
+  - Syntax highlighting
+  - Hover documentation
+  - Go to definition
+  - Symbol search
+
+section: conclusion
+
+  The LSP integration should provide a smooth editing experience.

--- a/editors/nvim/test/minimal_init.lua
+++ b/editors/nvim/test/minimal_init.lua
@@ -1,0 +1,40 @@
+-- Minimal init.lua for LSP testing (without auto-configuring LSP)
+-- This provides just the basic infrastructure without starting any LSP servers
+
+-- Add the plugin directory to the runtime path
+local script_path = debug.getinfo(1).source:sub(2)
+local config_dir = vim.fn.fnamemodify(script_path, ":p:h")
+local plugin_dir = vim.fn.fnamemodify(config_dir, ":h")
+vim.opt.rtp:prepend(plugin_dir)
+
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Minimal settings
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- Setup lazy.nvim with just lspconfig (no auto-setup)
+require("lazy").setup({
+  {
+    "neovim/nvim-lspconfig",
+  },
+})
+
+-- Filetype detection for .lex files
+vim.filetype.add({
+  extension = {
+    lex = "lex",
+  },
+})

--- a/editors/nvim/test/run_headless.sh
+++ b/editors/nvim/test/run_headless.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Headless test runner for Lex Neovim plugin
+# This script runs tests without opening a GUI
+
+set -e
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$PLUGIN_DIR/config/init.lua"
+
+echo "===================================="
+echo "Lex Neovim Plugin - Headless Tests"
+echo "===================================="
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counter
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Function to run a test
+run_test() {
+    local test_name="$1"
+    local test_file="$2"
+    local config="${3:-$CONFIG_FILE}"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -n "Running: $test_name ... "
+
+    if NVIM_APPNAME=lex-test nvim --headless -u "$config" -l "$test_file" 2>&1 | grep -q "TEST_PASSED"; then
+        echo -e "${GREEN}PASSED${NC}"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "${RED}FAILED${NC}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# Run tests
+echo "Running plugin tests..."
+echo ""
+
+run_test "Plugin loads successfully" "$SCRIPT_DIR/test_plugin_loads.lua"
+run_test "Filetype detection for .lex files" "$SCRIPT_DIR/test_filetype.lua"
+run_test "LSP hover functionality" "$SCRIPT_DIR/test_lsp_hover.lua" "$SCRIPT_DIR/minimal_init.lua"
+
+# Summary
+echo ""
+echo "===================================="
+echo "Test Summary"
+echo "===================================="
+echo "Total:  $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+fi

--- a/editors/nvim/test/test_filetype.lua
+++ b/editors/nvim/test/test_filetype.lua
@@ -1,0 +1,36 @@
+-- Test: Filetype detection for .lex files
+-- This test verifies that .lex files are correctly identified
+
+-- Add plugin directory to runtime path
+local script_path = debug.getinfo(1).source:sub(2)
+local plugin_dir = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.rtp:prepend(plugin_dir)
+
+-- Load the plugin
+local lex = require("lex")
+lex.setup()
+
+-- Create a test .lex file
+local test_file = vim.fn.tempname() .. ".lex"
+vim.fn.writefile({ "# Test .lex file", "section: test" }, test_file)
+
+-- Open the file
+vim.cmd("edit " .. test_file)
+
+-- Wait a moment for filetype detection
+vim.wait(100)
+
+-- Check the filetype
+local filetype = vim.bo.filetype
+
+if filetype ~= "lex" then
+  print("TEST_FAILED: Expected filetype 'lex', got '" .. tostring(filetype) .. "'")
+  vim.fn.delete(test_file)
+  vim.cmd("cquit 1")
+end
+
+-- Clean up
+vim.fn.delete(test_file)
+
+print("TEST_PASSED: Filetype detection works correctly")
+vim.cmd("qall!")

--- a/editors/nvim/test/test_lsp_hover.lua
+++ b/editors/nvim/test/test_lsp_hover.lua
@@ -1,0 +1,140 @@
+-- Test: LSP hover functionality
+-- This test verifies that the LSP server can provide hover information
+-- Run with: nvim --headless -u test/minimal_init.lua -l test/test_lsp_hover.lua
+
+-- Get paths
+local script_path = debug.getinfo(1).source:sub(2)
+local plugin_dir = vim.fn.fnamemodify(script_path, ":p:h:h")
+
+-- Set up LSP
+local lspconfig_ok, lspconfig = pcall(require, "lspconfig")
+if not lspconfig_ok then
+  print("TEST_FAILED: lspconfig not available")
+  vim.cmd("cquit 1")
+end
+
+local configs = require("lspconfig.configs")
+
+-- Find the lex-lsp binary
+local project_root = vim.fn.fnamemodify(plugin_dir, ":h:h")
+local lex_lsp_path = project_root .. "/target/debug/lex-lsp"
+
+if vim.fn.filereadable(lex_lsp_path) ~= 1 then
+  print("TEST_FAILED: lex-lsp binary not found at " .. lex_lsp_path)
+  print("Please build with: cargo build --bin lex-lsp")
+  vim.cmd("cquit 1")
+end
+
+-- Register lex LSP config
+if not configs.lex_lsp then
+  configs.lex_lsp = {
+    default_config = {
+      cmd = { lex_lsp_path },
+      filetypes = { "lex" },
+      root_dir = function(fname)
+        return lspconfig.util.find_git_ancestor(fname) or vim.fn.getcwd()
+      end,
+      settings = {},
+    },
+  }
+end
+
+-- Track if LSP attached
+local lsp_attached = false
+local hover_result = nil
+
+-- Setup LSP with callback
+lspconfig.lex_lsp.setup({
+  on_attach = function(client, bufnr)
+    lsp_attached = true
+    print("LSP attached: client=" .. client.name .. ", bufnr=" .. bufnr)
+  end,
+})
+
+-- Register .lex filetype
+vim.filetype.add({
+  extension = {
+    lex = "lex",
+  },
+})
+
+-- Create a test .lex file with content that triggers hover
+local test_file = vim.fn.tempname() .. ".lex"
+local test_content = {
+  "# Test document",
+  "section: introduction",
+  "",
+  "  :: callout ::",
+  "    This is an annotation.",
+  "",
+  "  Some text with a [^ref] footnote.",
+  "",
+  ":: ref ::",
+  "  Footnote content here.",
+}
+vim.fn.writefile(test_content, test_file)
+
+-- Open the file
+vim.cmd("edit " .. test_file)
+
+-- Wait for LSP to attach (with timeout)
+local max_wait = 5000 -- 5 seconds
+local waited = 0
+local wait_step = 100
+
+while not lsp_attached and waited < max_wait do
+  vim.wait(wait_step)
+  waited = waited + wait_step
+end
+
+if not lsp_attached then
+  print("TEST_FAILED: LSP did not attach within timeout")
+  vim.fn.delete(test_file)
+  vim.cmd("cquit 1")
+end
+
+-- Wait a bit more for LSP to be fully ready
+vim.wait(500)
+
+-- Move cursor to line 4 (annotation line: "  :: callout ::")
+vim.api.nvim_win_set_cursor(0, {4, 5})
+
+-- Request hover information
+local params = vim.lsp.util.make_position_params()
+local result = vim.lsp.buf_request_sync(0, 'textDocument/hover', params, 2000)
+
+if not result or vim.tbl_isempty(result) then
+  print("TEST_FAILED: No hover result returned from LSP")
+  vim.fn.delete(test_file)
+  vim.cmd("cquit 1")
+end
+
+-- Check if we got a hover response
+local got_hover = false
+for client_id, response in pairs(result) do
+  if response.result and response.result.contents then
+    got_hover = true
+    local contents = response.result.contents
+    print("Hover result received:")
+    if type(contents) == "table" then
+      if contents.value then
+        print("  " .. contents.value)
+      elseif contents.kind then
+        print("  (kind: " .. contents.kind .. ")")
+      end
+    else
+      print("  " .. vim.inspect(contents))
+    end
+  end
+end
+
+-- Clean up
+vim.fn.delete(test_file)
+
+if got_hover then
+  print("TEST_PASSED: LSP hover functionality working")
+  vim.cmd("qall!")
+else
+  print("TEST_FAILED: Did not receive hover information")
+  vim.cmd("cquit 1")
+end

--- a/editors/nvim/test/test_plugin_loads.lua
+++ b/editors/nvim/test/test_plugin_loads.lua
@@ -1,0 +1,36 @@
+-- Test: Plugin loads successfully
+-- This test verifies that the Lex plugin can be loaded
+
+-- Add plugin directory to runtime path
+local script_path = debug.getinfo(1).source:sub(2)
+local plugin_dir = vim.fn.fnamemodify(script_path, ":p:h:h")
+vim.opt.rtp:prepend(plugin_dir)
+
+-- Attempt to load the plugin
+local ok, lex = pcall(require, "lex")
+
+if not ok then
+  print("TEST_FAILED: Could not load lex plugin")
+  print("Error: " .. tostring(lex))
+  vim.cmd("cquit 1")
+end
+
+-- Check that the plugin has expected fields
+if type(lex) ~= "table" then
+  print("TEST_FAILED: Plugin did not return a table")
+  vim.cmd("cquit 1")
+end
+
+if type(lex.setup) ~= "function" then
+  print("TEST_FAILED: Plugin does not have a setup function")
+  vim.cmd("cquit 1")
+end
+
+if type(lex.version) ~= "string" then
+  print("TEST_FAILED: Plugin does not have a version string")
+  vim.cmd("cquit 1")
+end
+
+print("TEST_PASSED: Plugin loaded successfully")
+print("Version: " .. lex.version)
+vim.cmd("qall!")


### PR DESCRIPTION
## Summary

This PR implements Phase 0 of the Neovim integration as outlined in #295. It establishes the foundation for the first editor plugin, proving the full chain: Neovim → lex-lsp → lex-parser works reliably and can be tested headlessly.

### What's included

#### Step 1: Minimal Lua config
- LazyVim-style configuration with LSP plumbing
- Bootstrap script for lazy.nvim package manager
- nvim-lspconfig integration for LSP support
- nvim-treesitter setup for syntax highlighting
- Comprehensive README documentation

#### Step 2: Plugin skeleton
- Filetype detection for `.lex` files (ftdetect/lex.lua)
- Plugin entry point with setup() function (lua/lex/init.lua)
- Headless test runner script (test/run_headless.sh)
- Plugin loading test
- Filetype detection test
- Example .lex fixture file

#### Step 3: LSP handshake
- Minimal init for LSP testing without auto-configuration
- LSP hover functionality test
- Verifies connectivity: editor ↔ lex-lsp ↔ parser
- Tests hover on annotations to prove the chain works
- Focus on connectivity, not semantic accuracy

## Test Results

All tests pass headlessly (no GUI required):

```bash
$ editors/nvim/test/run_headless.sh
====================================
Lex Neovim Plugin - Headless Tests
====================================

Running plugin tests...

Running: Plugin loads successfully ... PASSED
Running: Filetype detection for .lex files ... PASSED
Running: LSP hover functionality ... PASSED

====================================
Test Summary
====================================
Total:  3
Passed: 3
Failed: 0

All tests passed!
```

## Project Structure

```
editors/nvim/
├── README.md              # Setup docs and overview
├── config/                
│   └── init.lua           # Minimal LazyVim config
├── ftdetect/
│   └── lex.lua            # Filetype detection
├── lua/lex/
│   └── init.lua           # Plugin entry point
└── test/
    ├── run_headless.sh    # Test runner
    ├── minimal_init.lua   # LSP test config
    ├── test_plugin_loads.lua
    ├── test_filetype.lua
    ├── test_lsp_hover.lua
    └── fixtures/
        └── example.lex
```

## How to Test

### Prerequisites
```bash
# Build the LSP server
cargo build --bin lex-lsp
```

### Run headless tests
```bash
./editors/nvim/test/run_headless.sh
```

### Manual testing
```bash
# Use isolated config (won't affect your personal Neovim setup)
NVIM_APPNAME=lex-test nvim -u editors/nvim/config/init.lua test/fixtures/example.lex

# Trigger hover on an annotation
# Position cursor over ":: callout ::" and press K
```

## What Works

✅ Plugin loads in Neovim  
✅ .lex files are detected with correct filetype  
✅ LSP server connects and attaches to buffers  
✅ Hover functionality returns markdown from LSP  
✅ All tests run headlessly for CI  
✅ Isolated config doesn't interfere with personal setup  

## Next Steps

Future PRs will add:
- Go to definition
- Symbol search  
- Semantic token highlighting
- Diagnostics
- Additional LSP features

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)