### PR TITLE
LSP config integration: load .lex.toml via clapfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,8 +1093,10 @@ dependencies = [
 name = "lex-lsp"
 version = "0.4.0"
 dependencies = [
+ "clapfig",
  "lex-analysis",
  "lex-babel",
+ "lex-config",
  "lex-core",
  "lsp-types",
  "proptest",

--- a/comms/docs/content/tools.lex
+++ b/comms/docs/content/tools.lex
@@ -101,7 +101,7 @@ Tools
 
 5. Configuration
 
-    Settings are loaded from `lex.toml` files, `LEX__*` environment variables, and CLI flags. Use `lex config` to manage settings.
+    Settings are loaded from `.lex.toml` files, `LEX__*` environment variables, and CLI flags. Use `lex config` to manage settings.
 
         # Show all resolved settings
         lex config list
@@ -110,10 +110,10 @@ Tools
         lex config set convert.html.theme fancy-serif
 
         # Generate a template config file
-        lex config gen -o lex.toml
+        lex config gen -o .lex.toml
 
         # Override the config file path
-        lex document.lex --to html --config ./my-lex.toml
+        lex document.lex --to html --config ./my-.lex.toml
     :: shell ::
     Definition:
         Format-specific flags:
@@ -128,7 +128,7 @@ Tools
             # Inspect with full AST properties
             lex inspect document.lex --ast-full
         :: shell ::
-    Example `lex.toml`:
+    Example `.lex.toml`:
 
         [formatting.rules]
         session_blank_lines_before = 2

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -19,7 +19,7 @@
 //
 // Configuration:
 //
-// Settings are loaded from lex.toml files (CWD, project root, platform config dir),
+// Settings are loaded from .lex.toml files (CWD, project root, platform config dir),
 // environment variables (LEX__*), and CLI flags. Use `lex config` to manage settings.
 
 use lex_cli::transforms;
@@ -30,7 +30,7 @@ use lex_babel::{
     formats::lex::formatting_rules::FormattingRules, transforms::serialize_to_lex_with_rules,
     FormatRegistry, SerializedDocument,
 };
-use lex_config::{LexConfig, PdfPageSize};
+use lex_config::{LexConfig, PdfPageSize, CONFIG_FILE_NAME};
 use lex_core::lex::ast::{find_node_path_at_position, Position};
 use std::collections::HashMap;
 use std::fs;
@@ -46,7 +46,7 @@ fn build_cli() -> Command {
             - convert: Transform between document formats (lex, markdown, HTML, etc.)\n  \
             - config:  Manage configuration (list, get, set, gen)\n\n\
             Configuration:\n  \
-            Settings are loaded from lex.toml files, LEX__* env vars, and CLI flags.\n  \
+            Settings are loaded from .lex.toml files, LEX__* env vars, and CLI flags.\n  \
             Use `lex config list` to see resolved settings.\n\n\
             Examples:\n  \
             lex inspect file.lex                    # View AST tree visualization\n  \
@@ -70,7 +70,7 @@ fn build_cli() -> Command {
             Arg::new("config-path")
                 .long("config")
                 .value_name("PATH")
-                .help("Path to a lex.toml configuration file")
+                .help("Path to a .lex.toml configuration file")
                 .value_hint(ValueHint::FilePath)
                 .global(true),
         )
@@ -432,7 +432,7 @@ fn main() {
 fn make_builder(matches: &ArgMatches) -> ClapfigBuilder<LexConfig> {
     let mut builder = Clapfig::builder::<LexConfig>()
         .app_name("lex")
-        .file_name("lex.toml")
+        .file_name(CONFIG_FILE_NAME)
         .search_paths(vec![
             SearchPath::Platform,
             SearchPath::Ancestors(Boundary::Marker(".git")),

--- a/crates/lex-cli/tests/format_config.rs
+++ b/crates/lex-cli/tests/format_config.rs
@@ -8,7 +8,7 @@ fn format_respects_indent_from_config() {
     let input_path = dir.path().join("doc.lex");
     fs::write(&input_path, "Session:\n    Body\n").unwrap();
 
-    let config_path = dir.path().join("lex.toml");
+    let config_path = dir.path().join(".lex.toml");
     fs::write(
         &config_path,
         r#"[formatting.rules]

--- a/crates/lex-cli/tests/theme_config.rs
+++ b/crates/lex-cli/tests/theme_config.rs
@@ -9,7 +9,7 @@ fn convert_uses_default_theme_from_config() {
     fs::write(&input_path, "Session:\n    Body\n").unwrap();
 
     // Create a config file with a custom default theme
-    let config_path = dir.path().join("lex.toml");
+    let config_path = dir.path().join(".lex.toml");
     fs::write(
         &config_path,
         r#"[convert.html]
@@ -81,7 +81,7 @@ fn convert_cli_override_precedes_config() {
     let input_path = dir.path().join("doc.lex");
     fs::write(&input_path, "Session:\n    Body\n").unwrap();
 
-    let config_path = dir.path().join("lex.toml");
+    let config_path = dir.path().join(".lex.toml");
     fs::write(
         &config_path,
         r#"[convert.html]

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -8,6 +8,9 @@ use confique::Config;
 use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use serde::{Deserialize, Serialize};
 
+/// Canonical config file name used by the CLI and LSP.
+pub const CONFIG_FILE_NAME: &str = ".lex.toml";
+
 /// Top-level configuration consumed by Lex applications.
 #[derive(Debug, Clone, Config, Serialize, Deserialize)]
 pub struct LexConfig {

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/bin/lex-lsp.rs"
 lex-core = { workspace = true }
 lex-analysis = { workspace = true }
 lex-babel = { workspace = true }
+lex-config = { workspace = true }
+clapfig = { workspace = true }
 tower-lsp = "0.20"
 lsp-types = { workspace = true }
 tokio = { workspace = true }

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -15,6 +15,7 @@ use crate::features::references::find_references;
 use crate::features::semantic_tokens::{
     collect_semantic_tokens, LexSemanticToken, SEMANTIC_TOKEN_KINDS,
 };
+use clapfig::{Boundary, Clapfig, SearchPath};
 use lex_analysis::completion::{completion_items, CompletionCandidate, CompletionWorkspace};
 use lex_analysis::diagnostics::{
     analyze as analyze_diagnostics, AnalysisDiagnostic, DiagnosticKind,
@@ -23,6 +24,7 @@ use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use lex_babel::templates::{
     build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
 };
+use lex_config::{LexConfig, CONFIG_FILE_NAME};
 use lex_core::lex::ast::links::{DocumentLink as AstDocumentLink, LinkType};
 use lex_core::lex::ast::range::SourceLocation;
 use lex_core::lex::ast::{Document, Position as AstPosition, Range as AstRange};
@@ -259,6 +261,7 @@ pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
     documents: DocumentStore,
     features: Arc<P>,
     workspace_roots: RwLock<Vec<PathBuf>>,
+    config: RwLock<LexConfig>,
 }
 
 impl LexLanguageServer<Client, DefaultFeatureProvider> {
@@ -273,11 +276,13 @@ where
     P: FeatureProvider,
 {
     pub fn with_features(client: C, features: Arc<P>) -> Self {
+        let config = load_config(None);
         Self {
             _client: client,
             documents: DocumentStore::default(),
             features,
             workspace_roots: RwLock::new(Vec::new()),
+            config: RwLock::new(config),
         }
     }
 
@@ -341,6 +346,42 @@ where
             document_path,
         })
     }
+
+    /// Build formatting rules from stored config, with per-request LSP overrides on top.
+    async fn resolve_formatting_rules(&self, options: &FormattingOptions) -> FormattingRules {
+        let config = self.config.read().await;
+        let mut rules = FormattingRules::from(&config.formatting.rules);
+
+        // Layer per-request LSP overrides (editors can send lex.* properties)
+        apply_formatting_overrides(&mut rules, options);
+
+        rules
+    }
+}
+
+/// Load a [`LexConfig`] via clapfig, searching from an optional workspace root.
+fn load_config(workspace_root: Option<&Path>) -> LexConfig {
+    let mut search_paths = vec![SearchPath::Platform];
+    if let Some(root) = workspace_root {
+        search_paths.push(SearchPath::Path(root.to_path_buf()));
+    } else {
+        search_paths.push(SearchPath::Ancestors(Boundary::Marker(".git")));
+        search_paths.push(SearchPath::Cwd);
+    }
+    Clapfig::builder::<LexConfig>()
+        .app_name("lex")
+        .file_name(CONFIG_FILE_NAME)
+        .search_paths(search_paths)
+        .load()
+        .unwrap_or_else(|_| {
+            // Fall back to compiled defaults if config loading fails
+            Clapfig::builder::<LexConfig>()
+                .app_name("lex")
+                .no_env()
+                .search_paths(vec![])
+                .load()
+                .expect("compiled defaults must load")
+        })
 }
 
 fn best_matching_root(roots: &[PathBuf], document_path: &Path) -> Option<PathBuf> {
@@ -397,7 +438,7 @@ fn to_formatting_line_range(range: &Range) -> FormattingLineRange {
 
 use lsp_types::{FormattingOptions, FormattingProperty};
 
-/// Extract FormattingRules from LSP FormattingOptions.
+/// Apply per-request LSP overrides onto existing formatting rules.
 ///
 /// Clients can pass custom Lex formatting options through the `properties` field
 /// of FormattingOptions. Supported keys (all under "lex." prefix):
@@ -409,24 +450,7 @@ use lsp_types::{FormattingOptions, FormattingProperty};
 /// - lex.indent_string
 /// - lex.preserve_trailing_blanks
 /// - lex.normalize_verbatim_markers
-fn extract_formatting_rules(options: &FormattingOptions) -> Option<FormattingRules> {
-    // Check if any lex-specific properties are present
-    let has_lex_options = options.properties.keys().any(|k| k.starts_with("lex."));
-
-    if !has_lex_options {
-        return None;
-    }
-
-    let mut rules = FormattingRules::default();
-
-    // Apply tab_size/insert_spaces from LSP standard options
-    if options.insert_spaces {
-        rules.indent_string = " ".repeat(options.tab_size as usize);
-    } else {
-        rules.indent_string = "\t".to_string();
-    }
-
-    // Apply lex-specific overrides from properties
+fn apply_formatting_overrides(rules: &mut FormattingRules, options: &FormattingOptions) {
     for (key, value) in &options.properties {
         match key.as_str() {
             "lex.session_blank_lines_before" => {
@@ -474,8 +498,6 @@ fn extract_formatting_rules(options: &FormattingOptions) -> Option<FormattingRul
             _ => {}
         }
     }
-
-    Some(rules)
 }
 
 fn from_lsp_position(position: Position) -> AstPosition {
@@ -679,6 +701,14 @@ where
 {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         self.update_workspace_roots(&params).await;
+
+        // Reload config now that we know the workspace root
+        {
+            let roots = self.workspace_roots.read().await;
+            let root = roots.first().map(|p| p.as_path());
+            *self.config.write().await = load_config(root);
+        }
+
         let capabilities = ServerCapabilities {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
@@ -753,6 +783,13 @@ where
     }
 
     async fn did_change_configuration(&self, _params: DidChangeConfigurationParams) {
+        // Reload config from disk (e.g. .lex.toml changed)
+        {
+            let roots = self.workspace_roots.read().await;
+            let root = roots.first().map(|p| p.as_path());
+            *self.config.write().await = load_config(root);
+        }
+
         // Re-check all documents with new settings
         let uris: Vec<Url> = self
             .documents
@@ -901,10 +938,10 @@ where
         let uri = params.text_document.uri;
         if let Some(entry) = self.document_entry(&uri).await {
             let DocumentEntry { document, text } = entry;
-            let rules = extract_formatting_rules(&params.options);
+            let rules = self.resolve_formatting_rules(&params.options).await;
             let edits = self
                 .features
-                .format_document(&document, text.as_str(), rules);
+                .format_document(&document, text.as_str(), Some(rules));
             Ok(Some(spans_to_text_edits(text.as_str(), edits)))
         } else {
             Ok(None)
@@ -919,10 +956,10 @@ where
         if let Some(entry) = self.document_entry(&uri).await {
             let DocumentEntry { document, text } = entry;
             let line_range = to_formatting_line_range(&params.range);
-            let rules = extract_formatting_rules(&params.options);
-            let edits = self
-                .features
-                .format_range(&document, text.as_str(), line_range, rules);
+            let rules = self.resolve_formatting_rules(&params.options).await;
+            let edits =
+                self.features
+                    .format_range(&document, text.as_str(), line_range, Some(rules));
             Ok(Some(spans_to_text_edits(text.as_str(), edits)))
         } else {
             Ok(None)
@@ -1864,7 +1901,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_formatting_rules_returns_none_without_lex_properties() {
+    fn apply_formatting_overrides_noop_without_lex_properties() {
         let options = FormattingOptions {
             tab_size: 4,
             insert_spaces: true,
@@ -1873,11 +1910,15 @@ mod tests {
             insert_final_newline: None,
             trim_final_newlines: None,
         };
-        assert!(extract_formatting_rules(&options).is_none());
+        let mut rules = FormattingRules::default();
+        let original = rules.clone();
+        apply_formatting_overrides(&mut rules, &options);
+        assert_eq!(rules.indent_string, original.indent_string);
+        assert_eq!(rules.max_blank_lines, original.max_blank_lines);
     }
 
     #[test]
-    fn extract_formatting_rules_parses_lex_properties() {
+    fn apply_formatting_overrides_applies_lex_properties() {
         use std::collections::HashMap;
 
         let mut properties = HashMap::new();
@@ -1907,7 +1948,8 @@ mod tests {
             trim_final_newlines: None,
         };
 
-        let rules = extract_formatting_rules(&options).expect("should return Some");
+        let mut rules = FormattingRules::default();
+        apply_formatting_overrides(&mut rules, &options);
         assert_eq!(rules.indent_string, "  ");
         assert_eq!(rules.max_blank_lines, 3);
         assert!(!rules.normalize_seq_markers);


### PR DESCRIPTION
## Summary

- **Rename config file** from `lex.toml` to `.lex.toml` (hidden by default)
- **Add `CONFIG_FILE_NAME` const** to `lex-config` — single source of truth for the filename, used by both CLI and LSP
- **LSP loads config via clapfig** at `initialize` using the workspace root, stores `LexConfig` in the server struct
- **Formatting uses stored config as base** — per-request `lex.*` overrides from `FormattingOptions` are layered on top
- **`didChangeConfiguration` reloads from disk** — editors can notify the LSP when `.lex.toml` changes

This means editors get project-level formatting settings from `.lex.toml` without any editor-side plumbing. The existing per-request `lex.*` property override mechanism is preserved for editors that want fine-grained control.

## Test plan

- [x] All workspace tests pass (unit + integration)
- [x] CLI `config list` works with new `.lex.toml` name
- [x] `format_config` and `theme_config` integration tests pass with `.lex.toml`
- [x] LSP server tests pass (formatting override tests updated)
- [x] Pre-commit hooks pass (fmt, clippy, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)