### PR TITLE
Implement implicit anchor resolution for references

### DIFF
--- a/crates/lex-babel/src/common/links.rs
+++ b/crates/lex-babel/src/common/links.rs
@@ -191,6 +191,69 @@ pub fn insert_reference_with_anchor(
     content
 }
 
+/// Returns true if the reference raw text looks like a linkable target
+/// (URL, file path, or document anchor).
+fn is_linkable_reference(raw: &str) -> bool {
+    raw.starts_with("http://")
+        || raw.starts_with("https://")
+        || raw.starts_with("mailto:")
+        || raw.starts_with("./")
+        || raw.starts_with('/')
+        || raw.starts_with('#')
+}
+
+/// Resolve implicit anchors in inline content.
+///
+/// Scans for `Reference` nodes that are linkable (URLs, file paths) and extracts
+/// the implicit anchor word from adjacent text, producing `Link` nodes.
+///
+/// Rules (per spec section 2.3):
+/// - Default: anchor is the last word **before** the reference
+/// - If reference is first in inline content: anchor is the first word **after**
+/// - If reference is the only content: anchor is the URL itself
+pub fn resolve_implicit_anchors(content: Vec<InlineContent>) -> Vec<InlineContent> {
+    // Find indices of linkable references
+    let ref_indices: Vec<usize> = content
+        .iter()
+        .enumerate()
+        .filter_map(|(i, item)| match item {
+            InlineContent::Reference(raw) if is_linkable_reference(raw) => Some(i),
+            _ => None,
+        })
+        .collect();
+
+    if ref_indices.is_empty() {
+        return content;
+    }
+
+    // Process one reference at a time (from last to first to preserve indices)
+    let mut result = content;
+    for &ref_idx in ref_indices.iter().rev() {
+        if let Some((anchor, href, modified)) = extract_anchor_for_reference(&result, ref_idx) {
+            // Replace content with modified version + insert Link where the reference was
+            let insert_at = ref_idx.min(modified.len());
+            let mut new_result = Vec::with_capacity(modified.len() + 1);
+            let mut inserted = false;
+            for (i, item) in modified.into_iter().enumerate() {
+                if !inserted && i >= insert_at {
+                    new_result.push(InlineContent::Link {
+                        text: anchor.clone(),
+                        href: href.clone(),
+                    });
+                    inserted = true;
+                }
+                new_result.push(item);
+            }
+            if !inserted {
+                new_result.push(InlineContent::Link { text: anchor, href });
+            }
+            result = new_result;
+        }
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -263,5 +326,72 @@ mod tests {
         assert!(matches!(&modified[1], InlineContent::Text(t) if t == "bahamas"));
         assert!(matches!(&modified[2], InlineContent::Text(t) if t == " "));
         assert!(matches!(&modified[3], InlineContent::Reference(r) if r == "bahamas.gov"));
+    }
+
+    #[test]
+    fn test_resolve_implicit_anchors_word_before() {
+        let content = vec![
+            InlineContent::Text("visit the website ".to_string()),
+            InlineContent::Reference("https://example.com".to_string()),
+        ];
+        let resolved = resolve_implicit_anchors(content);
+        assert!(resolved
+            .iter()
+            .any(|i| matches!(i, InlineContent::Link { text, href }
+            if text == "website" && href == "https://example.com")));
+        // "website" should be removed from text
+        assert!(resolved
+            .iter()
+            .any(|i| matches!(i, InlineContent::Text(t) if t == "visit the ")));
+    }
+
+    #[test]
+    fn test_resolve_implicit_anchors_word_after() {
+        let content = vec![
+            InlineContent::Reference("https://example.com".to_string()),
+            InlineContent::Text(" Example is great".to_string()),
+        ];
+        let resolved = resolve_implicit_anchors(content);
+        assert!(resolved
+            .iter()
+            .any(|i| matches!(i, InlineContent::Link { text, href }
+            if text == "Example" && href == "https://example.com")));
+    }
+
+    #[test]
+    fn test_resolve_implicit_anchors_only_ref() {
+        // Reference is the only content — anchor should be the URL itself
+        let content = vec![InlineContent::Reference("https://example.com".to_string())];
+        let resolved = resolve_implicit_anchors(content);
+        assert!(resolved
+            .iter()
+            .any(|i| matches!(i, InlineContent::Link { text, href }
+            if text == "https://example.com" && href == "https://example.com")));
+    }
+
+    #[test]
+    fn test_resolve_non_linkable_references_untouched() {
+        // Non-linkable references (footnotes, citations, etc.) stay as Reference
+        let content = vec![
+            InlineContent::Text("See ".to_string()),
+            InlineContent::Reference("@smith2023".to_string()),
+        ];
+        let resolved = resolve_implicit_anchors(content);
+        assert_eq!(resolved.len(), 2);
+        assert!(matches!(&resolved[1], InlineContent::Reference(r) if r == "@smith2023"));
+    }
+
+    #[test]
+    fn test_resolve_session_reference() {
+        // Session references (#...) are linkable
+        let content = vec![
+            InlineContent::Text("See section ".to_string()),
+            InlineContent::Reference("#introduction".to_string()),
+        ];
+        let resolved = resolve_implicit_anchors(content);
+        assert!(resolved
+            .iter()
+            .any(|i| matches!(i, InlineContent::Link { text, href }
+            if text == "section" && href == "#introduction")));
     }
 }

--- a/crates/lex-babel/src/common/nested_to_flat.rs
+++ b/crates/lex-babel/src/common/nested_to_flat.rs
@@ -144,6 +144,8 @@ fn walk_node(node: &DocNode, events: &mut Vec<Event>) {
                                 text_content.push_str(t);
                             } else if let InlineContent::Reference(r) = inline {
                                 text_content.push_str(r);
+                            } else if let InlineContent::Link { text, .. } = inline {
+                                text_content.push_str(text);
                             }
                             // Ignore other inline types for now or implement full serialization
                         }

--- a/crates/lex-babel/src/common/verbatim/table.rs
+++ b/crates/lex-babel/src/common/verbatim/table.rs
@@ -288,6 +288,7 @@ fn cell_text(cell: &TableCell) -> String {
                 InlineContent::Code(c) => format!("`{c}`"),
                 InlineContent::Math(c) => format!("${c}$"),
                 InlineContent::Reference(c) => format!("[{c}]"),
+                InlineContent::Link { text, href } => format!("{text} [{href}]"),
                 InlineContent::Marker(c) => c.clone(),
                 InlineContent::Image(image) => {
                     let mut text = format!("![{}]({})", image.alt, image.src);
@@ -317,6 +318,7 @@ fn inline_content_to_text(content: &[InlineContent]) -> String {
             InlineContent::Code(c) => format!("`{c}`"),
             InlineContent::Math(c) => format!("${c}$"),
             InlineContent::Reference(c) => format!("[{c}]"),
+            InlineContent::Link { text, href } => format!("{text} [{href}]"),
             InlineContent::Marker(c) => c.clone(),
             InlineContent::Image(image) => {
                 let mut text = format!("![{}]({})", image.alt, image.src);

--- a/crates/lex-babel/src/formats/html/serializer.rs
+++ b/crates/lex-babel/src/formats/html/serializer.rs
@@ -491,7 +491,7 @@ fn add_inline_to_node(parent: &Handle, inline: &InlineContent) -> Result<(), For
         }
 
         InlineContent::Reference(ref_text) => {
-            // Convert to anchor
+            // Unresolved reference (non-linkable types like citations, footnotes, etc.)
             // Handle citations (@...) by targeting a reference ID
             let href = if let Some(citation) = ref_text.strip_prefix('@') {
                 format!("#ref-{citation}")
@@ -501,6 +501,13 @@ fn add_inline_to_node(parent: &Handle, inline: &InlineContent) -> Result<(), For
 
             let anchor = create_element("a", vec![("href", &href)]);
             let anchor_text = create_text(ref_text);
+            anchor.children.borrow_mut().push(anchor_text);
+            parent.children.borrow_mut().push(anchor);
+        }
+
+        InlineContent::Link { text, href } => {
+            let anchor = create_element("a", vec![("href", href)]);
+            let anchor_text = create_text(text);
             anchor.children.borrow_mut().push(anchor_text);
             parent.children.borrow_mut().push(anchor);
         }

--- a/crates/lex-babel/src/formats/markdown/parser.rs
+++ b/crates/lex-babel/src/formats/markdown/parser.rs
@@ -371,7 +371,11 @@ fn collect_inline_events<'a>(
         }
 
         NodeValue::Link(link) => {
-            events.push(Event::Inline(InlineContent::Reference(link.url.clone())));
+            let text = collect_text_from_children(node);
+            events.push(Event::Inline(InlineContent::Link {
+                text,
+                href: link.url.clone(),
+            }));
         }
 
         NodeValue::SoftBreak | NodeValue::LineBreak => {
@@ -442,7 +446,11 @@ fn collect_inline_content<'a>(
         }
 
         NodeValue::Link(link) => {
-            content.push(InlineContent::Reference(link.url.clone()));
+            let text = collect_text_from_children(node);
+            content.push(InlineContent::Link {
+                text,
+                href: link.url.clone(),
+            });
         }
 
         NodeValue::SoftBreak | NodeValue::LineBreak => {

--- a/crates/lex-babel/src/formats/markdown/serializer.rs
+++ b/crates/lex-babel/src/formats/markdown/serializer.rs
@@ -800,19 +800,10 @@ fn add_inline_to_node<'a>(
         }
 
         InlineContent::Reference(ref_text) => {
-            // Lex references can be URLs, anchors, citations, or placeholders.
-            // Try to convert known types to Markdown links.
-            let url = if ref_text.starts_with("http")
-                || ref_text.starts_with('/')
-                || ref_text.starts_with("./")
-                || ref_text.starts_with('#')
-            {
-                Some(ref_text.clone())
-            } else {
-                ref_text
-                    .strip_prefix('@')
-                    .map(|citation| format!("#ref-{citation}"))
-            };
+            // Unresolved reference (non-linkable types: citations, footnotes, general, etc.)
+            let url = ref_text
+                .strip_prefix('@')
+                .map(|citation| format!("#ref-{citation}"));
 
             if let Some(url) = url {
                 let link_node = arena.alloc(AstNode::new(RefCell::new(Ast::new(
@@ -838,6 +829,23 @@ fn add_inline_to_node<'a>(
                 ))));
                 parent.append(text_node);
             }
+        }
+
+        InlineContent::Link { text, href } => {
+            let link_node = arena.alloc(AstNode::new(RefCell::new(Ast::new(
+                NodeValue::Link(comrak::nodes::NodeLink {
+                    url: href.clone(),
+                    title: String::new(),
+                }),
+                (0, 0).into(),
+            ))));
+            parent.append(link_node);
+
+            let text_node = arena.alloc(AstNode::new(RefCell::new(Ast::new(
+                NodeValue::Text(text.clone()),
+                (0, 0).into(),
+            ))));
+            link_node.append(text_node);
         }
 
         InlineContent::Math(math_text) => {

--- a/crates/lex-babel/src/formats/rfc_xml/parser.rs
+++ b/crates/lex-babel/src/formats/rfc_xml/parser.rs
@@ -306,7 +306,21 @@ fn parse_inline_content(node: Node) -> Result<Vec<InlineContent>, FormatError> {
                 }
                 "eref" => {
                     let target = child.attribute("target").unwrap_or("?");
-                    content.push(InlineContent::Reference(target.to_string()));
+                    let mut inner_text = String::new();
+                    for c in child.children() {
+                        if c.node_type() == NodeType::Text {
+                            inner_text.push_str(c.text().unwrap_or(""));
+                        }
+                    }
+                    let text = if !inner_text.trim().is_empty() {
+                        inner_text
+                    } else {
+                        target.to_string()
+                    };
+                    content.push(InlineContent::Link {
+                        text,
+                        href: target.to_string(),
+                    });
                 }
                 _ => {
                     content.extend(parse_inline_content(child)?);

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -141,17 +141,21 @@ fn extract_attached_annotations(item: &LexContentItem, level: usize) -> Vec<DocN
         .collect()
 }
 
-/// Converts TextContent to IR InlineContent
+/// Converts TextContent to IR InlineContent, resolving implicit anchors for linkable references.
 fn convert_inline_content(text: &TextContent) -> Vec<InlineContent> {
+    use crate::common::links::resolve_implicit_anchors;
+
     // Get inline items from TextContent
     let inline_items = text.inline_items();
 
-    if inline_items.is_empty() {
+    let content = if inline_items.is_empty() {
         // If no inline items, use raw string
         vec![InlineContent::Text(text.as_string().to_string())]
     } else {
         inline_items.iter().map(convert_inline_node).collect()
-    }
+    };
+
+    resolve_implicit_anchors(content)
 }
 
 /// Converts a single InlineNode to IR InlineContent

--- a/crates/lex-babel/src/ir/nodes.rs
+++ b/crates/lex-babel/src/ir/nodes.rs
@@ -149,6 +149,13 @@ pub enum InlineContent {
     Code(String),
     Math(String),
     Reference(String),
+    /// A resolved link with explicit anchor text and href.
+    /// Produced by resolving implicit anchors from Lex references,
+    /// or by importing from formats that have explicit link anchors (Markdown, HTML).
+    Link {
+        text: String,
+        href: String,
+    },
     Marker(String),
     Image(Image),
 }

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -329,6 +329,7 @@ fn inline_to_text(inline: &InlineContent) -> String {
         InlineContent::Code(code) => format!("`{code}`"),
         InlineContent::Math(math) => format!("#{math}#"),
         InlineContent::Reference(ref_text) => format!("[{ref_text}]"),
+        InlineContent::Link { text, href } => format!("{text} [{href}]"),
         InlineContent::Marker(marker) => marker.clone(),
         InlineContent::Image(image) => {
             let mut text = format!("![{}]({})", image.alt, image.src);
@@ -357,6 +358,7 @@ fn inline_content_to_text(content: &[InlineContent]) -> String {
             InlineContent::Code(code) => format!("`{code}`"),
             InlineContent::Math(math) => format!("#{math}#"),
             InlineContent::Reference(ref_text) => format!("[{ref_text}]"),
+            InlineContent::Link { text, href } => format!("{text} [{href}]"),
             InlineContent::Marker(marker) => marker.clone(),
             InlineContent::Image(image) => {
                 let mut text = format!("![{}]({})", image.alt, image.src);

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -327,15 +327,14 @@ fn test_reference_anchor_converted_to_link() {
     let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
     let md = MarkdownFormat.serialize(&lex_doc).unwrap();
 
-    // Anchors should be converted to Markdown links [text](url)
-    // The # in link text is escaped as \# which is correct Markdown
+    // Implicit anchor: the word before the reference ("section") becomes the link text
     assert!(
         md.contains("(#introduction)"),
         "Anchor should link to #introduction"
     );
     assert!(
-        md.contains("[\\#introduction]") || md.contains("[#introduction]"),
-        "Anchor text should contain #introduction"
+        md.contains("[section]"),
+        "Link text should be the implicit anchor word 'section'"
     );
 }
 

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_commonmark_reference.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_commonmark_reference.snap
@@ -1,5 +1,5 @@
 ---
-source: lex-babel/tests/markdown/import.rs
+source: crates/lex-babel/tests/markdown/import.rs
 expression: serialized
 ---
 <document>
@@ -8,10 +8,10 @@ expression: serialized
       <text-line>CommonMark is a rationalized version of Markdown s…</text-line>
     </paragraph>
     <paragraph>1 line(s)
-      <text-line>[https://spec.commonmark.org/dingus/]</text-line>
+      <text-line>Try it now! [https://spec.commonmark.org/dingus/]</text-line>
     </paragraph>
     <paragraph>1 line(s)
-      <text-line>For more details, see [https://commonmark.org].</text-line>
+      <text-line>For more details, see https://commonmark.org [http…</text-line>
     </paragraph>
     <paragraph>1 line(s)
       <text-line>This repository contains the spec itself, along wi…</text-line>
@@ -24,14 +24,14 @@ expression: serialized
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.com/commonmark/cmark] (C)</text-line>
+          <text-line>https://github.com/commonmark/cmark [https://githu…</text-line>
         </paragraph>
       </list-item>
       <list-item>
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.com/commonmark/commonmark.js] (Jav…</text-line>
+          <text-line>https://github.com/commonmark/commonmark.js [https…</text-line>
         </paragraph>
       </list-item>
     </list>
@@ -40,7 +40,7 @@ expression: serialized
     </paragraph>
     <session>Running tests against the spec
       <paragraph>1 line(s)
-        <text-line>[https://spec.commonmark.org/] contains over 500 e…</text-line>
+        <text-line>The spec [https://spec.commonmark.org/] contains o…</text-line>
       </paragraph>
       <verbatim-block>
         <verbatim-group>
@@ -74,7 +74,7 @@ expression: serialized
     </session>
     <session>The spec
       <paragraph>1 line(s)
-        <text-line>The source of [https://spec.commonmark.org/] is `s…</text-line>
+        <text-line>The source of the spec [https://spec.commonmark.or…</text-line>
       </paragraph>
       <verbatim-block>
         <verbatim-group>
@@ -92,7 +92,7 @@ expression: serialized
         <text-line>The spec is written from the point of view of the …</text-line>
       </paragraph>
       <paragraph>1 line(s)
-        <text-line>Because John Gruber&apos;s [https://daringfireball.net/…</text-line>
+        <text-line>Because John Gruber&apos;s canonical syntax description…</text-line>
       </paragraph>
       <paragraph>1 line(s)
         <text-line>For the most part, we have limited ourselves to th…</text-line>
@@ -188,7 +188,7 @@ expression: serialized
     </session>
     <session>Contributing
       <paragraph>1 line(s)
-        <text-line>There is a [https://talk.commonmark.org]; you shou…</text-line>
+        <text-line>There is a forum for discussing CommonMark [https:…</text-line>
       </paragraph>
     </session>
     <session>Authors

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_readme.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_readme.snap
@@ -1,5 +1,5 @@
 ---
-source: lex-babel/tests/markdown/import.rs
+source: crates/lex-babel/tests/markdown/import.rs
 expression: serialized
 ---
 <document>
@@ -7,13 +7,13 @@ expression: serialized
     <text-line>Comrak</text-line>
   </paragraph>
   <paragraph>1 line(s)
-    <text-line>[https://github.com/kivikakk/comrak/actions/workfl…</text-line>
+    <text-line>Build status [https://github.com/kivikakk/comrak/a…</text-line>
   </paragraph>
   <paragraph>1 line(s)
-    <text-line>Rust port of [https://github.com/github/cmark-gfm]…</text-line>
+    <text-line>Rust port of github&apos;s  [https://github.com/github/…</text-line>
   </paragraph>
   <paragraph>1 line(s)
-    <text-line>Compliant with [https://spec.commonmark.org/0.31.2…</text-line>
+    <text-line>Compliant with CommonMark 0.31.2 [https://spec.com…</text-line>
   </paragraph>
   <session>Installation
     <paragraph>1 line(s)
@@ -85,7 +85,7 @@ expression: serialized
         </list-item>
       </list>
       <paragraph>1 line(s)
-        <text-line>You can also find builds I&apos;ve published in [https:…</text-line>
+        <text-line>You can also find builds I&apos;ve published in GitHub …</text-line>
       </paragraph>
     </session>
   </session>
@@ -281,7 +281,7 @@ expression: serialized
   </session>
   <session>Security
     <paragraph>1 line(s)
-      <text-line>As with [https://github.com/commonmark/cmark] and …</text-line>
+      <text-line>As with  [https://github.com/commonmark/cmark] and…</text-line>
     </paragraph>
     <paragraph>1 line(s)
       <text-line>To allow these, use the `unsafe_` option (or `--un…</text-line>
@@ -296,35 +296,35 @@ expression: serialized
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.github.com/gfm/#tables-extension-]</text-line>
+          <text-line>Tables [https://github.github.com/gfm/#tables-exte…</text-line>
         </paragraph>
       </list-item>
       <list-item>
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.github.com/gfm/#task-list-items-ex…</text-line>
+          <text-line>Task list items [https://github.github.com/gfm/#ta…</text-line>
         </paragraph>
       </list-item>
       <list-item>
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.github.com/gfm/#strikethrough-exte…</text-line>
+          <text-line>Strikethrough [https://github.github.com/gfm/#stri…</text-line>
         </paragraph>
       </list-item>
       <list-item>
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.github.com/gfm/#autolinks-extensio…</text-line>
+          <text-line>Autolinks [https://github.github.com/gfm/#autolink…</text-line>
         </paragraph>
       </list-item>
       <list-item>
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.github.com/gfm/#disallowed-raw-htm…</text-line>
+          <text-line>Disallowed Raw HTML [https://github.github.com/gfm…</text-line>
         </paragraph>
       </list-item>
     </list>
@@ -434,14 +434,14 @@ expression: serialized
       </paragraph>
       <session>Syntect
         <paragraph>1 line(s)
-          <text-line>[https://github.com/trishume/syntect] is a syntax …</text-line>
+          <text-line> [https://github.com/trishume/syntect] is a syntax…</text-line>
         </paragraph>
       </session>
     </session>
   </session>
   <session>Related projects
     <paragraph>1 line(s)
-      <text-line>Comrak&apos;s design goal is to model the upstream [htt…</text-line>
+      <text-line>Comrak&apos;s design goal is to model the upstream  [ht…</text-line>
     </paragraph>
     <paragraph>1 line(s)
       <text-line>The downside, of course, is that the code often di…</text-line>
@@ -451,14 +451,14 @@ expression: serialized
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.com/raphlinus]&apos;s [https://github.c…</text-line>
+          <text-line>Raph Levien [https://github.com/raphlinus]&apos;s  [htt…</text-line>
         </paragraph>
       </list-item>
       <list-item>
         <marker>-</marker>
         <text></text>
         <paragraph>1 line(s)
-          <text-line>[https://github.com/wooorm/markdown-rs] (1.x) look…</text-line>
+          <text-line>markdown-rs [https://github.com/wooorm/markdown-rs…</text-line>
         </paragraph>
       </list-item>
       <list-item>
@@ -475,7 +475,7 @@ expression: serialized
   </session>
   <session>Benchmarking
     <paragraph>1 line(s)
-      <text-line>You&apos;ll need to [https://github.com/sharkdp/hyperfi…</text-line>
+      <text-line>You&apos;ll need to install hyperfine [https://github.c…</text-line>
     </paragraph>
     <paragraph>1 line(s)
       <text-line>If you want to just run the benchmark for the `com…</text-line>
@@ -505,14 +505,14 @@ expression: serialized
       <text-line>Contributions are *highly encouraged*; if you&apos;d li…</text-line>
     </paragraph>
     <paragraph>1 line(s)
-      <text-line>Where possible I practice [http://hintjens.com/blo…</text-line>
+      <text-line>Where possible I practice Optimistic Merging [http…</text-line>
     </paragraph>
     <paragraph>1 line(s)
       <text-line>Thank you to Comrak&apos;s many contributors for PRs an…</text-line>
     </paragraph>
     <session>Code Contributors
       <paragraph>1 line(s)
-        <text-line>[https://github.com/kivikakk/comrak/graphs/contrib…</text-line>
+        <text-line>Small chart showing Comrak contributors. [https://…</text-line>
       </paragraph>
     </session>
     <session>Financial Contributors
@@ -524,7 +524,7 @@ expression: serialized
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.com/sponsors/kivikakk]</text-line>
+            <text-line>GitHub Sponsors [https://github.com/sponsors/kivik…</text-line>
           </paragraph>
         </list-item>
       </list>
@@ -543,7 +543,7 @@ expression: serialized
       <text-line>`cmark` itself is is copyright (c) 2014, John MacF…</text-line>
     </paragraph>
     <paragraph>1 line(s)
-      <text-line>See [COPYING] for all the details.</text-line>
+      <text-line>See COPYING [COPYING] for all the details.</text-line>
     </paragraph>
   </session>
 </document>

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_reference.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_reference.snap
@@ -1,17 +1,17 @@
 ---
-source: lex-babel/tests/markdown/import.rs
+source: crates/lex-babel/tests/markdown/import.rs
 expression: serialized
 ---
 <document>
-  <session>[https://comrak.ee/]
+  <session>Comrak [https://comrak.ee/]
     <paragraph>1 line(s)
-      <text-line>[https://github.com/kivikakk/comrak/actions/workfl…</text-line>
+      <text-line>Build status [https://github.com/kivikakk/comrak/a…</text-line>
     </paragraph>
     <paragraph>1 line(s)
-      <text-line>[https://comrak.ee/] is a [https://commonmark.org/…</text-line>
+      <text-line>Comrak [https://comrak.ee/] is a CommonMark [https…</text-line>
     </paragraph>
     <paragraph>1 line(s)
-      <text-line>Compliant with [https://spec.commonmark.org/0.31.2…</text-line>
+      <text-line>Compliant with CommonMark 0.31.2 [https://spec.com…</text-line>
     </paragraph>
     <session>Installation
       <paragraph>1 line(s)
@@ -46,7 +46,7 @@ expression: serialized
                 <marker>-</marker>
                 <text></text>
                 <paragraph>1 line(s)
-                  <text-line>[https://github.com/cargo-bins/cargo-binstall] com…</text-line>
+                  <text-line>cargo binstall [https://github.com/cargo-bins/carg…</text-line>
                 </paragraph>
               </list-item>
             </list>
@@ -90,7 +90,7 @@ expression: serialized
           </list-item>
         </list>
         <paragraph>1 line(s)
-          <text-line>You can also find builds I&apos;ve published in [https:…</text-line>
+          <text-line>You can also find builds I&apos;ve published in GitHub …</text-line>
         </paragraph>
       </session>
     </session>
@@ -294,7 +294,7 @@ expression: serialized
     </session>
     <session>Security
       <paragraph>1 line(s)
-        <text-line>As with [https://github.com/commonmark/cmark] and …</text-line>
+        <text-line>As with  [https://github.com/commonmark/cmark] and…</text-line>
       </paragraph>
       <paragraph>1 line(s)
         <text-line>To allow these, use the `r#unsafe` option (or `--u…</text-line>
@@ -309,35 +309,35 @@ expression: serialized
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.github.com/gfm/#tables-extension-]</text-line>
+            <text-line>Tables [https://github.github.com/gfm/#tables-exte…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.github.com/gfm/#task-list-items-ex…</text-line>
+            <text-line>Task list items [https://github.github.com/gfm/#ta…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.github.com/gfm/#strikethrough-exte…</text-line>
+            <text-line>Strikethrough [https://github.github.com/gfm/#stri…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.github.com/gfm/#autolinks-extensio…</text-line>
+            <text-line>Autolinks [https://github.github.com/gfm/#autolink…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.github.com/gfm/#disallowed-raw-htm…</text-line>
+            <text-line>Disallowed Raw HTML [https://github.github.com/gfm…</text-line>
           </paragraph>
         </list-item>
       </list>
@@ -440,7 +440,7 @@ expression: serialized
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.com/tats-u/markdown-cjk-friendly]</text-line>
+            <text-line>CJK friendly emphasis [https://github.com/tats-u/m…</text-line>
           </paragraph>
         </list-item>
       </list>
@@ -466,7 +466,7 @@ expression: serialized
         </paragraph>
         <session>Syntect
           <paragraph>1 line(s)
-            <text-line>[https://github.com/trishume/syntect] is a syntax …</text-line>
+            <text-line> [https://github.com/trishume/syntect] is a syntax…</text-line>
           </paragraph>
         </session>
       </session>
@@ -479,7 +479,7 @@ expression: serialized
         <text-line>Over the years, we have increasingly opted to fix …</text-line>
       </paragraph>
       <paragraph>1 line(s)
-        <text-line>This library offers an AST backed by [https://gith…</text-line>
+        <text-line>This library offers an AST backed by  [https://git…</text-line>
       </paragraph>
       <paragraph>1 line(s)
         <text-line>For whatever reason, Comrak may not meet your requ…</text-line>
@@ -489,28 +489,28 @@ expression: serialized
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.com/raphlinus]&apos;s [https://github.c…</text-line>
+            <text-line>Raph Levien [https://github.com/raphlinus]&apos;s  [htt…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.com/wooorm/markdown-rs] looks real…</text-line>
+            <text-line>markdown-rs [https://github.com/wooorm/markdown-rs…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://github.com/markdown-it-rust/markdown-it] …</text-line>
+            <text-line>markdown-it [https://github.com/markdown-it-rust/m…</text-line>
           </paragraph>
         </list-item>
         <list-item>
           <marker>-</marker>
           <text></text>
           <paragraph>1 line(s)
-            <text-line>[https://babelmark.github.io/] lets you compare ma…</text-line>
+            <text-line>babelmark [https://babelmark.github.io/] lets you …</text-line>
           </paragraph>
         </list-item>
         <list-item>
@@ -527,35 +527,35 @@ expression: serialized
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://github.com/gjtorikian/commonmarker] — Rub…</text-line>
+              <text-line>Commonmarker [https://github.com/gjtorikian/common…</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://github.com/leandrocp/mdex] — Elixir bindi…</text-line>
+              <text-line>MDEx [https://github.com/leandrocp/mdex] — Elixir …</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://github.com/lmmx/comrak] — Python bindings…</text-line>
+              <text-line>comrak [https://github.com/lmmx/comrak] — Python b…</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://github.com/Martin005/comrak-ext] — Python…</text-line>
+              <text-line>comrak-ext [https://github.com/Martin005/comrak-ex…</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://github.com/nberlette/comrak-wasm] — TypeS…</text-line>
+              <text-line>comrak-wasm [https://github.com/nberlette/comrak-w…</text-line>
             </paragraph>
           </list-item>
         </list>
@@ -569,42 +569,42 @@ expression: serialized
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://crates.io], [https://docs.rs] and [https:…</text-line>
+              <text-line>crates.io [https://crates.io], docs.rs [https://do…</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://gitlab.com] uses Comrak to render Markdow…</text-line>
+              <text-line>GitLab [https://gitlab.com] uses Comrak to render …</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://deno.com] uses Comrak to render documenta…</text-line>
+              <text-line>Deno [https://deno.com] uses Comrak to render docu…</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://reddit.com]&apos;s new-style site uses a Comra…</text-line>
+              <text-line>Reddit [https://reddit.com]&apos;s new-style site uses …</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://lockbook.net/] is a Markdown-based secure…</text-line>
+              <text-line>Lockbook [https://lockbook.net/] is a Markdown-bas…</text-line>
             </paragraph>
           </list-item>
           <list-item>
             <marker>-</marker>
             <text></text>
             <paragraph>1 line(s)
-              <text-line>[https://github.com/kivikakk/comrak/network/depend…</text-line>
+              <text-line>many [https://github.com/kivikakk/comrak/network/d…</text-line>
             </paragraph>
           </list-item>
         </list>
@@ -621,7 +621,7 @@ expression: serialized
         <text-line>We offer some tools to perform stdin-to-stdout ben…</text-line>
       </paragraph>
       <paragraph>1 line(s)
-        <text-line>You&apos;ll need to [https://github.com/sharkdp/hyperfi…</text-line>
+        <text-line>You&apos;ll need to install hyperfine [https://github.c…</text-line>
       </paragraph>
       <paragraph>1 line(s)
         <text-line>If you want to just run the benchmark for the `com…</text-line>
@@ -651,19 +651,19 @@ expression: serialized
         <text-line>Contributions are *highly encouraged*; if you&apos;d li…</text-line>
       </paragraph>
       <paragraph>1 line(s)
-        <text-line>Where possible I practice [http://hintjens.com/blo…</text-line>
+        <text-line>Where possible I practice Optimistic Merging [http…</text-line>
       </paragraph>
       <paragraph>1 line(s)
         <text-line>Thank you to Comrak&apos;s many contributors for PRs an…</text-line>
       </paragraph>
       <session>Code Contributors
         <paragraph>1 line(s)
-          <text-line>[https://github.com/kivikakk/comrak/graphs/contrib…</text-line>
+          <text-line>Small chart showing Comrak contributors. [https://…</text-line>
         </paragraph>
       </session>
       <session>Financial Contributors
         <paragraph>1 line(s)
-          <text-line>Since September 2025, the scope of my [https://abo…</text-line>
+          <text-line>Since September 2025, the scope of my day job [htt…</text-line>
         </paragraph>
         <paragraph>1 line(s)
           <text-line>If you feel like you would like to do so anyway, h…</text-line>
@@ -683,7 +683,7 @@ expression: serialized
         <text-line>`cmark` itself is is copyright (c) 2014, John MacF…</text-line>
       </paragraph>
       <paragraph>1 line(s)
-        <text-line>See [COPYING] for all the details.</text-line>
+        <text-line>See COPYING [COPYING] for all the details.</text-line>
       </paragraph>
     </session>
   </session>


### PR DESCRIPTION
## Summary

- Implements spec section 2.3 (Implicit Anchors): the word before a `[url]` reference becomes the link's anchor text when exporting to HTML/Markdown
- Adds `Link { text, href }` variant to IR `InlineContent` — the resolved form of a reference with its implicit anchor
- Adds `resolve_implicit_anchors()` in `links.rs` that transforms linkable `Reference` nodes into `Link` nodes by extracting adjacent words
- Wires resolution into `from_lex.rs` IR conversion so all exporters benefit
- Fixes Markdown import: link anchor text was previously dropped (only URL preserved)

### Anchor rules (from spec):
1. **Default**: anchor is the last word before the ref — `foo [url]` → `<a href="url">foo</a>`
2. **First in line**: anchor is the first word after — `[url] bar` → `<a href="url">bar</a>`
3. **Alone in line**: anchor is the URL itself — `[url]` → `<a href="url">url</a>`

### Files changed:
- `ir/nodes.rs` — new `Link` variant
- `common/links.rs` — `resolve_implicit_anchors()` + 5 new tests
- `ir/from_lex.rs` — calls resolution during IR conversion
- `formats/html/serializer.rs` — handles `Link`
- `formats/markdown/serializer.rs` — handles `Link`
- `formats/markdown/parser.rs` — preserves anchor text on import
- `formats/rfc_xml/parser.rs` — `eref` uses `Link`
- `ir/to_lex.rs`, `table.rs`, `nested_to_flat.rs` — exhaustive match updates
- Updated 3 snapshots + 1 export test

## Test plan

- [x] All 93 workspace tests pass (including 5 new anchor resolution tests)
- [x] E2E verified: `lex convert --to markdown` and `--to html` produce correct anchored links
- [x] Pre-commit hook passes (fmt, clippy, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)