### PR TITLE
feat: add element-at command to lex-cli

### DIFF
--- a/lex-cli/tests/element_at.rs
+++ b/lex-cli/tests/element_at.rs
@@ -1,0 +1,131 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+
+#[allow(deprecated)]
+#[test]
+fn test_element_at_basic() {
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at")
+        .arg("../specs/v1/benchmark/010-kitchensink.lex")
+        .arg("17")
+        .arg("5");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Session:"));
+}
+
+#[test]
+fn test_element_at_with_all_flag() {
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at")
+        .arg("../specs/v1/benchmark/010-kitchensink.lex")
+        .arg("17")
+        .arg("5")
+        .arg("--all");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Document:"))
+        .stdout(predicate::str::contains("Session:"));
+}
+
+#[test]
+fn test_element_at_no_element_found() {
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at")
+        .arg("../specs/v1/benchmark/010-kitchensink.lex")
+        .arg("10000")
+        .arg("10000");
+
+    // When no element is found, the command exits with 0 but prints to stderr
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("No element found"));
+}
+
+#[test]
+fn test_element_at_missing_arguments() {
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at")
+        .arg("specs/v1/benchmark/010-kitchensink.lex");
+
+    cmd.assert().failure();
+}
+
+#[test]
+fn test_element_at_file_not_found() {
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at")
+        .arg("nonexistent.lex")
+        .arg("1")
+        .arg("0");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Error reading file"));
+}
+
+#[test]
+fn test_element_at_on_paragraph() {
+    // Create a simple test file
+    let test_content = "This is a paragraph.";
+    let test_file = "test_element_at_paragraph.lex";
+    fs::write(test_file, test_content).unwrap();
+
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at").arg(test_file).arg("1").arg("5");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("TextLine:"));
+
+    // Cleanup
+    fs::remove_file(test_file).ok();
+}
+
+#[test]
+fn test_element_at_shows_deepest_element() {
+    // Create a test file with nested structure
+    let test_content = "Session Title\n\n    Nested paragraph.";
+    let test_file = "test_element_at_nested.lex";
+    fs::write(test_file, test_content).unwrap();
+
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at").arg(test_file).arg("3").arg("5");
+
+    // Without --all, should show only the deepest element
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("TextLine:"));
+
+    // Cleanup
+    fs::remove_file(test_file).ok();
+}
+
+#[test]
+fn test_element_at_all_shows_ancestors() {
+    // Create a test file with nested structure
+    let test_content = "Session Title\n\n    Nested paragraph.";
+    let test_file = "test_element_at_all.lex";
+    fs::write(test_file, test_content).unwrap();
+
+    let mut cmd = cargo_bin_cmd!("lex");
+    cmd.arg("element-at")
+        .arg(test_file)
+        .arg("3")
+        .arg("5")
+        .arg("--all");
+
+    // With --all, should show all ancestors
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Document:"))
+        .stdout(predicate::str::contains("Session:"))
+        .stdout(predicate::str::contains("Paragraph:"))
+        .stdout(predicate::str::contains("TextLine:"));
+
+    // Cleanup
+    fs::remove_file(test_file).ok();
+}

--- a/lex-parser/src/lex/ast.rs
+++ b/lex-parser/src/lex/ast.rs
@@ -140,6 +140,14 @@ pub fn find_nodes_at_position(document: &Document, position: Position) -> Vec<&d
     document.root.find_nodes_at_position(position)
 }
 
+/// Find the path of nodes at a given position in the document
+///
+/// Returns a vector containing the path of AST nodes from root to the deepest node at the given position.
+#[inline]
+pub fn find_node_path_at_position(document: &Document, position: Position) -> Vec<&dyn AstNode> {
+    document.node_path_at_position(position)
+}
+
 /// Format information about nodes at a given position
 ///
 /// This is a convenience wrapper around `Document::format_at_position()`.

--- a/lex-parser/src/lex/ast/elements/container.rs
+++ b/lex-parser/src/lex/ast/elements/container.rs
@@ -652,6 +652,17 @@ impl<P: ContainerPolicy> Container<P> {
         None
     }
 
+    /// Returns the path of nodes at the given position
+    pub fn node_path_at_position(&self, pos: Position) -> Vec<&ContentItem> {
+        for item in &self.children {
+            let path = item.node_path_at_position(pos);
+            if !path.is_empty() {
+                return path;
+            }
+        }
+        Vec::new()
+    }
+
     /// Returns the deepest AST node at the given position, if any
     pub fn find_nodes_at_position(&self, position: Position) -> Vec<&dyn AstNode> {
         if let Some(item) = self.element_at(position) {

--- a/lex-parser/src/lex/ast/elements/content_item.rs
+++ b/lex-parser/src/lex/ast/elements/content_item.rs
@@ -383,6 +383,28 @@ impl ContentItem {
         }
     }
 
+    /// Find the path of nodes at the given position, starting from this item
+    /// Returns a vector of nodes [self, child, grandchild, ...]
+    pub fn node_path_at_position(&self, pos: Position) -> Vec<&ContentItem> {
+        // Check nested items first
+        if let Some(children) = self.children() {
+            for child in children {
+                let mut path = child.node_path_at_position(pos);
+                if !path.is_empty() {
+                    path.insert(0, self);
+                    return path;
+                }
+            }
+        }
+
+        // If no children matched, check if this item contains the position
+        if self.range().contains(pos) {
+            vec![self]
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Recursively iterate all descendants of this node (depth-first pre-order)
     /// Does not include the node itself, only its descendants
     pub fn descendants(&self) -> Box<dyn Iterator<Item = &ContentItem> + '_> {

--- a/lex-parser/src/lex/ast/elements/document.rs
+++ b/lex-parser/src/lex/ast/elements/document.rs
@@ -32,7 +32,7 @@
 //! - Document-level metadata via annotations
 //! - All body content accessible via document.root.children
 
-use super::super::range::Range;
+use super::super::range::{Position, Range};
 use super::super::traits::{AstNode, Container, Visitor};
 use super::annotation::Annotation;
 use super::content_item::ContentItem;
@@ -98,6 +98,19 @@ impl Document {
 
     pub fn into_root(self) -> Session {
         self.root
+    }
+
+    /// Returns the path of nodes at the given position, starting from the document
+    pub fn node_path_at_position(&self, pos: Position) -> Vec<&dyn AstNode> {
+        let path = self.root.node_path_at_position(pos);
+        if !path.is_empty() {
+            let mut nodes: Vec<&dyn AstNode> = Vec::with_capacity(path.len() + 1);
+            nodes.push(self);
+            nodes.extend(path);
+            nodes
+        } else {
+            Vec::new()
+        }
     }
 
     /// All annotations attached directly to the document (document-level metadata).

--- a/lex-parser/src/lex/ast/elements/session.rs
+++ b/lex-parser/src/lex/ast/elements/session.rs
@@ -361,6 +361,23 @@ impl Session {
         self.children.find_nodes_at_position(position)
     }
 
+    /// Returns the path of nodes at the given position, starting from this session
+    pub fn node_path_at_position(&self, pos: Position) -> Vec<&dyn AstNode> {
+        let path = self.children.node_path_at_position(pos);
+        if !path.is_empty() {
+            let mut nodes: Vec<&dyn AstNode> = Vec::with_capacity(path.len() + 1);
+            nodes.push(self);
+            for item in path {
+                nodes.push(item);
+            }
+            nodes
+        } else if self.location.contains(pos) {
+            vec![self]
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Formats information about nodes located at a given position
     pub fn format_at_position(&self, position: Position) -> String {
         self.children.format_at_position(position)


### PR DESCRIPTION
## Summary
Implements the `element-at` command for `lex-cli` to retrieve information about AST elements at specific positions in lex files.

## Changes
- Added `node_path_at_position` methods to `ContentItem`, `Container`, `Session`, and `Document` to support ancestor path retrieval
- Implemented `element-at` CLI command with the following syntax:
  - `lex element-at <path> <row> <col>` - Returns the deepest element at the position
  - `lex element-at <path> <row> <col> --all` - Returns all ancestors from document root to deepest element
- Added comprehensive test suite with 8 tests covering basic usage, --all flag, error cases, and nested structures
- Exposed `find_node_path_at_position` in the public AST API

## Testing
- All new tests pass (8/8)
- Existing lex-parser and lex-cli tests pass
- Manual verification with benchmark files confirms correct behavior

## Examples
```bash
# Get element at line 17, column 5
lex element-at specs/v1/benchmark/010-kitchensink.lex 17 5
# Output: Session: 1. Primary Session {{session}}

# Get all ancestors
lex element-at specs/v1/benchmark/010-kitchensink.lex 17 5 --all
# Output:
# Document: Document (0 annotations, 10 items)
# Session: 
# Session: 1. Primary Session {{session}}
```