### PR TITLE
fix(ci): enable workflows on all branches

### DIFF
--- a/.github/workflows/test-nvim-plugin.yml
+++ b/.github/workflows/test-nvim-plugin.yml
@@ -2,7 +2,7 @@ name: Neovim Plugin
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -2,7 +2,7 @@ name: Rust CI
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test-vscode-plugin.yml
+++ b/.github/workflows/test-vscode-plugin.yml
@@ -2,7 +2,7 @@ name: VS Code Extension
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Enables CI workflows to run on all branch pushes, not just main. This allows early detection of issues in feature branches before PR creation.