### PR TITLE
build(vscode): add extension packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,35 @@ jobs:
           files: |
             ${{ matrix.asset_name }}.tar.gz
             ${{ matrix.asset_name }}.zip
+
+  build-vscode-extension:
+    name: Build VS Code Extension
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Build VS Code extension bundle
+        run: ./editors/vscode/scripts/build_extension.sh
+
+      - name: Package VS Code extension
+        working-directory: editors/vscode
+        run: npx vsce package --no-dependencies --out lex-vscode.vsix
+
+      - name: Upload VS Code extension asset
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: editors/vscode/lex-vscode.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules/
 editors/vscode/out/
 editors/vscode/dist/
 editors/vscode/.vscode-test/
+editors/vscode/resources/lex-lsp*
 
 # OS
 .DS_Store

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lex Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/README.lex
+++ b/editors/vscode/README.lex
@@ -20,6 +20,11 @@ npm test               # unit + VS Code integration
 ```
 CI mirrors the same sequence via `.github/workflows/vscode-plugin.yml`.
 
+Packaging
+---------
+- `./editors/vscode/scripts/build_extension.sh` builds `lex-lsp` in release mode, copies it into `editors/vscode/resources/lex-lsp`, installs npm dependencies, and runs `npm run bundle`.
+- Run `npx vsce package` afterwards to create the VSIX.
+
 Features Covered
 ----------------
 - Activation + handshake with lex-lsp (configurable binary path).

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -4,8 +4,10 @@ This package hosts the VS Code extension for the Lex language. The extension is 
 
 ## Developer Setup
 
+
 ```
 cargo build --bin lex-lsp
+cd editors/vscode
 npm install
 npm run build
 npm test
@@ -20,3 +22,13 @@ npm run test:integration
 ```
 
 The integration runner uses `@vscode/test-electron` to launch a headless VS Code instance and spins up the `lex-lsp` binary from `target/debug/lex-lsp`. If the binary is missing, the runner instructs you to build it first.
+
+## Building the Extension Bundle
+
+Use the helper script to build `lex-lsp` in release mode, copy it into the extension’s `resources/` directory, and bundle the TypeScript sources:
+
+```
+./editors/vscode/scripts/build_extension.sh
+```
+
+This produces `resources/lex-lsp` (the path shipped in the VSIX) and refreshes `dist/extension.js`. Follow up with `npx vsce package` if you want to produce a distributable VSIX.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "main": "./out/src/main.js",
   "engines": {
-    "vscode": "^1.95.0",
+    "vscode": "^1.106.0",
     "node": ">=20"
   },
   "activationEvents": [

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -37,7 +37,7 @@
         "lex.lspBinaryPath": {
           "type": "string",
           "markdownDescription": "Absolute or workspace-relative path to the lex-lsp binary.",
-          "default": "../../target/debug/lex-lsp"
+          "default": "./resources/lex-lsp"
         }
       }
     }
@@ -52,7 +52,8 @@
     "test:unit": "node ./out/test/unit/index.js",
     "test:integration": "node ./out/test/runTests.js",
     "lint": "eslint src test",
-    "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"
+    "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
+    "build:with-binary": "bash ./scripts/build_extension.sh"
   },
   "repository": {
     "type": "git",

--- a/editors/vscode/scripts/build_extension.sh
+++ b/editors/vscode/scripts/build_extension.sh
@@ -37,6 +37,7 @@ echo "lex-lsp copied to $BINARY_DEST"
 
 pushd "$EXT_DIR" >/dev/null
 npm ci
+npm run build
 npm run bundle
 popd >/dev/null
 

--- a/editors/vscode/scripts/build_extension.sh
+++ b/editors/vscode/scripts/build_extension.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+EXT_DIR="$REPO_ROOT/editors/vscode"
+RESOURCES_DIR="$EXT_DIR/resources"
+BINARY_DEST="$RESOURCES_DIR/lex-lsp"
+
+BUILD_PROFILE="release"
+TARGET_DIR="$REPO_ROOT/target/$BUILD_PROFILE"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo is required to build lex-lsp" >&2
+  exit 1
+fi
+
+pushd "$REPO_ROOT" >/dev/null
+cargo build --bin lex-lsp --release
+popd >/dev/null
+
+BINARY_SRC="$TARGET_DIR/lex-lsp"
+if [[ ! -f "$BINARY_SRC" && -f "$BINARY_SRC.exe" ]]; then
+  BINARY_SRC="$BINARY_SRC.exe"
+fi
+
+if [[ ! -f "$BINARY_SRC" ]]; then
+  echo "lex-lsp binary not found at $BINARY_SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$RESOURCES_DIR"
+cp "$BINARY_SRC" "$BINARY_DEST"
+chmod +x "$BINARY_DEST"
+
+echo "lex-lsp copied to $BINARY_DEST"
+
+pushd "$EXT_DIR" >/dev/null
+npm ci
+npm run bundle
+popd >/dev/null
+
+echo "Extension bundle written to $EXT_DIR/dist/extension.js"


### PR DESCRIPTION
## Summary
- add script that builds lex-lsp, copies it into editors/vscode/resources, and bundles the TypeScript output
- update package.json defaults/docs so the VSIX uses the bundled binary
- extend release workflow to produce/upload a VS Code .vsix alongside the existing binaries