### PR TITLE
test(vscode): add VSIX activation smoke

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -5,6 +5,8 @@ test
 src
 scripts
 .vscode
+.vscode-vsix-test
+.vscode-vsix-integration-test
 .eslintrc.*
 *.ts
 *.ts.map

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -18,10 +18,11 @@ Tests currently cover configuration helpers, VS Code activation, lex-lsp handsha
 ```
 npm run test:unit
 npm run test:integration
+npm run test:vsix
 ./test/run_suite.sh --format=simple
 ```
 
-The integration runner uses `@vscode/test-electron` to launch a headless VS Code instance and spins up the `lex-lsp` binary from `target/debug/lex-lsp`. If the binary is missing, the runner instructs you to build it first.
+The integration runner uses `@vscode/test-electron` to launch a headless VS Code instance and spins up the `lex-lsp` binary from `target/debug/lex-lsp`. If the binary is missing, the runner instructs you to build it first. The `npm run test:vsix` command packages the extension with `vsce`, installs the VSIX into a clean VS Code profile, opens a sample `.lex` document, and asserts that the shipped extension activates. Set `LEX_VSIX_KEEP_PROFILE=1` when running it if you want to inspect the cached VS Code profile after execution; otherwise it is cleaned automatically.
 
 ## Building the Extension Bundle
 

--- a/editors/vscode/eslint.config.mjs
+++ b/editors/vscode/eslint.config.mjs
@@ -50,5 +50,15 @@ export default [
       '@typescript-eslint/no-floating-promises': 'off',
       'no-undef': 'off'
     }
+  },
+  {
+    files: ['test/vsix-smoke-extension/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'script',
+      globals: {
+        ...globals.node
+      }
+    }
   }
 ];

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -215,6 +215,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "node ./out/test/unit/index.js",
     "test:integration": "node ./out/test/runTests.js",
+    "test:vsix": "npm run build && npm run bundle && node ./out/test/runVsixSmoke.js",
     "lint": "eslint src test",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "build:with-binary": "bash ./scripts/build_extension.sh"

--- a/editors/vscode/test/fixtures/sample-workspace-vsix.code-workspace
+++ b/editors/vscode/test/fixtures/sample-workspace-vsix.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "./sample-workspace"
+    }
+  ],
+  "settings": {
+    "workbench.colorTheme": "Default Dark Modern"
+  }
+}

--- a/editors/vscode/test/integration/helpers.ts
+++ b/editors/vscode/test/integration/helpers.ts
@@ -53,3 +53,29 @@ export async function openWorkspaceDocument(
 export async function closeAllEditors(): Promise<void> {
   await vscode.commands.executeCommand('workbench.action.closeAllEditors');
 }
+
+export async function waitForExtensionActivation<T>(
+  extensionId: string,
+  timeoutMs = 10000
+): Promise<vscode.Extension<T>> {
+  const extension = vscode.extensions.getExtension<T>(extensionId);
+  if (!extension) {
+    throw new Error(`Extension ${extensionId} is not installed`);
+  }
+
+  if (extension.isActive) {
+    return extension;
+  }
+
+  const start = Date.now();
+  const pollIntervalMs = 200;
+
+  while (Date.now() - start < timeoutMs) {
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    if (extension.isActive) {
+      return extension;
+    }
+  }
+
+  throw new Error(`Timed out waiting for ${extensionId} activation`);
+}

--- a/editors/vscode/test/lex_vscode_extension.bats
+++ b/editors/vscode/test/lex_vscode_extension.bats
@@ -24,6 +24,17 @@ teardown() {
   [[ "$output" =~ "VSCode Integration" ]]
 }
 
+# Ensures we can package, install, and activate the extension through a VSIX
+@test "VSIX install smoke test" {
+  cd "$EXTENSION_DIR"
+  run npm run test:vsix
+  if [ "$status" -ne 0 ]; then
+    echo "$output" >&2
+  fi
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "VSIX smoke tests" ]]
+}
+
 @test "VSIX packaging produces valid extension" {
   cd "$EXTENSION_DIR"
 

--- a/editors/vscode/test/runVsixSmoke.ts
+++ b/editors/vscode/test/runVsixSmoke.ts
@@ -1,0 +1,130 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+import type { SpawnOptionsWithoutStdio } from 'node:child_process';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { resolveCliArgsFromVSCodeExecutablePath, runTests } from '@vscode/test-electron';
+import { defaultCachePath } from '@vscode/test-electron/out/download.js';
+
+async function main() {
+  const currentFile = fileURLToPath(import.meta.url);
+  const currentDir = path.dirname(currentFile);
+  const extensionRoot = path.resolve(currentDir, '..', '..');
+  const workspacePath = path.resolve(
+    extensionRoot,
+    'test/fixtures/sample-workspace-vsix.code-workspace'
+  );
+  const harnessExtensionPath = path.resolve(
+    extensionRoot,
+    'test/vsix-smoke-extension'
+  );
+  const testRunnerPath = path.resolve(
+    extensionRoot,
+    'out/test/vsix-smoke/index.js'
+  );
+
+  const keepProfile = process.env.LEX_VSIX_KEEP_PROFILE === '1';
+
+  console.log('Packaging VSIX for smoke test...');
+  const { vsixPath, cleanup } = await packageVsix(extensionRoot);
+
+  try {
+    await resetTestProfile();
+    const vscodeExecutablePath = await downloadAndUnzipVSCode({
+      cachePath: defaultCachePath
+    });
+
+    console.log('Installing VSIX into VS Code test profile...');
+    await installVsix(vscodeExecutablePath, vsixPath);
+
+    console.log('Running VSIX smoke tests...');
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath: harnessExtensionPath,
+      extensionTestsPath: testRunnerPath,
+      launchArgs: [workspacePath],
+      reuseMachineInstall: false
+    });
+  } finally {
+    await cleanup();
+    if (!keepProfile) {
+      await resetTestProfile();
+    } else {
+      console.warn('Preserving VS Code test profile for inspection:', defaultCachePath);
+    }
+  }
+}
+
+async function packageVsix(extensionRoot: string) {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'lex-vsix-smoke-'));
+  const vsixPath = path.join(tempDir, 'lex-vscode-smoke.vsix');
+  await runCommand('npx', ['vsce', 'package', '--no-dependencies', '--out', vsixPath], {
+    cwd: extensionRoot
+  });
+
+  return {
+    vsixPath,
+    cleanup: () => rm(tempDir, { recursive: true, force: true })
+  };
+}
+
+async function installVsix(vscodeExecutablePath: string, vsixPath: string) {
+  const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(
+    vscodeExecutablePath
+  );
+  await runCommand(cli, [...cliArgs, '--install-extension', vsixPath, '--force']);
+}
+
+async function resetTestProfile() {
+  const targets = ['extensions', 'user-data'];
+  await Promise.all(
+    targets.map(target =>
+      rm(path.join(defaultCachePath, target), { recursive: true, force: true })
+    )
+  );
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithoutStdio = {}
+) {
+  const resolvedCommand = resolveCommand(command);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(resolvedCommand, args, {
+      stdio: 'inherit',
+      ...options
+    });
+
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function resolveCommand(command: string): string {
+  if (process.platform !== 'win32') {
+    return command;
+  }
+
+  const hasPathSeparator = /[\\/]/.test(command);
+  const hasExtension = Boolean(path.extname(command));
+  if (hasPathSeparator || hasExtension) {
+    return command;
+  }
+
+  return `${command}.cmd`;
+}
+
+main().catch(error => {
+  console.error('VSIX smoke tests failed');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/editors/vscode/test/vsix-smoke-extension/extension.js
+++ b/editors/vscode/test/vsix-smoke-extension/extension.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 function activate() {
   console.log('Lex VSIX smoke harness activated');
 }

--- a/editors/vscode/test/vsix-smoke-extension/extension.js
+++ b/editors/vscode/test/vsix-smoke-extension/extension.js
@@ -1,0 +1,9 @@
+function activate() {
+  console.log('Lex VSIX smoke harness activated');
+}
+
+function deactivate() {
+  // no-op
+}
+
+module.exports = { activate, deactivate };

--- a/editors/vscode/test/vsix-smoke-extension/package.json
+++ b/editors/vscode/test/vsix-smoke-extension/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "lex-vsix-smoke-extension",
+  "displayName": "Lex VSIX Smoke Harness",
+  "version": "0.0.0",
+  "private": true,
+  "publisher": "lex",
+  "engines": {
+    "vscode": "^1.106.0"
+  },
+  "main": "./extension.js",
+  "activationEvents": ["*"]
+}

--- a/editors/vscode/test/vsix-smoke/index.ts
+++ b/editors/vscode/test/vsix-smoke/index.ts
@@ -1,0 +1,6 @@
+import { runRegisteredTests } from '../integration/harness.js';
+
+export async function run(): Promise<void> {
+  await import('./vsix_activation.test.js');
+  await runRegisteredTests();
+}

--- a/editors/vscode/test/vsix-smoke/vsix_activation.test.ts
+++ b/editors/vscode/test/vsix-smoke/vsix_activation.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import * as vscode from 'vscode';
+import type { LexExtensionApi } from '../../src/main.js';
+import { integrationTest } from '../integration/harness.js';
+import {
+  closeAllEditors,
+  openWorkspaceDocument,
+  TEST_DOCUMENT_PATH,
+  waitForExtensionActivation
+} from '../integration/helpers.js';
+
+const EXTENSION_ID = 'lex.lex-vscode';
+
+integrationTest('activates VSIX-installed extension when opening a Lex document', async () => {
+  const extension = vscode.extensions.getExtension<LexExtensionApi>(EXTENSION_ID);
+  assert.ok(extension, 'VSIX-installed extension should be discoverable');
+  assert.equal(extension.isActive, false, 'Extension should be idle before opening Lex documents');
+
+  const document = await openWorkspaceDocument(TEST_DOCUMENT_PATH);
+  assert.equal(document.languageId, 'lex', 'Lex documents should retain lex language id');
+
+  const activated = await waitForExtensionActivation<LexExtensionApi>(EXTENSION_ID, 15000);
+  await activated.exports?.clientReady();
+  assert.equal(activated.isActive, true, 'Extension should activate after Lex document opens');
+
+  await closeAllEditors();
+});


### PR DESCRIPTION
## Summary
- add VSIX packaging/install smoke runner plus harness to verify activation
- expose npm test:vsix command, hook into bats suite, and document workflow
- ensure temp VS Code profiles are excluded from VSIX and tighten activation polling helper

## Testing
- npm test
- npm run test:vsix
