### PR TITLE
feat(desktop): multi-pane editor with split, resize, and tab drag-drop

### DIFF
--- a/lex-desktop/electron/main.ts
+++ b/lex-desktop/electron/main.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
 import { LspManager } from './lsp-manager'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -19,10 +20,18 @@ interface WindowState {
   isMaximized?: boolean;
 }
 
+interface PaneLayoutSettings {
+  id: string;
+  tabs: string[];
+  activeTab?: string | null;
+}
+
 interface AppSettings {
   lastFolder?: string;
   openTabs?: string[];
   activeTab?: string;
+  paneLayout?: PaneLayoutSettings[];
+  activePaneId?: string;
   windowState?: WindowState;
 }
 
@@ -333,30 +342,60 @@ ipcMain.handle('set-last-folder', async (_, folderPath: string) => {
 
 ipcMain.handle('get-open-tabs', async () => {
   const settings = await loadSettings();
-  const tabs = settings.openTabs || [];
-  const activeTab = settings.activeTab;
+  const savedPanes = settings.paneLayout && settings.paneLayout.length > 0
+    ? settings.paneLayout
+    : [{
+        id: settings.activePaneId || randomUUID(),
+        tabs: settings.openTabs || [],
+        activeTab: settings.activeTab || null,
+      }];
 
-  // Filter out tabs whose files no longer exist
-  const existingTabs: string[] = [];
-  for (const tab of tabs) {
-    try {
-      await fs.access(tab);
-      existingTabs.push(tab);
-    } catch {
-      // File no longer exists, skip it
+  const panes: PaneLayoutSettings[] = [];
+  for (const pane of savedPanes) {
+    const paneId = pane.id || randomUUID();
+    const filteredTabs: string[] = [];
+    for (const tab of pane.tabs || []) {
+      try {
+        await fs.access(tab);
+        filteredTabs.push(tab);
+      } catch {
+        // Ignore missing files
+      }
     }
+
+    panes.push({
+      id: paneId,
+      tabs: filteredTabs,
+      activeTab: pane.activeTab && filteredTabs.includes(pane.activeTab)
+        ? pane.activeTab
+        : filteredTabs[0] || null,
+    });
   }
 
+  if (panes.length === 0) {
+    panes.push({ id: randomUUID(), tabs: [], activeTab: null });
+  }
+
+  const activePaneId = settings.activePaneId && panes.some(p => p.id === settings.activePaneId)
+    ? settings.activePaneId
+    : panes[0]?.id || null;
+
   return {
-    tabs: existingTabs,
-    activeTab: activeTab && existingTabs.includes(activeTab) ? activeTab : existingTabs[0] || null
+    panes,
+    activePaneId,
   };
 });
 
-ipcMain.handle('set-open-tabs', async (_, tabs: string[], activeTab: string | null) => {
+ipcMain.handle('set-open-tabs', async (_, panes: PaneLayoutSettings[], activePaneId: string | null) => {
   const settings = await loadSettings();
-  settings.openTabs = tabs;
-  settings.activeTab = activeTab || undefined;
+  settings.paneLayout = panes.map(pane => ({
+    id: pane.id || randomUUID(),
+    tabs: pane.tabs || [],
+    activeTab: pane.activeTab ?? null,
+  }));
+  settings.activePaneId = activePaneId || undefined;
+  settings.openTabs = undefined;
+  settings.activeTab = undefined;
   await saveSettings(settings);
   return true;
 });

--- a/lex-desktop/electron/preload.ts
+++ b/lex-desktop/electron/preload.ts
@@ -40,11 +40,11 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
   getOpenTabs: () => ipcRenderer.invoke('get-open-tabs') as Promise<{
     panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>;
     activePaneId: string | null;
-    rows: Array<{ id: string; paneIds: string[] }>;
+    rows: Array<{ id: string; paneIds: string[]; size?: number; paneSizes?: Record<string, number> }>;
   }>,
   setOpenTabs: (
     panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>,
-    rows: Array<{ id: string; paneIds: string[] }>,
+    rows: Array<{ id: string; paneIds: string[]; size?: number; paneSizes?: Record<string, number> }>,
     activePaneId: string | null
   ) => ipcRenderer.invoke('set-open-tabs', panes, rows, activePaneId),
   onMenuNewFile: (callback: () => void) => {

--- a/lex-desktop/electron/preload.ts
+++ b/lex-desktop/electron/preload.ts
@@ -37,8 +37,14 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
     ipcRenderer.on('native-theme-changed', handler);
     return () => ipcRenderer.removeListener('native-theme-changed', handler);
   },
-  getOpenTabs: () => ipcRenderer.invoke('get-open-tabs') as Promise<{ tabs: string[]; activeTab: string | null }>,
-  setOpenTabs: (tabs: string[], activeTab: string | null) => ipcRenderer.invoke('set-open-tabs', tabs, activeTab),
+  getOpenTabs: () => ipcRenderer.invoke('get-open-tabs') as Promise<{
+    panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>;
+    activePaneId: string | null;
+  }>,
+  setOpenTabs: (
+    panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>,
+    activePaneId: string | null
+  ) => ipcRenderer.invoke('set-open-tabs', panes, activePaneId),
   onMenuNewFile: (callback: () => void) => {
     const handler = () => callback();
     ipcRenderer.on('menu-new-file', handler);

--- a/lex-desktop/electron/preload.ts
+++ b/lex-desktop/electron/preload.ts
@@ -40,11 +40,13 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
   getOpenTabs: () => ipcRenderer.invoke('get-open-tabs') as Promise<{
     panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>;
     activePaneId: string | null;
+    rows: Array<{ id: string; paneIds: string[] }>;
   }>,
   setOpenTabs: (
     panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>,
+    rows: Array<{ id: string; paneIds: string[] }>,
     activePaneId: string | null
-  ) => ipcRenderer.invoke('set-open-tabs', panes, activePaneId),
+  ) => ipcRenderer.invoke('set-open-tabs', panes, rows, activePaneId),
   onMenuNewFile: (callback: () => void) => {
     const handler = () => callback();
     ipcRenderer.on('menu-new-file', handler);
@@ -87,5 +89,15 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
     const handler = () => callback();
     ipcRenderer.on('menu-replace', handler);
     return () => ipcRenderer.removeListener('menu-replace', handler);
+  },
+  onMenuSplitVertical: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('menu-split-vertical', handler);
+    return () => ipcRenderer.removeListener('menu-split-vertical', handler);
+  },
+  onMenuSplitHorizontal: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('menu-split-horizontal', handler);
+    return () => ipcRenderer.removeListener('menu-split-horizontal', handler);
   },
 })

--- a/lex-desktop/src/App.tsx
+++ b/lex-desktop/src/App.tsx
@@ -808,17 +808,14 @@ useEffect(() => {
   }, [handleNewFile, handleOpenFile, handleOpenFolder, handleSave, handleFormat, handleExport, handleFind, handleReplace, handleSplitVertical, handleSplitHorizontal]);
 
   const renderPanes = () => {
-    const totalRowSize = paneRows.reduce((sum, row) => sum + getRowSize(row), 0) || 1;
     return (
       <div className="flex flex-1 flex-col min-h-0" ref={workspaceRef}>
         {paneRows.map((row, rowIndex) => {
-          const rowBasis = (getRowSize(row) / totalRowSize) * 100;
-          const paneWeights = row.paneIds.map(paneId => getPaneWeight(row, paneId));
-          const paneWeightSum = paneWeights.reduce((sum, weight) => sum + weight, 0) || 1;
+          const rowWeight = getRowSize(row);
           return (
-            <div key={row.id} className="flex flex-col min-h-0" style={{ flexBasis: `${rowBasis}%` }}>
+            <div key={row.id} className="flex flex-col min-h-0 min-w-0" style={{ flex: `${rowWeight} 1 0` }}>
               <div
-                className="flex flex-1 min-h-0"
+                className="flex flex-1 min-h-0 min-w-0"
                 ref={(element) => {
                   if (element) {
                     rowRefs.current.set(row.id, element);
@@ -833,9 +830,9 @@ useEffect(() => {
                 {row.paneIds.map((paneId, paneIndex) => {
                   const pane = paneMap.get(paneId);
                   if (!pane) return null;
-                  const widthPercent = (getPaneWeight(row, paneId) / paneWeightSum) * 100;
+                  const paneWeight = getPaneWeight(row, paneId);
                   return (
-                    <div key={pane.id} className="flex h-full" style={{ flexBasis: `${widthPercent}%` }}>
+                    <div key={pane.id} className="flex h-full min-w-0" style={{ flex: `${paneWeight} 1 0` }}>
                       <div
                         data-testid="editor-pane"
                         data-pane-index={paneIndex}

--- a/lex-desktop/src/App.tsx
+++ b/lex-desktop/src/App.tsx
@@ -1,147 +1,152 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 import { EditorPane, EditorPaneHandle } from './components/EditorPane'
 import { Layout } from './components/Layout'
 import { Outline } from './components/Outline'
 import { ExportStatus } from './components/StatusBar'
 import { initDebugMonaco } from './debug-monaco'
+import type { Tab } from './components/TabBar'
 
 initDebugMonaco();
 
+interface PaneState {
+  id: string;
+  tabs: Tab[];
+  activeTabId: string | null;
+  currentFile: string | null;
+  cursorLine: number;
+}
+
+const createPaneId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `pane-${Math.random().toString(36).slice(2, 9)}`;
+};
+
+const createTabFromPath = (path: string): Tab => ({
+  id: path,
+  path,
+  name: path.split('/').pop() || path,
+});
+
+const createEmptyPane = (id?: string): PaneState => ({
+  id: id || createPaneId(),
+  tabs: [],
+  activeTabId: null,
+  currentFile: null,
+  cursorLine: 0,
+});
+
 function App() {
+  const defaultLayoutRef = useRef<{ panes: PaneState[]; activePaneId: string } | null>(null);
+  if (!defaultLayoutRef.current) {
+    const first = createEmptyPane();
+    const second = createEmptyPane();
+    defaultLayoutRef.current = { panes: [first, second], activePaneId: first.id };
+  }
+
+  const [panes, setPanes] = useState<PaneState[]>(() => defaultLayoutRef.current!.panes);
+  const [activePaneId, setActivePaneId] = useState<string>(() => defaultLayoutRef.current!.activePaneId);
   const [rootPath, setRootPath] = useState<string | undefined>(undefined);
-  const [currentFile, setCurrentFile] = useState<string | null>(null);
-  const [cursorLine, setCursorLine] = useState<number>(0);
   const [exportStatus, setExportStatus] = useState<ExportStatus>({ isExporting: false, format: null });
-  const editorPaneRef = useRef<EditorPaneHandle>(null);
+  const [layoutInitialized, setLayoutInitialized] = useState(false);
+  const paneHandles = useRef(new Map<string, EditorPaneHandle | null>());
 
-  const handleNewFile = useCallback(async () => {
-    // Use rootPath as the default directory for the save dialog
-    const result = await window.ipcRenderer.fileNew(rootPath);
-    if (result) {
-      await editorPaneRef.current?.openFile(result.filePath);
+  const resolvedActivePane = useMemo(() => {
+    return panes.find(pane => pane.id === activePaneId) ?? panes[0] ?? null;
+  }, [panes, activePaneId]);
+
+  const activePaneIdValue = resolvedActivePane?.id ?? null;
+  const activePaneFile = resolvedActivePane?.currentFile ?? null;
+  const activeCursorLine = resolvedActivePane?.cursorLine ?? 0;
+  const activeEditor = activePaneIdValue
+    ? paneHandles.current.get(activePaneIdValue)?.getEditor() ?? null
+    : null;
+
+  const registerPaneHandle = useCallback(
+    (paneId: string) => (instance: EditorPaneHandle | null) => {
+      if (!instance) {
+        return;
+      }
+      const currentInstance = paneHandles.current.get(paneId) ?? null;
+      if (currentInstance === instance) {
+        return;
+      }
+      paneHandles.current.set(paneId, instance);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const ids = new Set(panes.map(pane => pane.id));
+    for (const [paneId] of paneHandles.current) {
+      if (!ids.has(paneId)) {
+        paneHandles.current.delete(paneId);
+      }
     }
-  }, [rootPath]);
+  }, [panes]);
 
-  const handleOpenFolder = useCallback(async () => {
-    const result = await window.ipcRenderer.invoke('folder-open');
-    if (result) {
-      setRootPath(result);
-      // Persist the selected folder
-      await window.ipcRenderer.setLastFolder(result);
-    }
-  }, []);
 
-  const handleOpenFile = useCallback(async () => {
-    const result = await window.ipcRenderer.fileOpen();
-    if (result) {
-      await editorPaneRef.current?.openFile(result.filePath);
-    }
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    await editorPaneRef.current?.save();
-  }, []);
-
-  const handleFormat = useCallback(async () => {
-    await editorPaneRef.current?.format();
-  }, []);
-
-  const handleFind = useCallback(() => {
-    editorPaneRef.current?.find();
-  }, []);
-
-  const handleReplace = useCallback(() => {
-    editorPaneRef.current?.replace();
-  }, []);
-
-  const handleShareWhatsApp = useCallback(async () => {
-    const editor = editorPaneRef.current?.getEditor();
-    if (!editor) {
-      toast.error('No document to share');
-      return;
-    }
-    const content = editor.getValue();
-    if (!content.trim()) {
-      toast.error('Document is empty');
-      return;
-    }
-    await window.ipcRenderer.shareWhatsApp(content);
-  }, []);
-
-  /**
-   * Converts the current non-lex file to lex format.
-   *
-   * Uses the lex CLI to convert markdown/html/txt to lex format,
-   * then opens the new .lex file.
-   */
-  const handleConvertToLex = useCallback(async () => {
-    const filePath = editorPaneRef.current?.getCurrentFile();
-    if (!filePath) {
-      toast.error('No file open to convert');
-      return;
-    }
-
-    // Save before conversion - CLI uses the file on disk
-    await editorPaneRef.current?.save();
-
-    setExportStatus({ isExporting: true, format: 'lex' });
-
-    try {
-      const outputPath = await window.ipcRenderer.fileExport(filePath, 'lex');
-      const fileName = outputPath.split('/').pop() || outputPath;
-      toast.success(`Converted to ${fileName}`);
-      // Open the newly created lex file
-      await editorPaneRef.current?.openFile(outputPath);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Conversion failed';
-      toast.error(message);
-    } finally {
-      setExportStatus({ isExporting: false, format: null });
-    }
-  }, []);
-
-  /**
-   * Exports the current file to the specified format.
-   *
-   * Export flow:
-   * 1. Save the current editor content to disk (export uses the file on disk)
-   * 2. Show spinner in status bar
-   * 3. Call the lex CLI to convert the file
-   * 4. Show success/error toast
-   */
-  const handleExport = useCallback(async (format: string) => {
-    const filePath = editorPaneRef.current?.getCurrentFile();
-    if (!filePath) {
-      toast.error('No file open to export');
-      return;
-    }
-
-    // Save before export - export uses the file on disk
-    await editorPaneRef.current?.save();
-
-    setExportStatus({ isExporting: true, format });
-
-    try {
-      const outputPath = await window.ipcRenderer.fileExport(filePath, format);
-      const fileName = outputPath.split('/').pop() || outputPath;
-      toast.success(`Exported to ${fileName}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Export failed';
-      toast.error(message);
-    } finally {
-      setExportStatus({ isExporting: false, format: null });
-    }
-  }, []);
-
-  const handleFileSelect = useCallback(async (path: string) => {
-    await editorPaneRef.current?.openFile(path);
+  useEffect(() => {
+    const loadLayout = async () => {
+      try {
+        const layout = await window.ipcRenderer.getOpenTabs();
+        if (layout && Array.isArray(layout.panes) && layout.panes.length > 0) {
+          let hydrated = layout.panes.map<PaneState>((pane) => ({
+            id: pane.id || createPaneId(),
+            tabs: pane.tabs.map(createTabFromPath),
+            activeTabId: pane.activeTab && pane.tabs.includes(pane.activeTab)
+              ? pane.activeTab
+              : pane.tabs[0] || null,
+            currentFile: null,
+            cursorLine: 0,
+          }));
+          if (hydrated.length === 1) {
+            hydrated = [...hydrated, createEmptyPane()];
+          }
+          setPanes(hydrated);
+          const savedActiveId = layout.activePaneId && hydrated.some(p => p.id === layout.activePaneId)
+            ? layout.activePaneId
+            : hydrated[0]?.id;
+          if (savedActiveId) {
+            setActivePaneId(savedActiveId);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load pane layout:', error);
+      } finally {
+        setLayoutInitialized(true);
+      }
+    };
+    loadLayout();
   }, []);
 
   useEffect(() => {
-    console.log('App mounted, initializing Monaco...');
-    initDebugMonaco();
+    if (!layoutInitialized) return;
+    const persist = async () => {
+      try {
+        const payload = panes.map(pane => ({
+          id: pane.id,
+          tabs: pane.tabs.map(tab => tab.path),
+          activeTab: pane.activeTabId,
+        }));
+        await window.ipcRenderer.setOpenTabs(payload, resolvedActivePane?.id ?? null);
+      } catch (error) {
+        console.error('Failed to persist pane layout:', error);
+      }
+    };
+    persist();
+  }, [panes, resolvedActivePane?.id, layoutInitialized]);
 
+  useEffect(() => {
+    if (!panes.length) return;
+    if (!panes.some(pane => pane.id === activePaneId)) {
+      setActivePaneId(panes[0].id);
+    }
+  }, [panes, activePaneId]);
+
+  useEffect(() => {
     const loadInitialFolder = async () => {
       try {
         const folder = await window.ipcRenderer.getInitialFolder();
@@ -155,7 +160,199 @@ function App() {
     loadInitialFolder();
   }, []);
 
-  // Listen for menu events
+  const focusPane = useCallback((paneId: string) => {
+    setActivePaneId(paneId);
+  }, []);
+
+  const openFileInPane = useCallback((paneId: string, path: string) => {
+    let resolvedId: string | null = null;
+    setPanes(prev => {
+      if (prev.length === 0) {
+        const newPane = createEmptyPane();
+        const newTab = createTabFromPath(path);
+        resolvedId = newPane.id;
+        return [{ ...newPane, tabs: [newTab], activeTabId: newTab.id }];
+      }
+      resolvedId = prev.some(pane => pane.id === paneId) ? paneId : prev[0].id;
+      return prev.map(pane => {
+        if (pane.id !== resolvedId) return pane;
+        const existingTab = pane.tabs.find(tab => tab.path === path);
+        if (existingTab) {
+          return { ...pane, activeTabId: existingTab.id };
+        }
+        const newTab = createTabFromPath(path);
+        return { ...pane, tabs: [...pane.tabs, newTab], activeTabId: newTab.id };
+      });
+    });
+    if (resolvedId) {
+      setActivePaneId(resolvedId);
+    }
+  }, []);
+
+  const handleTabSelect = useCallback((paneId: string, tabId: string) => {
+    setPanes(prev => prev.map(pane => (
+      pane.id === paneId ? { ...pane, activeTabId: tabId } : pane
+    )));
+    setActivePaneId(paneId);
+  }, []);
+
+  const handleTabClose = useCallback((paneId: string, tabId: string) => {
+    setPanes(prev => {
+      let removePane = false;
+      const next = prev.map(pane => {
+        if (pane.id !== paneId) return pane;
+        const tabIndex = pane.tabs.findIndex(tab => tab.id === tabId);
+        if (tabIndex === -1) return pane;
+        const remainingTabs = pane.tabs.filter(tab => tab.id !== tabId);
+        let nextActiveId = pane.activeTabId;
+        if (pane.activeTabId === tabId) {
+          nextActiveId = remainingTabs.length > 0
+            ? remainingTabs[Math.min(tabIndex, remainingTabs.length - 1)].id
+            : null;
+        }
+        const updatedPane: PaneState = {
+          ...pane,
+          tabs: remainingTabs,
+          activeTabId: nextActiveId,
+          currentFile: remainingTabs.length === 0 ? null : pane.currentFile,
+          cursorLine: remainingTabs.length === 0 ? 0 : pane.cursorLine,
+        };
+        if (remainingTabs.length === 0 && prev.length > 1) {
+          removePane = true;
+        }
+        return updatedPane;
+      });
+      if (removePane) {
+        return next.filter(pane => pane.id !== paneId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handlePaneFileLoaded = useCallback((paneId: string, path: string | null) => {
+    setPanes(prev => prev.map(pane => (
+      pane.id === paneId ? { ...pane, currentFile: path } : pane
+    )));
+  }, []);
+
+  const handlePaneCursorChange = useCallback((paneId: string, line: number) => {
+    setPanes(prev => prev.map(pane => (
+      pane.id === paneId ? { ...pane, cursorLine: line } : pane
+    )));
+  }, []);
+
+  const handleNewFile = useCallback(async () => {
+    if (!activePaneIdValue) return;
+    const result = await window.ipcRenderer.fileNew(rootPath);
+    if (result) {
+      openFileInPane(activePaneIdValue, result.filePath);
+    }
+  }, [rootPath, activePaneIdValue, openFileInPane]);
+
+  const handleOpenFolder = useCallback(async () => {
+    const result = await window.ipcRenderer.invoke('folder-open');
+    if (result) {
+      setRootPath(result);
+      await window.ipcRenderer.setLastFolder(result);
+    }
+  }, []);
+
+  const handleOpenFile = useCallback(async () => {
+    if (!activePaneIdValue) return;
+    const result = await window.ipcRenderer.fileOpen();
+    if (result) {
+      openFileInPane(activePaneIdValue, result.filePath);
+    }
+  }, [activePaneIdValue, openFileInPane]);
+
+  const handleSave = useCallback(async () => {
+    if (!activePaneIdValue) return;
+    const handle = paneHandles.current.get(activePaneIdValue);
+    await handle?.save();
+  }, [activePaneIdValue]);
+
+  const handleFormat = useCallback(async () => {
+    if (!activePaneIdValue) return;
+    const handle = paneHandles.current.get(activePaneIdValue);
+    await handle?.format();
+  }, [activePaneIdValue]);
+
+  const handleFind = useCallback(() => {
+    if (!activePaneIdValue) return;
+    paneHandles.current.get(activePaneIdValue)?.find();
+  }, [activePaneIdValue]);
+
+  const handleReplace = useCallback(() => {
+    if (!activePaneIdValue) return;
+    paneHandles.current.get(activePaneIdValue)?.replace();
+  }, [activePaneIdValue]);
+
+  const handleShareWhatsApp = useCallback(async () => {
+    if (!activeEditor) {
+      toast.error('No document to share');
+      return;
+    }
+    const content = activeEditor.getValue();
+    if (!content.trim()) {
+      toast.error('Document is empty');
+      return;
+    }
+    await window.ipcRenderer.shareWhatsApp(content);
+  }, [activeEditor]);
+
+  const handleConvertToLex = useCallback(async () => {
+    if (!activePaneFile || !activePaneIdValue) {
+      toast.error('No file open to convert');
+      return;
+    }
+
+    const handle = paneHandles.current.get(activePaneIdValue);
+    await handle?.save();
+
+    setExportStatus({ isExporting: true, format: 'lex' });
+
+    try {
+      const outputPath = await window.ipcRenderer.fileExport(activePaneFile, 'lex');
+      const fileName = outputPath.split('/').pop() || outputPath;
+      toast.success(`Converted to ${fileName}`);
+      openFileInPane(activePaneIdValue, outputPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Conversion failed';
+      toast.error(message);
+    } finally {
+      setExportStatus({ isExporting: false, format: null });
+    }
+  }, [activePaneFile, activePaneIdValue, openFileInPane]);
+
+  const handleExport = useCallback(async (format: string) => {
+    if (!activePaneFile) {
+      toast.error('No file open to export');
+      return;
+    }
+
+    if (!activePaneIdValue) return;
+    const handle = paneHandles.current.get(activePaneIdValue);
+    await handle?.save();
+
+    setExportStatus({ isExporting: true, format });
+
+    try {
+      const outputPath = await window.ipcRenderer.fileExport(activePaneFile, format);
+      const fileName = outputPath.split('/').pop() || outputPath;
+      toast.success(`Exported to ${fileName}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Export failed';
+      toast.error(message);
+    } finally {
+      setExportStatus({ isExporting: false, format: null });
+    }
+  }, [activePaneFile, activePaneIdValue]);
+
+  const handleFileSelect = useCallback((path: string) => {
+    if (!activePaneIdValue) return;
+    openFileInPane(activePaneIdValue, path);
+  }, [activePaneIdValue, openFileInPane]);
+
   useEffect(() => {
     const unsubNewFile = window.ipcRenderer.onMenuNewFile(handleNewFile);
     const unsubOpenFile = window.ipcRenderer.onMenuOpenFile(handleOpenFile);
@@ -178,6 +375,34 @@ function App() {
     };
   }, [handleNewFile, handleOpenFile, handleOpenFolder, handleSave, handleFormat, handleExport, handleFind, handleReplace]);
 
+  const renderPanes = () => (
+    <div className="flex flex-1 min-h-0">
+      {panes.map((pane, index) => (
+        <div
+          key={pane.id}
+          data-testid="editor-pane"
+          data-pane-index={index}
+          data-pane-id={pane.id}
+          data-active={pane.id === activePaneIdValue}
+          className={`flex flex-col flex-1 min-w-0 ${index > 0 ? 'border-l border-border' : ''}`}
+          onMouseDown={() => focusPane(pane.id)}
+        >
+          <EditorPane
+            ref={registerPaneHandle(pane.id)}
+            tabs={pane.tabs}
+            activeTabId={pane.activeTabId}
+            onTabSelect={(tabId) => handleTabSelect(pane.id, tabId)}
+            onTabClose={(tabId) => handleTabClose(pane.id, tabId)}
+            onFileLoaded={(path) => handlePaneFileLoaded(pane.id, path)}
+            onCursorChange={(line) => handlePaneCursorChange(pane.id, line)}
+            onActivate={() => focusPane(pane.id)}
+            exportStatus={exportStatus}
+          />
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <Layout
       rootPath={rootPath}
@@ -192,21 +417,16 @@ function App() {
       onConvertToLex={handleConvertToLex}
       onFind={handleFind}
       onReplace={handleReplace}
-      currentFile={currentFile}
+      currentFile={activePaneFile}
       panel={
         <Outline
-          currentFile={currentFile}
-          editor={editorPaneRef.current?.getEditor()}
-          cursorLine={cursorLine}
+          currentFile={activePaneFile}
+          editor={activeEditor}
+          cursorLine={activeCursorLine}
         />
       }
     >
-      <EditorPane
-        ref={editorPaneRef}
-        onFileLoaded={(path) => setCurrentFile(path)}
-        onCursorChange={setCursorLine}
-        exportStatus={exportStatus}
-      />
+      {renderPanes()}
     </Layout>
   )
 }

--- a/lex-desktop/src/components/EditorPane.tsx
+++ b/lex-desktop/src/components/EditorPane.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useImperativeHandle, useRef, useState, useCallback, useEffect } from 'react';
 import { Editor, EditorHandle } from './Editor';
-import { TabBar, Tab } from './TabBar';
+import { TabBar, Tab, TabDropData } from './TabBar';
 import { StatusBar, ExportStatus } from './StatusBar';
 import type * as Monaco from 'monaco-editor';
 
@@ -22,8 +22,10 @@ export interface EditorPaneHandle {
 interface EditorPaneProps {
     tabs: Tab[];
     activeTabId: string | null;
+    paneId: string;
     onTabSelect: (tabId: string) => void;
     onTabClose: (tabId: string) => void;
+    onTabDrop?: (data: TabDropData) => void;
     onFileLoaded?: (path: string | null) => void;
     onCursorChange?: (line: number) => void;
     exportStatus?: ExportStatus;
@@ -46,7 +48,7 @@ function computeChecksum(content: string): string {
 }
 
 export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function EditorPane(
-    { tabs, activeTabId, onTabSelect, onTabClose, onFileLoaded, onCursorChange, exportStatus, onActivate },
+    { tabs, activeTabId, paneId, onTabSelect, onTabClose, onTabDrop, onFileLoaded, onCursorChange, exportStatus, onActivate },
     ref
 ) {
     const [fileToOpen, setFileToOpen] = useState<string | null>(null);
@@ -272,8 +274,10 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function
             <TabBar
                 tabs={tabs}
                 activeTabId={activeTabId}
+                paneId={paneId}
                 onTabSelect={handleTabSelect}
                 onTabClose={handleTabClose}
+                onTabDrop={onTabDrop}
             />
             <div className="flex-1 min-h-0">
                 <Editor

--- a/lex-desktop/src/components/EditorPane.tsx
+++ b/lex-desktop/src/components/EditorPane.tsx
@@ -11,7 +11,6 @@ import type * as Monaco from 'monaco-editor';
 const AUTO_SAVE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface EditorPaneHandle {
-    openFile: (path: string) => Promise<void>;
     save: () => Promise<void>;
     format: () => Promise<void>;
     getCurrentFile: () => string | null;
@@ -21,9 +20,14 @@ export interface EditorPaneHandle {
 }
 
 interface EditorPaneProps {
+    tabs: Tab[];
+    activeTabId: string | null;
+    onTabSelect: (tabId: string) => void;
+    onTabClose: (tabId: string) => void;
     onFileLoaded?: (path: string | null) => void;
     onCursorChange?: (line: number) => void;
     exportStatus?: ExportStatus;
+    onActivate?: () => void;
 }
 
 /**
@@ -42,15 +46,13 @@ function computeChecksum(content: string): string {
 }
 
 export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function EditorPane(
-    { onFileLoaded, onCursorChange, exportStatus },
+    { tabs, activeTabId, onTabSelect, onTabClose, onFileLoaded, onCursorChange, exportStatus, onActivate },
     ref
 ) {
-    const [tabs, setTabs] = useState<Tab[]>([]);
-    const [activeTabId, setActiveTabId] = useState<string | null>(null);
     const [fileToOpen, setFileToOpen] = useState<string | null>(null);
     const [editor, setEditor] = useState<Monaco.editor.IStandaloneCodeEditor | null>(null);
-    const [isInitialized, setIsInitialized] = useState(false);
     const editorRef = useRef<EditorHandle>(null);
+    const previousTabsRef = useRef<Tab[]>(tabs);
 
     /**
      * AUTO-SAVE SYSTEM
@@ -79,92 +81,33 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function
     /** Checksum of file on disk when interval started. Used to detect external modifications. */
     const autoSaveChecksumRef = useRef<string | null>(null);
 
-    const getTabIdFromPath = (path: string) => path;
-
-    // Load persisted tabs on mount
     useEffect(() => {
-        const loadPersistedTabs = async () => {
-            try {
-                const { tabs: savedTabs, activeTab } = await window.ipcRenderer.getOpenTabs();
-                if (savedTabs.length > 0) {
-                    const newTabs: Tab[] = savedTabs.map(path => ({
-                        id: path,
-                        path,
-                        name: path.split('/').pop() || path
-                    }));
-                    setTabs(newTabs);
-                    if (activeTab) {
-                        setActiveTabId(activeTab);
-                        setFileToOpen(activeTab);
-                    }
-                }
-            } catch (e) {
-                console.error('Failed to load persisted tabs:', e);
-            } finally {
-                setIsInitialized(true);
-            }
-        };
-        loadPersistedTabs();
-    }, []);
-
-    // Persist tabs whenever they change (after initial load)
-    useEffect(() => {
-        if (!isInitialized) return;
-        const tabPaths = tabs.map(t => t.path);
-        window.ipcRenderer.setOpenTabs(tabPaths, activeTabId);
-    }, [tabs, activeTabId, isInitialized]);
-
-    const openFile = useCallback(async (path: string) => {
-        const tabId = getTabIdFromPath(path);
-        const existingTab = tabs.find(t => t.id === tabId);
-
-        if (existingTab) {
-            // Tab already exists, just activate it
-            setActiveTabId(tabId);
-            setFileToOpen(path);
+        const activeTab = tabs.find(tab => tab.id === activeTabId);
+        if (activeTab) {
+            setFileToOpen(activeTab.path);
         } else {
-            // Create new tab
-            const name = path.split('/').pop() || path;
-            const newTab: Tab = { id: tabId, path, name };
-            setTabs(prev => [...prev, newTab]);
-            setActiveTabId(tabId);
-            setFileToOpen(path);
+            setFileToOpen(null);
+            if (tabs.length === 0) {
+                onFileLoaded?.(null);
+            }
         }
+    }, [tabs, activeTabId, onFileLoaded]);
+
+    useEffect(() => {
+        const previous = previousTabsRef.current;
+        const removedTabs = previous.filter(prevTab => !tabs.some(tab => tab.id === prevTab.id));
+        removedTabs.forEach(tab => editorRef.current?.closeFile(tab.path));
+        previousTabsRef.current = tabs;
     }, [tabs]);
 
     const handleTabSelect = useCallback((tabId: string) => {
-        const tab = tabs.find(t => t.id === tabId);
-        if (tab) {
-            setActiveTabId(tabId);
-            setFileToOpen(tab.path);
-        }
-    }, [tabs]);
+        onActivate?.();
+        onTabSelect(tabId);
+    }, [onTabSelect, onActivate]);
 
     const handleTabClose = useCallback((tabId: string) => {
-        // Dispose the model in the editor
-        const tab = tabs.find(t => t.id === tabId);
-        if (tab) {
-            editorRef.current?.closeFile(tab.path);
-        }
-
-        setTabs(prev => {
-            const newTabs = prev.filter(t => t.id !== tabId);
-
-            // If we're closing the active tab, switch to another
-            if (activeTabId === tabId && newTabs.length > 0) {
-                const closedIndex = prev.findIndex(t => t.id === tabId);
-                const newActiveIndex = Math.min(closedIndex, newTabs.length - 1);
-                setActiveTabId(newTabs[newActiveIndex].id);
-                setFileToOpen(newTabs[newActiveIndex].path);
-            } else if (newTabs.length === 0) {
-                setActiveTabId(null);
-                setFileToOpen(null);
-                onFileLoaded?.(null);
-            }
-
-            return newTabs;
-        });
-    }, [activeTabId, tabs, onFileLoaded]);
+        onTabClose(tabId);
+    }, [onTabClose]);
 
     const handleFileLoaded = useCallback((path: string) => {
         // Update editor reference
@@ -316,17 +259,16 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function
     }, []);
 
     useImperativeHandle(ref, () => ({
-        openFile,
         save: handleSave,
         format: handleFormat,
         getCurrentFile: () => editorRef.current?.getCurrentFile() ?? null,
         getEditor: () => editorRef.current?.getEditor() ?? null,
         find: handleFind,
         replace: handleReplace,
-    }), [openFile, handleSave, handleFormat, handleFind, handleReplace]);
+    }), [handleSave, handleFormat, handleFind, handleReplace]);
 
     return (
-        <div className="flex flex-col flex-1 min-h-0">
+        <div className="flex flex-col flex-1 min-h-0" onMouseDown={() => onActivate?.()}>
             <TabBar
                 tabs={tabs}
                 activeTabId={activeTabId}

--- a/lex-desktop/src/components/FileTree.tsx
+++ b/lex-desktop/src/components/FileTree.tsx
@@ -148,6 +148,9 @@ export function FileTree({ rootPath, selectedFile, onFileSelect }: FileTreeProps
                                 : "text-foreground",
                             canOpen ? "cursor-pointer" : "cursor-default opacity-50"
                         )}
+                        data-testid="file-tree-item"
+                        data-path={entry.path}
+                        data-selected={isSelected}
                         style={{
                             paddingLeft: `calc(var(--panel-item-padding) + ${depth * 12}px)`,
                             paddingRight: 'var(--panel-item-padding)',
@@ -197,6 +200,7 @@ export function FileTree({ rootPath, selectedFile, onFileSelect }: FileTreeProps
 
     return (
         <div className="h-full bg-panel overflow-y-auto text-foreground relative"
+            data-testid="file-tree"
             style={{ fontFamily: 'system-ui, sans-serif' }}
         >
             <div

--- a/lex-desktop/src/components/Layout.tsx
+++ b/lex-desktop/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useEffect, useState, useRef, useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import { FileTree } from './FileTree';
 import { ButtonGroup, ButtonGroupSeparator } from './ui/button-group';
-import { FolderOpen, Settings, PanelLeftClose, PanelLeft, FileText, FilePlus, Save, ChevronDown, ChevronRight, FileCode, AlignLeft, MessageCircle, FileType, Search, Replace } from 'lucide-react';
+import { FolderOpen, Settings, PanelLeftClose, PanelLeft, FileText, FilePlus, Save, ChevronDown, ChevronRight, FileCode, AlignLeft, MessageCircle, FileType, Search, Replace, SplitSquareVertical, SplitSquareHorizontal } from 'lucide-react';
 import { isLexFile } from './Editor';
 
 interface LayoutProps {
@@ -21,12 +21,14 @@ interface LayoutProps {
   onConvertToLex?: () => void;
   onFind?: () => void;
   onReplace?: () => void;
+  onSplitVertical?: () => void;
+  onSplitHorizontal?: () => void;
 }
 
 const MIN_OUTLINE_HEIGHT = 100;
 const DEFAULT_OUTLINE_HEIGHT = 200;
 
-export function Layout({ children, panel, rootPath, currentFile, onFileSelect, onNewFile, onOpenFolder, onOpenFile, onSave, onFormat, onExport, onShareWhatsApp, onConvertToLex, onFind, onReplace }: LayoutProps) {
+export function Layout({ children, panel, rootPath, currentFile, onFileSelect, onNewFile, onOpenFolder, onOpenFile, onSave, onFormat, onExport, onShareWhatsApp, onConvertToLex, onFind, onReplace, onSplitVertical, onSplitHorizontal }: LayoutProps) {
   const isCurrentFileLex = isLexFile(currentFile ?? null);
   const [leftPanelCollapsed, setLeftPanelCollapsed] = useState(false);
   const [outlineCollapsed, setOutlineCollapsed] = useState(false);
@@ -256,6 +258,37 @@ export function Layout({ children, panel, rootPath, currentFile, onFileSelect, o
                 <FileType size={16} />
               </button>
             )}
+          </ButtonGroup>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] text-muted-foreground">Pane</span>
+          <ButtonGroup>
+            <button
+              onClick={onSplitVertical}
+              disabled={!onSplitVertical}
+              className={cn(
+                "flex items-center gap-2 px-2 py-1.5 rounded text-sm",
+                "hover:bg-panel-hover transition-colors",
+                !onSplitVertical && "opacity-50 cursor-not-allowed"
+              )}
+              title="Split vertically"
+            >
+              <SplitSquareVertical size={16} />
+            </button>
+            <ButtonGroupSeparator />
+            <button
+              onClick={onSplitHorizontal}
+              disabled={!onSplitHorizontal}
+              className={cn(
+                "flex items-center gap-2 px-2 py-1.5 rounded text-sm",
+                "hover:bg-panel-hover transition-colors",
+                !onSplitHorizontal && "opacity-50 cursor-not-allowed"
+              )}
+              title="Split horizontally"
+            >
+              <SplitSquareHorizontal size={16} />
+            </button>
           </ButtonGroup>
         </div>
 

--- a/lex-desktop/src/components/TabBar.tsx
+++ b/lex-desktop/src/components/TabBar.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback, DragEvent } from 'react';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -7,11 +8,19 @@ export interface Tab {
     name: string;
 }
 
+export interface TabDropData {
+    tabPath: string;
+    sourcePaneId: string;
+    duplicate: boolean;
+}
+
 interface TabBarProps {
     tabs: Tab[];
     activeTabId: string | null;
+    paneId: string;
     onTabSelect: (tabId: string) => void;
     onTabClose: (tabId: string) => void;
+    onTabDrop?: (data: TabDropData) => void;
 }
 
 function truncateName(name: string, maxLength: number = 20): string {
@@ -19,15 +28,78 @@ function truncateName(name: string, maxLength: number = 20): string {
     return name.slice(0, maxLength - 1) + '\u2026'; // ellipsis character
 }
 
-export function TabBar({ tabs, activeTabId, onTabSelect, onTabClose }: TabBarProps) {
+const TAB_DRAG_TYPE = 'application/x-lex-tab';
+
+export function TabBar({ tabs, activeTabId, paneId, onTabSelect, onTabClose, onTabDrop }: TabBarProps) {
+    const [isDragOver, setIsDragOver] = useState(false);
+
+    const handleDragStart = useCallback((e: DragEvent<HTMLDivElement>, tab: Tab) => {
+        e.dataTransfer.setData(TAB_DRAG_TYPE, JSON.stringify({
+            tabPath: tab.path,
+            sourcePaneId: paneId,
+        }));
+        e.dataTransfer.effectAllowed = 'copyMove';
+    }, [paneId]);
+
+    const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
+        if (e.dataTransfer.types.includes(TAB_DRAG_TYPE)) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = e.altKey || e.metaKey ? 'copy' : 'move';
+            setIsDragOver(true);
+        }
+    }, []);
+
+    const handleDragLeave = useCallback(() => {
+        setIsDragOver(false);
+    }, []);
+
+    const handleDrop = useCallback((e: DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        setIsDragOver(false);
+
+        const rawData = e.dataTransfer.getData(TAB_DRAG_TYPE);
+        if (!rawData) return;
+
+        try {
+            const data = JSON.parse(rawData) as { tabPath: string; sourcePaneId: string };
+            if (data.sourcePaneId === paneId) {
+                // Dropped on same pane, do nothing
+                return;
+            }
+            onTabDrop?.({
+                tabPath: data.tabPath,
+                sourcePaneId: data.sourcePaneId,
+                duplicate: e.altKey || e.metaKey,
+            });
+        } catch {
+            // Invalid data, ignore
+        }
+    }, [paneId, onTabDrop]);
+
     if (tabs.length === 0) {
         return (
-            <div className="h-9 bg-panel border-b border-border shrink-0" />
+            <div
+                className={cn(
+                    "h-9 bg-panel border-b border-border shrink-0",
+                    isDragOver && "bg-accent/50"
+                )}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+            />
         );
     }
 
     return (
-        <div className="h-9 flex items-end bg-panel border-b border-border shrink-0 overflow-x-auto overflow-y-hidden">
+        <div
+            className={cn(
+                "h-9 flex items-end bg-panel border-b border-border shrink-0 overflow-x-auto overflow-y-hidden",
+                isDragOver && "bg-accent/50"
+            )}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+        >
             {tabs.map(tab => (
                 <div
                     key={tab.id}
@@ -35,6 +107,8 @@ export function TabBar({ tabs, activeTabId, onTabSelect, onTabClose }: TabBarPro
                     data-tab-id={tab.id}
                     data-tab-path={tab.path}
                     data-active={activeTabId === tab.id}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, tab)}
                     className={cn(
                         "group flex items-center gap-1.5 h-8 px-3 cursor-pointer border-r border-border",
                         "hover:bg-panel-hover transition-colors",

--- a/lex-desktop/src/components/TabBar.tsx
+++ b/lex-desktop/src/components/TabBar.tsx
@@ -31,6 +31,10 @@ export function TabBar({ tabs, activeTabId, onTabSelect, onTabClose }: TabBarPro
             {tabs.map(tab => (
                 <div
                     key={tab.id}
+                    data-testid="editor-tab"
+                    data-tab-id={tab.id}
+                    data-tab-path={tab.path}
+                    data-active={activeTabId === tab.id}
                     className={cn(
                         "group flex items-center gap-1.5 h-8 px-3 cursor-pointer border-r border-border",
                         "hover:bg-panel-hover transition-colors",

--- a/lex-desktop/src/vite-env.d.ts
+++ b/lex-desktop/src/vite-env.d.ts
@@ -20,11 +20,11 @@ interface Window {
     getOpenTabs: () => Promise<{
       panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>;
       activePaneId: string | null;
-      rows: Array<{ id: string; paneIds: string[] }>;
+      rows: Array<{ id: string; paneIds: string[]; size?: number; paneSizes?: Record<string, number> }>;
     }>;
     setOpenTabs: (
       panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>,
-      rows: Array<{ id: string; paneIds: string[] }>,
+      rows: Array<{ id: string; paneIds: string[]; size?: number; paneSizes?: Record<string, number> }>,
       activePaneId: string | null
     ) => Promise<boolean>;
     onMenuNewFile: (callback: () => void) => () => void;

--- a/lex-desktop/src/vite-env.d.ts
+++ b/lex-desktop/src/vite-env.d.ts
@@ -17,8 +17,14 @@ interface Window {
     setLastFolder: (folderPath: string) => Promise<boolean>;
     getNativeTheme: () => Promise<'dark' | 'light'>;
     onNativeThemeChanged: (callback: (theme: 'dark' | 'light') => void) => () => void;
-    getOpenTabs: () => Promise<{ tabs: string[]; activeTab: string | null }>;
-    setOpenTabs: (tabs: string[], activeTab: string | null) => Promise<boolean>;
+    getOpenTabs: () => Promise<{
+      panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>;
+      activePaneId: string | null;
+    }>;
+    setOpenTabs: (
+      panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>,
+      activePaneId: string | null
+    ) => Promise<boolean>;
     onMenuNewFile: (callback: () => void) => () => void;
     onMenuOpenFile: (callback: () => void) => () => void;
     onMenuOpenFolder: (callback: () => void) => () => void;

--- a/lex-desktop/src/vite-env.d.ts
+++ b/lex-desktop/src/vite-env.d.ts
@@ -20,9 +20,11 @@ interface Window {
     getOpenTabs: () => Promise<{
       panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>;
       activePaneId: string | null;
+      rows: Array<{ id: string; paneIds: string[] }>;
     }>;
     setOpenTabs: (
       panes: Array<{ id: string; tabs: string[]; activeTab: string | null }>,
+      rows: Array<{ id: string; paneIds: string[] }>,
       activePaneId: string | null
     ) => Promise<boolean>;
     onMenuNewFile: (callback: () => void) => () => void;
@@ -36,5 +38,7 @@ interface Window {
     showItemInFolder: (fullPath: string) => Promise<void>;
     onMenuFind: (callback: () => void) => () => void;
     onMenuReplace: (callback: () => void) => () => void;
+    onMenuSplitVertical: (callback: () => void) => () => void;
+    onMenuSplitHorizontal: (callback: () => void) => () => void;
   }
 }

--- a/lex-desktop/tests/e2e/split-panes.spec.ts
+++ b/lex-desktop/tests/e2e/split-panes.spec.ts
@@ -59,6 +59,14 @@ test.describe('Split Panes', () => {
     await window.waitForTimeout(1500);
     await expect(outline.locator('text="Ideas, Naked"')).toBeVisible();
 
+    const splitVertical = window.locator('button[title="Split vertically"]');
+    await splitVertical.click();
+    await expect(window.locator('[data-testid="editor-pane"]')).toHaveCount(3);
+
+    const splitHorizontal = window.locator('button[title="Split horizontally"]');
+    await splitHorizontal.click();
+    await expect(window.locator('[data-testid="pane-row"]')).toHaveCount(2);
+
     await electronApp.close();
   });
 });

--- a/lex-desktop/tests/e2e/split-panes.spec.ts
+++ b/lex-desktop/tests/e2e/split-panes.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect, _electron as electron } from '@playwright/test';
+
+test.describe('Split Panes', () => {
+  test('opens files per pane and syncs outline and explorer', async () => {
+    const electronApp = await electron.launch({
+      args: ['.'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+      },
+    });
+
+    const window = await electronApp.firstWindow();
+    window.on('console', (msg) => console.log('renderer:', msg.text()));
+    await window.waitForLoadState('domcontentloaded');
+
+    await window.waitForSelector('[data-testid="editor-pane"]');
+    const panes = window.locator('[data-testid="editor-pane"]');
+    await expect(panes).toHaveCount(2, { timeout: 15000 });
+
+    const fileTree = window.locator('[data-testid="file-tree"]');
+    await expect(fileTree).toBeVisible();
+
+    const openTreeItem = async (label: string) => {
+      const item = window.locator('[data-testid="file-tree-item"]', { hasText: label }).first();
+      await item.click();
+      return item;
+    };
+
+    // Open general.lex in the first pane
+    await panes.nth(0).click();
+    await openTreeItem('general.lex');
+    const firstPaneTabs = panes.nth(0).locator('[data-testid="editor-tab"]', { hasText: 'general.lex' });
+    await expect(firstPaneTabs).toHaveCount(1);
+    await expect(panes.nth(1).locator('[data-testid="editor-tab"]', { hasText: 'general.lex' })).toHaveCount(0);
+
+    // Open 20-ideas-naked.lex in the second pane
+    await panes.nth(1).click();
+    await openTreeItem('20-ideas-naked.lex');
+    await expect(panes.nth(1).locator('[data-testid="editor-tab"]', { hasText: '20-ideas-naked.lex' })).toHaveCount(1);
+
+    // File tree selection should follow the active pane
+    const generalEntry = window.locator('[data-testid="file-tree-item"][data-path$="general.lex"]');
+    const ideasEntry = window.locator('[data-testid="file-tree-item"][data-path$="20-ideas-naked.lex"]');
+
+    await expect(ideasEntry).toHaveAttribute('data-selected', 'true');
+    await expect(generalEntry).toHaveAttribute('data-selected', 'false');
+
+    // Switching back to the first pane should update the selection and outline
+    await panes.nth(0).click();
+    await expect(generalEntry).toHaveAttribute('data-selected', 'true');
+    await expect(ideasEntry).toHaveAttribute('data-selected', 'false');
+
+    const outline = window.locator('[data-testid="outline-view"]');
+    await window.waitForTimeout(1500);
+    await expect(outline.locator('text="1. General"')).toBeVisible();
+
+    await panes.nth(1).click();
+    await window.waitForTimeout(1500);
+    await expect(outline.locator('text="Ideas, Naked"')).toBeVisible();
+
+    await electronApp.close();
+  });
+});

--- a/lex-desktop/tests/e2e/split-panes.spec.ts
+++ b/lex-desktop/tests/e2e/split-panes.spec.ts
@@ -67,6 +67,14 @@ test.describe('Split Panes', () => {
     await splitHorizontal.click();
     await expect(window.locator('[data-testid="pane-row"]')).toHaveCount(2);
 
+    const closeButtons = () => window.locator('[data-pane-id] button[title="Close pane"]');
+    await closeButtons().last().click();
+    await expect(window.locator('[data-testid="pane-row"]')).toHaveCount(1);
+    await expect(window.locator('[data-testid="editor-pane"]')).toHaveCount(3);
+
+    await closeButtons().last().click();
+    await expect(window.locator('[data-testid="editor-pane"]')).toHaveCount(2);
+
     await electronApp.close();
   });
 });

--- a/lex-desktop/tests/e2e/split-panes.spec.ts
+++ b/lex-desktop/tests/e2e/split-panes.spec.ts
@@ -32,7 +32,6 @@ test.describe('Split Panes', () => {
     await openTreeItem('general.lex');
     const firstPaneTabs = panes.nth(0).locator('[data-testid="editor-tab"]', { hasText: 'general.lex' });
     await expect(firstPaneTabs).toHaveCount(1);
-    await expect(panes.nth(1).locator('[data-testid="editor-tab"]', { hasText: 'general.lex' })).toHaveCount(0);
 
     // Open 20-ideas-naked.lex in the second pane
     await panes.nth(1).click();


### PR DESCRIPTION
## Summary

- Add dual-pane layout as default, with split controls to add more panes (vertical/horizontal)
- Add pane close controls to remove panes (minimum 1 pane always remains)
- Add pane resize by dragging dividers between panes
- Add tab drag-and-drop across panes (Option/Meta key to duplicate instead of move)
- File tree selection and outline sync with active pane

## Features

### Pane Management
- Split vertically (add pane to the right) or horizontally (add row below)
- Close individual panes with the X button
- Resize panes by dragging the dividers between them

### Tab Drag and Drop
- Drag tabs between panes to move them
- Hold Option/Meta while dragging to duplicate (keep in source, add to target)
- If target pane already has that file open, just focuses it

### State Persistence
- Pane layout (rows, columns, sizes) persisted across sessions
- Tab state per pane persisted

## Test plan

- [x] Build passes (`npm run build`)
- [x] E2E tests pass (`npx playwright test tests/e2e/split-panes.spec.ts`)
- [ ] Manual testing of pane resize in both directions
- [ ] Manual testing of tab drag-drop with and without modifier key

🤖 Generated with [Claude Code](https://claude.com/claude-code)