### PR TITLE
Add semantic-tokens CLI and fix verbatim closing highlights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,6 +1055,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clapfig",
+ "lex-analysis",
  "lex-babel",
  "lex-config",
  "lex-core",

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 
 [dependencies]
 lex-core = { workspace = true }
+lex-analysis = { workspace = true }
 lex-babel = { workspace = true }
 lex-config = { workspace = true }
 clapfig = { workspace = true }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -26,6 +26,7 @@ use lex_cli::transforms;
 
 use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint};
 use clapfig::{Boundary, Clapfig, ClapfigBuilder, ConfigCommand, SearchPath};
+use lex_analysis::semantic_tokens::collect_semantic_tokens;
 use lex_babel::{
     formats::lex::formatting_rules::FormattingRules, transforms::serialize_to_lex_with_rules,
     FormatRegistry, SerializedDocument,
@@ -282,6 +283,31 @@ fn build_cli() -> Command {
                 ),
         )
         .subcommand(
+            Command::new("token-at")
+                .about("Get the semantic token at a specific position")
+                .arg(
+                    Arg::new("path")
+                        .help("Path to the lex file")
+                        .required(true)
+                        .index(1)
+                        .value_hint(ValueHint::FilePath),
+                )
+                .arg(
+                    Arg::new("row")
+                        .help("Row number (1-based)")
+                        .required(true)
+                        .index(2)
+                        .value_parser(clap::value_parser!(usize)),
+                )
+                .arg(
+                    Arg::new("col")
+                        .help("Column number (1-based)")
+                        .required(true)
+                        .index(3)
+                        .value_parser(clap::value_parser!(usize)),
+                ),
+        )
+        .subcommand(
             Command::new("generate-lex-css")
                 .about("Output the default CSS used for HTML export")
                 .long_about(
@@ -315,6 +341,7 @@ fn main() {
                     "config",
                     "format",
                     "element-at",
+                    "token-at",
                     "generate-lex-css",
                     "help",
                 ]
@@ -415,6 +442,18 @@ fn main() {
                         .expect("col is required");
                     let all = sub_matches.get_flag("all");
                     handle_element_at_command(path, row, col, all);
+                }
+                Some(("token-at", sub_matches)) => {
+                    let path = sub_matches
+                        .get_one::<String>("path")
+                        .expect("path is required");
+                    let row = *sub_matches
+                        .get_one::<usize>("row")
+                        .expect("row is required");
+                    let col = *sub_matches
+                        .get_one::<usize>("col")
+                        .expect("col is required");
+                    handle_token_at_command(path, row, col);
                 }
                 Some(("generate-lex-css", _)) => {
                     handle_generate_lex_css_command();
@@ -612,6 +651,83 @@ fn handle_element_at_command(path: &str, row: usize, col: usize, all: bool) {
         }
     } else if let Some(node) = path_nodes.last() {
         println!("{}: {}", node.node_type(), node.display_label());
+    }
+}
+
+/// Handle the token-at command
+fn handle_token_at_command(path: &str, row: usize, col: usize) {
+    let source = fs::read_to_string(path).unwrap_or_else(|e| {
+        eprintln!("Error reading file '{path}': {e}");
+        std::process::exit(1);
+    });
+
+    let registry = FormatRegistry::default();
+    let doc = registry.parse(&source, "lex").unwrap_or_else(|e| {
+        eprintln!("Parse error: {e}");
+        std::process::exit(1);
+    });
+
+    // Convert 1-based row/col to 0-based
+    let target_line = row.saturating_sub(1);
+    let target_col = col.saturating_sub(1);
+    let tokens = collect_semantic_tokens(&doc);
+    let lines: Vec<&str> = source.lines().collect();
+
+    let matching: Vec<_> = tokens
+        .iter()
+        .filter(|t| {
+            let s = &t.range.start;
+            let e = &t.range.end;
+            if s.line == e.line {
+                // Single-line token
+                s.line == target_line && target_col >= s.column && target_col < e.column
+            } else {
+                // Multi-line token
+                if target_line == s.line {
+                    target_col >= s.column
+                } else if target_line == e.line {
+                    target_col < e.column
+                } else {
+                    target_line > s.line && target_line < e.line
+                }
+            }
+        })
+        .collect();
+
+    if matching.is_empty() {
+        println!("No semantic token at {row}:{col}");
+    } else {
+        for token in &matching {
+            let start = &token.range.start;
+            let end = &token.range.end;
+            let excerpt = if start.line == end.line {
+                lines
+                    .get(start.line)
+                    .map(|l| {
+                        let s = start.column.min(l.len());
+                        let e = end.column.min(l.len());
+                        &l[s..e]
+                    })
+                    .unwrap_or("")
+            } else {
+                lines
+                    .get(start.line)
+                    .map(|l| {
+                        let s = start.column.min(l.len());
+                        &l[s..]
+                    })
+                    .unwrap_or("")
+            };
+            println!(
+                "{}:{}-{}:{}  {}  \"{}\"",
+                start.line + 1,
+                start.column + 1,
+                end.line + 1,
+                end.column + 1,
+                token.kind.as_str(),
+                excerpt,
+            );
+        }
     }
 }
 

--- a/crates/lex-cli/src/transforms.rs
+++ b/crates/lex-cli/src/transforms.rs
@@ -30,6 +30,7 @@
 //!
 //! Example: `lex inspect file.lex ast-tag --ast-full`
 
+use lex_analysis::semantic_tokens::collect_semantic_tokens;
 use lex_babel::formats::{
     linetreeviz::to_linetreeviz_str_with_params, nodemap::to_nodemap_str_with_params,
     tag::serialize_document_with_params as serialize_ast_tag_with_params,
@@ -58,6 +59,8 @@ pub const AVAILABLE_TRANSFORMS: &[&str] = &[
     "ast-treeviz",
     "ast-linetreeviz",
     "ast-nodemap",
+    "semantic-tokens",
+    "semantic-tokens-json",
 ];
 
 /// Execute a named transform on a source file with optional extra parameters
@@ -201,6 +204,21 @@ pub fn execute_transform(
                 .parse()
                 .map_err(|e| format!("Transform failed: {e}"))?;
             Ok(to_nodemap_str_with_params(&doc, source, &params))
+        }
+        "semantic-tokens" => {
+            let doc = loader
+                .parse()
+                .map_err(|e| format!("Transform failed: {e}"))?;
+            Ok(semantic_tokens_to_simple(&doc, source))
+        }
+        "semantic-tokens-json" => {
+            let doc = loader
+                .parse()
+                .map_err(|e| format!("Transform failed: {e}"))?;
+            Ok(
+                serde_json::to_string_pretty(&semantic_tokens_to_json(&doc, source))
+                    .map_err(|e| format!("JSON serialization failed: {e}"))?,
+            )
         }
         _ => Err(format!("Unknown transform: {transform_name}")),
     }
@@ -508,6 +526,97 @@ fn sequence_marker_to_json(
         "separator": format!("{}", marker.separator),
         "form": format!("{}", marker.form),
     })
+}
+
+/// Format semantic tokens as one line per token:
+///   startLine:startCol-endLine:endCol  TokenKind  "text excerpt"
+fn semantic_tokens_to_simple(doc: &lex_core::lex::parsing::Document, source: &str) -> String {
+    let tokens = collect_semantic_tokens(doc);
+    let lines: Vec<&str> = source.lines().collect();
+    let mut output = String::new();
+
+    for token in &tokens {
+        let start = &token.range.start;
+        let end = &token.range.end;
+
+        // Extract text excerpt from source (single-line only for readability)
+        let excerpt = if start.line == end.line {
+            lines
+                .get(start.line)
+                .map(|l| {
+                    let s = start.column.min(l.len());
+                    let e = end.column.min(l.len());
+                    &l[s..e]
+                })
+                .unwrap_or("")
+        } else {
+            lines
+                .get(start.line)
+                .map(|l| {
+                    let s = start.column.min(l.len());
+                    &l[s..]
+                })
+                .unwrap_or("")
+        };
+
+        // 1-based line and column numbers for display
+        output.push_str(&format!(
+            "{}:{}-{}:{}  {}  \"{}\"\n",
+            start.line + 1,
+            start.column + 1,
+            end.line + 1,
+            end.column + 1,
+            token.kind.as_str(),
+            excerpt.chars().take(60).collect::<String>(),
+        ));
+    }
+
+    output
+}
+
+/// Format semantic tokens as JSON array
+fn semantic_tokens_to_json(
+    doc: &lex_core::lex::parsing::Document,
+    source: &str,
+) -> serde_json::Value {
+    use serde_json::json;
+
+    let tokens = collect_semantic_tokens(doc);
+    let lines: Vec<&str> = source.lines().collect();
+
+    json!(tokens
+        .iter()
+        .map(|token| {
+            let start = &token.range.start;
+            let end = &token.range.end;
+            let excerpt = if start.line == end.line {
+                lines
+                    .get(start.line)
+                    .map(|l| {
+                        let s = start.column.min(l.len());
+                        let e = end.column.min(l.len());
+                        l[s..e].to_string()
+                    })
+                    .unwrap_or_default()
+            } else {
+                lines
+                    .get(start.line)
+                    .map(|l| {
+                        let s = start.column.min(l.len());
+                        l[s..].to_string()
+                    })
+                    .unwrap_or_default()
+            };
+            json!({
+                "kind": token.kind.as_str(),
+                "start_line": start.line + 1,
+                "start_col": start.column + 1,
+                "end_line": end.line + 1,
+                "end_col": end.column + 1,
+                "text": excerpt,
+            })
+        })
+        .collect::<Vec<_>>())
 }
 
 #[cfg(test)]

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -33,6 +33,14 @@
 (verbatim_block
   (list) @markup.raw)
 
+; Verbatim closing metadata — annotation nodes inside verbatim_block are
+; the closing `:: label ::` line (LSP: VerbatimLanguage/VerbatimAttribute).
+; These MUST appear before generic annotation captures to take priority.
+(verbatim_block
+  (annotation_marker) @markup.raw.block)
+(verbatim_block
+  (annotation_header) @markup.raw.block)
+
 ; === Lists ===
 ; List item lines — ONLY inside list_item nodes (LSP: ListMarker + ListItemText)
 ; list_item_line also appears as line_content in session titles, where it


### PR DESCRIPTION
## Summary

- Add `lex inspect file.lex semantic-tokens` and `semantic-tokens-json` transforms to the CLI — outputs the reference parser's semantic token classification with positions and text excerpts
- Add `lex token-at file.lex <line> <col>` subcommand — shows semantic tokens at a specific position (1-based line and column, consistent with `element-at`)
- Fix `highlights.scm`: verbatim closing `:: label ::` lines now correctly tagged as `markup.raw.block` instead of annotation captures

These tools enable direct comparison between tree-sitter highlights and the reference parser without needing an editor runtime. Running both on `010-kitchensink.lex` reveals the actual structural gap between the two parsers.

## Test plan

- [ ] `lex inspect comms/specs/benchmark/010-kitchensink.lex semantic-tokens` produces token listing
- [ ] `lex token-at comms/specs/benchmark/010-kitchensink.lex 50 8` returns `VerbatimLanguage`
- [ ] `tree-sitter query queries/highlights.scm` on kitchen-sink shows `markup.raw.block` for verbatim closing lines
- [ ] All 1325 tests pass, all 55 tree-sitter corpus tests pass

Refs #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)