### PR TITLE
fix(parsing): Resolve session marker extraction and compatibility issues

### DIFF
--- a/docs/dev/issues/202-extended-marker-normalization.md
+++ b/docs/dev/issues/202-extended-marker-normalization.md
@@ -1,7 +1,7 @@
 # Issue #202: Extended list markers flattened by formatter
 
 ## Summary
-The lex formatter now infers list style from `List.marker`, but `visit_list_item` ignores the `Form::Extended` flag. Extended markers such as `1.2.3` or `IV.2.1)` are serialized as simple incremental markers (`1.`, `2.`, …) whenever `normalize_list_markers` is true (the default). Previously those markers were left untouched, so documents relying on hierarchical numbering are now mangled.
+The lex formatter now infers list style from `List.marker`, but `visit_list_item` ignores the `Form::Extended` flag. Extended markers such as `1.2.3` or `IV.2.1)` are serialized as simple incremental markers (`1.`, `2.`, …) whenever `normalize_seq_markers` is true (the default). Previously those markers were left untouched, so documents relying on hierarchical numbering are now mangled.
 
 ## Impact
 - Multi-part list markers lose their structure, defeating outline numbering.

--- a/docs/dev/issues/203-extended-marker-normalization.md
+++ b/docs/dev/issues/203-extended-marker-normalization.md
@@ -1,7 +1,7 @@
 # Issue #203: Normalize extended list markers from structured segments
 
 ## Current Behavior
-Extended list markers (multi-part sequences such as `1.2.3` or `IV.b.2)`) are now preserved verbatim whenever the formatter's `normalize_list_markers` flag is enabled. This avoids corrupting hierarchy, but it also means extended lists never normalize—whatever the author typed is re-emitted, even if numbering is inconsistent.
+Extended list markers (multi-part sequences such as `1.2.3` or `IV.b.2)`) are now preserved verbatim whenever the formatter's `normalize_seq_markers` flag is enabled. This avoids corrupting hierarchy, but it also means extended lists never normalize—whatever the author typed is re-emitted, even if numbering is inconsistent.
 
 ## Desired Behavior
 When extended lists are normalized, the formatter should regenerate each marker deterministically using structured metadata, so the hierarchy becomes `1.1.1`, `1.1.2`, etc., according to the list's decoration style(s) and separators. That requires:
@@ -13,7 +13,7 @@ When extended lists are normalized, the formatter should regenerate each marker 
 
 ## Definition Of Done
 - Extend the formatter's list context to capture parsed segments for the entire ancestral path, not just the first item's overall style.
-- When `normalize_list_markers` is true and a list is `Form::Extended`, synthesize normalized markers from that structured state instead of copying the raw text.
+- When `normalize_seq_markers` is true and a list is `Form::Extended`, synthesize normalized markers from that structured state instead of copying the raw text.
 - Document the normalization rules for mixed-style segments and add tests covering numeric, alphabetic, roman, and mixed extended markers.
 
 ## Verification

--- a/docs/dev/proposals/formatter.lex
+++ b/docs/dev/proposals/formatter.lex
@@ -109,8 +109,8 @@
 
         - `session_blank_lines_before`: Count before session title (default: 1)
         - `session_blank_lines_after`: Count after session title (default: 1)
-        - `normalize_list_markers`: Standardize markers (default: true)
-        - `unordered_list_marker`: Default bullet char (default: '-')
+        - `normalize_seq_markers`: Standardize markers (default: true)
+        - `unordered_seq_marker`: Default bullet char (default: '-')
         - `max_blank_lines`: Collapse excess blanks (default: 2)
         - `indent_string`: Indentation unit (default: "    ")
         - `preserve_trailing_blanks`: Keep blanks at document end (default: false)
@@ -287,8 +287,8 @@
 
         Test each rule in isolation:
 
-        - `test_normalize_list_markers_bullets()`
-        - `test_normalize_list_markers_numbered()`
+        - `test_normalize_seq_markers_bullets()`
+        - `test_normalize_seq_markers_numbered()`
         - `test_collapse_blank_lines()`
         - `test_indentation_depth()`
         - `test_trailing_whitespace_removal()`

--- a/lex-babel/src/formats/lex/formatting_rules.rs
+++ b/lex-babel/src/formats/lex/formatting_rules.rs
@@ -10,10 +10,10 @@ pub struct FormattingRules {
     pub session_blank_lines_after: usize,
 
     /// Whether to normalize list markers (e.g. all bullets to '-')
-    pub normalize_list_markers: bool,
+    pub normalize_seq_markers: bool,
 
     /// The character to use for unordered list markers
-    pub unordered_list_marker: char,
+    pub unordered_seq_marker: char,
 
     /// Maximum number of consecutive blank lines allowed
     pub max_blank_lines: usize,
@@ -33,8 +33,8 @@ impl Default for FormattingRules {
         Self {
             session_blank_lines_before: 1,
             session_blank_lines_after: 1,
-            normalize_list_markers: true,
-            unordered_list_marker: '-',
+            normalize_seq_markers: true,
+            unordered_seq_marker: '-',
             max_blank_lines: 2,
             indent_string: "    ".to_string(),
             preserve_trailing_blanks: false,

--- a/lex-babel/src/formats/lex/serializer.rs
+++ b/lex-babel/src/formats/lex/serializer.rs
@@ -219,12 +219,12 @@ impl Visitor for LexSerializer {
             .last_mut()
             .expect("List stack empty in list item");
 
-        let marker = if self.rules.normalize_list_markers {
+        let marker = if self.rules.normalize_seq_markers {
             if matches!(context.marker_form, Some(Form::Extended)) {
                 list_item.marker.as_string().to_string()
             } else {
                 match context.marker_type {
-                    MarkerType::Bullet => self.rules.unordered_list_marker.to_string(),
+                    MarkerType::Bullet => self.rules.unordered_seq_marker.to_string(),
                     MarkerType::Numeric => format!("{}.", context.index),
                     MarkerType::AlphaLower => format!("{}.", to_alpha_lower(context.index)),
                     MarkerType::AlphaUpper => format!("{}.", to_alpha_upper(context.index)),

--- a/lex-parser/src/lex/building/extraction/list_item.rs
+++ b/lex-parser/src/lex/building/extraction/list_item.rs
@@ -3,7 +3,7 @@
 //! Extracts primitive data (text, byte ranges) from normalized token vectors
 //! for building ListItem AST nodes.
 
-use crate::lex::lexing::line_classification::parse_list_marker;
+use crate::lex::lexing::line_classification::parse_seq_marker;
 use crate::lex::token::normalization::utilities::{compute_bounding_box, extract_text};
 use crate::lex::token::Token;
 use std::ops::Range as ByteRange;
@@ -37,7 +37,7 @@ pub(in crate::lex::building) fn extract_list_item_data(
     tokens: Vec<(Token, ByteRange<usize>)>,
     source: &str,
 ) -> ListItemData {
-    let parsed_marker = parse_list_marker(
+    let parsed_marker = parse_seq_marker(
         &tokens
             .iter()
             .map(|(token, _)| token.clone())

--- a/lex-parser/src/lex/building/extraction/session.rs
+++ b/lex-parser/src/lex/building/extraction/session.rs
@@ -4,7 +4,7 @@
 //! for building Session AST nodes.
 
 use crate::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
-use crate::lex::lexing::line_classification::parse_list_marker;
+use crate::lex::lexing::line_classification::parse_seq_marker;
 use crate::lex::token::normalization::utilities::{compute_bounding_box, extract_text};
 use crate::lex::token::Token;
 use std::ops::Range as ByteRange;
@@ -47,10 +47,10 @@ pub(in crate::lex::building) fn extract_session_data(
     source: &str,
 ) -> SessionData {
     // Try to parse a marker from the tokens
-    // We reuse parse_list_marker because the syntax is identical,
+    // We reuse parse_seq_marker because the syntax is identical,
     // but we must filter out Plain style (dashes) which are not valid for sessions.
     let token_refs: Vec<Token> = tokens.iter().map(|(t, _)| t.clone()).collect();
-    let parsed_marker = parse_list_marker(&token_refs);
+    let parsed_marker = parse_seq_marker(&token_refs);
 
     if let Some(pm) = parsed_marker {
         // Sessions do not support Plain markers (dashes)

--- a/lex-parser/src/lex/building/extraction/session.rs
+++ b/lex-parser/src/lex/building/extraction/session.rs
@@ -3,19 +3,33 @@
 //! Extracts primitive data (text, byte ranges) from normalized token vectors
 //! for building Session AST nodes.
 
+use crate::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
+use crate::lex::lexing::line_classification::parse_list_marker;
 use crate::lex::token::normalization::utilities::{compute_bounding_box, extract_text};
 use crate::lex::token::Token;
 use std::ops::Range as ByteRange;
 
+/// Extracted marker data for a session
+#[derive(Debug, Clone)]
+pub(in crate::lex::building) struct SessionMarkerData {
+    pub text: String,
+    pub byte_range: ByteRange<usize>,
+    pub style: DecorationStyle,
+    pub separator: Separator,
+    pub form: Form,
+}
+
 /// Extracted data for building a Session AST node.
 ///
-/// Contains the title text and its byte range.
+/// Contains the title text (stripped of marker) and optional marker data.
 #[derive(Debug, Clone)]
 pub(in crate::lex::building) struct SessionData {
-    /// The session title text
+    /// The session title text (without marker)
     pub title_text: String,
-    /// Byte range of the title
+    /// Byte range of the title (without marker)
     pub title_byte_range: ByteRange<usize>,
+    /// Optional sequence marker data
+    pub marker: Option<SessionMarkerData>,
 }
 
 /// Extract session data from title tokens.
@@ -27,16 +41,52 @@ pub(in crate::lex::building) struct SessionData {
 ///
 /// # Returns
 ///
-/// SessionData containing the title text and byte range
+/// SessionData containing the parsed title and optional marker
 pub(in crate::lex::building) fn extract_session_data(
     tokens: Vec<(Token, ByteRange<usize>)>,
     source: &str,
 ) -> SessionData {
+    // Try to parse a marker from the tokens
+    // We reuse parse_list_marker because the syntax is identical,
+    // but we must filter out Plain style (dashes) which are not valid for sessions.
+    let token_refs: Vec<Token> = tokens.iter().map(|(t, _)| t.clone()).collect();
+    let parsed_marker = parse_list_marker(&token_refs);
+
+    if let Some(pm) = parsed_marker {
+        // Sessions do not support Plain markers (dashes)
+        if pm.style != DecorationStyle::Plain {
+            // We have a valid session marker
+            let marker_tokens = &tokens[pm.marker_start..pm.marker_end];
+            let marker_byte_range = compute_bounding_box(marker_tokens);
+            let marker_text = extract_text(marker_byte_range.clone(), source);
+
+            let marker_data = SessionMarkerData {
+                text: marker_text,
+                byte_range: marker_byte_range,
+                style: pm.style,
+                separator: pm.separator,
+                form: pm.form,
+            };
+
+            // Title includes EVERYTHING (marker + separator + body) for backward compatibility
+            let title_byte_range = compute_bounding_box(&tokens);
+            let title_text = extract_text(title_byte_range.clone(), source);
+
+            return SessionData {
+                title_text,
+                title_byte_range,
+                marker: Some(marker_data),
+            };
+        }
+    }
+
+    // No valid marker found, treat everything as title
     let title_byte_range = compute_bounding_box(&tokens);
     let title_text = extract_text(title_byte_range.clone(), source);
 
     SessionData {
         title_text,
         title_byte_range,
+        marker: None,
     }
 }

--- a/lex-parser/src/lex/lexing/line_classification.rs
+++ b/lex-parser/src/lex/lexing/line_classification.rs
@@ -405,8 +405,8 @@ fn is_roman_numeral(s: &str) -> bool {
 fn detect_segment_style(token: &Token) -> DecorationStyle {
     match token {
         Token::Number(_) => DecorationStyle::Numerical,
-        Token::Text(s) if is_single_letter(s) => DecorationStyle::Alphabetical,
         Token::Text(s) if is_roman_numeral(s) => DecorationStyle::Roman,
+        Token::Text(s) if is_single_letter(s) => DecorationStyle::Alphabetical,
         _ => DecorationStyle::Numerical, // Default fallback
     }
 }

--- a/lex-parser/src/lex/lexing/line_classification.rs
+++ b/lex-parser/src/lex/lexing/line_classification.rs
@@ -88,15 +88,15 @@ pub fn classify_line_tokens(tokens: &[Token]) -> LineType {
     }
 
     // Check if line both starts with list marker AND ends with colon
-    let has_list_marker = parse_list_marker(tokens).is_some();
+    let has_seq_marker = parse_seq_marker(tokens).is_some();
     let has_colon = ends_with_colon(tokens);
 
-    if has_list_marker && has_colon {
+    if has_seq_marker && has_colon {
         return LineType::SubjectOrListItemLine;
     }
 
     // LIST_LINE: Starts with list marker
-    if has_list_marker {
+    if has_seq_marker {
         return LineType::ListLine;
     }
 
@@ -262,7 +262,7 @@ fn is_data_line(tokens: &[Token]) -> bool {
 /// - Ordered single-part: "1.", "1)", "a.", "I." (with trailing space)
 /// - Ordered extended: multi-part sequences like "4.3.2" or "IV.2.1)" (with trailing space)
 /// - Parenthetical: "(1)", "(a)", "(I)" (with trailing space)
-pub fn parse_list_marker(tokens: &[Token]) -> Option<ParsedListMarker> {
+pub fn parse_seq_marker(tokens: &[Token]) -> Option<ParsedListMarker> {
     let mut i = 0;
 
     // Skip leading indentation and whitespace
@@ -376,8 +376,8 @@ pub fn parse_list_marker(tokens: &[Token]) -> Option<ParsedListMarker> {
 }
 
 /// Check if line starts with a list marker (after optional indentation)
-pub fn has_list_marker(tokens: &[Token]) -> bool {
-    parse_list_marker(tokens).is_some()
+pub fn has_seq_marker(tokens: &[Token]) -> bool {
+    parse_seq_marker(tokens).is_some()
 }
 
 /// Check if a string is a single letter (a-z, A-Z)
@@ -540,7 +540,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ordered_list_markers() {
+    fn test_ordered_seq_markers() {
         // Number-based
         let tokens = vec![
             Token::Number("1".to_string()),
@@ -548,7 +548,7 @@ mod tests {
             Token::Whitespace(1),
             Token::Text("Item".to_string()),
         ];
-        assert!(has_list_marker(&tokens));
+        assert!(has_seq_marker(&tokens));
 
         // Letter-based
         let tokens = vec![
@@ -557,7 +557,7 @@ mod tests {
             Token::Whitespace(1),
             Token::Text("Item".to_string()),
         ];
-        assert!(has_list_marker(&tokens));
+        assert!(has_seq_marker(&tokens));
 
         // Roman numeral
         let tokens = vec![
@@ -566,7 +566,7 @@ mod tests {
             Token::Whitespace(1),
             Token::Text("Item".to_string()),
         ];
-        assert!(has_list_marker(&tokens));
+        assert!(has_seq_marker(&tokens));
 
         // With close paren
         let tokens = vec![
@@ -575,11 +575,11 @@ mod tests {
             Token::Whitespace(1),
             Token::Text("Item".to_string()),
         ];
-        assert!(has_list_marker(&tokens));
+        assert!(has_seq_marker(&tokens));
     }
 
     #[test]
-    fn test_extended_ordered_list_marker() {
+    fn test_extended_ordered_seq_marker() {
         let tokens = vec![
             Token::Number("4".to_string()),
             Token::Period,
@@ -590,7 +590,7 @@ mod tests {
             Token::Text("Item".to_string()),
         ];
 
-        let parsed = parse_list_marker(&tokens).expect("expected list marker");
+        let parsed = parse_seq_marker(&tokens).expect("expected list marker");
         assert_eq!(parsed.marker_start, 0);
         assert_eq!(parsed.marker_end, 5);
         assert_eq!(parsed.body_start, 6);

--- a/lex-parser/src/lex/parsing/parser/builder/builders/session.rs
+++ b/lex-parser/src/lex/parsing/parser/builder/builders/session.rs
@@ -27,18 +27,26 @@ pub(in crate::lex::parsing::parser::builder) fn build_session(
         };
 
     // Filter out trailing Whitespace and BlankLine tokens from session label
-    let subject_tokens: Vec<_> = subject_token
+    // Filter out trailing Whitespace and BlankLine tokens from session label
+    // We must preserve internal whitespace for marker parsing!
+    let mut subject_tokens: Vec<_> = subject_token
         .source_tokens
         .clone()
         .into_iter()
         .zip(subject_token.token_spans.clone())
-        .filter(|(token, _)| {
-            !matches!(
-                token,
-                crate::lex::lexing::Token::Whitespace(_) | crate::lex::lexing::Token::BlankLine(_)
-            )
-        })
         .collect();
+
+    // Remove trailing whitespace/newlines
+    while let Some((token, _)) = subject_tokens.last() {
+        if matches!(
+            token,
+            crate::lex::lexing::Token::Whitespace(_) | crate::lex::lexing::Token::BlankLine(_)
+        ) {
+            subject_tokens.pop();
+        } else {
+            break;
+        }
+    }
 
     Ok(ParseNode::new(
         NodeType::Session,


### PR DESCRIPTION
## Summary
Successfully refactored session marker extraction to use the unified `parse_seq_marker` logic (renamed from `parse_list_marker`), resolving Issue #327. Addressed several issues discovered during the process, including whitespace handling, Roman numeral detection, and backward compatibility.

## Changes
- **Refactoring**: Replaced ad-hoc marker parsing in `extract_session_data` with `parse_seq_marker`.
- **Renaming**: Renamed `parse_list_marker` to `parse_seq_marker` and related functions to reflect their broader usage (sessions + lists).
- **Fixes**:
    - Modified `build_session` to preserve internal whitespace for marker parsing.
    - Prioritized Roman numerals in `detect_segment_style`.
    - Updated `Session` title accessors to handle full title storage while exposing marker data.
- **Cleanup**: Removed unused imports and debug prints.

## Verification
- All tests passed (`cargo test -p lex-parser`).
- Pre-commit checks passed.