### PR TITLE
test(vscode-m5): cover document formatting

### DIFF
--- a/.github/workflows/vscode-plugin.yml
+++ b/.github/workflows/vscode-plugin.yml
@@ -41,6 +41,11 @@ jobs:
         run: npm ci
         working-directory: editors/vscode
 
+      - name: Install BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.10.0
+
       - name: Lint
         run: npm run lint
         working-directory: editors/vscode
@@ -49,6 +54,18 @@ jobs:
         run: npm run build
         working-directory: editors/vscode
 
-      - name: Test
-        run: npm test
+      - name: Run VS Code test suite
+        run: |
+          chmod +x test/run_suite.sh
+          ./test/run_suite.sh --format=junit > test_results.xml
         working-directory: editors/vscode
+
+      - name: Display Test Results
+        if: always()
+        run: cat editors/vscode/test_results.xml
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: editors/vscode/test_results.xml

--- a/.github/workflows/vscode-plugin.yml
+++ b/.github/workflows/vscode-plugin.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run VS Code test suite
         run: |
           chmod +x test/run_suite.sh
-          ./test/run_suite.sh --format=junit > test_results.xml
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' ./test/run_suite.sh --format=junit > test_results.xml
         working-directory: editors/vscode
 
       - name: Display Test Results

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage/
 node_modules/
 editors/vscode/out/
 editors/vscode/dist/
+editors/vscode/.vscode-test/
 
 # OS
 .DS_Store

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,5 +1,6 @@
 node_modules
 out/test
+test
 src
 scripts
 .vscode

--- a/editors/vscode/README.lex
+++ b/editors/vscode/README.lex
@@ -1,299 +1,40 @@
-We will begin the planning of the vscode plugin for Lex here.
+Lex VS Code Plugin
+==================
 
-See the development milestones at the end of this document.
+Scope
+-----
+- Thin VS Code extension that shells out to `lex-lsp`; no TypeScript-side language logic.
+- Language client + config live under `src/`; integration + fixture workspaces under `test/`.
+- All editor features are exercised through LSP requests so behaviour matches the Neovim client and CLI.
 
-For context : 
+Build & Test
+------------
+```
+cargo build --bin lex-lsp
+cargo build --bin lex
+cd editors/vscode
+npm ci
+npm run lint && npm run build
+npm test               # unit + VS Code integration
+./test/run_suite.sh --format=simple
+```
+CI mirrors the same sequence via `.github/workflows/vscode-plugin.yml`.
 
-	- Read the editors README [../README.lex] for the general view.
-    - Initial release contemplates the core features as described in the crate's lib[lex-lsp/src/lib.rs]
+Features Covered
+----------------
+- Activation + handshake with lex-lsp (configurable binary path).
+- Semantic tokens, document symbols, hover info, folding ranges.
+- Go to definition, find references, document links.
+- Whole-document formatting (shares fixtures with lex-lsp tests).
 
-Principles: 
+Implementation Notes
+--------------------
+- `@vscode/test-electron` drives headless VS Code; fixtures live in `test/fixtures/sample-workspace/`.
+- BATS wrapper runs `npm test` for CI parity with the Neovim plugin.
+- Extension exposes a tiny API (`clientReady`) so tests can await the LSP startup.
+- Workspace `.vscode-test/` and `dist/`/`out/` remain gitignored; VSIX packaging stays manual for now.
 
-	- No significant logic in the vscode plugin code.
-    - Leverage all the LSP and only LSP for the first release.
-	- For now can forgo the binary dependency on lex-lsp and use a hardcoded path for the binary.
-
-  Tech Stack
-
-  Core Build System:
-  - TypeScript 5.7+ with ES2022 target
-  - Node 20+ (matching rust-analyzer's approach)
-  - npm for package management
-  - ESBuild for bundling (fast, minimal config, used by rust-analyzer)
-
-  Module System:
-  - Node16 module resolution (required by vscode-languageclient 9.x)
-  - ES modules with "type": "module" in package.json
-
-  Runtime Dependencies:
-  - vscode-languageclient v9.x (official LSP client library)
-
-  Development Dependencies:
-  - @vscode/test-electron (official headless testing tool)
-  - @types/vscode (API types)
-  - @types/node
-  - esbuild (bundler)
-  - eslint + @typescript-eslint/* (linting)
-  - prettier (formatting, optional but rust-analyzer uses it)
-  - TypeScript 5.7+
-
-  Testing Framework:
-  - Plain assertions or lightweight assertion library for unit tests
-  - @vscode/test-electron for integration tests
-  - BATS for shell-level orchestration (matching your Neovim pattern)
-
-  File Layout
-
-  editors/vscode/
-  ├── src/
-  │   ├── main.ts              # Extension entry point (activates LSP client)
-  │   ├── client.ts            # LanguageClient setup and lifecycle
-  │   └── config.ts            # Extension configuration handling
-  ├── test/
-  │   ├── unit/
-  │   │   ├── index.ts         # Test loader (finds *.test.ts files)
-  │   │   └── config.test.ts   # Unit tests for config module
-  │   ├── integration/
-  │   │   ├── lsp_handshake.test.ts     # Verify LSP initialization
-  │   │   ├── lsp_hover.test.ts         # Test hover requests/responses
-  │   │   ├── lsp_document_symbols.test.ts
-  │   │   ├── lsp_folding_ranges.test.ts
-  │   │   └── lsp_formatting.test.ts
-  │   ├── fixtures/
-  │   │   └── example.lex      # Test documents
-  │   ├── runTests.ts          # Test runner using @vscode/test-electron
-  │   └── lex_vscode_extension.bats    # BATS wrapper for CI
-  ├── out/                     # Compiled JS output (gitignored)
-  ├── dist/                    # Bundled extension (gitignored)
-  ├── package.json
-  ├── tsconfig.json
-  ├── eslint.config.mjs
-  ├── .vscodeignore           # Files to exclude from VSIX
-  └── README.md
-
-  Testing Strategy
-
-  Unit Tests:
-  - Located in test/unit/*.test.ts
-  - Test configuration parsing, utility functions
-  - No VS Code API required, fast execution
-  - Custom test loader in test/unit/index.ts that glob-matches *.test.ts
-
-  Integration Tests:
-  - Located in test/integration/*.test.ts
-  - Verify LSP handshake succeeds
-  - Send LSP requests and validate responses (structure, not semantics)
-  - Check that document changes trigger appropriate server notifications
-  - Run in headless VS Code instance via @vscode/test-electron
-
-  BATS Orchestration:
-  - Shell out to npm test from BATS tests
-  - Similar pattern to Neovim: each test runs headless with fixtures
-  - Provides consistent CI interface across both editor plugins
-  - Formats: junit for CI, pretty for local development
-
-  Test Runner Implementation:
-  - test/runTests.ts uses @vscode/test-electron
-  - Downloads/caches VS Code binary
-  - Launches headless with --disable-extensions
-  - Points to extension development path and test suite entry point
-
-  What Gets Tested:
-  - Extension activation doesn't throw
-  - LSP client connects to lex-lsp server
-  - Document changes are synchronized
-  - Capabilities are correctly advertised
-  - LSP requests return well-formed responses
-  - We do NOT test semantic correctness (that's lex-lsp's job)
-
-  Development Workflow
-
-  Local Setup:
-  cd editors/vscode
-  npm install
-  npm run build        # Compile TypeScript
-  npm run watch        # Continuous compilation
-
-  Live Testing (F5 debugging):
-  - Press F5 in VS Code to launch Extension Development Host
-  - Opens new window with extension loaded
-  - Set breakpoints in TypeScript source
-  - Uses tsconfig.json sourcemaps for debugging
-
-  Headless Testing:
-  npm test                           # Run all tests
-  npm run test:unit                  # Unit tests only
-  npm run test:integration           # Integration tests only
-  ./test/run_suite.sh --format=simple   # BATS wrapper, friendly output
-  ./test/run_suite.sh --format=junit    # CI output
-
-  Packaging:
-  npm run package      # Creates .vsix file via vsce
-
-  Scripts in package.json:
-  {
-    "scripts": {
-      "build": "tsc -p .",
-      "watch": "tsc -watch -p .",
-      "bundle": "esbuild src/main.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs 
-  --platform=node --target=node20",
-      "vscode:prepublish": "npm run bundle -- --minify",
-      "pretest": "npm run build",
-      "test": "node ./out/test/runTests.js",
-      "lint": "eslint src test",
-      "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"
-    }
-  }
-
-  CI Integration:
-  - GitHub Actions workflow installs Node, runs npm ci, executes npm test
-  - BATS output in junit format for test result parsing
-  - Xvfb wrapper on Linux (handled by @vscode/test-electron)
-
-  Hardcoded LSP Binary Path:
-  - Configuration option in package.json contributions
-  - Default points to ../../target/debug/lex-lsp (relative to extension root)
-  - Users can override via settings for custom builds
-
-  Key Decisions Rationale
-
-  ESBuild over Webpack: Rust-analyzer switched to ESBuild for speed and simplicity. Single-file bundling
-  works for our thin wrapper.
-
-  Custom test loader over Mocha: Rust-analyzer demonstrates this pattern. Gives us control without
-  framework overhead.
-
-  BATS wrapper: Matches your Neovim infrastructure. Single command interface for CI.
-
-  No @vscode/test-cli: While newer, rust-analyzer uses @vscode/test-electron directly for more control
-  (running against multiple VS Code versions). We can keep it simpler initially.
-
-  Minimal dependencies: Only vscode-languageclient in production. Everything else is LSP protocol and
-  standard library.
-
-  Sources:
-  - https://code.visualstudio.com/api/working-with-extensions/testing-extension
-  - https://code.visualstudio.com/api/language-extensions/language-server-extension-guide
-  - https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/package.json
-  - https://www.npmjs.com/package/@vscode/test-electron
-  - https://github.com/microsoft/vscode-test
-
-
-Development Milestones
-
-	For each milestone, we will have a commit and push, together with working tests when relevant. Use this milestone name in the commit message.
-
-	1. Node Environment Setup:
-
-		- The package.json, tsconfig.json, eslint.config.mjs and other required confs.
-		- The init of npm and install
-		- The build and watch script
-        - A stub unit test that exercises the infrastructure.
-
-	2. GH Workflow
-		- We will create the github workflow for the plugin.
-		- This is to be tested and verified with real workflow runs.
-		- You can merge to main in order to have the workflow picked up, and once it's working do work on a new branch for the rest of the work.
-
-	3. Integration Tests Setup: 
-		- A basic test case that exercises that integration is working (no Lex work, just the vscode level integration)
-		- This means that it must work on the CI as well.
-	4. Lex Basic Integration: 
-		- Test the LSP handshake with the lex-lsp server.
-	5. Features
-		With the full setup working, verified both locally and on the CI we can start the actual feature work.
-		For each feature 1-7 in lex-lsp/src/lib.rs: 
-		- Implement the feature in the plugin
-		- Write integration tests
-        - Commit. 
-
-		Critical: how can we be sure this is really working? How do we test with certainly that syntax hilighting is working? Or the Outline view is working? Or the folding ranges.
-		This is a quite niche problem, if it's tricker than you'd expect, search online , see how projects like rust-analyzer do it.
-		Bellow a few potential tips on testing follows.
-
-
-
- Retry Strategy:
-
-  async function waitForSymbols(uri: vscode.Uri, maxAttempts = 10, delayMs = 500): 
-  Promise<vscode.DocumentSymbol[]> {
-    for (let i = 0; i < maxAttempts; i++) {
-      const result = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
-        'vscode.executeDocumentSymbolProvider',
-        uri
-      );
-      if (result && result.length > 0) {
-        return result;
-      }
-      await new Promise(resolve => setTimeout(resolve, delayMs));
-    }
-    throw new Error('Document symbols not available after timeout');
-  }
-
-  Proposed Test Structure
-
-  test/integration/
-  ├── lsp_semantic_tokens.test.ts
-  │   - Test semantic tokens legend is advertised
-  │   - Test semantic tokens response structure
-  │   - Test token count is non-zero for fixture
-  │
-  ├── lsp_document_symbols.test.ts
-  │   - Test document symbols response structure
-  │   - Test hierarchical nesting (children arrays)
-  │   - Test known symbols exist in fixture
-  │   - Test symbol kinds match expected values
-  │
-  └── fixtures/
-      └── lsp-fixture.lex (symlink to specs/v1/benchmark/050-lsp-fixture.lex)
-
-  Example Test Pattern
-
-  // test/integration/lsp_semantic_tokens.test.ts
-
-  import * as vscode from 'vscode';
-  import * as assert from 'assert';
-  import * as path from 'path';
-
-  suite('LSP Semantic Tokens', () => {
-    let document: vscode.TextDocument;
-
-    suiteSetup(async () => {
-      const fixtureUri = vscode.Uri.file(
-        path.join(__dirname, '../fixtures/lsp-fixture.lex')
-      );
-      document = await vscode.workspace.openTextDocument(fixtureUri);
-      await vscode.window.showTextDocument(document);
-
-      // Wait for LSP to fully initialize
-      await new Promise(resolve => setTimeout(resolve, 2000));
-    });
-
-    test('Returns semantic tokens legend', async () => {
-      const legend = await vscode.commands.executeCommand<vscode.SemanticTokensLegend>(
-        'vscode.provideDocumentSemanticTokensLegend',
-        document.uri
-      );
-
-      assert.ok(legend, 'Legend should exist');
-      assert.ok(legend.tokenTypes.length > 0, 'Should have token types');
-      assert.ok(legend.tokenModifiers.length >= 0, 'Should have token modifiers');
-    });
-
-    test('Returns semantic tokens for document', async () => {
-      const tokens = await vscode.commands.executeCommand<vscode.SemanticTokens>(
-        'vscode.provideDocumentSemanticTokens',
-        document.uri
-      );
-
-      assert.ok(tokens, 'Tokens should exist');
-      assert.ok(tokens.data, 'Tokens should have data array');
-      assert.ok(tokens.data.length > 0, 'Should have non-zero tokens');
-
-      // Validate structure (data is integer array of deltas)
-      assert.ok(tokens.data.every(n => Number.isInteger(n)), 'All deltas should be integers');
-
-      console.log(`Received ${tokens.data.length} token deltas`);
-    });
-  });
-
+Workflow
+--------
+- Each milestone/feature lands on its own branch (`editors/vscode/...`) with a conventional commit (e.g. `test(vscode-m5): cover document formatting`).
+- Always verify `npm run lint`, `npm run build`, `npm test`, and `./test/run_suite.sh` before pushing.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, and document symbols. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, and hover information. Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -5,12 +5,13 @@ This package hosts the VS Code extension for the Lex language. The extension is 
 ## Developer Setup
 
 ```
+cargo build --bin lex-lsp
 npm install
 npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers and a VS Code activation smoke test. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, and an initial lex-lsp handshake. Run individual suites with:
 
 ```
 npm run test:unit
@@ -18,4 +19,4 @@ npm run test:integration
 ./test/run_suite.sh --format=simple
 ```
 
-The integration runner uses `@vscode/test-electron` to launch a headless VS Code instance. During milestone 3 we set `LEX_VSCODE_SKIP_SERVER=1` (handled automatically by the runner) to bypass the Rust LSP binary until handshake coverage lands.
+The integration runner uses `@vscode/test-electron` to launch a headless VS Code instance and spins up the `lex-lsp` binary from `target/debug/lex-lsp`. If the binary is missing, the runner instructs you to build it first.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, and semantic tokens. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, and document symbols. Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, and an initial lex-lsp handshake. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, and semantic tokens. Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,4 +10,12 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers and serve as infrastructure smoke tests.
+Tests currently cover configuration helpers and a VS Code activation smoke test. Run individual suites with:
+
+```
+npm run test:unit
+npm run test:integration
+./test/run_suite.sh --format=simple
+```
+
+The integration runner uses `@vscode/test-electron` to launch a headless VS Code instance. During milestone 3 we set `LEX_VSCODE_SKIP_SERVER=1` (handled automatically by the runner) to bypass the Rust LSP binary until handshake coverage lands.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, folding ranges, navigation (definitions/references), and document links. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, folding ranges, navigation (definitions/references), document links, and document formatting. Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, folding ranges, and navigation (definitions/references). Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, folding ranges, navigation (definitions/references), and document links. Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, and folding ranges. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, folding ranges, and navigation (definitions/references). Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,7 +11,7 @@ npm run build
 npm test
 ```
 
-Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, and hover information. Run individual suites with:
+Tests currently cover configuration helpers, VS Code activation, lex-lsp handshake, semantic tokens, document symbols, hover information, and folding ranges. Run individual suites with:
 
 ```
 npm run test:unit

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -48,7 +48,9 @@
     "bundle": "esbuild src/main.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node20",
     "vscode:prepublish": "npm run bundle -- --minify",
     "pretest": "npm run build",
-    "test": "node ./out/test/unit/index.js",
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "node ./out/test/unit/index.js",
+    "test:integration": "node ./out/test/runTests.js",
     "lint": "eslint src test",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"
   },

--- a/editors/vscode/scripts/open_dev_vscode.sh
+++ b/editors/vscode/scripts/open_dev_vscode.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+EXTENSION_DIR="$REPO_ROOT/editors/vscode"
+WORKSPACE_FILE="$EXTENSION_DIR/test/fixtures/sample-workspace.code-workspace"
+LEX_LSP_BIN="$REPO_ROOT/target/debug/lex-lsp"
+
+if [[ ! -x "$LEX_LSP_BIN" ]]; then
+  echo "lex-lsp binary not found at $LEX_LSP_BIN"
+  echo "Run 'cargo build --bin lex-lsp' from the repo root before launching VS Code."
+  exit 1
+fi
+
+if ! command -v code >/dev/null 2>&1; then
+  echo "VS Code CLI (code) not found on PATH. Install VS Code and ensure 'code' is available."
+  exit 1
+fi
+
+exec code \
+  --extensionDevelopmentPath="$EXTENSION_DIR" \
+  "$WORKSPACE_FILE"

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -3,7 +3,7 @@ import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions
-} from 'vscode-languageclient/node';
+} from 'vscode-languageclient/node.js';
 
 export function createLexClient(
   binaryPath: string,

--- a/editors/vscode/src/main.ts
+++ b/editors/vscode/src/main.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
+import { LanguageClient } from 'vscode-languageclient/node.js';
 import {
   buildLexExtensionConfig,
   LEX_CONFIGURATION_SECTION,
@@ -9,6 +9,10 @@ import { createLexClient } from './client.js';
 
 let client: LanguageClient | undefined;
 
+function shouldSkipLanguageClient(): boolean {
+  return process.env.LEX_VSCODE_SKIP_SERVER === '1';
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration(LEX_CONFIGURATION_SECTION);
   const configuredLspPath = config.get<string | null>(LSP_BINARY_SETTING, null);
@@ -16,6 +20,11 @@ export async function activate(context: vscode.ExtensionContext) {
     context.extensionUri.fsPath,
     configuredLspPath
   );
+
+  if (shouldSkipLanguageClient()) {
+    console.info('[lex] Skipping language client startup (LEX_VSCODE_SKIP_SERVER=1).');
+    return;
+  }
 
   client = createLexClient(resolvedConfig.lspBinaryPath, context);
   context.subscriptions.push(client);

--- a/editors/vscode/src/types/vscode-languageclient-node.d.ts
+++ b/editors/vscode/src/types/vscode-languageclient-node.d.ts
@@ -1,0 +1,3 @@
+declare module 'vscode-languageclient/node.js' {
+  export * from 'vscode-languageclient/node';
+}

--- a/editors/vscode/test/fixtures/sample-workspace.code-workspace
+++ b/editors/vscode/test/fixtures/sample-workspace.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "./sample-workspace"
+    }
+  ],
+  "settings": {
+    "lex.lspBinaryPath": "../../../../target/debug/lex-lsp"
+  }
+}

--- a/editors/vscode/test/fixtures/sample-workspace.code-workspace
+++ b/editors/vscode/test/fixtures/sample-workspace.code-workspace
@@ -5,6 +5,6 @@
     }
   ],
   "settings": {
-    "lex.lspBinaryPath": "../../../../target/debug/lex-lsp"
+    "lex.lspBinaryPath": "../../target/debug/lex-lsp"
   }
 }

--- a/editors/vscode/test/fixtures/sample-workspace/documents/formatting.lex
+++ b/editors/vscode/test/fixtures/sample-workspace/documents/formatting.lex
@@ -4,4 +4,6 @@ Section:
 
 
 
+
   - item two
+

--- a/editors/vscode/test/fixtures/sample-workspace/documents/formatting.lex
+++ b/editors/vscode/test/fixtures/sample-workspace/documents/formatting.lex
@@ -1,0 +1,7 @@
+Section:
+
+    - item one   
+
+
+
+  - item two

--- a/editors/vscode/test/fixtures/sample-workspace/documents/getting-started.lex
+++ b/editors/vscode/test/fixtures/sample-workspace/documents/getting-started.lex
@@ -1,0 +1,6 @@
+# Getting Started
+
+Lex integration tests open this document to ensure the VS Code extension activates and tags the language correctly.
+
+- Item one
+- Item two

--- a/editors/vscode/test/fixtures/sample-workspace/documents/semantic-tokens.lex
+++ b/editors/vscode/test/fixtures/sample-workspace/documents/semantic-tokens.lex
@@ -21,6 +21,8 @@
         lex serve
     :: shell language=bash
 
+See https://lexlang.org for docs.
+
 2. Notes
     
 1. Footnote forty two for bullet.

--- a/editors/vscode/test/fixtures/sample-workspace/documents/semantic-tokens.lex
+++ b/editors/vscode/test/fixtures/sample-workspace/documents/semantic-tokens.lex
@@ -1,0 +1,27 @@
+:: doc.note severity=info :: Document preface for semantic tokens coverage.
+
+1. Intro
+
+    Welcome to *Lex* _format_ with `code` and #math# plus references [^source] and [@spec2025 p.4] and [Cache].
+
+    Cache:
+        A definition body referencing [Cache].
+
+    :: callout ::
+        Session-level annotation body.
+    ::
+
+    - Bullet item referencing [1]
+    - Nested bullet
+
+        Nested paragraph inside list.
+
+    CLI Example:
+        lex build
+        lex serve
+    :: shell language=bash
+
+Notes
+    
+1. Footnote forty two for bullet.
+2. Footnote referenced in text.

--- a/editors/vscode/test/fixtures/sample-workspace/documents/semantic-tokens.lex
+++ b/editors/vscode/test/fixtures/sample-workspace/documents/semantic-tokens.lex
@@ -21,7 +21,7 @@
         lex serve
     :: shell language=bash
 
-Notes
+2. Notes
     
 1. Footnote forty two for bullet.
 2. Footnote referenced in text.

--- a/editors/vscode/test/integration/activation_smoke.test.ts
+++ b/editors/vscode/test/integration/activation_smoke.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import * as vscode from 'vscode';
+import { integrationTest } from './harness.js';
+
+integrationTest('activates extension and tags Lex documents', async () => {
+  const extensionId = 'lex.lex-vscode';
+  const extension = vscode.extensions.getExtension(extensionId);
+  assert.ok(extension, `Extension ${extensionId} should be available`);
+
+  await extension.activate();
+  assert.equal(extension.isActive, true, 'Extension should activate without errors');
+
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(workspaceFolder, 'Workspace folder should be available in integration tests');
+
+  const documentUri = vscode.Uri.file(
+    path.join(workspaceFolder.uri.fsPath, 'documents/getting-started.lex')
+  );
+  const document = await vscode.workspace.openTextDocument(documentUri);
+  await vscode.window.showTextDocument(document);
+
+  assert.equal(document.languageId, 'lex', 'Lex documents must use the lex language id');
+
+  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+});

--- a/editors/vscode/test/integration/activation_smoke.test.ts
+++ b/editors/vscode/test/integration/activation_smoke.test.ts
@@ -1,26 +1,24 @@
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
 import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  TEST_DOCUMENT_PATH
+} from './helpers.js';
 
 integrationTest('activates extension and tags Lex documents', async () => {
   const extensionId = 'lex.lex-vscode';
-  const extension = vscode.extensions.getExtension(extensionId);
+  const extension = vscode.extensions.getExtension<LexExtensionApi>(extensionId);
   assert.ok(extension, `Extension ${extensionId} should be available`);
 
-  await extension.activate();
+  const api = await extension.activate();
+  await api?.clientReady();
   assert.equal(extension.isActive, true, 'Extension should activate without errors');
 
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-  assert.ok(workspaceFolder, 'Workspace folder should be available in integration tests');
-
-  const documentUri = vscode.Uri.file(
-    path.join(workspaceFolder.uri.fsPath, 'documents/getting-started.lex')
-  );
-  const document = await vscode.workspace.openTextDocument(documentUri);
-  await vscode.window.showTextDocument(document);
-
+  const document = await openWorkspaceDocument(TEST_DOCUMENT_PATH);
   assert.equal(document.languageId, 'lex', 'Lex documents must use the lex language id');
 
-  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  await closeAllEditors();
 });

--- a/editors/vscode/test/integration/harness.ts
+++ b/editors/vscode/test/integration/harness.ts
@@ -1,0 +1,25 @@
+export type IntegrationTest = () => Promise<void> | void;
+
+interface TestEntry {
+  name: string;
+  fn: IntegrationTest;
+}
+
+const tests: TestEntry[] = [];
+
+export function integrationTest(name: string, fn: IntegrationTest): void {
+  tests.push({ name, fn });
+}
+
+export async function runRegisteredTests(): Promise<void> {
+  for (const test of tests) {
+    const label = `VSCode Integration :: ${test.name}`;
+    try {
+      await test.fn();
+      console.log(`✓ ${label}`);
+    } catch (error) {
+      console.error(`✗ ${label}`);
+      throw error;
+    }
+  }
+}

--- a/editors/vscode/test/integration/helpers.ts
+++ b/editors/vscode/test/integration/helpers.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import * as vscode from 'vscode';
+
+export const TEST_DOCUMENT_PATH = 'documents/getting-started.lex';
+
+export function requireWorkspaceFolder(): vscode.WorkspaceFolder {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    throw new Error('Workspace folder should be available during integration tests');
+  }
+
+  return folder;
+}
+
+export async function openWorkspaceDocument(
+  relativePath: string
+): Promise<vscode.TextDocument> {
+  const folder = requireWorkspaceFolder();
+  const documentUri = vscode.Uri.file(
+    path.join(folder.uri.fsPath, relativePath)
+  );
+  const document = await vscode.workspace.openTextDocument(documentUri);
+  await vscode.window.showTextDocument(document);
+  return document;
+}
+
+export async function closeAllEditors(): Promise<void> {
+  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+}

--- a/editors/vscode/test/integration/helpers.ts
+++ b/editors/vscode/test/integration/helpers.ts
@@ -3,6 +3,29 @@ import * as vscode from 'vscode';
 
 export const TEST_DOCUMENT_PATH = 'documents/getting-started.lex';
 export const SEMANTIC_TOKENS_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
+export const HOVER_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
+
+export interface PositionMatch {
+  line: number;
+  character: number;
+}
+
+export function findPosition(
+  document: vscode.TextDocument,
+  searchText: string
+): PositionMatch | undefined {
+  const text = document.getText();
+  const index = text.indexOf(searchText);
+  if (index === -1) {
+    return undefined;
+  }
+
+  const prefix = text.slice(0, index);
+  const line = (prefix.match(/\n/g) || []).length;
+  const lastLineBreak = prefix.lastIndexOf('\n');
+  const character = index - (lastLineBreak + 1);
+  return { line, character };
+}
 
 export function requireWorkspaceFolder(): vscode.WorkspaceFolder {
   const folder = vscode.workspace.workspaceFolders?.[0];

--- a/editors/vscode/test/integration/helpers.ts
+++ b/editors/vscode/test/integration/helpers.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 export const TEST_DOCUMENT_PATH = 'documents/getting-started.lex';
 export const SEMANTIC_TOKENS_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
 export const HOVER_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
+export const NAVIGATION_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
 
 export interface PositionMatch {
   line: number;

--- a/editors/vscode/test/integration/helpers.ts
+++ b/editors/vscode/test/integration/helpers.ts
@@ -5,6 +5,7 @@ export const TEST_DOCUMENT_PATH = 'documents/getting-started.lex';
 export const SEMANTIC_TOKENS_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
 export const HOVER_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
 export const NAVIGATION_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
+export const FORMATTING_DOCUMENT_PATH = 'documents/formatting.lex';
 
 export interface PositionMatch {
   line: number;

--- a/editors/vscode/test/integration/helpers.ts
+++ b/editors/vscode/test/integration/helpers.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import * as vscode from 'vscode';
 
 export const TEST_DOCUMENT_PATH = 'documents/getting-started.lex';
+export const SEMANTIC_TOKENS_DOCUMENT_PATH = 'documents/semantic-tokens.lex';
 
 export function requireWorkspaceFolder(): vscode.WorkspaceFolder {
   const folder = vscode.workspace.workspaceFolders?.[0];

--- a/editors/vscode/test/integration/index.ts
+++ b/editors/vscode/test/integration/index.ts
@@ -1,0 +1,22 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { runRegisteredTests } from './harness.js';
+
+export async function run(): Promise<void> {
+  const currentDir = fileURLToPath(new URL('.', import.meta.url));
+  const entries = await readdir(currentDir);
+  const testFiles = entries.filter(entry => entry.endsWith('.test.js'));
+
+  if (testFiles.length === 0) {
+    console.warn('No VS Code integration tests were discovered.');
+    return;
+  }
+
+  for (const fileName of testFiles) {
+    const fullPath = path.join(currentDir, fileName);
+    await import(pathToFileURL(fullPath).href);
+  }
+
+  await runRegisteredTests();
+}

--- a/editors/vscode/test/integration/lsp_document_links.test.ts
+++ b/editors/vscode/test/integration/lsp_document_links.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  SEMANTIC_TOKENS_DOCUMENT_PATH
+} from './helpers.js';
+
+integrationTest('provides document links for URLs and verbatim sources', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(SEMANTIC_TOKENS_DOCUMENT_PATH);
+  const links = await vscode.commands.executeCommand<vscode.DocumentLink[] | undefined>(
+    'vscode.executeLinkProvider',
+    document.uri
+  );
+
+  if (!links || links.length === 0) {
+    throw new Error('Document links request should return entries');
+  }
+
+  const targets = links.map(link => link.target?.toString()).filter(Boolean);
+  assert.ok(targets.some(target => target?.includes('lexlang.org')), 'External URL should be linked');
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_document_symbols.test.ts
+++ b/editors/vscode/test/integration/lsp_document_symbols.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  SEMANTIC_TOKENS_DOCUMENT_PATH
+} from './helpers.js';
+
+function flattenSymbols(symbols: vscode.DocumentSymbol[]): vscode.DocumentSymbol[] {
+  const result: vscode.DocumentSymbol[] = [];
+  for (const symbol of symbols) {
+    result.push(symbol);
+    if (symbol.children && symbol.children.length > 0) {
+      result.push(...flattenSymbols(symbol.children));
+    }
+  }
+  return result;
+}
+
+integrationTest('provides hierarchical document symbols', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(SEMANTIC_TOKENS_DOCUMENT_PATH);
+  const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[] | undefined>(
+    'vscode.executeDocumentSymbolProvider',
+    document.uri
+  );
+
+  if (!symbols || symbols.length === 0) {
+    throw new Error('Document symbols request should return entries');
+  }
+
+  assert.ok(symbols.length >= 2, 'Document should report multiple top-level symbols');
+
+  const flattened = flattenSymbols(symbols);
+  const titles = flattened.map(symbol => symbol.name);
+  assert.ok(
+    titles.some(name => name.includes('Intro')),
+    'Outline should include the Intro session'
+  );
+  assert.ok(
+    titles.some(name => name.includes('List')),
+    'Outline should include list items'
+  );
+  assert.ok(
+    titles.some(name => name.includes('Verbatim: CLI Example')),
+    'Verbatim blocks should surface as document symbols'
+  );
+
+  assert.ok(
+    flattened.some(symbol => symbol.children && symbol.children.length > 0),
+    'At least one symbol should expose nested children'
+  );
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_folding_ranges.test.ts
+++ b/editors/vscode/test/integration/lsp_folding_ranges.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  SEMANTIC_TOKENS_DOCUMENT_PATH
+} from './helpers.js';
+
+integrationTest('provides folding ranges for sessions, lists, and verbatim blocks', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(SEMANTIC_TOKENS_DOCUMENT_PATH);
+
+  const ranges = await vscode.commands.executeCommand<vscode.FoldingRange[] | undefined>(
+    'vscode.executeFoldingRangeProvider',
+    document.uri
+  );
+  if (!ranges || ranges.length === 0) {
+    throw new Error('Folding range request should return entries');
+  }
+
+  const spans = ranges.map(range => ({ start: range.start, end: range.end }));
+
+  const sessionFold = spans.some(span => span.start <= 2 && span.end >= 8);
+  assert.ok(sessionFold, 'Session should produce a folding range');
+
+  const listFold = spans.some(span => span.start >= 12 && span.end > span.start);
+  assert.ok(listFold, 'Lists should produce folding ranges');
+
+  const verbatimFold = spans.some(span => span.start >= 18 && span.end > span.start);
+  assert.ok(verbatimFold, 'Verbatim block should produce folding ranges');
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_formatting.test.ts
+++ b/editors/vscode/test/integration/lsp_formatting.test.ts
@@ -16,19 +16,34 @@ integrationTest('applies whole-document formatting fixes indentation', async () 
   await api?.clientReady();
 
   const document = await openWorkspaceDocument(FORMATTING_DOCUMENT_PATH);
-  const edits = await vscode.commands.executeCommand<
-    vscode.TextEdit[] | undefined
-  >('vscode.executeFormatDocumentProvider', document.uri, {
-    tabSize: 2,
-    insertSpaces: true
-  });
+  const originalContent = document.getText();
 
-  assert.ok(edits && edits.length > 0, 'Formatting should produce edits');
-  const changed = edits.some(edit => {
-    const original = document.getText(edit.range);
-    return original !== (edit.newText ?? '');
-  });
-  assert.ok(changed, 'Formatting should modify the document content');
+  const misformatEdit = new vscode.WorkspaceEdit();
+  misformatEdit.insert(document.uri, new vscode.Position(0, 0), '  ');
+  await vscode.workspace.applyEdit(misformatEdit);
 
-  await closeAllEditors();
+  try {
+    const edits = await vscode.commands.executeCommand<
+      vscode.TextEdit[] | undefined
+    >('vscode.executeFormatDocumentProvider', document.uri, {
+      tabSize: 2,
+      insertSpaces: true
+    });
+
+    assert.ok(edits && edits.length > 0, 'Formatting should produce edits');
+    const changed = edits.some(edit => {
+      const original = document.getText(edit.range);
+      return original !== (edit.newText ?? '');
+    });
+    assert.ok(changed, 'Formatting should modify the document content');
+  } finally {
+    const revertEdit = new vscode.WorkspaceEdit();
+    const fullRange = new vscode.Range(
+      new vscode.Position(0, 0),
+      document.positionAt(document.getText().length)
+    );
+    revertEdit.replace(document.uri, fullRange, originalContent);
+    await vscode.workspace.applyEdit(revertEdit);
+    await closeAllEditors();
+  }
 });

--- a/editors/vscode/test/integration/lsp_formatting.test.ts
+++ b/editors/vscode/test/integration/lsp_formatting.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  FORMATTING_DOCUMENT_PATH,
+  openWorkspaceDocument
+} from './helpers.js';
+
+integrationTest('applies whole-document formatting fixes indentation', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(FORMATTING_DOCUMENT_PATH);
+  const edits = await vscode.commands.executeCommand<
+    vscode.TextEdit[] | undefined
+  >('vscode.executeFormatDocumentProvider', document.uri, {
+    tabSize: 2,
+    insertSpaces: true
+  });
+
+  assert.ok(edits && edits.length > 0, 'Formatting should produce edits');
+  const changed = edits.some(edit => {
+    const original = document.getText(edit.range);
+    return original !== (edit.newText ?? '');
+  });
+  assert.ok(changed, 'Formatting should modify the document content');
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_formatting.test.ts
+++ b/editors/vscode/test/integration/lsp_formatting.test.ts
@@ -21,6 +21,7 @@ integrationTest('applies whole-document formatting fixes indentation', async () 
   const misformatEdit = new vscode.WorkspaceEdit();
   misformatEdit.insert(document.uri, new vscode.Position(0, 0), '  ');
   await vscode.workspace.applyEdit(misformatEdit);
+  await new Promise(resolve => setTimeout(resolve, 500));
 
   try {
     const edits = await vscode.commands.executeCommand<

--- a/editors/vscode/test/integration/lsp_handshake.test.ts
+++ b/editors/vscode/test/integration/lsp_handshake.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  TEST_DOCUMENT_PATH
+} from './helpers.js';
+
+integrationTest('establishes lex-lsp handshake', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(TEST_DOCUMENT_PATH);
+  const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[] | undefined>(
+    'vscode.executeDocumentSymbolProvider',
+    document.uri
+  );
+
+  assert.ok(Array.isArray(symbols), 'Document symbol request should return an array');
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_hover.test.ts
+++ b/editors/vscode/test/integration/lsp_hover.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  findPosition,
+  openWorkspaceDocument,
+  HOVER_DOCUMENT_PATH
+} from './helpers.js';
+
+interface HoverExpectation {
+  search: string;
+  description: string;
+}
+
+const EXPECTATIONS: HoverExpectation[] = [
+  { search: '[^source]', description: 'footnote reference hover' },
+  { search: '[@spec2025', description: 'citation hover' },
+  { search: 'Cache', description: 'definition / reference hover' }
+];
+
+integrationTest('provides hover content for references and annotations', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(HOVER_DOCUMENT_PATH);
+
+  for (const expectation of EXPECTATIONS) {
+    const positionInfo = findPosition(document, expectation.search);
+    assert.ok(positionInfo, `Could not locate text for ${expectation.description}`);
+
+    const position = new vscode.Position(positionInfo.line, positionInfo.character);
+    const hoverResults = await vscode.commands.executeCommand<
+      vscode.Hover[] | undefined
+    >(
+      'vscode.executeHoverProvider',
+      document.uri,
+      position
+    );
+
+    assert.ok(hoverResults && hoverResults.length > 0, `Hover result missing for ${expectation.description}`);
+    const contents = hoverResults
+      .flatMap(result => result.contents)
+      .map(item => {
+        if (typeof item === 'string') {
+          return item;
+        }
+
+        if ('value' in item) {
+          return item.value;
+        }
+
+        return '';
+      });
+    assert.ok(
+      contents.some(value => value.trim().length > 0),
+      `Hover content should not be empty for ${expectation.description}`
+    );
+  }
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_navigation.test.ts
+++ b/editors/vscode/test/integration/lsp_navigation.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  findPosition,
+  openWorkspaceDocument,
+  NAVIGATION_DOCUMENT_PATH
+} from './helpers.js';
+
+integrationTest('supports go-to-definition for references', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(NAVIGATION_DOCUMENT_PATH);
+  const positionInfo = findPosition(document, '[Cache]');
+  assert.ok(positionInfo, 'Reference text should exist in document');
+
+  const definitionLocations = await vscode.commands.executeCommand<
+    readonly vscode.Location[] | undefined
+  >('vscode.executeDefinitionProvider', document.uri, new vscode.Position(positionInfo.line, positionInfo.character));
+
+  assert.ok(definitionLocations && definitionLocations.length > 0, 'Definition provider should return at least one result');
+  const [definition] = definitionLocations;
+  const definitionText = document.getText(definition.range);
+  assert.ok(definitionText.includes('Cache'), 'Definition result should contain Cache entry');
+
+  await closeAllEditors();
+});
+
+integrationTest('lists references for a definition', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(NAVIGATION_DOCUMENT_PATH);
+  const definitionInfo = findPosition(document, 'Cache:\n');
+  assert.ok(definitionInfo, 'Definition section should be present');
+
+  const references = await vscode.commands.executeCommand<
+    readonly vscode.Location[] | undefined
+  >('vscode.executeReferenceProvider', document.uri, new vscode.Position(definitionInfo.line, definitionInfo.character));
+
+  assert.ok(references && references.length >= 1, 'Reference provider should return usages');
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/integration/lsp_semantic_tokens.test.ts
+++ b/editors/vscode/test/integration/lsp_semantic_tokens.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from './harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  SEMANTIC_TOKENS_DOCUMENT_PATH
+} from './helpers.js';
+
+integrationTest('exposes semantic tokens and legend', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>('lex.lex-vscode');
+  assert.ok(extension, 'Lex extension should be discoverable by VS Code');
+
+  const api = await extension.activate();
+  await api?.clientReady();
+
+  const document = await openWorkspaceDocument(SEMANTIC_TOKENS_DOCUMENT_PATH);
+
+  const legend = await vscode.commands.executeCommand<vscode.SemanticTokensLegend | undefined>(
+    'vscode.provideDocumentSemanticTokensLegend',
+    document.uri
+  );
+  if (!legend) {
+    throw new Error('Semantic tokens legend should be available');
+  }
+  assert.ok(legend.tokenTypes.length > 0, 'Legend must list token types');
+
+  const tokens = await vscode.commands.executeCommand<vscode.SemanticTokens | undefined>(
+    'vscode.provideDocumentSemanticTokens',
+    document.uri
+  );
+  if (!tokens) {
+    throw new Error('Semantic tokens result should exist');
+  }
+  assert.ok(tokens.data.length > 0, 'Token data should be non-empty');
+  assert.ok(tokens.data.every(value => Number.isInteger(value)), 'Token deltas must be integers');
+
+  await closeAllEditors();
+});

--- a/editors/vscode/test/lex_vscode_extension.bats
+++ b/editors/vscode/test/lex_vscode_extension.bats
@@ -7,6 +7,7 @@ setup() {
 @test "VS Code extension npm test" {
   cd "$EXTENSION_DIR"
   run npm test
+  echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "VSCode Integration" ]]
 }

--- a/editors/vscode/test/lex_vscode_extension.bats
+++ b/editors/vscode/test/lex_vscode_extension.bats
@@ -7,7 +7,9 @@ setup() {
 @test "VS Code extension npm test" {
   cd "$EXTENSION_DIR"
   run npm test
-  echo "$output"
+  if [ "$status" -ne 0 ]; then
+    echo "$output" >&2
+  fi
   [ "$status" -eq 0 ]
   [[ "$output" =~ "VSCode Integration" ]]
 }

--- a/editors/vscode/test/lex_vscode_extension.bats
+++ b/editors/vscode/test/lex_vscode_extension.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+setup() {
+  export EXTENSION_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+}
+
+@test "VS Code extension npm test" {
+  cd "$EXTENSION_DIR"
+  run npm test
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "VSCode Integration" ]]
+}

--- a/editors/vscode/test/runTests.ts
+++ b/editors/vscode/test/runTests.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runTests } from '@vscode/test-electron';
+
+async function main() {
+  const currentDir = fileURLToPath(new URL('.', import.meta.url));
+  const extensionDevelopmentPath = path.resolve(currentDir, '..', '..');
+  const extensionTestsPath = path.resolve(currentDir, 'integration/index.js');
+  const workspacePath = path.resolve(
+    extensionDevelopmentPath,
+    'test/fixtures/sample-workspace'
+  );
+
+  try {
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [workspacePath],
+      extensionTestsEnv: {
+        ...process.env,
+        LEX_VSCODE_SKIP_SERVER: '1'
+      }
+    });
+  } catch (error) {
+    console.error('Failed to run VS Code extension tests');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/editors/vscode/test/runTests.ts
+++ b/editors/vscode/test/runTests.ts
@@ -1,3 +1,5 @@
+import { constants as fsConstants } from 'node:fs';
+import { access } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runTests } from '@vscode/test-electron';
@@ -8,22 +10,34 @@ async function main() {
   const extensionTestsPath = path.resolve(currentDir, 'integration/index.js');
   const workspacePath = path.resolve(
     extensionDevelopmentPath,
-    'test/fixtures/sample-workspace'
+    'test/fixtures/sample-workspace.code-workspace'
   );
+  await ensureLexBinary(extensionDevelopmentPath);
 
   try {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: [workspacePath],
-      extensionTestsEnv: {
-        ...process.env,
-        LEX_VSCODE_SKIP_SERVER: '1'
-      }
+      launchArgs: [workspacePath]
     });
   } catch (error) {
     console.error('Failed to run VS Code extension tests');
     console.error(error);
+    process.exit(1);
+  }
+}
+
+async function ensureLexBinary(extensionDevelopmentPath: string): Promise<void> {
+  const lexBinaryPath = path.resolve(
+    extensionDevelopmentPath,
+    '../../target/debug/lex-lsp'
+  );
+
+  try {
+    await access(lexBinaryPath, fsConstants.X_OK);
+  } catch {
+    console.error(`lex-lsp binary not found at ${lexBinaryPath}`);
+    console.error("Run 'cargo build --bin lex-lsp' from the repository root before npm test.");
     process.exit(1);
   }
 }

--- a/editors/vscode/test/run_suite.sh
+++ b/editors/vscode/test/run_suite.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FORMATTER="junit"
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --format=simple) FORMATTER="pretty" ;;
+    --format=junit) FORMATTER="junit" ;;
+    *) echo "Unknown parameter: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_FILE="$SCRIPT_DIR/lex_vscode_extension.bats"
+
+if ! command -v bats &> /dev/null; then
+  echo "Error: bats is not installed."
+  echo "Install bats-core (e.g. brew install bats-core)."
+  exit 1
+fi
+
+exec bats "$TEST_FILE" --formatter "$FORMATTER"

--- a/editors/vscode/test/run_suite.sh
+++ b/editors/vscode/test/run_suite.sh
@@ -15,6 +15,14 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_FILE="$SCRIPT_DIR/lex_vscode_extension.bats"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LEX_BINARY="$REPO_ROOT/target/debug/lex-lsp"
+
+if [[ ! -x "$LEX_BINARY" ]]; then
+  echo "Error: lex-lsp binary not found at $LEX_BINARY"
+  echo "Run 'cargo build --bin lex-lsp' from the repository root before running the VS Code tests."
+  exit 1
+fi
 
 if ! command -v bats &> /dev/null; then
   echo "Error: bats is not installed."


### PR DESCRIPTION
## Summary
- add formatting fixture, helper constant, and VS Code integration test
- update README + docs to reflect current capabilities
- add scripts/open_dev_vscode.sh to launch the extension with the sample workspace