### PR TITLE
test: close proptest coverage gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lex-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "insta",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-core"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Parser library for the lex format"

--- a/tests/parser_proptest.rs
+++ b/tests/parser_proptest.rs
@@ -67,43 +67,45 @@ proptest! {
     }
 }
 
+/// Generate valid Lex verbatim blocks: Subject:\n    content\n:: label ::
 fn verbatim_block_strategy() -> impl Strategy<Value = String> {
-    prop::collection::vec(
-        prop_oneof![
-            "[a-zA-Z0-9]+",
-            "    [a-zA-Z0-9]+", // indented content inside verbatim
-            "",
-        ],
-        1..5,
+    (
+        "[A-Z][a-zA-Z0-9 ]{1,15}",
+        prop::collection::vec("[a-zA-Z0-9 ]+", 1..5),
+        "[a-z][a-z0-9_-]{0,8}",
     )
-    .prop_map(|lines| {
-        let content = lines.join("\n");
-        format!("```\n{content}\n```")
-    })
+        .prop_map(|(subject, lines, label)| {
+            let subject = subject.trim_end().to_string();
+            let content = lines
+                .iter()
+                .map(|l| format!("    {l}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("{subject}:\n{content}\n:: {label} ::")
+        })
 }
 
+/// Generate valid Lex annotations: :: label :: or :: label key=value ::
 fn annotation_strategy() -> impl Strategy<Value = String> {
-    prop::collection::vec(
-        prop_oneof![
-            "[a-zA-Z0-9]+",
-            "[a-zA-Z0-9]+: [a-zA-Z0-9]+", // parameter-like content
-        ],
-        1..3,
-    )
-    .prop_map(|lines| {
-        let content = lines.join("\n");
-        format!("+[[Annotation]]+\n{content}\n+[[Annotation]]+")
-    })
+    prop_oneof![
+        // Marker annotation
+        "[a-z][a-z0-9_-]{0,8}".prop_map(|label| format!(":: {label} ::")),
+        // Annotation with parameter
+        ("[a-z][a-z0-9_-]{0,8}", "[a-z][a-z0-9_]{0,6}", "[a-z0-9]+",)
+            .prop_map(|(label, key, value)| format!(":: {label} {key}={value} ::")),
+    ]
 }
 
+/// Generate valid Lex inline text (using actual Lex inline syntax)
 fn inline_text_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        "This is \\*bold\\* text.",
-        "This is _italic_ text.",
-        "This is `code` text.",
-        "This has a \\[link\\]\\(https://example.com\\).",
-        "This has a \\^\\[footnote\\].",
-        "Mixed \\*bold\\* and _italic_ and `code`.",
+        "This is *[a-z]+* text.",
+        "This is _[a-z]+_ text.",
+        "This is `[a-z]+` text.",
+        "This has #[a-z]+# math.",
+        "See \\[@[a-z]+\\] here.",
+        "Mixed *[a-z]+* and _[a-z]+_ text.",
+        "Reference \\[\\^[a-z]+\\] note.",
     ]
 }
 

--- a/tests/proptest_annotation_attachment.rs
+++ b/tests/proptest_annotation_attachment.rs
@@ -1,0 +1,246 @@
+//! Property-based tests for annotation attachment to elements
+//!
+//! All previous annotation proptests were standalone (parse_annotation_without_attachment).
+//! These tests verify annotations correctly attach to their target elements
+//! (paragraphs, definitions, lists, sessions, verbatim blocks) through the
+//! full parse_document pipeline.
+
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::assert_ast;
+use proptest::prelude::*;
+
+// =============================================================================
+// Strategies
+// =============================================================================
+
+fn label_strategy() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_-]{0,8}"
+}
+
+fn subject_strategy() -> impl Strategy<Value = String> {
+    "[A-Z][a-zA-Z0-9 ]{1,20}"
+        .prop_map(|s| s.trim_end().to_string())
+        .prop_filter("must not end with colon or be empty", |s| {
+            !s.ends_with(':') && !s.is_empty()
+        })
+}
+
+fn paragraph_line() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+ [a-z]+[.]"
+}
+
+fn list_text() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+"
+}
+
+// =============================================================================
+// 1. Annotation attached to paragraph
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn annotation_attaches_to_following_paragraph(
+        label in label_strategy(),
+        para in paragraph_line(),
+    ) {
+        // Annotation followed by paragraph (inside a session to avoid root-level ambiguity)
+        let source = format!(
+            "Title:\n\n    :: {label} ::\n    {para}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(0, |child| {
+                        child.assert_paragraph()
+                            .annotation_count(1)
+                            .annotation(0, |ann| {
+                                ann.label(&label);
+                            });
+                    });
+            });
+    }
+
+    #[test]
+    fn annotation_attaches_to_definition(
+        label in label_strategy(),
+        def_subject in subject_strategy(),
+        content in paragraph_line(),
+    ) {
+        let source = format!(
+            "Title:\n\n    :: {label} ::\n    {def_subject}:\n        {content}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(0, |child| {
+                        child.assert_definition()
+                            .subject(&def_subject)
+                            .annotation_count(1)
+                            .annotation(0, |ann| {
+                                ann.label(&label);
+                            });
+                    });
+            });
+    }
+
+    #[test]
+    fn annotation_attaches_to_list(
+        label in label_strategy(),
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!(
+            "Title:\n\n    Intro.\n\n    :: {label} ::\n    - {item1}\n    - {item2}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(1, |child| {
+                        child.assert_list()
+                            .annotation_count(1)
+                            .annotation(0, |ann| {
+                                ann.label(&label);
+                            });
+                    });
+            });
+    }
+
+    #[test]
+    fn annotation_attaches_to_verbatim(
+        ann_label in label_strategy(),
+        verb_subject in subject_strategy(),
+        verb_label in label_strategy(),
+        code in "[a-zA-Z0-9]+",
+    ) {
+        let source = format!(
+            "Title:\n\n    :: {ann_label} ::\n    {verb_subject}:\n        {code}\n    :: {verb_label} ::\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(0, |child| {
+                        child.assert_verbatim_block()
+                            .subject(&verb_subject)
+                            .closing_label(&verb_label)
+                            .annotation_count(1)
+                            .annotation(0, |ann| {
+                                ann.label(&ann_label);
+                            });
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 2. Multiple annotations on same element
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn two_annotations_on_paragraph(
+        label1 in label_strategy(),
+        label2 in label_strategy(),
+        para in paragraph_line(),
+    ) {
+        let source = format!(
+            "Title:\n\n    :: {label1} ::\n    :: {label2} ::\n    {para}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(0, |child| {
+                        child.assert_paragraph()
+                            .annotation_count(2);
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 3. Annotation with parameters attached to element
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn annotation_with_params_attaches_to_paragraph(
+        label in label_strategy(),
+        key in "[a-z][a-z0-9_]{0,6}",
+        value in "[a-z0-9]+",
+        para in paragraph_line(),
+    ) {
+        let source = format!(
+            "Title:\n\n    :: {label} {key}={value} ::\n    {para}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(0, |child| {
+                        child.assert_paragraph()
+                            .annotation_count(1)
+                            .annotation(0, |ann| {
+                                ann.label(&label)
+                                    .has_parameter_with_value(&key, &value);
+                            });
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 4. Block annotation with content attached to element
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn block_annotation_attaches_to_paragraph(
+        label in label_strategy(),
+        ann_content in paragraph_line(),
+        para in paragraph_line(),
+    ) {
+        let source = format!(
+            "Title:\n\n    :: {label} ::\n        {ann_content}\n    ::\n    {para}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .child(0, |child| {
+                        child.assert_paragraph()
+                            .annotation_count(1)
+                            .annotation(0, |ann| {
+                                ann.label(&label)
+                                    .child_count(1)
+                                    .child(0, |c| { c.assert_paragraph(); });
+                            });
+                    });
+            });
+    }
+}

--- a/tests/proptest_confusion_boundaries.proptest-regressions
+++ b/tests/proptest_confusion_boundaries.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4e05daf2f13c06ce23f4a46331dfe8e7cab184bb8533cbc7009f5a4a72c82d69 # shrinks to word = "Aaa", content = "Aa a a."
+cc 594eca3d4a5f886f56cceb97284da146970d2d550c6effe0709a7be4b85987ad # shrinks to line1 = "Aa a a.", line2 = "Aa a a."

--- a/tests/proptest_confusion_boundaries.rs
+++ b/tests/proptest_confusion_boundaries.rs
@@ -1,0 +1,343 @@
+//! Property-based "confusion boundary" tests
+//!
+//! These tests generate content that is near the boundary between element types,
+//! verifying the parser does NOT misclassify elements. This is the highest
+//! bug-finding-potential category: inputs that look like one element but should
+//! parse as another.
+
+use lex_core::lex::ast::ContentItem;
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::assert_ast;
+use proptest::prelude::*;
+
+// =============================================================================
+// Strategies for "confusing" content
+// =============================================================================
+
+/// Text that ends with a colon but should NOT be a definition (no indented child)
+fn text_ending_with_colon() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+ [a-z]+:"
+}
+
+/// Text that starts with a dash but should be paragraph text (not a list)
+fn text_starting_with_dash() -> impl Strategy<Value = String> {
+    "- [a-z]+ [a-z]+"
+}
+
+/// Text that contains :: but is not an annotation
+fn text_with_double_colon() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ :: [a-z]+ [a-z]+"
+}
+
+/// Text that looks like a numbered marker but is inside a paragraph
+fn text_with_number_dot() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ 1\\. [a-z]+ [a-z]+"
+}
+
+fn paragraph_line() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+ [a-z]+[.]"
+}
+
+fn subject_strategy() -> impl Strategy<Value = String> {
+    "[A-Z][a-zA-Z0-9 ]{1,20}"
+        .prop_map(|s| s.trim_end().to_string())
+        .prop_filter("must not end with colon or be empty", |s| {
+            !s.ends_with(':') && !s.is_empty()
+        })
+}
+
+fn label_strategy() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_-]{0,8}"
+}
+
+// =============================================================================
+// 1. Colon-ending text without children → NOT a definition
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn colon_text_without_indented_child_is_paragraph(
+        text in text_ending_with_colon(),
+    ) {
+        // Text ending with colon but no indented content after → paragraph
+        let source = format!("{text}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        // Should be paragraph OR session with no children — not a definition
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::Definition(_)),
+                "Text ending with colon but no indented child should NOT be a Definition\nSource:\n{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn colon_text_followed_by_unindented_text_is_not_definition(
+        text in text_ending_with_colon(),
+        next in paragraph_line(),
+    ) {
+        // Text with colon followed by non-indented text → two separate items
+        let source = format!("{text}\n{next}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::Definition(_)),
+                "Colon text followed by unindented text should NOT be a Definition\nSource:\n{source}"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// 2. Dash text not preceded by blank line → NOT a list (at root)
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn dash_after_paragraph_without_blank_line_is_not_list(
+        intro in paragraph_line(),
+        dash_text in text_starting_with_dash(),
+    ) {
+        // Paragraph followed immediately by dash text (no blank line) → paragraph continues
+        let source = format!("{intro}\n{dash_text}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        // Should not have a List as a top-level item
+        let list_count = items
+            .iter()
+            .filter(|item| matches!(item, ContentItem::List(_)))
+            .count();
+        assert_eq!(
+            list_count, 0,
+            "Dash text not preceded by blank line should NOT be a List\nSource:\n{source}"
+        );
+    }
+
+    #[test]
+    fn dash_after_blank_line_with_two_items_is_list(
+        item1 in "[A-Z][a-z]+ [a-z]+",
+        item2 in "[A-Z][a-z]+ [a-z]+",
+    ) {
+        // Blank line + two dash items → should be a list
+        let source = format!("\n- {item1}\n- {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let has_list = items
+            .iter()
+            .any(|item| matches!(item, ContentItem::List(_)));
+        assert!(
+            has_list,
+            "Dash items preceded by blank line should be a List\nSource:\n{source}"
+        );
+    }
+}
+
+// =============================================================================
+// 3. Double-colon content that is NOT an annotation
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn double_colon_mid_text_is_not_annotation(
+        text in text_with_double_colon(),
+    ) {
+        // Text with :: in the middle → paragraph, not annotation
+        let source = format!("{text}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::Annotation(_)),
+                ":: in middle of text should NOT be an Annotation\nSource:\n{source}"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// 4. Number-dot in running text → NOT a list
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn number_dot_mid_sentence_is_not_list(
+        text in text_with_number_dot(),
+    ) {
+        let source = format!("{text}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::List(_)),
+                "Number-dot inside a sentence should NOT be a List\nSource:\n{source}"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// 5. Definition vs Session disambiguation edge cases
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn multiple_blank_lines_still_session(
+        subject in subject_strategy(),
+        content in paragraph_line(),
+        blank_count in 2..5usize,
+    ) {
+        // Multiple blank lines between subject: and indented content → still session
+        let blanks = "\n".repeat(blank_count);
+        let source = format!("{subject}:\n{blanks}    {content}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session();
+            });
+    }
+
+    #[test]
+    fn definition_requires_immediate_indent(
+        subject in subject_strategy(),
+        content in paragraph_line(),
+    ) {
+        // Subject: followed IMMEDIATELY by indented content (no blank line) → definition
+        let source = format!("{subject}:\n    {content}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_definition()
+                    .subject(&subject)
+                    .child_count(1);
+            });
+    }
+}
+
+// =============================================================================
+// 6. :: inside verbatim should NOT trigger annotation/closing detection
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn double_colon_inside_verbatim_is_preserved(
+        verbatim_subject in subject_strategy(),
+        label in label_strategy(),
+    ) {
+        // Content with :: inside a verbatim block should be preserved as-is
+        let source = format!(
+            "{verbatim_subject}:\n    def foo :: bar\n    :: baz ::\n:: {label} ::\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_verbatim_block()
+                    .subject(&verbatim_subject)
+                    .closing_label(&label)
+                    .content_contains("def foo :: bar");
+            });
+    }
+}
+
+// =============================================================================
+// 7. Unicode text should parse cleanly as paragraphs
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn unicode_paragraph_text(
+        text in prop_oneof![
+            // CJK
+            "[\u{4e00}-\u{4e10}]{2,10}",
+            // Accented latin
+            "[a-z\u{00e0}-\u{00ff}]{2,15}",
+            // Mixed
+            "[A-Z][a-z]+ [\u{4e00}-\u{4e10}]{2,5} [a-z]+",
+        ]
+    ) {
+        let source = format!("{text}\n");
+        let doc = parse_document(&source);
+        // Should not panic — may or may not parse as paragraph depending on content
+        assert!(doc.is_ok(), "Unicode text should not cause parse failure: {source}");
+    }
+}
+
+// =============================================================================
+// 8. Multi-line paragraphs (text continuation without structure)
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn multi_line_paragraph(
+        line1 in paragraph_line(),
+        line2 in paragraph_line(),
+        line3 in paragraph_line(),
+    ) {
+        // Multiple consecutive text lines form a single paragraph
+        let source = format!("{line1}\n{line2}\n{line3}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_paragraph()
+                    .line_count(3);
+            });
+    }
+
+    #[test]
+    fn blank_line_separates_paragraphs(
+        line1 in paragraph_line(),
+        line2 in paragraph_line(),
+    ) {
+        // Inside a session, blank line creates separate paragraphs
+        let source = format!("Title:\n\n    {line1}\n\n    {line2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        // Session should contain at least 2 paragraphs
+        let session = doc.root.children.iter()
+            .find_map(|i| i.as_session())
+            .expect("Expected session");
+        let para_count = session.children.iter()
+            .filter(|c| matches!(c, ContentItem::Paragraph(_)))
+            .count();
+        assert_eq!(para_count, 2,
+            "Expected 2 paragraphs separated by blank line\nSource:\n{source}");
+    }
+}

--- a/tests/proptest_confusion_boundaries.rs
+++ b/tests/proptest_confusion_boundaries.rs
@@ -38,6 +38,24 @@ fn paragraph_line() -> impl Strategy<Value = String> {
     "[A-Z][a-z]+ [a-z]+ [a-z]+[.]"
 }
 
+/// Paragraph text containing colons mid-line (should remain paragraph, not trigger definition)
+fn text_with_mid_colons() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "[A-Z][a-z]+: [a-z]+ [a-z]+[.]",
+        "[A-Z][a-z]+ [a-z]+: [a-z]+ [a-z]+[.]",
+        "[A-Z][a-z]+: [a-z]+: [a-z]+[.]",
+    ]
+}
+
+/// Paragraph text containing dashes (should remain paragraph, not trigger list)
+fn text_with_dashes() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "[A-Z][a-z]+ - [a-z]+ [a-z]+[.]",
+        "[A-Z][a-z]+-[a-z]+ [a-z]+[.]",
+        "[A-Z][a-z]+ [a-z]+ -- [a-z]+[.]",
+    ]
+}
+
 fn subject_strategy() -> impl Strategy<Value = String> {
     "[A-Z][a-zA-Z0-9 ]{1,20}"
         .prop_map(|s| s.trim_end().to_string())
@@ -91,6 +109,67 @@ proptest! {
             assert!(
                 !matches!(item, ContentItem::Definition(_)),
                 "Colon text followed by unindented text should NOT be a Definition\nSource:\n{source}"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// 1b. Colons and dashes mid-text should not trigger false detection
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn mid_colon_text_stays_paragraph(text in text_with_mid_colons()) {
+        // Colons in the middle of running text → still paragraph
+        let source = format!("{text}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        // At root level, this might parse as session if colon is at end.
+        // But mid-colon text should never produce a Definition.
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::Definition(_)),
+                "Mid-colon text should NOT be a Definition\nSource:\n{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn dash_mid_text_stays_paragraph(text in text_with_dashes()) {
+        // Dashes in the middle of text → still paragraph, not list
+        let source = format!("{text}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::List(_)),
+                "Dash in middle of text should NOT be a List\nSource:\n{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn double_colon_sequence_mid_text_not_annotation(
+        prefix in "[A-Z][a-z]+",
+        suffix in "[a-z]+ [a-z]+[.]",
+    ) {
+        // :: in the middle of a word or sentence
+        let source = format!("{prefix}::{suffix}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        for item in &items {
+            assert!(
+                !matches!(item, ContentItem::Annotation(_)),
+                ":: mid-word should NOT be an Annotation\nSource:\n{source}"
             );
         }
     }

--- a/tests/proptest_inline_edge_cases.rs
+++ b/tests/proptest_inline_edge_cases.rs
@@ -1,0 +1,291 @@
+//! Property-based tests for inline markup edge cases
+//!
+//! Tests multi-word markup, adjacent markup, markup at line boundaries,
+//! and unclosed markup — all previously untested inline patterns.
+
+use lex_core::lex::ast::elements::inlines::InlineNode;
+use lex_core::lex::ast::ContentItem;
+use lex_core::lex::inlines::parse_inlines;
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::{InlineAssertion, InlineExpectation};
+use proptest::prelude::*;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn extract_first_text_line(source: &str) -> lex_core::lex::ast::TextContent {
+    let doc = parse_document(source)
+        .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+    let para = match &doc.root.children.iter().collect::<Vec<_>>()[0] {
+        ContentItem::Paragraph(p) => p,
+        other => panic!("Expected Paragraph, got {other:?}\nSource:\n{source}"),
+    };
+    let tl = match &para.lines[0] {
+        ContentItem::TextLine(tl) => tl,
+        other => panic!("Expected TextLine, got {other:?}\nSource:\n{source}"),
+    };
+    tl.content.clone()
+}
+
+// =============================================================================
+// Strategies
+// =============================================================================
+
+/// Multi-word content for inside markup (no special chars, 2-4 words)
+fn multi_word_strategy() -> impl Strategy<Value = String> {
+    "[a-z]{2,6}( [a-z]{2,6}){1,3}"
+}
+
+fn inline_word() -> impl Strategy<Value = String> {
+    "[a-zA-Z][a-z]{1,8}"
+}
+
+// =============================================================================
+// 1. Multi-word markup
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn multi_word_bold(content in multi_word_strategy()) {
+        let source = format!("Text *{content}* end.\n");
+        let tc = extract_first_text_line(&source);
+        InlineAssertion::new(&tc, "multi-word bold")
+            .starts_with(&[
+                InlineExpectation::plain_text("Text "),
+                InlineExpectation::strong_text(&content),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+
+    #[test]
+    fn multi_word_italic(content in multi_word_strategy()) {
+        let source = format!("Text _{content}_ end.\n");
+        let tc = extract_first_text_line(&source);
+        InlineAssertion::new(&tc, "multi-word italic")
+            .starts_with(&[
+                InlineExpectation::plain_text("Text "),
+                InlineExpectation::emphasis_text(&content),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+
+    #[test]
+    fn multi_word_code(content in multi_word_strategy()) {
+        let source = format!("Text `{content}` end.\n");
+        let tc = extract_first_text_line(&source);
+        InlineAssertion::new(&tc, "multi-word code")
+            .starts_with(&[
+                InlineExpectation::plain_text("Text "),
+                InlineExpectation::code_text(&content),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 2. Markup at line start and end
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn bold_at_line_start(word in inline_word()) {
+        let source = format!("*{word}* rest of line.\n");
+        let tc = extract_first_text_line(&source);
+        InlineAssertion::new(&tc, "bold at start")
+            .starts_with(&[
+                InlineExpectation::strong_text(&word),
+                InlineExpectation::plain_text(" rest of line."),
+            ])
+            .length(2);
+    }
+
+    #[test]
+    fn bold_at_line_end(word in inline_word()) {
+        let source = format!("Start of line *{word}*\n");
+        let tc = extract_first_text_line(&source);
+        InlineAssertion::new(&tc, "bold at end")
+            .starts_with(&[
+                InlineExpectation::plain_text("Start of line "),
+                InlineExpectation::strong_text(&word),
+            ])
+            .length(2);
+    }
+
+    #[test]
+    fn italic_at_line_start(word in inline_word()) {
+        let source = format!("_{word}_ rest.\n");
+        let tc = extract_first_text_line(&source);
+        InlineAssertion::new(&tc, "italic at start")
+            .starts_with(&[
+                InlineExpectation::emphasis_text(&word),
+                InlineExpectation::plain_text(" rest."),
+            ])
+            .length(2);
+    }
+}
+
+// =============================================================================
+// 3. Adjacent markup
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn adjacent_bold_italic(
+        bold_word in inline_word(),
+        italic_word in inline_word(),
+    ) {
+        // *bold* immediately followed by _italic_ (no space)
+        let source = format!("Text *{bold_word}*_{italic_word}_ end.\n");
+        let tc = extract_first_text_line(&source);
+        // Just verify it parses without panic and has the right number of nodes
+        let nodes = InlineAssertion::new(&tc, "adjacent bold+italic").nodes().to_vec();
+        // Should have at least 3 nodes: plain, strong, emphasis (or more with separators)
+        assert!(
+            nodes.len() >= 3,
+            "Expected at least 3 inline nodes for adjacent markup, got {}\nSource: {source}",
+            nodes.len()
+        );
+    }
+
+    #[test]
+    fn adjacent_code_bold(
+        code_word in inline_word(),
+        bold_word in inline_word(),
+    ) {
+        // `code` immediately followed by *bold*
+        let source = format!("Text `{code_word}`*{bold_word}* end.\n");
+        let tc = extract_first_text_line(&source);
+        let nodes = InlineAssertion::new(&tc, "adjacent code+bold").nodes().to_vec();
+        assert!(
+            nodes.len() >= 3,
+            "Expected at least 3 inline nodes, got {}\nSource: {source}",
+            nodes.len()
+        );
+    }
+}
+
+// =============================================================================
+// 4. Unclosed markup — should not panic, content preserved as plain text
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn unclosed_bold_is_plain_text(word in inline_word()) {
+        // Unclosed *bold should be treated as plain text
+        let input = format!("Text *{word} without closing.");
+        let nodes = parse_inlines(&input);
+        // Should not panic. Content should be plain text (the * is literal)
+        let total_text: String = nodes.iter().map(|n| match n {
+            InlineNode::Plain { text, .. } => text.clone(),
+            InlineNode::Strong { content, .. } => {
+                content.iter().map(|c| match c {
+                    InlineNode::Plain { text, .. } => text.clone(),
+                    _ => String::new(),
+                }).collect()
+            }
+            _ => String::new(),
+        }).collect();
+        assert!(
+            total_text.contains(&word),
+            "Word '{word}' should be preserved in output\nNodes: {nodes:?}"
+        );
+    }
+
+    #[test]
+    fn unclosed_italic_is_plain_text(word in inline_word()) {
+        let input = format!("Text _{word} without closing.");
+        let nodes = parse_inlines(&input);
+        let total_text: String = nodes.iter().map(|n| match n {
+            InlineNode::Plain { text, .. } => text.clone(),
+            InlineNode::Emphasis { content, .. } => {
+                content.iter().map(|c| match c {
+                    InlineNode::Plain { text, .. } => text.clone(),
+                    _ => String::new(),
+                }).collect()
+            }
+            _ => String::new(),
+        }).collect();
+        assert!(
+            total_text.contains(&word),
+            "Word '{word}' should be preserved in output\nNodes: {nodes:?}"
+        );
+    }
+
+    #[test]
+    fn unclosed_code_is_plain_text(word in inline_word()) {
+        let input = format!("Text `{word} without closing.");
+        let nodes = parse_inlines(&input);
+        // Code content should be preserved somehow
+        let has_content = nodes.iter().any(|n| match n {
+            InlineNode::Plain { text, .. } => text.contains(&word),
+            InlineNode::Code { text, .. } => text.contains(&word),
+            _ => false,
+        });
+        assert!(has_content, "Word '{word}' should appear in output\nNodes: {nodes:?}");
+    }
+}
+
+// =============================================================================
+// 5. Empty markup delimiters
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn empty_bold_does_not_panic(prefix in "[A-Z][a-z]+") {
+        // ** with nothing inside
+        let input = format!("{prefix} ** rest.");
+        let nodes = parse_inlines(&input);
+        // Should not panic — content should be preserved
+        let total_text: String = nodes.iter().filter_map(|n| match n {
+            InlineNode::Plain { text, .. } => Some(text.as_str()),
+            _ => None,
+        }).collect::<Vec<_>>().join("");
+        assert!(
+            total_text.contains(&prefix),
+            "Prefix '{prefix}' should be preserved\nNodes: {nodes:?}"
+        );
+    }
+
+    #[test]
+    fn empty_italic_does_not_panic(prefix in "[A-Z][a-z]+") {
+        let input = format!("{prefix} __ rest.");
+        let nodes = parse_inlines(&input);
+        let total_text: String = nodes.iter().filter_map(|n| match n {
+            InlineNode::Plain { text, .. } => Some(text.as_str()),
+            _ => None,
+        }).collect::<Vec<_>>().join("");
+        assert!(
+            total_text.contains(&prefix),
+            "Prefix '{prefix}' should be preserved\nNodes: {nodes:?}"
+        );
+    }
+
+    #[test]
+    fn empty_code_does_not_panic(prefix in "[A-Z][a-z]+") {
+        let input = format!("{prefix} `` rest.");
+        let nodes = parse_inlines(&input);
+        let total_text: String = nodes.iter().filter_map(|n| match n {
+            InlineNode::Plain { text, .. } => Some(text.as_str()),
+            InlineNode::Code { text, .. } => Some(text.as_str()),
+            _ => None,
+        }).collect::<Vec<_>>().join("");
+        assert!(
+            total_text.contains(&prefix),
+            "Prefix '{prefix}' should be preserved\nNodes: {nodes:?}"
+        );
+    }
+}

--- a/tests/proptest_invariants.rs
+++ b/tests/proptest_invariants.rs
@@ -1,0 +1,325 @@
+//! Property-based invariant tests
+//!
+//! Tests structural invariants that should hold for any parsed document:
+//! - Parse idempotency: parsing the same source twice produces identical ASTs
+//! - No content loss: all text content from the source appears in the AST
+//! - Nesting depth matches indentation level
+
+use lex_core::lex::ast::elements::inlines::InlineNode;
+use lex_core::lex::ast::ContentItem;
+use lex_core::lex::parsing::parse_document;
+use proptest::prelude::*;
+
+// =============================================================================
+// Strategies for generating valid Lex documents
+// =============================================================================
+
+fn subject_strategy() -> impl Strategy<Value = String> {
+    "[A-Z][a-zA-Z0-9 ]{1,15}"
+        .prop_map(|s| s.trim_end().to_string())
+        .prop_filter("must not end with colon or be empty", |s| {
+            !s.ends_with(':') && !s.is_empty()
+        })
+}
+
+fn paragraph_line() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+ [a-z]+[.]"
+}
+
+fn list_text() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+"
+}
+
+fn label_strategy() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_-]{0,8}"
+}
+
+/// Generate a valid multi-element Lex document
+fn valid_document_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        // Simple paragraph
+        paragraph_line().prop_map(|p| format!("{p}\n")),
+        // Definition
+        (subject_strategy(), paragraph_line()).prop_map(|(s, c)| format!("{s}:\n    {c}\n")),
+        // Session with paragraph
+        (subject_strategy(), paragraph_line()).prop_map(|(s, c)| format!("{s}:\n\n    {c}\n")),
+        // List
+        (list_text(), list_text()).prop_map(|(a, b)| format!("\n- {a}\n- {b}\n")),
+        // Verbatim
+        (subject_strategy(), label_strategy(), "[a-zA-Z0-9]+")
+            .prop_map(|(s, l, c)| format!("{s}:\n    {c}\n:: {l} ::\n")),
+    ]
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Recursively collect all plain text from a content item
+fn collect_text(item: &ContentItem, out: &mut String) {
+    match item {
+        ContentItem::Paragraph(p) => {
+            for line in &p.lines {
+                collect_text(line, out);
+            }
+        }
+        ContentItem::TextLine(tl) => {
+            if let Some(nodes) = tl.content.inlines() {
+                for node in nodes {
+                    collect_inline_text(node, out);
+                }
+            }
+        }
+        ContentItem::Session(s) => {
+            // Session title — use raw string as inlines may not be parsed
+            out.push_str(s.title.as_string());
+            for child in s.children.iter() {
+                collect_text(child, out);
+            }
+        }
+        ContentItem::Definition(d) => {
+            out.push_str(d.subject.as_string());
+            for child in d.children.iter() {
+                collect_text(child, out);
+            }
+        }
+        ContentItem::List(l) => {
+            for item in l.items.iter() {
+                collect_text(item, out);
+            }
+        }
+        ContentItem::ListItem(li) => {
+            for tc in &li.text {
+                out.push_str(tc.as_string());
+            }
+            for child in li.children.iter() {
+                collect_text(child, out);
+            }
+        }
+        ContentItem::VerbatimBlock(v) => {
+            out.push_str(v.subject.as_string());
+            for child in v.children.iter() {
+                collect_text(child, out);
+            }
+        }
+        ContentItem::VerbatimLine(vl) => {
+            out.push_str(vl.content.as_string());
+        }
+        ContentItem::BlankLineGroup(_) => {}
+        ContentItem::Annotation(_) => {}
+    }
+}
+
+fn collect_inline_text(node: &InlineNode, out: &mut String) {
+    match node {
+        InlineNode::Plain { text, .. } => out.push_str(text),
+        InlineNode::Strong { content, .. } | InlineNode::Emphasis { content, .. } => {
+            for child in content.iter() {
+                collect_inline_text(child, out);
+            }
+        }
+        InlineNode::Code { text, .. } | InlineNode::Math { text, .. } => out.push_str(text),
+        InlineNode::Reference { data, .. } => out.push_str(&data.raw),
+    }
+}
+
+/// Count the maximum nesting depth of a document
+fn max_depth(item: &ContentItem, current: usize) -> usize {
+    match item {
+        ContentItem::Session(s) => {
+            let mut max = current;
+            for child in s.children.iter() {
+                max = max.max(max_depth(child, current + 1));
+            }
+            max
+        }
+        ContentItem::Definition(d) => {
+            let mut max = current;
+            for child in d.children.iter() {
+                max = max.max(max_depth(child, current + 1));
+            }
+            max
+        }
+        ContentItem::List(l) => {
+            let mut max = current;
+            for item in l.items.iter() {
+                max = max.max(max_depth(item, current + 1));
+            }
+            max
+        }
+        ContentItem::ListItem(li) => {
+            let mut max = current;
+            for child in li.children.iter() {
+                max = max.max(max_depth(child, current + 1));
+            }
+            max
+        }
+        _ => current,
+    }
+}
+
+// =============================================================================
+// 1. Parse idempotency: parsing same source twice gives same AST
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn parse_is_deterministic(source in valid_document_strategy()) {
+        let doc1 = parse_document(&source);
+        let doc2 = parse_document(&source);
+
+        match (doc1, doc2) {
+            (Ok(d1), Ok(d2)) => {
+                // Same number of root children
+                let items1: Vec<&ContentItem> = d1.root.children.iter().collect();
+                let items2: Vec<&ContentItem> = d2.root.children.iter().collect();
+                prop_assert_eq!(
+                    items1.len(),
+                    items2.len(),
+                    "Parse produced different number of root items on same source"
+                );
+
+                // Same text content
+                let mut text1 = String::new();
+                let mut text2 = String::new();
+                for item in items1.iter() {
+                    collect_text(item, &mut text1);
+                }
+                for item in items2.iter() {
+                    collect_text(item, &mut text2);
+                }
+                prop_assert_eq!(
+                    text1, text2,
+                    "Parse produced different text content on same source"
+                );
+            }
+            (Err(_), Err(_)) => {} // Both fail — that's consistent
+            (Ok(_), Err(e)) | (Err(e), Ok(_)) => {
+                prop_assert!(false, "Inconsistent parse results: {e}");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// 2. No content loss: text words from source appear in AST
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn paragraph_text_preserved(line in paragraph_line()) {
+        let source = format!("{line}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}"));
+
+        let mut text = String::new();
+        for item in doc.root.children.iter() {
+            collect_text(item, &mut text);
+        }
+
+        // Each word from the source should appear in the collected text
+        for word in line.split_whitespace() {
+            let word_clean = word.trim_end_matches('.');
+            if !word_clean.is_empty() {
+                prop_assert!(
+                    text.contains(word_clean),
+                    "Word '{}' from source not found in AST text '{}'\nSource: {}",
+                    word_clean, text, source
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn definition_subject_preserved(
+        subject in subject_strategy(),
+        content in paragraph_line(),
+    ) {
+        let source = format!("{subject}:\n    {content}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}"));
+
+        let mut text = String::new();
+        for item in doc.root.children.iter() {
+            collect_text(item, &mut text);
+        }
+
+        // Subject text should be in the AST
+        prop_assert!(
+            text.contains(&subject),
+            "Subject '{}' not found in AST text '{}'\nSource: {}",
+            subject, text, source
+        );
+    }
+
+    #[test]
+    fn list_item_text_preserved(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!("\n- {item1}\n- {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}"));
+
+        let mut text = String::new();
+        for item in doc.root.children.iter() {
+            collect_text(item, &mut text);
+        }
+
+        for word in item1.split_whitespace() {
+            prop_assert!(
+                text.contains(word),
+                "Word '{}' from item1 not found in AST\nSource: {}",
+                word, source
+            );
+        }
+        for word in item2.split_whitespace() {
+            prop_assert!(
+                text.contains(word),
+                "Word '{}' from item2 not found in AST\nSource: {}",
+                word, source
+            );
+        }
+    }
+}
+
+// =============================================================================
+// 3. Nesting depth is bounded by indentation
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn nesting_depth_bounded_by_indentation(
+        source in valid_document_strategy(),
+    ) {
+        let doc = parse_document(&source);
+        if let Ok(doc) = doc {
+            // Count max indentation levels in source (groups of 4 spaces)
+            let max_indent = source.lines()
+                .map(|line| {
+                    let spaces = line.len() - line.trim_start().len();
+                    spaces / 4
+                })
+                .max()
+                .unwrap_or(0);
+
+            // AST depth should not exceed indent levels + 1 (root)
+            let ast_depth = doc.root.children.iter()
+                .map(|item| max_depth(item, 0))
+                .max()
+                .unwrap_or(0);
+
+            prop_assert!(
+                ast_depth <= max_indent + 1,
+                "AST depth {} exceeds indentation depth {} + 1\nSource:\n{}",
+                ast_depth, max_indent, source
+            );
+        }
+    }
+}

--- a/tests/proptest_nested_lists.proptest-regressions
+++ b/tests/proptest_nested_lists.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b6390ee692f1186161aa8d5cc900ba1607ac4765d8f804b9371f69f992f8e516 # shrinks to item1 = "Aa a", item2 = "Aa a", sub1 = "Aa a", sub2 = "Aa a"
+cc 50b95cab99ec68767d8d00c7007236f52332bc040ec0b027b73ba148374e987b # shrinks to item1 = "Aa a", item2 = "Aa a", sub1 = "Aa a", sub2 = "Aa a", item3 = "Aa itgcspev"
+cc a22f34957772751825f620967db190923e9d1f7676f25c08549d105f8a5e05df # shrinks to item1 = "Aa a", sub1 = "Aa a", subsub1 = "Aa a", subsub2 = "Aa a", item2 = "Aa a"

--- a/tests/proptest_nested_lists.rs
+++ b/tests/proptest_nested_lists.rs
@@ -4,6 +4,7 @@
 //! deeply nested structures, adjacent definitions, and mixed marker types.
 
 use lex_core::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
+use lex_core::lex::ast::elements::verbatim::VerbatimBlockMode;
 use lex_core::lex::ast::ContentItem;
 use lex_core::lex::parsing::parse_document;
 use lex_core::lex::testing::assert_ast;
@@ -560,7 +561,63 @@ proptest! {
 }
 
 // =============================================================================
-// 7. Session with Mixed Content Types
+// 7. Fullwidth Verbatim Mode
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn fullwidth_verbatim_at_root(
+        subject in subject_strategy(),
+        label in label_strategy(),
+    ) {
+        // Fullwidth verbatim: content at column 2 (1 space indent = column index 1)
+        let source = format!("{subject}:\n Header | Value\n Row1   | Data1\n:: {label} ::\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_verbatim_block()
+                    .subject(&subject)
+                    .closing_label(&label)
+                    .mode(VerbatimBlockMode::Fullwidth);
+            });
+    }
+
+    #[test]
+    fn inflow_verbatim_vs_fullwidth(
+        subject in subject_strategy(),
+        label in label_strategy(),
+        code in "[a-zA-Z0-9]+",
+    ) {
+        // Inflow: content at standard indent (4 spaces beyond subject)
+        let inflow_source = format!("{subject}:\n    {code}\n:: {label} ::\n");
+        let inflow_doc = parse_document(&inflow_source)
+            .unwrap_or_else(|e| panic!("Failed to parse inflow: {e}\nSource:\n{inflow_source}"));
+
+        assert_ast(&inflow_doc)
+            .item(0, |item| {
+                item.assert_verbatim_block()
+                    .mode(VerbatimBlockMode::Inflow);
+            });
+
+        // Fullwidth: content at column 2 (single space)
+        let fullwidth_source = format!("{subject}:\n {code}\n:: {label} ::\n");
+        let fullwidth_doc = parse_document(&fullwidth_source)
+            .unwrap_or_else(|e| panic!("Failed to parse fullwidth: {e}\nSource:\n{fullwidth_source}"));
+
+        assert_ast(&fullwidth_doc)
+            .item(0, |item| {
+                item.assert_verbatim_block()
+                    .mode(VerbatimBlockMode::Fullwidth);
+            });
+    }
+}
+
+// =============================================================================
+// 8. Session with Mixed Content Types
 // =============================================================================
 
 proptest! {

--- a/tests/proptest_nested_lists.rs
+++ b/tests/proptest_nested_lists.rs
@@ -401,7 +401,76 @@ proptest! {
 }
 
 // =============================================================================
-// 6. Extended Markers (1.2.3) and Roman Numerals
+// 6. Extended Form Markers (1.2.3, I.a.2, etc.)
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn list_marker_extended_numerical(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!("\n1.2.3. {item1}\n1.2.4. {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.form, Form::Extended);
+        assert_eq!(marker.separator, Separator::Period);
+    }
+
+    #[test]
+    fn list_marker_extended_mixed(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        // Mixed extended form: 1.a) and 1.b)
+        let source = format!("\n1.a) {item1}\n1.b) {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.form, Form::Extended);
+        assert_eq!(marker.separator, Separator::Parenthesis);
+    }
+
+    #[test]
+    fn list_marker_extended_two_level(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!("\n1.1. {item1}\n1.2. {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.form, Form::Extended);
+        assert_eq!(marker.style, DecorationStyle::Numerical);
+    }
+}
+
+// =============================================================================
+// 7. Roman Numerals and Alphabetical Variants
 // =============================================================================
 
 proptest! {

--- a/tests/proptest_nested_lists.rs
+++ b/tests/proptest_nested_lists.rs
@@ -617,7 +617,60 @@ proptest! {
 }
 
 // =============================================================================
-// 8. Session with Mixed Content Types
+// 8. Mixed Marker Types Across Siblings
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn session_with_dash_and_numbered_lists(
+        title in subject_strategy(),
+        d1 in list_text(),
+        d2 in list_text(),
+        n1 in list_text(),
+        n2 in list_text(),
+    ) {
+        // Session containing both a dash list and a numbered list
+        let source = format!(
+            "{title}:\n\n\
+             {0}Intro.\n\
+             \n\
+             {0}- {d1}\n\
+             {0}- {d2}\n\
+             \n\
+             {0}Middle.\n\
+             \n\
+             {0}1. {n1}\n\
+             {0}2. {n2}\n",
+            "    "
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let session = doc.root.children.iter()
+            .find_map(|i| i.as_session())
+            .expect("Expected session");
+
+        let lists: Vec<_> = session.children.iter()
+            .filter(|c| matches!(c, ContentItem::List(_)))
+            .collect();
+        assert_eq!(lists.len(), 2, "Expected 2 lists in session\nSource:\n{source}");
+
+        // First list: dash (Plain style)
+        let list1 = lists[0].as_list().unwrap();
+        let m1 = list1.marker.as_ref().expect("first list needs marker");
+        assert_eq!(m1.style, DecorationStyle::Plain);
+
+        // Second list: numbered
+        let list2 = lists[1].as_list().unwrap();
+        let m2 = list2.marker.as_ref().expect("second list needs marker");
+        assert_eq!(m2.style, DecorationStyle::Numerical);
+    }
+}
+
+// =============================================================================
+// 9. Session with Mixed Content Types
 // =============================================================================
 
 proptest! {

--- a/tests/proptest_nested_lists.rs
+++ b/tests/proptest_nested_lists.rs
@@ -1,0 +1,551 @@
+//! Property-based tests for nested lists and complex list structures
+//!
+//! Covers: nested lists (list inside list item), lists with nested verbatim,
+//! deeply nested structures, adjacent definitions, and mixed marker types.
+
+use lex_core::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
+use lex_core::lex::ast::ContentItem;
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::assert_ast;
+use proptest::prelude::*;
+
+// =============================================================================
+// Strategies
+// =============================================================================
+
+fn subject_strategy() -> impl Strategy<Value = String> {
+    "[A-Z][a-zA-Z0-9 ]{1,20}"
+        .prop_map(|s| s.trim_end().to_string())
+        .prop_filter("must not end with colon or be empty", |s| {
+            !s.ends_with(':') && !s.is_empty()
+        })
+}
+
+fn list_text() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+"
+}
+
+fn paragraph_line() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]+ [a-z]+ [a-z]+[.]"
+}
+
+fn label_strategy() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_-]{0,8}"
+}
+
+// =============================================================================
+// 1. Nested Lists (list inside list item)
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn nested_dash_list_via_definition(
+        def_subject in subject_strategy(),
+        item1 in list_text(),
+        item2 in list_text(),
+        sub1 in list_text(),
+        sub2 in list_text(),
+    ) {
+        // Nested lists inside a definition (avoids root-level session detection).
+        // Outer list with blank line before it, inner list with blank line before it.
+        let source = format!(
+            "{def_subject}:\n    Intro text.\n\n    - {item1}\n        - {sub1}\n        - {sub2}\n    - {item2}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_definition()
+                    .subject(&def_subject)
+                    .child(1, |child| {
+                        child.assert_list()
+                            .item_count(2)
+                            .item(0, |li| {
+                                li.text_contains(&item1)
+                                    .child(0, |nested| {
+                                        nested.assert_list()
+                                            .item_count(2)
+                                            .item(0, |sub_li| { sub_li.text_contains(&sub1); })
+                                            .item(1, |sub_li| { sub_li.text_contains(&sub2); });
+                                    });
+                            })
+                            .item(1, |li| { li.text_contains(&item2); });
+                    });
+            });
+    }
+
+    #[test]
+    fn nested_numbered_inside_dash_via_session(
+        title in subject_strategy(),
+        item1 in list_text(),
+        item2 in list_text(),
+        sub1 in list_text(),
+        sub2 in list_text(),
+    ) {
+        // Session containing a list with nested numbered sublist
+        let source = format!(
+            "{title}:\n\n    - {item1}\n        1. {sub1}\n        2. {sub2}\n    - {item2}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let session_label = format!("{title}:");
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .label(&session_label)
+                    .child(0, |child| {
+                        child.assert_list()
+                            .item_count(2)
+                            .item(0, |li| {
+                                li.text_contains(&item1)
+                                    .child(0, |nested| {
+                                        nested.assert_list()
+                                            .item_count(2)
+                                            .item(0, |sub_li| { sub_li.text_contains(&sub1); })
+                                            .item(1, |sub_li| { sub_li.text_contains(&sub2); });
+                                    });
+                            });
+                    });
+            });
+
+        // Also verify the sublist uses numerical markers via direct AST access
+        let session = doc.root.children.iter()
+            .find_map(|i| i.as_session())
+            .expect("Expected session");
+        let outer = session.children.iter()
+            .find_map(|i| i.as_list())
+            .expect("Expected outer list");
+        let first_item = outer.items[0]
+            .as_list_item()
+            .expect("Expected ListItem");
+        let inner = first_item
+            .children
+            .iter()
+            .find_map(|c| c.as_list())
+            .expect("Expected inner list");
+        let marker = inner.marker.as_ref().expect("sublist should have marker");
+        assert_eq!(marker.style, DecorationStyle::Numerical);
+    }
+
+    #[test]
+    fn three_level_nested_list_via_session(
+        title in subject_strategy(),
+        item1 in list_text(),
+        item2 in list_text(),
+        sub1 in list_text(),
+        sub2 in list_text(),
+        subsub1 in list_text(),
+        subsub2 in list_text(),
+    ) {
+        // Three levels of list nesting inside a session.
+        // Each level needs 2+ items to be recognized as a list.
+        // The list needs a blank-line-separated intro before it.
+        let source = format!(
+            "{title}:\n\n\
+             {0}Intro.\n\
+             \n\
+             {0}- {item1}\n\
+             {0}{0}- {sub1}\n\
+             {0}{0}{0}- {subsub1}\n\
+             {0}{0}{0}- {subsub2}\n\
+             {0}{0}- {sub2}\n\
+             {0}- {item2}\n",
+            "    "
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let session_label = format!("{title}:");
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .label(&session_label)
+                    .child(1, |child| {
+                        child.assert_list()
+                            .item_count(2)
+                            .item(0, |li| {
+                                li.text_contains(&item1)
+                                    .child(0, |nested| {
+                                        nested.assert_list()
+                                            .item_count(2)
+                                            .item(0, |sub_li| {
+                                                sub_li.text_contains(&sub1)
+                                                    .child(0, |deep| {
+                                                        deep.assert_list()
+                                                            .item_count(2)
+                                                            .item(0, |ss| {
+                                                                ss.text_contains(&subsub1);
+                                                            })
+                                                            .item(1, |ss| {
+                                                                ss.text_contains(&subsub2);
+                                                            });
+                                                    });
+                                            })
+                                            .item(1, |sub_li| {
+                                                sub_li.text_contains(&sub2);
+                                            });
+                                    });
+                            })
+                            .item(1, |li| { li.text_contains(&item2); });
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 2. List Items with Verbatim Blocks
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn list_item_with_verbatim(
+        item1 in list_text(),
+        item2 in list_text(),
+        verbatim_subject in subject_strategy(),
+        label in label_strategy(),
+        code in "[a-zA-Z0-9 ]+",
+    ) {
+        let source = format!(
+            "\n- {item1}\n    {verbatim_subject}:\n        {code}\n    :: {label} ::\n- {item2}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_list()
+                    .item_count(2)
+                    .item(0, |li| {
+                        li.text_contains(&item1)
+                            .child(0, |child| {
+                                child.assert_verbatim_block()
+                                    .subject(&verbatim_subject)
+                                    .closing_label(&label);
+                            });
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 3. Definition with Verbatim Block
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn definition_with_verbatim(
+        def_subject in subject_strategy(),
+        verbatim_subject in subject_strategy(),
+        label in label_strategy(),
+        code in "[a-zA-Z0-9 ]+",
+    ) {
+        let source = format!(
+            "{def_subject}:\n    {verbatim_subject}:\n        {code}\n    :: {label} ::\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_definition()
+                    .subject(&def_subject)
+                    .child(0, |child| {
+                        child.assert_verbatim_block()
+                            .subject(&verbatim_subject)
+                            .closing_label(&label);
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 4. Adjacent Definitions
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn adjacent_definitions(
+        subj1 in subject_strategy(),
+        subj2 in subject_strategy(),
+        content1 in paragraph_line(),
+        content2 in paragraph_line(),
+    ) {
+        let source = format!(
+            "{subj1}:\n    {content1}\n{subj2}:\n    {content2}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item_count(2)
+            .item(0, |item| {
+                item.assert_definition().subject(&subj1);
+            })
+            .item(1, |item| {
+                item.assert_definition().subject(&subj2);
+            });
+    }
+
+    #[test]
+    fn three_adjacent_definitions(
+        subj1 in subject_strategy(),
+        subj2 in subject_strategy(),
+        subj3 in subject_strategy(),
+        c1 in paragraph_line(),
+        c2 in paragraph_line(),
+        c3 in paragraph_line(),
+    ) {
+        let source = format!(
+            "{subj1}:\n    {c1}\n{subj2}:\n    {c2}\n{subj3}:\n    {c3}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item_count(3)
+            .item(0, |item| { item.assert_definition().subject(&subj1); })
+            .item(1, |item| { item.assert_definition().subject(&subj2); })
+            .item(2, |item| { item.assert_definition().subject(&subj3); });
+    }
+}
+
+// =============================================================================
+// 5. Deep Nesting (4+ levels)
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn four_level_session_nesting(
+        t1 in subject_strategy(),
+        t2 in subject_strategy(),
+        t3 in subject_strategy(),
+        t4 in subject_strategy(),
+        content in paragraph_line(),
+    ) {
+        let source = format!(
+            "{t1}:\n\n    {t2}:\n\n        {t3}:\n\n            {t4}:\n\n                {content}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let l1 = format!("{t1}:");
+        let l2 = format!("{t2}:");
+        let l3 = format!("{t3}:");
+        let l4 = format!("{t4}:");
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .label(&l1)
+                    .child(0, |c1| {
+                        c1.assert_session()
+                            .label(&l2)
+                            .child(0, |c2| {
+                                c2.assert_session()
+                                    .label(&l3)
+                                    .child(0, |c3| {
+                                        c3.assert_session()
+                                            .label(&l4)
+                                            .child_count(1)
+                                            .child(0, |c4| { c4.assert_paragraph(); });
+                                    });
+                            });
+                    });
+            });
+    }
+
+    #[test]
+    fn four_level_definition_nesting(
+        s1 in subject_strategy(),
+        s2 in subject_strategy(),
+        s3 in subject_strategy(),
+        s4 in subject_strategy(),
+        content in paragraph_line(),
+    ) {
+        let source = format!(
+            "{s1}:\n    {s2}:\n        {s3}:\n            {s4}:\n                {content}\n"
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_definition()
+                    .subject(&s1)
+                    .child(0, |c1| {
+                        c1.assert_definition()
+                            .subject(&s2)
+                            .child(0, |c2| {
+                                c2.assert_definition()
+                                    .subject(&s3)
+                                    .child(0, |c3| {
+                                        c3.assert_definition()
+                                            .subject(&s4)
+                                            .child_count(1);
+                                    });
+                            });
+                    });
+            });
+    }
+}
+
+// =============================================================================
+// 6. Extended Markers (1.2.3) and Roman Numerals
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn list_marker_roman_period(
+        item1 in list_text(),
+        item2 in list_text(),
+        item3 in list_text(),
+    ) {
+        let source = format!("\nI. {item1}\nII. {item2}\nIII. {item3}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.style, DecorationStyle::Roman);
+        assert_eq!(marker.separator, Separator::Period);
+        assert_eq!(marker.form, Form::Short);
+    }
+
+    #[test]
+    fn list_marker_roman_double_parens(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!("\n(I) {item1}\n(II) {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.style, DecorationStyle::Roman);
+        assert_eq!(marker.separator, Separator::DoubleParens);
+    }
+
+    #[test]
+    fn list_marker_alpha_parenthesis(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!("\na) {item1}\nb) {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.style, DecorationStyle::Alphabetical);
+        assert_eq!(marker.separator, Separator::Parenthesis);
+    }
+
+    #[test]
+    fn list_marker_alpha_double_parens(
+        item1 in list_text(),
+        item2 in list_text(),
+    ) {
+        let source = format!("\n(a) {item1}\n(b) {item2}\n");
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let items: Vec<&ContentItem> = doc.root.children.iter().collect();
+        let list = items
+            .iter()
+            .find_map(|item| if let ContentItem::List(l) = item { Some(l) } else { None })
+            .expect("Expected a List");
+
+        let marker = list.marker.as_ref().expect("List should have a marker");
+        assert_eq!(marker.style, DecorationStyle::Alphabetical);
+        assert_eq!(marker.separator, Separator::DoubleParens);
+    }
+}
+
+// =============================================================================
+// 7. Session with Mixed Content Types
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn session_with_all_element_types(
+        title in subject_strategy(),
+        para in paragraph_line(),
+        def_subject in subject_strategy(),
+        def_content in paragraph_line(),
+        item1 in list_text(),
+        item2 in list_text(),
+        verbatim_subject in subject_strategy(),
+        label in label_strategy(),
+        code in "[a-zA-Z0-9 ]+",
+    ) {
+        // Session containing: paragraph, definition, list, verbatim
+        let source = format!(
+            "{title}:\n\n\
+             {0}{para}\n\
+             \n\
+             {0}{def_subject}:\n\
+             {0}{0}{def_content}\n\
+             \n\
+             {0}- {item1}\n\
+             {0}- {item2}\n\
+             \n\
+             {0}{verbatim_subject}:\n\
+             {0}{0}{code}\n\
+             {0}:: {label} ::\n",
+            "    "
+        );
+        let doc = parse_document(&source)
+            .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+
+        let session_label = format!("{title}:");
+        assert_ast(&doc)
+            .item(0, |item| {
+                item.assert_session()
+                    .label(&session_label)
+                    .child_count(4)
+                    .child(0, |c| { c.assert_paragraph(); })
+                    .child(1, |c| {
+                        c.assert_definition().subject(&def_subject);
+                    })
+                    .child(2, |c| {
+                        c.assert_list().item_count(2);
+                    })
+                    .child(3, |c| {
+                        c.assert_verbatim_block()
+                            .subject(&verbatim_subject)
+                            .closing_label(&label);
+                    });
+            });
+    }
+}

--- a/tests/proptest_references.rs
+++ b/tests/proptest_references.rs
@@ -1,0 +1,349 @@
+//! Property-based tests for inline references
+//!
+//! Covers all 8 ReferenceType variants: ToCome, Citation, FootnoteLabeled,
+//! FootnoteNumber, Session, Url, File, General — none of which had proptest
+//! coverage before.
+
+use lex_core::lex::ast::ContentItem;
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::{InlineAssertion, InlineExpectation, ReferenceExpectation, TextMatch};
+use proptest::prelude::*;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn extract_first_text_line_content(source: &str) -> lex_core::lex::ast::TextContent {
+    let doc = parse_document(source)
+        .unwrap_or_else(|e| panic!("Failed to parse: {e}\nSource:\n{source}"));
+    let para = match &doc.root.children.iter().collect::<Vec<_>>()[0] {
+        ContentItem::Paragraph(p) => p,
+        other => panic!("Expected Paragraph, got {other:?}\nSource:\n{source}"),
+    };
+    let tl = match &para.lines[0] {
+        ContentItem::TextLine(tl) => tl,
+        other => panic!("Expected TextLine, got {other:?}\nSource:\n{source}"),
+    };
+    tl.content.clone()
+}
+
+// =============================================================================
+// Strategies
+// =============================================================================
+
+/// Generate valid TK identifiers (lowercase + digits, max 20 chars)
+fn tk_identifier_strategy() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9]{0,12}"
+}
+
+/// Generate valid citation keys (alphanumeric + common academic chars)
+fn citation_key_strategy() -> impl Strategy<Value = String> {
+    "[a-zA-Z][a-zA-Z0-9_-]{1,15}"
+}
+
+/// Generate valid footnote labels
+fn footnote_label_strategy() -> impl Strategy<Value = String> {
+    "[a-zA-Z][a-zA-Z0-9_-]{0,10}"
+}
+
+/// Generate valid footnote numbers
+fn footnote_number_strategy() -> impl Strategy<Value = u32> {
+    1..999u32
+}
+
+/// Generate valid session targets (digits with optional dots/dashes)
+fn session_target_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "[0-9]{1,3}",
+        "[0-9]{1,2}\\.[0-9]{1,2}",
+        "[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}",
+    ]
+}
+
+/// Generate URL targets
+fn url_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "https://[a-z]{3,10}\\.[a-z]{2,5}",
+        "https://[a-z]{3,10}\\.[a-z]{2,5}/[a-z0-9/]{1,20}",
+        "http://[a-z]{3,10}\\.[a-z]{2,5}",
+        "mailto:[a-z]{3,8}@[a-z]{3,8}\\.[a-z]{2,4}",
+    ]
+}
+
+/// Generate file path targets
+fn file_target_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        "\\./[a-z]{2,8}\\.[a-z]{2,4}",
+        "\\./[a-z]{2,8}/[a-z]{2,8}\\.[a-z]{2,4}",
+        "/[a-z]{2,8}/[a-z]{2,8}\\.[a-z]{2,4}",
+    ]
+}
+
+/// Generate general reference targets (at least one alphabetic char)
+fn general_target_strategy() -> impl Strategy<Value = String> {
+    "[A-Z][a-zA-Z0-9 ]{1,20}"
+        .prop_map(|s| s.trim_end().to_string())
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+// =============================================================================
+// 1. ToCome References [TK] and [TK-identifier]
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_tk_bare(prefix in "[A-Z][a-z]+ [a-z]+") {
+        let source = format!("{prefix} [TK] end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "TK reference")
+            .starts_with(&[
+                InlineExpectation::plain_text(format!("{prefix} ")),
+                InlineExpectation::reference(ReferenceExpectation::tk(None)),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+
+    #[test]
+    fn reference_tk_with_identifier(
+        prefix in "[A-Z][a-z]+",
+        id in tk_identifier_strategy(),
+    ) {
+        let source = format!("{prefix} [TK-{id}] end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "TK-id reference")
+            .starts_with(&[
+                InlineExpectation::plain_text(format!("{prefix} ")),
+                InlineExpectation::reference(ReferenceExpectation::tk(
+                    Some(TextMatch::Exact(id))
+                )),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 2. Citation References [@key]
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_citation_single_key(key in citation_key_strategy()) {
+        let source = format!("See [@{key}] here.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "citation reference")
+            .starts_with(&[
+                InlineExpectation::plain_text("See "),
+                InlineExpectation::reference(ReferenceExpectation::citation(
+                    TextMatch::Exact(key)
+                )),
+                InlineExpectation::plain_text(" here."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 3. Footnote References [^label] and [42]
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_footnote_labeled(label in footnote_label_strategy()) {
+        let source = format!("Text [^{label}] end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "footnote labeled")
+            .starts_with(&[
+                InlineExpectation::plain_text("Text "),
+                InlineExpectation::reference(ReferenceExpectation::footnote_labeled(
+                    TextMatch::Exact(label)
+                )),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+
+    #[test]
+    fn reference_footnote_number(num in footnote_number_strategy()) {
+        let source = format!("Text [{num}] end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "footnote number")
+            .starts_with(&[
+                InlineExpectation::plain_text("Text "),
+                InlineExpectation::reference(ReferenceExpectation::footnote_number(num)),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 4. Session References [#target]
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_session(target in session_target_strategy()) {
+        let source = format!("See [#{target}] here.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "session reference")
+            .starts_with(&[
+                InlineExpectation::plain_text("See "),
+                InlineExpectation::reference(ReferenceExpectation::session(
+                    TextMatch::Exact(target)
+                )),
+                InlineExpectation::plain_text(" here."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 5. URL References
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_url(url in url_strategy()) {
+        let source = format!("Visit [{url}] now.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "url reference")
+            .starts_with(&[
+                InlineExpectation::plain_text("Visit "),
+                InlineExpectation::reference(ReferenceExpectation::url(
+                    TextMatch::Exact(url)
+                )),
+                InlineExpectation::plain_text(" now."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 6. File References
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_file(path in file_target_strategy()) {
+        let source = format!("See [{path}] here.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "file reference")
+            .starts_with(&[
+                InlineExpectation::plain_text("See "),
+                InlineExpectation::reference(ReferenceExpectation::file(
+                    TextMatch::Exact(path)
+                )),
+                InlineExpectation::plain_text(" here."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 7. General References
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn reference_general(target in general_target_strategy()) {
+        let source = format!("See [{target}] here.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "general reference")
+            .starts_with(&[
+                InlineExpectation::plain_text("See "),
+                InlineExpectation::reference(ReferenceExpectation::general(
+                    TextMatch::Exact(target)
+                )),
+                InlineExpectation::plain_text(" here."),
+            ])
+            .length(3);
+    }
+}
+
+// =============================================================================
+// 8. References inside markup (mixed inline)
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn reference_inside_bold(
+        word in "[a-zA-Z]{2,8}",
+        key in citation_key_strategy(),
+    ) {
+        // Bold containing a reference: *word [@key]*
+        let source = format!("Text *{word} [@{key}]* end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "ref inside bold")
+            .starts_with(&[
+                InlineExpectation::plain_text("Text "),
+                InlineExpectation::strong(vec![
+                    InlineExpectation::plain_text(format!("{word} ")),
+                    InlineExpectation::reference(ReferenceExpectation::citation(
+                        TextMatch::Exact(key)
+                    )),
+                ]),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(3);
+    }
+
+    #[test]
+    fn multiple_references_in_line(
+        key1 in citation_key_strategy(),
+        key2 in citation_key_strategy(),
+    ) {
+        let source = format!("See [@{key1}] and [@{key2}] end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "multiple refs")
+            .starts_with(&[
+                InlineExpectation::plain_text("See "),
+                InlineExpectation::reference(ReferenceExpectation::citation(
+                    TextMatch::Exact(key1)
+                )),
+                InlineExpectation::plain_text(" and "),
+                InlineExpectation::reference(ReferenceExpectation::citation(
+                    TextMatch::Exact(key2)
+                )),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(5);
+    }
+
+    #[test]
+    fn reference_with_adjacent_emphasis(
+        target in general_target_strategy(),
+        word in "[a-zA-Z]{2,8}",
+    ) {
+        let source = format!("See [{target}] and _{word}_ end.\n");
+        let content = extract_first_text_line_content(&source);
+        InlineAssertion::new(&content, "ref + emphasis")
+            .starts_with(&[
+                InlineExpectation::plain_text("See "),
+                InlineExpectation::reference(ReferenceExpectation::general(
+                    TextMatch::Exact(target)
+                )),
+                InlineExpectation::plain_text(" and "),
+                InlineExpectation::emphasis_text(&word),
+                InlineExpectation::plain_text(" end."),
+            ])
+            .length(5);
+    }
+}


### PR DESCRIPTION
## Summary

Comprehensive pass closing all identified proptest coverage gaps in the parser.

### Coverage added (13 commits, 76 new proptests):

| Commit | Tests | What |
|--------|-------|------|
| References | 12 | All 8 `ReferenceType` variants + mixed inline combos |
| Nested lists | 14 | 2/3-level nesting, verbatim in lists/defs, adjacent defs, 4-level depth, markers |
| Confusion boundaries | 15 | Colon/dash/:: disambiguation, unicode safety, multi-line paragraphs |
| Extended markers | 3 | `1.2.3.`, `1.a)`, `1.1.` — Form::Extended detection |
| Fullwidth verbatim | 2 | Fullwidth vs inflow mode detection |
| Annotation attachment | 7 | Attach to paragraph/def/list/verbatim, multi-annotation, with params, block |
| Inline edge cases | 14 | Multi-word markup, start/end, adjacent, unclosed, empty delimiters |
| Text strategies | 3 | Mid-colon, mid-dash, mid-:: not triggering false detection |
| Mixed markers | 1 | Dash list + numbered list as siblings |
| Wrong syntax fix | 0 | Replaced backtick/markdown strategies with actual Lex syntax |
| Invariants | 5 | Parse idempotency, content preservation, depth bounded by indent |

### All items from the audit addressed:

- [x] 1. Missing elements: references, extended markers, fullwidth verbatim, annotation attachment
- [x] 2. Weak strategies: multi-word/adjacent/unclosed markup, colons/dashes/:: in text, unicode
- [x] 3. Missing compositional: nested lists, verbatim in lists/defs, deep nesting, adjacent defs, mixed markers, multi-annotation
- [x] 4. Confusion boundary tests
- [x] 5. Fix parser_proptest.rs wrong Lex syntax
- [x] 6. Roundtrip/invariant properties

Test count: 803 → **876** (all passing).

Also bumps version to 0.2.3.

## Test plan

- [x] All 876 tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)