### PR TITLE
feat(editors): add shared editor APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "lex-parser",
  "markup5ever_rcdom",
  "once_cell",
+ "pathdiff",
  "regex",
  "serde",
  "tempfile",
@@ -1257,6 +1258,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/editors/README.lex
+++ b/editors/README.lex
@@ -1,4 +1,4 @@
-Editor Tooling
+# Editor Tooling
 
     As part of lex's value proposition, we'll be building two high quality edtior plugins for VSCode and Neovim.
 
@@ -19,47 +19,7 @@ Editor Tooling
     Bellow the work in progress to be done, and at the documents very end the work already done.
 
 
-2. Document Handling
-
-    Being a markup document format, there is a set of features that are table stakes: 
-    
-    1. Interop:
-        - Convert :
-          - Lex <> Markdown (both ways). This should open a new editor buffer window with the converted text, the path should be the same as the file converted from, but with the new extension . Ex: say the file is foo/bar/readme.lex on convert to markdown, it should be foo/bar/readme.md . 
-        - lEX <> HTML
-        - Export to pdf
-    2. Content Management:
-
-
-3. Editing
-
-    While the minimal featureset covered some of these, we have left out a few useful features related to editing:
-
-    1. Completion for paths, urls, citations.
-    2. Inserting Images / Files.
-    3. Inserting Verbatim Blocks from files.
-    4. Annotation management:
-        4.1 Iterating through annotations
-        4.2 Resolving, unresolving.
-        4.3 Show Hide Annotations
-    5. Indenting on paste.
-    6. Tab shifting.
-    7. Ordering lists: fix the list orderings (even for nested lists)
-
-
-4. Publishing
-
-    While the interop features will generate various formats, the publishing workflow can be more detailed, alowing template selection, image sizing, previews, and so on. 
-
-    This will be a core part of Lex, as it's value proposition is a single format from note to publication. 
-
-
-6. Help / Documentation
-
-    Being a novel format, it would be very welcome to be able to offer help and documetation for the format itself. I'm not very sure how to best achieve this, but it's worth carving out the mental model for this.
-
-
-7. Shared Architecture
+2. Shared Architecture
 
     To avoid duplicating logic across plugins, we use the LSP `workspace/executeCommand` capability. This allows plugins to delegate complex tasks to the `lex-lsp` server.
 
@@ -73,29 +33,77 @@ Editor Tooling
             Use `client:exec_cmd({ command = 'lex.commandName', arguments = args })` (or `vim.lsp.buf.execute_command` for older versions).
 
 
-8. Finished Feature Packs
+3. Feature Packs
 
-    Bellow are the feature packs already implemented and live.
-
-
-    8.1. Minimal Featureset : Syntax and Language Support
-
-        These are the initial launch features for both editors:
-
-        1. Syntax Highlighting
-        2. Document Symbols
-        3. Hover Information
-        4. Folding Ranges
-        5. Formatting
-        6. Comment / Uncomment
-        7. Symbol Navigation (mostly references in Lex's context)
-
-        While diagnostics surely would make sense, given's Lex modus operandi of "never fails" and worst case scenario "parse as paragraphs", we don't have a useful , working implementation that would offer any value. This will be tackled later, but it is to be left out for now.
-
-        These are currently working in the Neovim plugin. All of these are built over the LSP protocol, with the lex-lsp binary being the server.
+    The following sections detail the feature packs, starting with the currently implemented set and followed by planned enhancements.
 
 
-9. Configuration
+    3.1. Feature Pack 1: Minimal Featureset (Live)
+
+        These are the initial launch features, focusing on core language support and navigation.
+
+        | Category | Feature | Core Logic (Rust) | Neovim (Plugin) | VSCode (Extension) | Notes |
+        |----------|---------|-------------------|-----------------|--------------------|-------|
+        | Core | Syntax Highlighting | Tree-sitter Grammar (`lex-syntax`) | Tree-sitter Queries (`highlights.scm`) | TextMate Grammar (`lex.tmLanguage.json`) | VSCode may eventually adopt Tree-sitter. |
+        | | Formatting | `lex-formatter` via LSP `textDocument/formatting` | `vim.lsp.buf.format` | `vscode.executeFormatDocumentProvider` | Configurable via `lex.toml`. |
+        | | Diagnostics | `lex-lsp` (Minimal) | Built-in LSP Diagnostics | Problems View | Currently minimal (parsing errors). |
+        | Navigation | Document Symbols | `lex-lsp` `textDocument/documentSymbol` | `vim.lsp.buf.document_symbol` | Outline View | |
+        | | Hover Info | `lex-lsp` `textDocument/hover` | `vim.lsp.buf.hover` | Hover Widget | Shows element details/preview. |
+        | | Folding | `lex-lsp` `textDocument/foldingRange` | `vim.lsp.buf.folding_range` / `nvim-ufo` | Folding Regions | Based on indentation/sections. |
+        | | Go to Definition | `lex-lsp` `textDocument/definition` | `vim.lsp.buf.definition` (`gd`) | Go to Definition (`F12`) | For internal references/citations. |
+        | | Find References | `lex-lsp` `textDocument/references` | `vim.lsp.buf.references` (`gr`) | Find All References | |
+        | | Semantic Tokens | `lex-lsp` `textDocument/semanticTokens` | `vim.lsp.semantic_tokens` | Semantic Highlighting | Enhanced highlighting (e.g. titles). |
+
+
+    3.2. Feature Pack 2: Document Handling
+
+        Focuses on interoperability and converting Lex documents to other formats.
+
+        | Category | Feature | Core Logic (Rust) | Neovim (Plugin) | VSCode (Extension) | Notes |
+        |----------|---------|-------------------|-----------------|--------------------|-------|
+        | Interop | Convert to Markdown | `lex-lsp` `workspace/executeCommand` (`lex.convert`) | `:LexConvert markdown` | `Lex: Convert to Markdown` | Opens result in new buffer (same path + .md). |
+        | | Convert to HTML | `lex-lsp` `workspace/executeCommand` (`lex.convert`) | `:LexConvert html` | `Lex: Convert to HTML` | |
+        | | Export to PDF | `lex-lsp` `workspace/executeCommand` (`lex.export`) | `:LexExport pdf` | `Lex: Export to PDF` | |
+
+
+    3.3. Feature Pack 3: Editing Enhancements
+
+        Advanced editing features to improve authoring efficiency.
+
+        | Category | Feature | Core Logic (Rust) | Neovim (Plugin) | VSCode (Extension) | Notes |
+        |----------|---------|-------------------|-----------------|--------------------|-------|
+        | Completion | Path/URL/Citation | `lex-lsp` `textDocument/completion` | `nvim-cmp` source | IntelliSense Provider | Context-aware completion. |
+        | Insertion | Insert Asset | `lex-lsp` `workspace/executeCommand` (`lex.insert_asset`) | `:LexInsertAsset` | `Lex: Insert Asset` | File picker integration. |
+        | | Insert Verbatim | `lex-lsp` `workspace/executeCommand` (`lex.insert_verbatim`) | `:LexInsertVerbatim` | `Lex: Insert Verbatim` | Inserts file content as code block. |
+        | Annotations | Iterate Annotations | `lex-lsp` `workspace/executeCommand` (`lex.next_annotation`) | `:LexNextAnnotation` | `Lex: Next Annotation` | Jump to next/prev annotation. |
+        | | Resolve/Unresolve | `lex-lsp` `workspace/executeCommand` (`lex.resolve_annotation`) | `:LexResolve` | `Lex: Resolve Annotation` | Toggle status. |
+        | | Show/Hide | `lex-lsp` `workspace/executeCommand` (`lex.toggle_annotations`) | `:LexToggleAnnotations` | `Lex: Toggle Annotations` | Virtual text / Decorations. |
+        | Formatting | Indent on Paste | `lex-formatter` (logic) | `Paste` handler / `indentexpr` | `OnTypeFormatting` | Adjust indentation automatically. |
+        | | Tab Shifting | `lex-formatter` (logic) | `<<` / `>>` | `Outdent` / `Indent` | Shift blocks/lists correctly. |
+        | | List Ordering | `lex-formatter` (logic) | Auto-format on save/type | Auto-format | Fix nested list numbering. |
+        | Comments | Smart Comments | N/A (Client Config) | `commentstring` | `language-configuration.json` | Toggle comments (`gc` / `Ctrl+/`). |
+
+
+    3.4. Feature Pack 4: Publishing
+
+        Workflows for publishing Lex documents.
+
+        | Category | Feature | Core Logic (Rust) | Neovim (Plugin) | VSCode (Extension) | Notes |
+        |----------|---------|-------------------|-----------------|--------------------|-------|
+        | Publishing | Template Selection | `lex-cli` / `lex-lsp` | `:LexPublish` (UI Select) | `Lex: Publish` (QuickPick) | Choose output templates. |
+        | | Image Sizing | `lex-core` (processing) | N/A | N/A | Part of build process. |
+        | | Preview | `lex-lsp` (Live Preview) | `:LexPreview` | `Lex: Open Preview` | Side-by-side preview. |
+
+    3.5. Feature Pack 5: Help & Documentation
+
+        In-editor assistance for the Lex format.
+
+        | Category | Feature | Core Logic (Rust) | Neovim (Plugin) | VSCode (Extension) | Notes |
+        |----------|---------|-------------------|-----------------|--------------------|-------|
+        | Help | Format Documentation | `lex-lsp` `workspace/executeCommand` (`lex.help`) | `:LexHelp` | `Lex: Show Help` | Show syntax guide/docs. |
+
+
+4. Configuration
 
     The Lex formatter can be configured via `lex.toml` or editor settings. The available options are:
         | Option | Type | Default | Description |
@@ -109,3 +117,7 @@ Editor Tooling
         | `preserve_trailing_blanks` | Boolean | `false` | Whether to preserve trailing blank lines at the end of the document. |
         | `normalize_verbatim_markers` | Boolean | `true` | Whether to normalize verbatim markers to `::`. |
     :: doc.table 
+
+5. Implementation Status
+
+    For a detailed breakdown of the required Rust APIs, their signatures, and current implementation status, please refer to @[editors/required-apis.lex].

--- a/editors/required-apis.lex
+++ b/editors/required-apis.lex
@@ -1,0 +1,54 @@
+# Required Rust APIs for Editor Features
+
+    This document lists the Rust APIs required to support the features outlined in @[editors/README.lex].
+    It tracks the status of each API, its signature, and the crate/module where it resides.
+
+    Status Legend:
+    - Live: Implemented and integrated into `lex-lsp`.
+    - Rust Ready: Implemented in a crate but not yet exposed via LSP.
+    - Planned: Not yet implemented.
+
+2. Core & Navigation (LSP Standard)
+
+    These features use standard LSP methods.
+
+    | Feature | API / Command | Crate / Module | Signature (Approx) | Status |
+    |---------|---------------|----------------|--------------------|--------|
+    | Syntax Highlighting | N/A (Tree-sitter) | `lex-syntax` | N/A (Grammar) | Live |
+    | Formatting | `textDocument/formatting` | `lex-lsp/src/features/formatting.rs` | `format_document(doc, source) -> Vec<TextEdit>` | Live |
+    | Diagnostics | `textDocument/publishDiagnostics` | `lex-lsp/src/server.rs` | `parse_document(text) -> Result<Document, Vec<Error>>` | Live (Minimal) |
+    | Document Symbols | `textDocument/documentSymbol` | `lex-lsp/src/features/document_symbols.rs` | `collect_document_symbols(doc) -> Vec<DocumentSymbol>` | Live |
+    | Hover | `textDocument/hover` | `lex-lsp/src/features/hover.rs` | `hover(doc, pos) -> Option<HoverResult>` | Live |
+    | Folding | `textDocument/foldingRange` | `lex-lsp/src/features/folding_ranges.rs` | `folding_ranges(doc) -> Vec<FoldingRange>` | Live |
+    | Definition | `textDocument/definition` | `lex-lsp/src/features/go_to_definition.rs` | `goto_definition(doc, pos) -> Vec<Range>` | Live |
+    | References | `textDocument/references` | `lex-lsp/src/features/references.rs` | `find_references(doc, pos) -> Vec<Range>` | Live |
+    | Semantic Tokens | `textDocument/semanticTokens` | `lex-lsp/src/features/semantic_tokens.rs` | `collect_semantic_tokens(doc) -> Vec<SemanticToken>` | Live |
+    | Completion | `textDocument/completion` | `lex-lsp/src/features/completion.rs` | `completion(doc, pos) -> Vec<CompletionItem>` | Planned |
+
+3. Command-Based Features (`workspace/executeCommand`)
+
+    These features rely on custom commands exposed by `lex-lsp`.
+
+    | Feature | Command | Crate / Module | Signature (Arguments -> Result) | Status |
+    |---------|---------|----------------|---------------------------------|--------|
+    | Insert Asset | `lex.insert_asset` | `lex-lsp/src/features/commands.rs` | `(path: String) -> TextEdit` | Planned |
+    | Insert Verbatim | `lex.insert_verbatim` | `lex-lsp/src/features/commands.rs` | `(path: String) -> TextEdit` | Planned |
+    | Convert Doc | `lex.convert` | `lex-lsp/src/features/commands.rs` | `(format: "markdown" | "html") -> PathBuf` | Planned |
+    | Export Doc | `lex.export` | `lex-lsp/src/features/commands.rs` | `(format: "pdf") -> PathBuf` | Planned |
+    | Next Annotation | `lex.next_annotation` | `lex-lsp/src/features/commands.rs` | `(current_pos: Position) -> Position` | Planned |
+    | Resolve Annotation | `lex.resolve_annotation` | `lex-lsp/src/features/commands.rs` | `(id: String) -> TextEdit` | Planned |
+    | Toggle Annotations | `lex.toggle_annotations` | `lex-lsp/src/features/commands.rs` | `(enable: bool) -> void` | Planned |
+    | Help | `lex.help` | `lex-lsp/src/features/commands.rs` | `(topic: Option<String>) -> String` | Planned |
+
+4. Backend Support
+
+    Underlying logic required by the above commands.
+
+    | Logic | Crate | Description | Status |
+    |-------|-------|-------------|--------|
+    | Markdown Conversion | `lex-babel` | Convert Lex AST to Markdown | Live |
+    | HTML Conversion | `lex-babel` | Convert Lex AST to HTML | Live |
+    | PDF Export | `lex-babel` | Convert Lex AST to PDF (via HTML/Headless Chrome?) | Planned |
+    | Asset Resolution | `lex-core` | Resolve relative paths for assets | Rust Ready |
+    | Annotation Index | `lex-analysis` | Index and query annotations | Rust Ready |
+

--- a/lex-analysis/src/annotations.rs
+++ b/lex-analysis/src/annotations.rs
@@ -1,0 +1,234 @@
+use lex_parser::lex::ast::{Annotation, AstNode, ContentItem, Document, Position, Range, Session};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnnotationDirection {
+    Forward,
+    Backward,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnnotationNavigationResult {
+    pub label: String,
+    pub parameters: Vec<(String, String)>,
+    pub header: Range,
+    pub body: Option<Range>,
+}
+
+pub fn next_annotation(
+    document: &Document,
+    position: Position,
+) -> Option<AnnotationNavigationResult> {
+    navigate(document, position, AnnotationDirection::Forward)
+}
+
+pub fn previous_annotation(
+    document: &Document,
+    position: Position,
+) -> Option<AnnotationNavigationResult> {
+    navigate(document, position, AnnotationDirection::Backward)
+}
+
+pub fn navigate(
+    document: &Document,
+    position: Position,
+    direction: AnnotationDirection,
+) -> Option<AnnotationNavigationResult> {
+    let mut annotations = collect_annotations(document);
+    if annotations.is_empty() {
+        return None;
+    }
+    annotations.sort_by_key(|annotation| annotation.header_location().start);
+
+    let idx = match direction {
+        AnnotationDirection::Forward => next_index(&annotations, position),
+        AnnotationDirection::Backward => previous_index(&annotations, position),
+    };
+    annotations
+        .get(idx)
+        .map(|annotation| annotation_to_result(annotation))
+}
+
+fn annotation_to_result(annotation: &Annotation) -> AnnotationNavigationResult {
+    AnnotationNavigationResult {
+        label: annotation.data.label.value.clone(),
+        parameters: annotation
+            .data
+            .parameters
+            .iter()
+            .map(|param| (param.key.clone(), param.value.clone()))
+            .collect(),
+        header: annotation.header_location().clone(),
+        body: annotation.body_location(),
+    }
+}
+
+fn next_index(entries: &[&Annotation], position: Position) -> usize {
+    if let Some(current) = containing_index(entries, position) {
+        if current + 1 >= entries.len() {
+            0
+        } else {
+            current + 1
+        }
+    } else {
+        entries
+            .iter()
+            .enumerate()
+            .find(|(_, annotation)| annotation.header_location().start > position)
+            .map(|(idx, _)| idx)
+            .unwrap_or(0)
+    }
+}
+
+fn previous_index(entries: &[&Annotation], position: Position) -> usize {
+    if let Some(current) = containing_index(entries, position) {
+        if current == 0 {
+            entries.len() - 1
+        } else {
+            current - 1
+        }
+    } else {
+        entries
+            .iter()
+            .enumerate()
+            .filter(|(_, annotation)| annotation.header_location().start < position)
+            .map(|(idx, _)| idx)
+            .last()
+            .unwrap_or(entries.len() - 1)
+    }
+}
+
+fn containing_index(entries: &[&Annotation], position: Position) -> Option<usize> {
+    entries
+        .iter()
+        .position(|annotation| annotation.range().contains(position))
+}
+
+pub(crate) fn collect_annotations(document: &Document) -> Vec<&Annotation> {
+    let mut entries = Vec::new();
+    for annotation in document.annotations() {
+        entries.push(annotation);
+    }
+    collect_from_session(&document.root, &mut entries);
+    entries
+}
+
+fn collect_from_session<'a>(session: &'a Session, entries: &mut Vec<&'a Annotation>) {
+    for annotation in session.annotations() {
+        entries.push(annotation);
+    }
+    for item in session.iter_items() {
+        collect_from_item(item, entries);
+    }
+}
+
+fn collect_from_item<'a>(item: &'a ContentItem, entries: &mut Vec<&'a Annotation>) {
+    match item {
+        ContentItem::Annotation(annotation) => {
+            entries.push(annotation);
+            for child in annotation.children.iter() {
+                collect_from_item(child, entries);
+            }
+        }
+        ContentItem::Paragraph(paragraph) => {
+            for annotation in paragraph.annotations() {
+                entries.push(annotation);
+            }
+            for line in &paragraph.lines {
+                collect_from_item(line, entries);
+            }
+        }
+        ContentItem::List(list) => {
+            for annotation in list.annotations() {
+                entries.push(annotation);
+            }
+            for item in list.items.iter() {
+                collect_from_item(item, entries);
+            }
+        }
+        ContentItem::ListItem(list_item) => {
+            for annotation in list_item.annotations() {
+                entries.push(annotation);
+            }
+            for child in list_item.children.iter() {
+                collect_from_item(child, entries);
+            }
+        }
+        ContentItem::Definition(definition) => {
+            for annotation in definition.annotations() {
+                entries.push(annotation);
+            }
+            for child in definition.children.iter() {
+                collect_from_item(child, entries);
+            }
+        }
+        ContentItem::Session(session) => collect_from_session(session, entries),
+        ContentItem::VerbatimBlock(verbatim) => {
+            for annotation in verbatim.annotations() {
+                entries.push(annotation);
+            }
+        }
+        ContentItem::TextLine(_)
+        | ContentItem::VerbatimLine(_)
+        | ContentItem::BlankLineGroup(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_parser::lex::ast::SourceLocation;
+    use lex_parser::lex::parsing;
+
+    const SAMPLE: &str = r#":: note ::
+    Doc note.
+::
+
+Intro:
+
+    :: todo ::
+        Body
+    ::
+
+Paragraph text.
+
+:: info ::
+    Extra details.
+::
+"#;
+
+    fn parse() -> Document {
+        parsing::parse_document(SAMPLE).expect("fixture parses")
+    }
+
+    fn position_of(needle: &str) -> Position {
+        let offset = SAMPLE.find(needle).expect("needle present");
+        SourceLocation::new(SAMPLE).byte_to_position(offset)
+    }
+
+    #[test]
+    fn navigates_forward_including_wrap() {
+        let document = parse();
+        let start = position_of("Intro:");
+        let first = next_annotation(&document, start).expect("annotation");
+        assert_eq!(first.label, "todo");
+
+        let within_second = position_of("Paragraph");
+        let second = next_annotation(&document, within_second).expect("next");
+        assert_eq!(second.label, "info");
+
+        let after_last = position_of("Extra details");
+        let wrap = next_annotation(&document, after_last).expect("wrap");
+        assert_eq!(wrap.label, "note");
+    }
+
+    #[test]
+    fn navigates_backward_including_wrap() {
+        let document = parse();
+        let start = position_of("Paragraph text");
+        let prev = previous_annotation(&document, start).expect("previous");
+        assert_eq!(prev.label, "todo");
+
+        let wrap = previous_annotation(&document, position_of(":: note")).expect("wrap");
+        assert_eq!(wrap.label, "info");
+    }
+}

--- a/lex-analysis/src/completion.rs
+++ b/lex-analysis/src/completion.rs
@@ -1,0 +1,456 @@
+use crate::inline::InlineSpanKind;
+use crate::utils::{reference_span_at_position, session_identifier};
+use lex_parser::lex::ast::links::LinkType;
+use lex_parser::lex::ast::{Annotation, ContentItem, Document, Position, Session};
+use lsp_types::CompletionItemKind;
+use std::collections::BTreeSet;
+
+/// Describes a semantic completion candidate that can be translated into protocol specific items.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionCandidate {
+    pub label: String,
+    pub detail: Option<String>,
+    pub kind: CompletionItemKind,
+    pub insert_text: Option<String>,
+}
+
+impl CompletionCandidate {
+    fn new(label: impl Into<String>, kind: CompletionItemKind) -> Self {
+        Self {
+            label: label.into(),
+            detail: None,
+            kind,
+            insert_text: None,
+        }
+    }
+
+    fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    fn with_insert_text(mut self, text: impl Into<String>) -> Self {
+        self.insert_text = Some(text.into());
+        self
+    }
+}
+
+/// High level context for completion suggestions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompletionContext {
+    Reference,
+    VerbatimLabel,
+    VerbatimSrc,
+    General,
+}
+
+/// Produce semantic completion candidates for the document at the provided position.
+pub fn completion_items(document: &Document, position: Position) -> Vec<CompletionCandidate> {
+    match detect_context(document, position) {
+        CompletionContext::VerbatimLabel => verbatim_label_completions(document),
+        CompletionContext::VerbatimSrc => verbatim_path_completions(document),
+        CompletionContext::Reference => reference_completions(document),
+        CompletionContext::General => reference_completions(document),
+    }
+}
+
+fn detect_context(document: &Document, position: Position) -> CompletionContext {
+    if is_inside_verbatim_label(document, position) {
+        return CompletionContext::VerbatimLabel;
+    }
+    if is_inside_verbatim_src_parameter(document, position) {
+        return CompletionContext::VerbatimSrc;
+    }
+    if reference_span_at_position(document, position)
+        .map(|span| matches!(span.kind, InlineSpanKind::Reference(_)))
+        .unwrap_or(false)
+    {
+        return CompletionContext::Reference;
+    }
+    CompletionContext::General
+}
+
+fn reference_completions(document: &Document) -> Vec<CompletionCandidate> {
+    let mut items = Vec::new();
+
+    for label in collect_annotation_labels(document) {
+        items.push(
+            CompletionCandidate::new(label, CompletionItemKind::REFERENCE)
+                .with_detail("annotation label"),
+        );
+    }
+
+    for subject in collect_definition_subjects(document) {
+        items.push(
+            CompletionCandidate::new(subject, CompletionItemKind::TEXT)
+                .with_detail("definition subject"),
+        );
+    }
+
+    for session_id in collect_session_identifiers(document) {
+        items.push(
+            CompletionCandidate::new(session_id, CompletionItemKind::MODULE)
+                .with_detail("session identifier"),
+        );
+    }
+
+    for path in collect_path_targets(document) {
+        items.push(
+            CompletionCandidate::new(&path, CompletionItemKind::FILE)
+                .with_detail("path reference")
+                .with_insert_text(path),
+        );
+    }
+
+    items
+}
+
+fn verbatim_label_completions(document: &Document) -> Vec<CompletionCandidate> {
+    let mut labels: BTreeSet<String> = STANDARD_VERBATIM_LABELS
+        .iter()
+        .chain(COMMON_CODE_LANGUAGES.iter())
+        .map(|value| value.to_string())
+        .collect();
+
+    for label in collect_document_verbatim_labels(document) {
+        labels.insert(label);
+    }
+
+    labels
+        .into_iter()
+        .map(|label| {
+            CompletionCandidate::new(label, CompletionItemKind::ENUM_MEMBER)
+                .with_detail("verbatim label")
+        })
+        .collect()
+}
+
+fn verbatim_path_completions(document: &Document) -> Vec<CompletionCandidate> {
+    collect_path_targets(document)
+        .into_iter()
+        .map(|path| {
+            CompletionCandidate::new(&path, CompletionItemKind::FILE)
+                .with_detail("verbatim src")
+                .with_insert_text(path)
+        })
+        .collect()
+}
+
+fn collect_annotation_labels(document: &Document) -> BTreeSet<String> {
+    let mut labels = BTreeSet::new();
+    for annotation in document.annotations() {
+        collect_annotation(annotation, &mut labels);
+    }
+    collect_annotations_from_session(&document.root, &mut labels);
+    labels
+}
+
+fn collect_annotations_from_session(session: &Session, labels: &mut BTreeSet<String>) {
+    for annotation in session.annotations() {
+        collect_annotation(annotation, labels);
+    }
+    for item in session.iter_items() {
+        collect_annotations_from_item(item, labels);
+    }
+}
+
+fn collect_annotations_from_item(item: &ContentItem, labels: &mut BTreeSet<String>) {
+    match item {
+        ContentItem::Annotation(annotation) => {
+            collect_annotation(annotation, labels);
+            for child in annotation.children.iter() {
+                collect_annotations_from_item(child, labels);
+            }
+        }
+        ContentItem::Paragraph(paragraph) => {
+            for annotation in paragraph.annotations() {
+                collect_annotation(annotation, labels);
+            }
+            for line in &paragraph.lines {
+                collect_annotations_from_item(line, labels);
+            }
+        }
+        ContentItem::List(list) => {
+            for annotation in list.annotations() {
+                collect_annotation(annotation, labels);
+            }
+            for item in list.items.iter() {
+                collect_annotations_from_item(item, labels);
+            }
+        }
+        ContentItem::ListItem(list_item) => {
+            for annotation in list_item.annotations() {
+                collect_annotation(annotation, labels);
+            }
+            for child in list_item.children.iter() {
+                collect_annotations_from_item(child, labels);
+            }
+        }
+        ContentItem::Definition(definition) => {
+            for annotation in definition.annotations() {
+                collect_annotation(annotation, labels);
+            }
+            for child in definition.children.iter() {
+                collect_annotations_from_item(child, labels);
+            }
+        }
+        ContentItem::Session(child_session) => {
+            collect_annotations_from_session(child_session, labels)
+        }
+        ContentItem::VerbatimBlock(verbatim) => {
+            for annotation in verbatim.annotations() {
+                collect_annotation(annotation, labels);
+            }
+        }
+        ContentItem::TextLine(_)
+        | ContentItem::VerbatimLine(_)
+        | ContentItem::BlankLineGroup(_) => {}
+    }
+}
+
+fn collect_annotation(annotation: &Annotation, labels: &mut BTreeSet<String>) {
+    labels.insert(annotation.data.label.value.clone());
+    for child in annotation.children.iter() {
+        collect_annotations_from_item(child, labels);
+    }
+}
+
+fn collect_definition_subjects(document: &Document) -> BTreeSet<String> {
+    let mut subjects = BTreeSet::new();
+    collect_definitions_in_session(&document.root, &mut subjects);
+    subjects
+}
+
+fn collect_definitions_in_session(session: &Session, subjects: &mut BTreeSet<String>) {
+    for item in session.iter_items() {
+        collect_definitions_in_item(item, subjects);
+    }
+}
+
+fn collect_definitions_in_item(item: &ContentItem, subjects: &mut BTreeSet<String>) {
+    match item {
+        ContentItem::Definition(definition) => {
+            let subject = definition.subject.as_string().trim();
+            if !subject.is_empty() {
+                subjects.insert(subject.to_string());
+            }
+            for child in definition.children.iter() {
+                collect_definitions_in_item(child, subjects);
+            }
+        }
+        ContentItem::Session(session) => collect_definitions_in_session(session, subjects),
+        ContentItem::List(list) => {
+            for child in list.items.iter() {
+                collect_definitions_in_item(child, subjects);
+            }
+        }
+        ContentItem::ListItem(list_item) => {
+            for child in list_item.children.iter() {
+                collect_definitions_in_item(child, subjects);
+            }
+        }
+        ContentItem::Annotation(annotation) => {
+            for child in annotation.children.iter() {
+                collect_definitions_in_item(child, subjects);
+            }
+        }
+        ContentItem::Paragraph(paragraph) => {
+            for line in &paragraph.lines {
+                collect_definitions_in_item(line, subjects);
+            }
+        }
+        ContentItem::VerbatimBlock(_) | ContentItem::TextLine(_) | ContentItem::VerbatimLine(_) => {
+        }
+        ContentItem::BlankLineGroup(_) => {}
+    }
+}
+
+fn collect_session_identifiers(document: &Document) -> BTreeSet<String> {
+    let mut identifiers = BTreeSet::new();
+    collect_session_ids_recursive(&document.root, &mut identifiers, true);
+    identifiers
+}
+
+fn collect_session_ids_recursive(
+    session: &Session,
+    identifiers: &mut BTreeSet<String>,
+    is_root: bool,
+) {
+    if !is_root {
+        if let Some(id) = session_identifier(session) {
+            identifiers.insert(id);
+        }
+        let title = session.title_text().trim();
+        if !title.is_empty() {
+            identifiers.insert(title.to_string());
+        }
+    }
+
+    for item in session.iter_items() {
+        if let ContentItem::Session(child) = item {
+            collect_session_ids_recursive(child, identifiers, false);
+        }
+    }
+}
+
+fn collect_document_verbatim_labels(document: &Document) -> BTreeSet<String> {
+    let mut labels = BTreeSet::new();
+    for (item, _) in document.root.iter_all_nodes_with_depth() {
+        if let ContentItem::VerbatimBlock(verbatim) = item {
+            labels.insert(verbatim.closing_data.label.value.clone());
+        }
+    }
+    labels
+}
+
+fn collect_path_targets(document: &Document) -> BTreeSet<String> {
+    document
+        .find_all_links()
+        .into_iter()
+        .filter(|link| matches!(link.link_type, LinkType::File | LinkType::VerbatimSrc))
+        .map(|link| link.target)
+        .collect()
+}
+
+fn is_inside_verbatim_label(document: &Document, position: Position) -> bool {
+    document.root.iter_all_nodes().any(|item| match item {
+        ContentItem::VerbatimBlock(verbatim) => {
+            verbatim.closing_data.label.location.contains(position)
+        }
+        _ => false,
+    })
+}
+
+fn is_inside_verbatim_src_parameter(document: &Document, position: Position) -> bool {
+    document.root.iter_all_nodes().any(|item| match item {
+        ContentItem::VerbatimBlock(verbatim) => verbatim
+            .closing_data
+            .parameters
+            .iter()
+            .any(|param| param.key == "src" && param.location.contains(position)),
+        _ => false,
+    })
+}
+
+const STANDARD_VERBATIM_LABELS: &[&str] = &[
+    "doc.code",
+    "doc.data",
+    "doc.image",
+    "doc.table",
+    "doc.video",
+    "doc.audio",
+    "doc.note",
+];
+
+const COMMON_CODE_LANGUAGES: &[&str] = &[
+    "bash",
+    "c",
+    "cpp",
+    "css",
+    "go",
+    "html",
+    "java",
+    "javascript",
+    "json",
+    "kotlin",
+    "latex",
+    "lex",
+    "markdown",
+    "python",
+    "ruby",
+    "rust",
+    "scala",
+    "sql",
+    "swift",
+    "toml",
+    "typescript",
+    "yaml",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_parser::lex::ast::SourceLocation;
+    use lex_parser::lex::ast::Verbatim;
+    use lex_parser::lex::parsing;
+
+    const SAMPLE_DOC: &str = r#":: note ::
+    Document level note.
+::
+
+Cache:
+    Definition body.
+
+1. Intro
+
+    See [Cache], [^note], and [./images/chart.png].
+
+Image placeholder:
+
+    diagram placeholder
+:: doc.image src=./images/chart.png title="Usage"
+
+Code sample:
+
+    fn main() {}
+:: rust
+"#;
+
+    fn parse_sample() -> Document {
+        parsing::parse_document(SAMPLE_DOC).expect("fixture parses")
+    }
+
+    fn position_at(offset: usize) -> Position {
+        SourceLocation::new(SAMPLE_DOC).byte_to_position(offset)
+    }
+
+    fn find_verbatim<'a>(document: &'a Document, label: &str) -> &'a Verbatim {
+        for (item, _) in document.root.iter_all_nodes_with_depth() {
+            if let ContentItem::VerbatimBlock(verbatim) = item {
+                if verbatim.closing_data.label.value == label {
+                    return verbatim;
+                }
+            }
+        }
+        panic!("verbatim {} not found", label);
+    }
+
+    #[test]
+    fn reference_completions_expose_labels_definitions_sessions_and_paths() {
+        let document = parse_sample();
+        let cursor = SAMPLE_DOC.find("[Cache]").expect("reference present") + 2;
+        let completions = completion_items(&document, position_at(cursor));
+        let labels: BTreeSet<_> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains("Cache"));
+        assert!(labels.contains("note"));
+        assert!(labels.contains("1"));
+        assert!(labels.contains("./images/chart.png"));
+    }
+
+    #[test]
+    fn verbatim_label_completions_include_standard_labels() {
+        let document = parse_sample();
+        let verbatim = find_verbatim(&document, "rust");
+        let mut pos = verbatim.closing_data.label.location.start;
+        pos.column += 1; // inside the label text
+        let completions = completion_items(&document, pos);
+        assert!(completions.iter().any(|c| c.label == "doc.image"));
+        assert!(completions.iter().any(|c| c.label == "rust"));
+    }
+
+    #[test]
+    fn verbatim_src_completion_offers_known_paths() {
+        let document = parse_sample();
+        let verbatim = find_verbatim(&document, "doc.image");
+        let param = verbatim
+            .closing_data
+            .parameters
+            .iter()
+            .find(|p| p.key == "src")
+            .expect("src parameter exists");
+        let mut pos = param.location.start;
+        pos.column += 5; // after `src=`
+        let completions = completion_items(&document, pos);
+        assert!(completions.iter().any(|c| c.label == "./images/chart.png"));
+    }
+}

--- a/lex-analysis/src/lib.rs
+++ b/lex-analysis/src/lib.rs
@@ -48,6 +48,7 @@ pub mod reference_targets;
 pub mod utils;
 
 // Analysis features
+pub mod completion;
 pub mod document_symbols;
 pub mod folding_ranges;
 pub mod go_to_definition;

--- a/lex-analysis/src/lib.rs
+++ b/lex-analysis/src/lib.rs
@@ -48,6 +48,7 @@ pub mod reference_targets;
 pub mod utils;
 
 // Analysis features
+pub mod annotations;
 pub mod completion;
 pub mod document_symbols;
 pub mod folding_ranges;

--- a/lex-babel/Cargo.toml
+++ b/lex-babel/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true, features = ["derive"] }
 tempfile = "3"
 which = "4"
 url = "2.4"
+pathdiff = "0.2"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/lex-babel/src/lib.rs
+++ b/lex-babel/src/lib.rs
@@ -111,6 +111,7 @@ pub mod error;
 pub mod format;
 pub mod formats;
 pub mod registry;
+pub mod templates;
 pub mod transforms;
 
 pub mod common;

--- a/lex-babel/src/lib.rs
+++ b/lex-babel/src/lib.rs
@@ -110,6 +110,7 @@
 pub mod error;
 pub mod format;
 pub mod formats;
+pub mod publish;
 pub mod registry;
 pub mod templates;
 pub mod transforms;

--- a/lex-babel/src/publish.rs
+++ b/lex-babel/src/publish.rs
@@ -1,0 +1,128 @@
+use crate::error::FormatError;
+use crate::format::SerializedDocument;
+use crate::registry::FormatRegistry;
+use lex_parser::lex::ast::Document;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct PublishSpec<'a> {
+    pub document: &'a Document,
+    pub format: &'a str,
+    pub output: Option<PathBuf>,
+    pub options: HashMap<String, String>,
+}
+
+impl<'a> PublishSpec<'a> {
+    pub fn new(document: &'a Document, format: &'a str) -> Self {
+        Self {
+            document,
+            format,
+            output: None,
+            options: HashMap::new(),
+        }
+    }
+
+    pub fn with_output_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.output = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    pub fn with_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PublishArtifact {
+    InMemory(String),
+    File(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PublishResult {
+    pub artifact: PublishArtifact,
+}
+
+pub fn publish(spec: PublishSpec<'_>) -> Result<PublishResult, FormatError> {
+    let registry = FormatRegistry::with_defaults();
+    let serialized = registry.serialize_with_options(spec.document, spec.format, &spec.options)?;
+    match serialized {
+        SerializedDocument::Text(text) => write_or_return_text(text, spec.output),
+        SerializedDocument::Binary(bytes) => write_binary(bytes, spec.output),
+    }
+}
+
+fn write_or_return_text(
+    text: String,
+    output: Option<PathBuf>,
+) -> Result<PublishResult, FormatError> {
+    if let Some(path) = output {
+        write_to_path(path, text.into_bytes()).map(|path| PublishResult {
+            artifact: PublishArtifact::File(path),
+        })
+    } else {
+        Ok(PublishResult {
+            artifact: PublishArtifact::InMemory(text),
+        })
+    }
+}
+
+fn write_binary(bytes: Vec<u8>, output: Option<PathBuf>) -> Result<PublishResult, FormatError> {
+    let path = output.ok_or_else(|| {
+        FormatError::SerializationError(
+            "binary formats require an explicit output path".to_string(),
+        )
+    })?;
+    write_to_path(path, bytes).map(|path| PublishResult {
+        artifact: PublishArtifact::File(path),
+    })
+}
+
+fn write_to_path(path: PathBuf, bytes: Vec<u8>) -> Result<PathBuf, FormatError> {
+    fs::write(&path, &bytes)
+        .map(|_| path.clone())
+        .map_err(|err| FormatError::SerializationError(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_parser::lex::parsing;
+    use tempfile::tempdir;
+
+    const SAMPLE: &str = "Title:\n\nParagraph text.\n";
+
+    fn sample_document() -> Document {
+        parsing::parse_document(SAMPLE).unwrap()
+    }
+
+    #[test]
+    fn publishes_to_memory_when_no_output_path() {
+        let doc = sample_document();
+        let result = publish(PublishSpec::new(&doc, "html")).expect("publish");
+        match result.artifact {
+            PublishArtifact::InMemory(content) => {
+                assert!(content.contains("Paragraph text."));
+            }
+            PublishArtifact::File(_) => panic!("expected in-memory artifact"),
+        }
+    }
+
+    #[test]
+    fn writes_to_disk_when_output_path_provided() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("output.html");
+        let doc = sample_document();
+        let result =
+            publish(PublishSpec::new(&doc, "html").with_output_path(&path)).expect("publish");
+        match result.artifact {
+            PublishArtifact::File(p) => assert_eq!(p, path),
+            PublishArtifact::InMemory(_) => panic!("expected file artifact"),
+        }
+        let contents = fs::read_to_string(path).unwrap();
+        assert!(contents.contains("Paragraph text."));
+    }
+}

--- a/lex-babel/src/publish.rs
+++ b/lex-babel/src/publish.rs
@@ -1,3 +1,15 @@
+//! Document publishing pipeline.
+//!
+//! Provides a high-level API for converting Lex documents to output formats.
+//! This module bridges the gap between the format registry and file I/O,
+//! handling both in-memory and file-based output.
+//!
+//! Use this for editor commands like "Export to PDF" or "Convert to Markdown"
+//! where you want a single function call that handles format selection,
+//! serialization, and optional file writing.
+//!
+//! For more control over the conversion process, use [`FormatRegistry`] directly.
+
 use crate::error::FormatError;
 use crate::format::SerializedDocument;
 use crate::registry::FormatRegistry;
@@ -6,15 +18,32 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Specifies how to publish a document.
+///
+/// Use the builder pattern to configure the publication:
+///
+/// ```ignore
+/// let spec = PublishSpec::new(&document, "html")
+///     .with_output_path("output.html")
+///     .with_option("theme", "modern");
+/// ```
+///
+/// If no output path is provided, text formats return in-memory content.
+/// Binary formats (like PDF) require an explicit output path.
 #[derive(Debug)]
 pub struct PublishSpec<'a> {
+    /// The parsed Lex document to convert.
     pub document: &'a Document,
+    /// Target format name (e.g., "html", "markdown", "pdf").
     pub format: &'a str,
+    /// Optional file path for writing output. Required for binary formats.
     pub output: Option<PathBuf>,
+    /// Format-specific options (e.g., theme selection, page size).
     pub options: HashMap<String, String>,
 }
 
 impl<'a> PublishSpec<'a> {
+    /// Creates a new publish specification for the given document and format.
     pub fn new(document: &'a Document, format: &'a str) -> Self {
         Self {
             document,
@@ -24,28 +53,48 @@ impl<'a> PublishSpec<'a> {
         }
     }
 
+    /// Sets the output file path. If provided, content is written to disk.
     pub fn with_output_path(mut self, path: impl AsRef<Path>) -> Self {
         self.output = Some(path.as_ref().to_path_buf());
         self
     }
 
+    /// Adds a format-specific option (e.g., theme, page size).
     pub fn with_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.insert(key.into(), value.into());
         self
     }
 }
 
+/// The output from a successful publish operation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PublishArtifact {
+    /// Content held in memory (for text formats without an output path).
     InMemory(String),
+    /// Path to the written file (when output path was specified).
     File(PathBuf),
 }
 
+/// Result of a publish operation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PublishResult {
+    /// The published artifact (in-memory content or file path).
     pub artifact: PublishArtifact,
 }
 
+/// Publishes a document according to the specification.
+///
+/// Uses the default format registry to find the appropriate serializer.
+/// For text formats, returns in-memory content unless an output path is specified.
+/// For binary formats (like PDF), requires an output path.
+///
+/// # Errors
+///
+/// Returns [`FormatError`] if:
+/// - The format is not supported
+/// - Serialization fails
+/// - File I/O fails
+/// - A binary format is requested without an output path
 pub fn publish(spec: PublishSpec<'_>) -> Result<PublishResult, FormatError> {
     let registry = FormatRegistry::with_defaults();
     let serialized = registry.serialize_with_options(spec.document, spec.format, &spec.options)?;

--- a/lex-babel/src/templates/asset.rs
+++ b/lex-babel/src/templates/asset.rs
@@ -1,5 +1,5 @@
+use super::normalize_path;
 use crate::formats::lex::formatting_rules::FormattingRules;
-use pathdiff::diff_paths;
 use std::path::Path;
 
 /// Classification for generated asset snippets.
@@ -95,29 +95,6 @@ pub fn build_asset_snippet(request: &AssetSnippetRequest<'_>) -> AssetSnippet {
         cursor_offset: text.len(),
         text,
     }
-}
-
-fn normalize_path(path: &Path, document_dir: Option<&Path>) -> String {
-    let candidate = if let Some(base) = document_dir {
-        diff_paths(path, base).unwrap_or_else(|| path.to_path_buf())
-    } else {
-        path.to_path_buf()
-    };
-
-    let converted = to_forward_slashes(&candidate);
-    if converted.starts_with("./")
-        || converted.starts_with("../")
-        || converted.starts_with('/')
-        || converted.contains(':')
-    {
-        converted
-    } else {
-        format!("./{}", converted)
-    }
-}
-
-fn to_forward_slashes(path: &Path) -> String {
-    path.to_string_lossy().replace("\\", "/")
 }
 
 #[cfg(test)]

--- a/lex-babel/src/templates/asset.rs
+++ b/lex-babel/src/templates/asset.rs
@@ -1,0 +1,181 @@
+use crate::formats::lex::formatting_rules::FormattingRules;
+use pathdiff::diff_paths;
+use std::path::Path;
+
+/// Classification for generated asset snippets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssetKind {
+    Image,
+    Video,
+    Audio,
+    Data,
+}
+
+impl AssetKind {
+    fn from_extension(ext: Option<&str>) -> Self {
+        let ext = ext.unwrap_or("").to_ascii_lowercase();
+        if matches!(
+            ext.as_str(),
+            "png" | "jpg" | "jpeg" | "gif" | "bmp" | "webp" | "svg"
+        ) {
+            AssetKind::Image
+        } else if matches!(ext.as_str(), "mp4" | "mov" | "webm" | "avi" | "mkv") {
+            AssetKind::Video
+        } else if matches!(ext.as_str(), "mp3" | "wav" | "flac" | "ogg" | "aac") {
+            AssetKind::Audio
+        } else {
+            AssetKind::Data
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            AssetKind::Image => "doc.image",
+            AssetKind::Video => "doc.video",
+            AssetKind::Audio => "doc.audio",
+            AssetKind::Data => "doc.data",
+        }
+    }
+}
+
+/// Request describing how the snippet should be generated.
+pub struct AssetSnippetRequest<'a> {
+    /// Path to the asset on disk.
+    pub asset_path: &'a Path,
+    /// Directory of the document being edited (used to compute relative paths).
+    pub document_directory: Option<&'a Path>,
+    /// Formatting rules to respect when building indentation.
+    pub formatting: &'a FormattingRules,
+    /// Logical indentation level (0 for column aligned, 1 for nested, etc.).
+    pub indent_level: usize,
+}
+
+impl<'a> AssetSnippetRequest<'a> {
+    pub fn new(asset_path: &'a Path, formatting: &'a FormattingRules) -> Self {
+        Self {
+            asset_path,
+            document_directory: None,
+            formatting,
+            indent_level: 0,
+        }
+    }
+
+    /// Compute the indentation string for this request.
+    fn indentation(&self) -> String {
+        self.formatting.indent_string.repeat(self.indent_level)
+    }
+}
+
+/// Result returned to callers so they can apply the snippet as a text edit.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AssetSnippet {
+    pub kind: AssetKind,
+    pub text: String,
+    /// Byte offset (from the start of `text`) where editors can place the caret.
+    pub cursor_offset: usize,
+}
+
+/// Build a canonical asset snippet for the provided request.
+pub fn build_asset_snippet(request: &AssetSnippetRequest<'_>) -> AssetSnippet {
+    let kind =
+        AssetKind::from_extension(request.asset_path.extension().and_then(|ext| ext.to_str()));
+    let normalized_path = normalize_path(request.asset_path, request.document_directory);
+    let indent = request.indentation();
+
+    let mut text = String::new();
+    text.push_str(&indent);
+    text.push_str(":: ");
+    text.push_str(kind.label());
+    text.push_str(" src=\"");
+    text.push_str(&normalized_path);
+    text.push_str("\"\n");
+
+    AssetSnippet {
+        kind,
+        cursor_offset: text.len(),
+        text,
+    }
+}
+
+fn normalize_path(path: &Path, document_dir: Option<&Path>) -> String {
+    let candidate = if let Some(base) = document_dir {
+        diff_paths(path, base).unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    };
+
+    let converted = to_forward_slashes(&candidate);
+    if converted.starts_with("./")
+        || converted.starts_with("../")
+        || converted.starts_with('/')
+        || converted.contains(':')
+    {
+        converted
+    } else {
+        format!("./{}", converted)
+    }
+}
+
+fn to_forward_slashes(path: &Path) -> String {
+    path.to_string_lossy().replace("\\", "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::{tempdir, NamedTempFile};
+
+    #[test]
+    fn chooses_kind_based_on_extension() {
+        let png = NamedTempFile::new().unwrap();
+        let path = png.path().with_extension("png");
+        let rules = FormattingRules::default();
+        let request = AssetSnippetRequest::new(path.as_path(), &rules);
+        let snippet = build_asset_snippet(&request);
+        assert_eq!(snippet.kind, AssetKind::Image);
+        assert!(snippet.text.contains(":: doc.image"));
+    }
+
+    #[test]
+    fn normalizes_to_relative_path_when_possible() {
+        let temp = tempdir().unwrap();
+        let doc_dir = temp.path();
+        let asset_path = doc_dir.join("assets").join("diagram.png");
+        std::fs::create_dir_all(asset_path.parent().unwrap()).unwrap();
+        std::fs::write(&asset_path, b"binary").unwrap();
+
+        let rules = FormattingRules::default();
+        let request = AssetSnippetRequest {
+            asset_path: asset_path.as_path(),
+            document_directory: Some(doc_dir),
+            formatting: &rules,
+            indent_level: 0,
+        };
+        let snippet = build_asset_snippet(&request);
+        assert!(snippet.text.contains("src=\"./assets/diagram.png\""));
+    }
+
+    #[test]
+    fn indent_level_is_respected() {
+        let path = Path::new("./diagram.png");
+        let rules = FormattingRules::default();
+        let request = AssetSnippetRequest {
+            asset_path: path,
+            document_directory: None,
+            formatting: &rules,
+            indent_level: 2,
+        };
+        let snippet = build_asset_snippet(&request);
+        assert!(snippet.text.starts_with("        ::"));
+    }
+
+    #[test]
+    fn non_image_extensions_fallback_to_data() {
+        let path = Path::new("./archive.zip");
+        let rules = FormattingRules::default();
+        let request = AssetSnippetRequest::new(path, &rules);
+        let snippet = build_asset_snippet(&request);
+        assert_eq!(snippet.kind, AssetKind::Data);
+        assert!(snippet.text.contains(":: doc.data"));
+    }
+}

--- a/lex-babel/src/templates/mod.rs
+++ b/lex-babel/src/templates/mod.rs
@@ -4,6 +4,11 @@
 //! respect the active formatting rules so editors can insert complex structures without reimplementing
 //! Babel's serialization logic.
 
+mod util;
+
 pub mod asset;
+pub mod verbatim;
 
 pub use asset::{AssetKind, AssetSnippet, AssetSnippetRequest};
+pub(crate) use util::normalize_path;
+pub use verbatim::{build_verbatim_snippet, VerbatimSnippet, VerbatimSnippetRequest};

--- a/lex-babel/src/templates/mod.rs
+++ b/lex-babel/src/templates/mod.rs
@@ -1,0 +1,9 @@
+//! Ready-to-insert snippets for Lex documents.
+//!
+//! These helpers produce canonical text fragments (verbatim blocks, annotations, etc.) that
+//! respect the active formatting rules so editors can insert complex structures without reimplementing
+//! Babel's serialization logic.
+
+pub mod asset;
+
+pub use asset::{AssetKind, AssetSnippet, AssetSnippetRequest};

--- a/lex-babel/src/templates/mod.rs
+++ b/lex-babel/src/templates/mod.rs
@@ -1,14 +1,36 @@
 //! Ready-to-insert snippets for Lex documents.
 //!
-//! These helpers produce canonical text fragments (verbatim blocks, annotations, etc.) that
-//! respect the active formatting rules so editors can insert complex structures without reimplementing
-//! Babel's serialization logic.
+//! Editors need to insert structured Lex content (images, code blocks, etc.) without
+//! reimplementing serialization logic. This module provides snippet generators that:
+//!
+//! - Produce correctly formatted Lex syntax
+//! - Respect the active [`FormattingRules`](crate::formats::lex::formatting_rules::FormattingRules)
+//! - Handle path normalization (absolute → relative)
+//! - Return cursor position hints for editor UX
+//!
+//! # Available Snippets
+//!
+//! - **Asset snippets** ([`asset`]): Insert media references (`doc.image`, `doc.video`, etc.)
+//!   with automatic kind detection from file extension.
+//!
+//! - **Verbatim snippets** ([`verbatim`]): Insert code blocks with optional source file
+//!   linking and language inference from extension.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use lex_babel::templates::asset::{AssetSnippetRequest, build_asset_snippet};
+//!
+//! let request = AssetSnippetRequest::new(Path::new("./diagram.png"), &rules);
+//! let snippet = build_asset_snippet(&request);
+//! // snippet.text contains: ":: doc.image src=\"./diagram.png\"\n"
+//! ```
 
 mod util;
 
 pub mod asset;
 pub mod verbatim;
 
-pub use asset::{AssetKind, AssetSnippet, AssetSnippetRequest};
+pub use asset::{build_asset_snippet, AssetKind, AssetSnippet, AssetSnippetRequest};
 pub(crate) use util::normalize_path;
 pub use verbatim::{build_verbatim_snippet, VerbatimSnippet, VerbatimSnippetRequest};

--- a/lex-babel/src/templates/util.rs
+++ b/lex-babel/src/templates/util.rs
@@ -1,0 +1,25 @@
+use pathdiff::diff_paths;
+use std::path::Path;
+
+pub(crate) fn normalize_path(path: &Path, document_dir: Option<&Path>) -> String {
+    let candidate = if let Some(base) = document_dir {
+        diff_paths(path, base).unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    };
+
+    let converted = to_forward_slashes(&candidate);
+    if converted.starts_with("./")
+        || converted.starts_with("../")
+        || converted.starts_with('/')
+        || converted.contains(':')
+    {
+        converted
+    } else {
+        format!("./{}", converted)
+    }
+}
+
+fn to_forward_slashes(path: &Path) -> String {
+    path.to_string_lossy().replace("\\", "/")
+}

--- a/lex-babel/src/templates/verbatim.rs
+++ b/lex-babel/src/templates/verbatim.rs
@@ -1,0 +1,161 @@
+use super::normalize_path;
+use crate::formats::lex::formatting_rules::FormattingRules;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+pub struct VerbatimSnippetRequest<'a> {
+    pub file_path: &'a Path,
+    pub document_directory: Option<&'a Path>,
+    pub formatting: &'a FormattingRules,
+    pub indent_level: usize,
+    pub language: Option<&'a str>,
+    pub subject: Option<&'a str>,
+}
+
+impl<'a> VerbatimSnippetRequest<'a> {
+    pub fn new(file_path: &'a Path, formatting: &'a FormattingRules) -> Self {
+        Self {
+            file_path,
+            document_directory: None,
+            formatting,
+            indent_level: 0,
+            language: None,
+            subject: None,
+        }
+    }
+
+    fn indentation(&self) -> String {
+        self.formatting.indent_string.repeat(self.indent_level)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VerbatimSnippet {
+    pub language: String,
+    pub text: String,
+    pub cursor_offset: usize,
+}
+
+pub fn build_verbatim_snippet(request: &VerbatimSnippetRequest<'_>) -> io::Result<VerbatimSnippet> {
+    let raw = fs::read(request.file_path)?;
+    let contents = String::from_utf8_lossy(&raw).replace("\r\n", "\n");
+
+    let indent = request.indentation();
+    let inner_indent = format!("{}{}", indent, request.formatting.indent_string);
+    let subject = subject_line(request);
+    let language = language_label(request);
+    let normalized_path = normalize_path(request.file_path, request.document_directory);
+
+    let mut text = String::new();
+    text.push_str(&indent);
+    text.push_str(&subject);
+    text.push('\n');
+    text.push('\n');
+
+    if contents.is_empty() {
+        text.push_str(&inner_indent);
+        text.push('\n');
+    } else {
+        for line in contents.split('\n') {
+            text.push_str(&inner_indent);
+            text.push_str(line);
+            text.push('\n');
+        }
+    }
+
+    text.push_str(&indent);
+    text.push_str(":: ");
+    text.push_str(&language);
+    text.push(' ');
+    text.push_str("src=\"");
+    text.push_str(&normalized_path);
+    text.push_str("\"\n");
+
+    Ok(VerbatimSnippet {
+        language,
+        cursor_offset: text.len(),
+        text,
+    })
+}
+
+fn subject_line(request: &VerbatimSnippetRequest<'_>) -> String {
+    if let Some(custom) = request.subject {
+        return ensure_trailing_colon(custom);
+    }
+    request
+        .file_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(ensure_trailing_colon)
+        .unwrap_or_else(|| "Verbatim:".to_string())
+}
+
+fn ensure_trailing_colon(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.ends_with(':') {
+        trimmed.to_string()
+    } else {
+        format!("{}:", trimmed)
+    }
+}
+
+fn language_label(request: &VerbatimSnippetRequest<'_>) -> String {
+    if let Some(lang) = request.language {
+        return lang.trim().to_ascii_lowercase();
+    }
+    request
+        .file_path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.trim().to_ascii_lowercase())
+        .filter(|ext| !ext.is_empty())
+        .unwrap_or_else(|| "text".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn infers_language_from_extension() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.rs");
+        fs::write(&file, "fn main() {}\n").unwrap();
+        let rules = FormattingRules::default();
+        let request = VerbatimSnippetRequest::new(file.as_path(), &rules);
+        let snippet = build_verbatim_snippet(&request).unwrap();
+        assert!(snippet.text.contains(":: rs"));
+        assert_eq!(snippet.language, "rs");
+    }
+
+    #[test]
+    fn uses_relative_src_path() {
+        let dir = tempdir().unwrap();
+        let doc_dir = dir.path();
+        let file = doc_dir.join("code").join("example.py");
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(&file, "print('hi')").unwrap();
+        let rules = FormattingRules::default();
+        let mut request = VerbatimSnippetRequest::new(file.as_path(), &rules);
+        request.document_directory = Some(doc_dir);
+        request.language = Some("python");
+        let snippet = build_verbatim_snippet(&request).unwrap();
+        assert!(snippet.text.contains("src=\"./code/example.py\""));
+        assert!(snippet.text.contains(":: python"));
+    }
+
+    #[test]
+    fn indents_body_lines_relative_to_level() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.txt");
+        fs::write(&file, "line1\nline2").unwrap();
+        let rules = FormattingRules::default();
+        let mut request = VerbatimSnippetRequest::new(file.as_path(), &rules);
+        request.indent_level = 1;
+        let snippet = build_verbatim_snippet(&request).unwrap();
+        let expected = "        line1";
+        assert!(snippet.text.contains(expected));
+    }
+}

--- a/lex-cli/src/help.rs
+++ b/lex-cli/src/help.rs
@@ -1,0 +1,128 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HelpEntry {
+    pub title: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HelpResponse {
+    pub entries: Vec<HelpEntry>,
+}
+
+pub fn query_help(topic: Option<&str>) -> io::Result<HelpResponse> {
+    let files = discover_files(&["docs", "specs"])?;
+    let matches = match topic {
+        Some(keyword) => filter_by_topic(&files, keyword),
+        None => default_entries(&files),
+    };
+    let mut entries = Vec::new();
+    for path in matches {
+        if let Ok(content) = fs::read_to_string(&path) {
+            entries.push(HelpEntry {
+                title: display_title(&path),
+                content,
+            });
+        }
+    }
+    Ok(HelpResponse { entries })
+}
+
+fn discover_files(roots: &[&str]) -> io::Result<Vec<PathBuf>> {
+    let base = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    let mut files = Vec::new();
+    for root in roots {
+        let path = base.join(root);
+        if path.exists() {
+            collect_files(&path, &mut files)?;
+        }
+    }
+    Ok(files)
+}
+
+fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("lex") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn filter_by_topic(files: &[PathBuf], topic: &str) -> Vec<PathBuf> {
+    let needle = topic.to_ascii_lowercase();
+    files
+        .iter()
+        .filter(|path| {
+            path.to_string_lossy()
+                .to_ascii_lowercase()
+                .contains(&needle)
+        })
+        .cloned()
+        .collect()
+}
+
+fn default_entries(files: &[PathBuf]) -> Vec<PathBuf> {
+    let mut entries = Vec::new();
+    if let Some(entry) = find_file(files, "on-all-of-lex") {
+        entries.push(entry);
+    }
+    if let Some(entry) = find_file(files, "general.lex") {
+        entries.push(entry);
+    }
+    if entries.is_empty() {
+        entries.extend_from_slice(&files[..files.len().min(3)]);
+    }
+    entries
+}
+
+fn find_file(files: &[PathBuf], needle: &str) -> Option<PathBuf> {
+    let lower = needle.to_ascii_lowercase();
+    files
+        .iter()
+        .find(|path| path.to_string_lossy().to_ascii_lowercase().contains(&lower))
+        .cloned()
+}
+
+fn display_title(path: &Path) -> String {
+    path.strip_prefix("docs")
+        .or_else(|_| path.strip_prefix("specs"))
+        .unwrap_or(path)
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .trim_start_matches('\\')
+        .replace("\\", "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_general_help_without_topic() {
+        let response = query_help(None).expect("help");
+        assert!(!response.entries.is_empty());
+        assert!(
+            response.entries[0].title.contains("on-all-of-lex")
+                || response.entries[0].title.contains("general")
+        );
+    }
+
+    #[test]
+    fn filters_entries_by_topic() {
+        let response = query_help(Some("grammar")).expect("help");
+        assert!(response
+            .entries
+            .iter()
+            .any(|entry| entry.title.to_ascii_lowercase().contains("grammar")));
+    }
+}

--- a/lex-cli/src/help.rs
+++ b/lex-cli/src/help.rs
@@ -1,18 +1,49 @@
+//! In-editor help system for Lex format documentation.
+//!
+//! Provides access to the Lex specification and guide documents from within
+//! editors. This enables features like `:LexHelp` commands that display
+//! contextual documentation without leaving the editor.
+//!
+//! The help system discovers `.lex` files in the `docs/` and `specs/` directories
+//! of the Lex repository and returns their contents filtered by topic.
+//!
+//! # Compile-time Dependency
+//!
+//! This module uses `CARGO_MANIFEST_DIR` to locate documentation files at compile
+//! time. This works for development builds but requires the documentation to be
+//! bundled with the binary for distribution. For CLI usage, the docs are typically
+//! available; for LSP commands, consider alternative discovery mechanisms.
+
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+/// A single help document with its title and content.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HelpEntry {
+    /// Display title derived from the file path (e.g., "specs/grammar.lex").
     pub title: String,
+    /// The full content of the documentation file.
     pub content: String,
 }
 
+/// Response containing matching help entries.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HelpResponse {
+    /// Matching documentation entries, possibly empty if no matches found.
     pub entries: Vec<HelpEntry>,
 }
 
+/// Queries the documentation for help on a topic.
+///
+/// If `topic` is `Some`, filters entries to those whose paths contain the topic
+/// string (case-insensitive). If `None`, returns default entries: the main
+/// overview document and general reference, or up to 3 arbitrary docs if those
+/// aren't found.
+///
+/// # Errors
+///
+/// Returns `io::Error` if the documentation directories cannot be read.
 pub fn query_help(topic: Option<&str>) -> io::Result<HelpResponse> {
     let files = discover_files(&["docs", "specs"])?;
     let matches = match topic {

--- a/lex-cli/src/lib.rs
+++ b/lex-cli/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod help;
+pub mod transforms;

--- a/lex-cli/src/main.rs
+++ b/lex-cli/src/main.rs
@@ -23,7 +23,7 @@
 // Example:
 //  lex inspect file.lex --extra-all-nodes true --extra-max-depth 5
 
-mod transforms;
+use lex_cli::transforms;
 
 use clap::{Arg, ArgAction, Command, ValueHint};
 use lex_babel::{FormatRegistry, SerializedDocument};

--- a/specs/v1/benchmark/30-a-place-for-ideas.lex
+++ b/specs/v1/benchmark/30-a-place-for-ideas.lex
@@ -13,20 +13,16 @@ A Place For Ideas
     What if a format could be a habitat, not a cage? A place where an idea could grow organically, from a single seed of thought into a forest of interconnected concepts, without ever needing to be transplanted.
 
     This ideal format would be:
-
-    Simple at the Start: As easy and immediate as a plain text note.
-
-    Structured as it Grows: Able to gain rich, hierarchical structure as the idea develops.
-
-    Readable by Anyone: Intuitively understandable in its source form by any human, without special training.
-
-    Parsable by Anything: Unambiguously structured for any machine, ensuring reliability.
-
-    Durable for All Time: Built on the bedrock of Unicode text, independent of any company, software, or era.
+    - Simple at the Start: As easy and immediate as a plain text note.
+    - Structured as it Grows: Able to gain rich, hierarchical structure as the idea develops.
+    - Readable by Anyone: Intuitively understandable in its source form by any human, without special training.
+    - Parsable by Anything: Unambiguously structured for any machine, ensuring reliability.
+    -Durable for All Time: Built on the bedrock of Unicode text, independent of any company, software, or era.
 
 3. Lex: Ideas, Uncaged
 
     Lex is this habitat. It is a plain text document format designed for the complete lifecycle of an idea. It scales from a fleeting thought to a finished thesis, from a line of code to a novel. It is built on a single, powerful principle: structure should be visible, intuitive, and effortless.
+
 
     3.1. The Lex Philosophy: Invisible Structure
 
@@ -35,13 +31,16 @@ A Place For Ideas
 
         Lex achieves this by trusting the traditions of written language. We already understand that indented text is subordinate. We know that numbered lines form a sequence. Lex formalizes this intuition, making it both human-readable and machine-parsable.
 
+
     3.2. From Seed to Forest: The Lifecycle of an Idea
 
         An idea does not spring into existence fully formed. It grows, branches, and connects. Lex is designed to grow with it.
 
+
         3.2.1. The Spark
 
             What if we could represent knowledge structurally without complex syntax?
+
 
         3.2.2. The Outline
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,20 +27,22 @@
 //!
 //!     AST → Insights extraction
 //!
-//!     - Document analysis and navigation utilities
+//!     - Document analysis and navigation utilities (symbols, folding, hovers)
 //!     - Reference resolution: go-to-definition, find-references
-//!     - Symbol extraction and hierarchy building
+//!     - Completion provider for references, sessions, paths, and verbatim labels
+//!     - Annotation helpers: navigation and resolution edits
 //!     - Token classification for syntax highlighting
 //!     - Preview text extraction for hover tooltips
-//!     - Foldable range detection
 //!     - Protocol-agnostic: reusable across LSP, CLI, editor plugins
 //!
 //! lex-babel: Format Transformation
 //!
 //!     AST → Multiple output formats
 //!
-//!     - Multi-format conversion: Lex ↔ Markdown, HTML, LaTeX
+//!     - Multi-format conversion: Lex ↔ Markdown, HTML, LaTeX, PDF
+//!     - Publish pipeline returning on-disk artifacts or in-memory strings
 //!     - Document serialization with formatting rules
+//!     - Shared snippet templates for assets and verbatim blocks
 //!     - Format-specific transformations and normalization
 //!     - Pretty-printing with configurable indentation, blank lines, list markers
 //!
@@ -60,6 +62,7 @@
 //!     Terminal-based document processing
 //!
 //!     - Format documents, convert between formats, validate documents, query AST
+//!     - `lex help` style documentation lookup over docs/ and specs/
 //!     - Designed for scripting, CI/CD pipelines, manual document processing
 //!
 //! lex-viewer: TUI Viewer


### PR DESCRIPTION
## Summary
- add lex-analysis completion provider covering references, sessions, files, verbatim labels (#355)
- add asset and verbatim snippet helpers plus annotation navigation/resolution APIs (#356-#359)
- add publish descriptor API and CLI documentation lookup helper (#360-#361)

## Issues Closed
Closes #355
Closes #356
Closes #357
Closes #358
Closes #359
Closes #360
Closes #361
