### PR TITLE
Rewrite semantic token layer to use InlineNode from AST

### DIFF
--- a/crates/lex-analysis/src/completion.rs
+++ b/crates/lex-analysis/src/completion.rs
@@ -15,8 +15,7 @@
 //! in the current document. For cross-document completion (e.g., bibliography
 //! entries), the LSP layer would need to aggregate from multiple sources.
 
-use crate::inline::InlineSpanKind;
-use crate::utils::{for_each_annotation, reference_span_at_position, session_identifier};
+use crate::utils::{for_each_annotation, reference_at_position, session_identifier};
 use ignore::WalkBuilder;
 use lex_core::lex::ast::links::LinkType;
 use lex_core::lex::ast::{ContentItem, Document, Position, Session};
@@ -191,10 +190,7 @@ fn detect_context(
     if is_at_potential_verbatim_start(document, position, current_line) {
         return CompletionContext::VerbatimLabel;
     }
-    if reference_span_at_position(document, position)
-        .map(|span| matches!(span.kind, InlineSpanKind::Reference(_)))
-        .unwrap_or(false)
-    {
+    if reference_at_position(document, position).is_some() {
         return CompletionContext::Reference;
     }
     CompletionContext::General

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use crate::inline::{extract_inline_spans, InlineSpanKind};
+use crate::inline::extract_references;
 use crate::utils::for_each_text_content;
 use lex_core::lex::ast::{Document, Range};
 use lex_core::lex::inlines::ReferenceType;
@@ -26,17 +26,9 @@ fn check_footnotes(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic
     // 1. Collect all footnote references
     let mut references = Vec::new();
     for_each_text_content(document, &mut |text| {
-        for span in extract_inline_spans(text) {
-            if let InlineSpanKind::Reference(ReferenceType::FootnoteNumber { number }) = span.kind {
-                references.push((number, span.range));
-            } else if let InlineSpanKind::Reference(ReferenceType::FootnoteLabeled { label: _ }) =
-                span.kind
-            {
-                // We handle numeric footnotes primarily as per request, but let's track labels too if needed.
-                // For now, the user specifically mentioned numeric reordering and validation.
-                // Let's stick to numeric for the specific "footnote" validation if the user context implies it.
-                // Actually, the user said "add diagnotics for mismatched footnotes".
-                // Let's handle both if possible, but the renumbering task implies numeric.
+        for reference in extract_references(text) {
+            if let ReferenceType::FootnoteNumber { number } = reference.reference_type {
+                references.push((number, reference.range));
             }
         }
     });

--- a/crates/lex-analysis/src/go_to_definition.rs
+++ b/crates/lex-analysis/src/go_to_definition.rs
@@ -1,20 +1,17 @@
-use crate::inline::InlineSpanKind;
 use crate::reference_targets::targets_from_annotation;
 use crate::reference_targets::{targets_from_reference_type, ReferenceTarget};
 use crate::references::reference_occurrences;
 use crate::utils::{
     find_annotation_at_position, find_definitions_by_subject, find_sessions_by_identifier,
-    reference_span_at_position,
+    reference_at_position,
 };
 use lex_core::lex::ast::traits::AstNode;
 use lex_core::lex::ast::{Document, Position, Range};
 
 pub fn goto_definition(document: &Document, position: Position) -> Vec<Range> {
-    if let Some(span) = reference_span_at_position(document, position) {
-        if let InlineSpanKind::Reference(reference_type) = span.kind {
-            let targets = targets_from_reference_type(&reference_type);
-            return resolve_targets(document, &targets);
-        }
+    if let Some(reference) = reference_at_position(document, position) {
+        let targets = targets_from_reference_type(&reference.reference_type);
+        return resolve_targets(document, &targets);
     }
 
     // Reverse lookup: If we are on an annotation (footnote definition), go to references

--- a/crates/lex-analysis/src/hover.rs
+++ b/crates/lex-analysis/src/hover.rs
@@ -1,7 +1,6 @@
-use crate::inline::{extract_inline_spans, InlineSpanKind};
 use crate::utils::{
     find_annotation_at_position, find_definition_by_subject, find_session_at_position,
-    for_each_text_content, session_identifier,
+    reference_at_position, session_identifier,
 };
 use lex_core::lex::ast::{Annotation, ContentItem, Document, Position, Range};
 use lex_core::lex::inlines::ReferenceType;
@@ -19,26 +18,13 @@ pub fn hover(document: &Document, position: Position) -> Option<HoverResult> {
 }
 
 fn inline_hover(document: &Document, position: Position) -> Option<HoverResult> {
-    let mut result = None;
-    for_each_text_content(document, &mut |text| {
-        if result.is_some() {
-            return;
-        }
-        for span in extract_inline_spans(text) {
-            if span.range.contains(position) {
-                result = match span.kind {
-                    InlineSpanKind::Reference(reference_type) => {
-                        hover_for_reference(document, &span.range, &span.raw, reference_type)
-                    }
-                    _ => None,
-                };
-                if result.is_some() {
-                    break;
-                }
-            }
-        }
-    });
-    result
+    let reference = reference_at_position(document, position)?;
+    hover_for_reference(
+        document,
+        &reference.range,
+        &reference.raw,
+        reference.reference_type,
+    )
 }
 
 fn hover_for_reference(

--- a/crates/lex-analysis/src/inline.rs
+++ b/crates/lex-analysis/src/inline.rs
@@ -1,249 +1,155 @@
+//! Inline-level analysis utilities.
+//!
+//! Extracts positioned references from text content by walking the AST's InlineNode
+//! tree and raw source text in parallel to compute correct byte positions.
+
 use lex_core::lex::ast::{Position, Range, TextContent};
-use lex_core::lex::inlines::{parse_inlines, InlineNode, ReferenceType};
+use lex_core::lex::inlines::{InlineNode, ReferenceInline, ReferenceType};
 
+/// A reference found in inline text, with its source position and classified type.
 #[derive(Debug, Clone, PartialEq)]
-pub enum InlineSpanKind {
-    Strong,
-    Emphasis,
-    Code,
-    Math,
-    Reference(ReferenceType),
-    StrongMarkerStart,
-    StrongMarkerEnd,
-    EmphasisMarkerStart,
-    EmphasisMarkerEnd,
-    CodeMarkerStart,
-    CodeMarkerEnd,
-    MathMarkerStart,
-    MathMarkerEnd,
-    RefMarkerStart,
-    RefMarkerEnd,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct InlineSpan {
-    pub kind: InlineSpanKind,
+pub struct PositionedReference {
     pub range: Range,
+    pub reference_type: ReferenceType,
     pub raw: String,
 }
 
-/// Extract inline spans (formatting + references) from a text node.
-pub fn extract_inline_spans(text: &TextContent) -> Vec<InlineSpan> {
+/// Extract all references from a text node with their source positions.
+///
+/// Walks the InlineNode tree (from `TextContent::inline_items()`) and the raw source
+/// text in parallel. Non-reference nodes (Plain, Strong, Emphasis, Code, Math) are
+/// skipped over — only Reference nodes produce output.
+pub fn extract_references(text: &TextContent) -> Vec<PositionedReference> {
     let Some(base_range) = text.location.as_ref() else {
         return Vec::new();
     };
-
-    let content = text.as_string();
-    if content.is_empty() {
+    let raw = text.as_string();
+    if raw.is_empty() {
         return Vec::new();
     }
-
-    let mut spans = Vec::new();
-    spans.extend(spans_from_marker(
-        content,
+    let nodes = text.inline_items();
+    let mut walker = ReferenceWalker {
+        raw,
         base_range,
-        '*',
-        InlineSpanKind::Strong,
-        InlineSpanKind::StrongMarkerStart,
-        InlineSpanKind::StrongMarkerEnd,
-    ));
-    spans.extend(spans_from_marker(
-        content,
-        base_range,
-        '_',
-        InlineSpanKind::Emphasis,
-        InlineSpanKind::EmphasisMarkerStart,
-        InlineSpanKind::EmphasisMarkerEnd,
-    ));
-    spans.extend(spans_from_marker(
-        content,
-        base_range,
-        '`',
-        InlineSpanKind::Code,
-        InlineSpanKind::CodeMarkerStart,
-        InlineSpanKind::CodeMarkerEnd,
-    ));
-    spans.extend(spans_from_marker(
-        content,
-        base_range,
-        '#',
-        InlineSpanKind::Math,
-        InlineSpanKind::MathMarkerStart,
-        InlineSpanKind::MathMarkerEnd,
-    ));
-    spans.extend(reference_spans(content, base_range));
-    spans
+        cursor: 0,
+        refs: Vec::new(),
+    };
+    walker.walk_nodes(&nodes);
+    walker.refs
 }
 
-fn spans_from_marker(
-    text: &str,
-    base_range: &Range,
-    marker: char,
-    content_kind: InlineSpanKind,
-    start_marker_kind: InlineSpanKind,
-    end_marker_kind: InlineSpanKind,
-) -> Vec<InlineSpan> {
-    let mut spans = Vec::new();
-    for (start, end) in scan_symmetric_pairs(text, marker) {
-        let marker_len = marker.len_utf8();
-        let inner_start = start + marker_len;
-        let inner_end = end.saturating_sub(marker_len);
-        if inner_end <= inner_start {
-            continue;
-        }
-
-        // Opening marker
-        spans.push(InlineSpan {
-            kind: start_marker_kind.clone(),
-            range: sub_range(base_range, text, start, inner_start),
-            raw: marker.to_string(),
-        });
-
-        // Content
-        spans.push(InlineSpan {
-            kind: content_kind.clone(),
-            range: sub_range(base_range, text, inner_start, inner_end),
-            raw: text[inner_start..inner_end].to_string(),
-        });
-
-        // Closing marker
-        spans.push(InlineSpan {
-            kind: end_marker_kind.clone(),
-            range: sub_range(base_range, text, inner_end, end),
-            raw: marker.to_string(),
-        });
-    }
-    spans
+struct ReferenceWalker<'a> {
+    raw: &'a str,
+    base_range: &'a Range,
+    cursor: usize,
+    refs: Vec<PositionedReference>,
 }
 
-fn reference_spans(text: &str, base_range: &Range) -> Vec<InlineSpan> {
-    let mut spans = Vec::new();
-    for (start, end) in scan_bracket_pairs(text) {
-        let inner_start = start + '['.len_utf8();
-        let inner_end = end.saturating_sub(']'.len_utf8());
-        if inner_end <= inner_start {
-            continue;
-        }
-        let raw = text[inner_start..inner_end].to_string();
-        let reference_type = classify_reference(&raw);
-
-        // Opening bracket
-        spans.push(InlineSpan {
-            kind: InlineSpanKind::RefMarkerStart,
-            range: sub_range(base_range, text, start, inner_start),
-            raw: "[".to_string(),
-        });
-
-        // Reference content
-        spans.push(InlineSpan {
-            kind: InlineSpanKind::Reference(reference_type),
-            range: sub_range(base_range, text, inner_start, inner_end),
-            raw,
-        });
-
-        // Closing bracket
-        spans.push(InlineSpan {
-            kind: InlineSpanKind::RefMarkerEnd,
-            range: sub_range(base_range, text, inner_end, end),
-            raw: "]".to_string(),
-        });
-    }
-    spans
-}
-
-fn classify_reference(raw: &str) -> ReferenceType {
-    let wrapped = format!("[{raw}]");
-    for node in parse_inlines(&wrapped) {
-        if let InlineNode::Reference { data, .. } = node {
-            return data.reference_type;
+impl<'a> ReferenceWalker<'a> {
+    fn walk_nodes(&mut self, nodes: &[InlineNode]) {
+        for node in nodes {
+            self.walk_node(node);
         }
     }
-    ReferenceType::NotSure
-}
 
-fn scan_symmetric_pairs(text: &str, marker: char) -> Vec<(usize, usize)> {
-    let mut spans = Vec::new();
-    let mut open: Option<usize> = None;
-    let mut escape = false;
-    for (idx, ch) in text.char_indices() {
-        if escape {
-            escape = false;
-            continue;
+    fn walk_node(&mut self, node: &InlineNode) {
+        match node {
+            InlineNode::Plain { text, .. } => self.skip_plain(text),
+            InlineNode::Strong { content, .. } => self.skip_container(content, '*'),
+            InlineNode::Emphasis { content, .. } => self.skip_container(content, '_'),
+            InlineNode::Code { text, .. } => self.skip_literal(text, '`'),
+            InlineNode::Math { text, .. } => self.skip_literal(text, '#'),
+            InlineNode::Reference { data, .. } => self.collect_reference(data),
         }
-        if ch == '\\' {
-            escape = true;
-            continue;
+    }
+
+    fn skip_plain(&mut self, text: &str) {
+        self.advance_unescaped(text);
+    }
+
+    fn skip_container(&mut self, content: &[InlineNode], marker: char) {
+        self.cursor += marker.len_utf8(); // opening marker
+        self.walk_nodes(content);
+        self.cursor += marker.len_utf8(); // closing marker
+    }
+
+    fn skip_literal(&mut self, text: &str, marker: char) {
+        self.cursor += marker.len_utf8(); // opening marker
+        self.cursor += text.len(); // verbatim content
+        self.cursor += marker.len_utf8(); // closing marker
+    }
+
+    fn collect_reference(&mut self, data: &ReferenceInline) {
+        self.cursor += 1; // opening '['
+
+        let content_start = self.cursor;
+        self.cursor += data.raw.len();
+        let content_end = self.cursor;
+
+        self.cursor += 1; // closing ']'
+
+        if content_start < content_end {
+            self.refs.push(PositionedReference {
+                range: self.make_range(content_start, content_end),
+                reference_type: data.reference_type.clone(),
+                raw: data.raw.clone(),
+            });
         }
-        if ch == marker {
-            if let Some(start_idx) = open {
-                if idx > start_idx + marker.len_utf8() {
-                    spans.push((start_idx, idx + marker.len_utf8()));
+    }
+
+    /// Advance cursor through raw text matching unescaped plain text.
+    fn advance_unescaped(&mut self, text: &str) {
+        for _expected in text.chars() {
+            if self.cursor >= self.raw.len() {
+                break;
+            }
+            let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
+            if raw_ch == '\\' {
+                let next_ch = self.raw[self.cursor + 1..].chars().next();
+                match next_ch {
+                    Some(nc) if !nc.is_alphanumeric() => {
+                        // Escaped: raw `\X` → unescaped `X`
+                        self.cursor += 1 + nc.len_utf8();
+                    }
+                    _ => {
+                        // Literal backslash
+                        self.cursor += 1;
+                    }
                 }
-                open = None;
             } else {
-                open = Some(idx);
+                self.cursor += raw_ch.len_utf8();
             }
         }
     }
-    spans
-}
 
-fn scan_bracket_pairs(text: &str) -> Vec<(usize, usize)> {
-    let mut spans = Vec::new();
-    let mut open: Option<usize> = None;
-    let mut escape = false;
-    for (idx, ch) in text.char_indices() {
-        if escape {
-            escape = false;
-            continue;
-        }
-        if ch == '\\' {
-            escape = true;
-            continue;
-        }
-        if ch == '[' {
-            if open.is_none() {
-                open = Some(idx);
-            }
-        } else if ch == ']' {
-            if let Some(start_idx) = open.take() {
-                if idx > start_idx + '['.len_utf8() {
-                    spans.push((start_idx, idx + ']'.len_utf8()));
-                }
+    fn make_range(&self, start: usize, end: usize) -> Range {
+        let start_pos = self.position_at(start);
+        let end_pos = self.position_at(end);
+        Range::new(
+            (self.base_range.span.start + start)..(self.base_range.span.start + end),
+            start_pos,
+            end_pos,
+        )
+    }
+
+    fn position_at(&self, offset: usize) -> Position {
+        let mut line = self.base_range.start.line;
+        let mut column = self.base_range.start.column;
+        for ch in self.raw[..offset].chars() {
+            if ch == '\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += ch.len_utf8();
             }
         }
+        Position::new(line, column)
     }
-    spans
-}
-
-fn sub_range(base: &Range, text: &str, start: usize, end: usize) -> Range {
-    let start_pos = position_for_offset(base, text, start);
-    let end_pos = position_for_offset(base, text, end);
-    Range::new(
-        (base.span.start + start)..(base.span.start + end),
-        start_pos,
-        end_pos,
-    )
-}
-
-fn position_for_offset(base: &Range, text: &str, offset: usize) -> Position {
-    let mut line = base.start.line;
-    let mut column = base.start.column;
-    for ch in text[..offset].chars() {
-        if ch == '\n' {
-            line += 1;
-            column = 0;
-        } else {
-            column += ch.len_utf8();
-        }
-    }
-    Position::new(line, column)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lex_core::lex::ast::Range;
 
     fn text_with_range(content: &str, line: usize, column: usize) -> TextContent {
         let start = Position::new(line, column);
@@ -253,51 +159,57 @@ mod tests {
     }
 
     #[test]
-    fn detects_basic_inline_spans() {
-        let text = text_with_range("*bold* _em_ `code` #math#", 2, 4);
-        let spans = extract_inline_spans(&text);
-        // Each inline produces 3 spans: start marker, content, end marker
-        assert_eq!(spans.len(), 12);
-        assert!(spans
+    fn extracts_references_with_classification() {
+        let text = text_with_range("See [^note] and [@spec2024] plus [42]", 0, 0);
+        let refs = extract_references(&text);
+        assert_eq!(refs.len(), 3);
+        assert!(refs
             .iter()
-            .any(|span| matches!(span.kind, InlineSpanKind::Strong)));
-        assert!(spans
+            .any(|r| matches!(r.reference_type, ReferenceType::FootnoteLabeled { .. })));
+        assert!(refs
             .iter()
-            .any(|span| matches!(span.kind, InlineSpanKind::Emphasis)));
-        assert!(spans
+            .any(|r| matches!(r.reference_type, ReferenceType::Citation(_))));
+        assert!(refs
             .iter()
-            .any(|span| matches!(span.kind, InlineSpanKind::Code)));
-        assert!(spans
-            .iter()
-            .any(|span| matches!(span.kind, InlineSpanKind::Math)));
-        assert!(spans
-            .iter()
-            .any(|span| matches!(span.kind, InlineSpanKind::StrongMarkerStart)));
-        assert!(spans
-            .iter()
-            .any(|span| matches!(span.kind, InlineSpanKind::StrongMarkerEnd)));
+            .any(|r| matches!(r.reference_type, ReferenceType::FootnoteNumber { .. })));
     }
 
     #[test]
-    fn detects_references_with_classification() {
-        let text = text_with_range("See [^note] and [@spec2024] plus [42]", 0, 0);
-        let spans = extract_inline_spans(&text);
-        let kinds: Vec<_> = spans
-            .iter()
-            .filter_map(|span| match &span.kind {
-                InlineSpanKind::Reference(reference) => Some(reference.clone()),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(kinds.len(), 3);
-        assert!(kinds
-            .iter()
-            .any(|kind| matches!(kind, ReferenceType::FootnoteLabeled { .. })));
-        assert!(kinds
-            .iter()
-            .any(|kind| matches!(kind, ReferenceType::Citation(_))));
-        assert!(kinds
-            .iter()
-            .any(|kind| matches!(kind, ReferenceType::FootnoteNumber { .. })));
+    fn reference_ranges_are_correct() {
+        let text = text_with_range("Hello [world] end", 0, 0);
+        let refs = extract_references(&text);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].raw, "world");
+        // "world" starts at byte 7 (after "Hello ["), ends at byte 12
+        assert_eq!(refs[0].range.span, 7..12);
+    }
+
+    #[test]
+    fn references_inside_formatting() {
+        let text = text_with_range("*bold [ref]* end", 0, 0);
+        let refs = extract_references(&text);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].raw, "ref");
+    }
+
+    #[test]
+    fn escaped_brackets_not_references() {
+        let text = text_with_range("\\[not a ref\\]", 0, 0);
+        let refs = extract_references(&text);
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn empty_text_returns_nothing() {
+        let text = text_with_range("", 0, 0);
+        let refs = extract_references(&text);
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn no_location_returns_nothing() {
+        let text = TextContent::from_string("Hello [world]".to_string(), None);
+        let refs = extract_references(&text);
+        assert!(refs.is_empty());
     }
 }

--- a/crates/lex-analysis/src/references.rs
+++ b/crates/lex-analysis/src/references.rs
@@ -1,4 +1,4 @@
-use crate::inline::{extract_inline_spans, InlineSpanKind};
+use crate::inline::extract_references;
 use crate::reference_targets::{
     targets_from_annotation, targets_from_definition, targets_from_reference_type,
     targets_from_session, ReferenceTarget,
@@ -6,7 +6,7 @@ use crate::reference_targets::{
 use crate::utils::{
     find_annotation_at_position, find_definition_at_position, find_definitions_by_subject,
     find_session_at_position, find_sessions_by_identifier, for_each_text_content,
-    reference_span_at_position,
+    reference_at_position,
 };
 use lex_core::lex::ast::traits::AstNode;
 use lex_core::lex::ast::{Document, Position, Range};
@@ -31,12 +31,10 @@ pub fn find_references(
 }
 
 fn determine_targets(document: &Document, position: Position) -> Vec<ReferenceTarget> {
-    if let Some(span) = reference_span_at_position(document, position) {
-        if let InlineSpanKind::Reference(reference_type) = span.kind {
-            let targets = targets_from_reference_type(&reference_type);
-            if !targets.is_empty() {
-                return targets;
-            }
+    if let Some(reference) = reference_at_position(document, position) {
+        let targets = targets_from_reference_type(&reference.reference_type);
+        if !targets.is_empty() {
+            return targets;
         }
     }
 
@@ -115,14 +113,12 @@ fn definition_ranges(document: &Document, subject: &str) -> Vec<Range> {
 pub fn reference_occurrences(document: &Document, targets: &[ReferenceTarget]) -> Vec<Range> {
     let mut matches = Vec::new();
     for_each_text_content(document, &mut |text| {
-        for span in extract_inline_spans(text) {
-            if let InlineSpanKind::Reference(reference_type) = span.kind {
-                if targets
-                    .iter()
-                    .any(|target| reference_matches(&reference_type, target))
-                {
-                    matches.push(span.range.clone());
-                }
+        for reference in extract_references(text) {
+            if targets
+                .iter()
+                .any(|target| reference_matches(&reference.reference_type, target))
+            {
+                matches.push(reference.range);
             }
         }
     });

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -38,12 +38,11 @@
 //!
 //! The file editors/vscode/themes/lex-light.json has the reocommended theming for Lex to be used in
 //! tests and so forth.
-use crate::inline::{extract_inline_spans, InlineSpanKind};
 use lex_core::lex::ast::{
-    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Range, Session,
-    TextContent, Verbatim,
+    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Position, Range,
+    Session, TextContent, Verbatim,
 };
-use lex_core::lex::inlines::ReferenceType;
+use lex_core::lex::inlines::{InlineNode, ReferenceType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LexSemanticTokenKind {
@@ -399,46 +398,272 @@ impl TokenCollector {
     }
 
     fn process_text_content(&mut self, text: &TextContent) {
-        for span in extract_inline_spans(text) {
-            let kind = match span.kind {
-                InlineSpanKind::Strong => Some(LexSemanticTokenKind::InlineStrong),
-                InlineSpanKind::Emphasis => Some(LexSemanticTokenKind::InlineEmphasis),
-                InlineSpanKind::Code => Some(LexSemanticTokenKind::InlineCode),
-                InlineSpanKind::Math => Some(LexSemanticTokenKind::InlineMath),
-                InlineSpanKind::Reference(reference_type) => Some(match reference_type {
-                    ReferenceType::Citation(_) => LexSemanticTokenKind::ReferenceCitation,
-                    ReferenceType::FootnoteNumber { .. }
-                    | ReferenceType::FootnoteLabeled { .. } => {
-                        LexSemanticTokenKind::ReferenceFootnote
-                    }
-                    _ => LexSemanticTokenKind::Reference,
-                }),
-                InlineSpanKind::StrongMarkerStart => {
-                    Some(LexSemanticTokenKind::InlineMarkerStrongStart)
-                }
-                InlineSpanKind::StrongMarkerEnd => {
-                    Some(LexSemanticTokenKind::InlineMarkerStrongEnd)
-                }
-                InlineSpanKind::EmphasisMarkerStart => {
-                    Some(LexSemanticTokenKind::InlineMarkerEmphasisStart)
-                }
-                InlineSpanKind::EmphasisMarkerEnd => {
-                    Some(LexSemanticTokenKind::InlineMarkerEmphasisEnd)
-                }
-                InlineSpanKind::CodeMarkerStart => {
-                    Some(LexSemanticTokenKind::InlineMarkerCodeStart)
-                }
-                InlineSpanKind::CodeMarkerEnd => Some(LexSemanticTokenKind::InlineMarkerCodeEnd),
-                InlineSpanKind::MathMarkerStart => {
-                    Some(LexSemanticTokenKind::InlineMarkerMathStart)
-                }
-                InlineSpanKind::MathMarkerEnd => Some(LexSemanticTokenKind::InlineMarkerMathEnd),
-                InlineSpanKind::RefMarkerStart => Some(LexSemanticTokenKind::InlineMarkerRefStart),
-                InlineSpanKind::RefMarkerEnd => Some(LexSemanticTokenKind::InlineMarkerRefEnd),
+        let Some(base_range) = text.location.as_ref() else {
+            return;
+        };
+        let raw = text.as_string();
+        if raw.is_empty() {
+            return;
+        }
+        let nodes = text.inline_items();
+        let mut walker = InlineWalker {
+            raw,
+            base_range,
+            cursor: 0,
+            tokens: &mut self.tokens,
+            in_annotation: self.in_annotation,
+            in_definition: self.in_definition,
+            in_formatted: false,
+        };
+        walker.walk_nodes(&nodes);
+    }
+}
+
+/// Walks the InlineNode tree and raw text in parallel to produce positioned semantic tokens.
+///
+/// The inline parser consumes escape sequences and delimiters, so InlineNode text doesn't
+/// directly correspond to byte offsets in the raw source. This walker maintains a cursor
+/// into the raw text and advances it according to the same rules the inline parser uses,
+/// producing correctly positioned Range values for each token.
+struct InlineWalker<'a> {
+    raw: &'a str,
+    base_range: &'a Range,
+    cursor: usize,
+    tokens: &'a mut Vec<LexSemanticToken>,
+    in_annotation: bool,
+    in_definition: bool,
+    /// True when inside a formatting container (Strong/Emphasis). Plain text inside
+    /// containers is covered by the container's content span, so context-dependent
+    /// tokens (AnnotationContent, DefinitionContent) are suppressed.
+    in_formatted: bool,
+}
+
+impl<'a> InlineWalker<'a> {
+    fn walk_nodes(&mut self, nodes: &[InlineNode]) {
+        for node in nodes {
+            self.walk_node(node);
+        }
+    }
+
+    fn walk_node(&mut self, node: &InlineNode) {
+        match node {
+            InlineNode::Plain { text, .. } => self.walk_plain(text),
+            InlineNode::Strong { content, .. } => self.walk_container(
+                content,
+                '*',
+                LexSemanticTokenKind::InlineStrong,
+                LexSemanticTokenKind::InlineMarkerStrongStart,
+                LexSemanticTokenKind::InlineMarkerStrongEnd,
+            ),
+            InlineNode::Emphasis { content, .. } => self.walk_container(
+                content,
+                '_',
+                LexSemanticTokenKind::InlineEmphasis,
+                LexSemanticTokenKind::InlineMarkerEmphasisStart,
+                LexSemanticTokenKind::InlineMarkerEmphasisEnd,
+            ),
+            InlineNode::Code { text, .. } => self.walk_literal(
+                text,
+                '`',
+                LexSemanticTokenKind::InlineCode,
+                LexSemanticTokenKind::InlineMarkerCodeStart,
+                LexSemanticTokenKind::InlineMarkerCodeEnd,
+            ),
+            InlineNode::Math { text, .. } => self.walk_literal(
+                text,
+                '#',
+                LexSemanticTokenKind::InlineMath,
+                LexSemanticTokenKind::InlineMarkerMathStart,
+                LexSemanticTokenKind::InlineMarkerMathEnd,
+            ),
+            InlineNode::Reference { data, .. } => self.walk_reference(data),
+        }
+    }
+
+    /// Walk a Plain text node, advancing cursor through escape sequences in raw text.
+    /// Emits AnnotationContent or DefinitionContent when inside those contexts.
+    fn walk_plain(&mut self, text: &str) {
+        let start = self.cursor;
+        self.advance_unescaped(text);
+        let end = self.cursor;
+
+        if start < end {
+            let kind = if self.in_formatted {
+                None // Covered by the container's content span
+            } else if self.in_annotation {
+                Some(LexSemanticTokenKind::AnnotationContent)
+            } else if self.in_definition {
+                Some(LexSemanticTokenKind::DefinitionContent)
+            } else {
+                None
             };
             if let Some(kind) = kind {
-                self.push_range(&span.range, kind);
+                self.push(self.make_range(start, end), kind);
             }
+        }
+    }
+
+    /// Walk a container node (Strong/Emphasis) which has an opening marker, children, and closing marker.
+    fn walk_container(
+        &mut self,
+        content: &[InlineNode],
+        marker: char,
+        content_kind: LexSemanticTokenKind,
+        start_marker_kind: LexSemanticTokenKind,
+        end_marker_kind: LexSemanticTokenKind,
+    ) {
+        let marker_len = marker.len_utf8();
+
+        // Opening marker
+        let marker_start = self.cursor;
+        self.cursor += marker_len;
+        self.push(
+            self.make_range(marker_start, self.cursor),
+            start_marker_kind,
+        );
+
+        // Recurse into children — record span boundaries for the content token
+        let content_start = self.cursor;
+        let was_in_formatted = self.in_formatted;
+        self.in_formatted = true;
+        self.walk_nodes(content);
+        self.in_formatted = was_in_formatted;
+        let content_end = self.cursor;
+
+        // Emit a single content span covering all children
+        if content_start < content_end {
+            self.push(self.make_range(content_start, content_end), content_kind);
+        }
+
+        // Closing marker
+        let close_start = self.cursor;
+        self.cursor += marker_len;
+        self.push(self.make_range(close_start, self.cursor), end_marker_kind);
+    }
+
+    /// Walk a literal node (Code/Math) — no escape processing inside.
+    fn walk_literal(
+        &mut self,
+        text: &str,
+        marker: char,
+        content_kind: LexSemanticTokenKind,
+        start_marker_kind: LexSemanticTokenKind,
+        end_marker_kind: LexSemanticTokenKind,
+    ) {
+        let marker_len = marker.len_utf8();
+
+        // Opening marker
+        let marker_start = self.cursor;
+        self.cursor += marker_len;
+        self.push(
+            self.make_range(marker_start, self.cursor),
+            start_marker_kind,
+        );
+
+        // Literal content (verbatim, no escape processing)
+        let content_start = self.cursor;
+        self.cursor += text.len();
+        if content_start < self.cursor {
+            self.push(self.make_range(content_start, self.cursor), content_kind);
+        }
+
+        // Closing marker
+        let close_start = self.cursor;
+        self.cursor += marker_len;
+        self.push(self.make_range(close_start, self.cursor), end_marker_kind);
+    }
+
+    /// Walk a Reference node — literal content wrapped in `[` `]`.
+    fn walk_reference(&mut self, data: &lex_core::lex::inlines::ReferenceInline) {
+        let ref_kind = match &data.reference_type {
+            ReferenceType::Citation(_) => LexSemanticTokenKind::ReferenceCitation,
+            ReferenceType::FootnoteNumber { .. } | ReferenceType::FootnoteLabeled { .. } => {
+                LexSemanticTokenKind::ReferenceFootnote
+            }
+            _ => LexSemanticTokenKind::Reference,
+        };
+
+        // Opening bracket
+        let open_start = self.cursor;
+        self.cursor += 1;
+        self.push(
+            self.make_range(open_start, self.cursor),
+            LexSemanticTokenKind::InlineMarkerRefStart,
+        );
+
+        // Reference content (literal — matches raw verbatim)
+        let content_start = self.cursor;
+        self.cursor += data.raw.len();
+        if content_start < self.cursor {
+            self.push(self.make_range(content_start, self.cursor), ref_kind);
+        }
+
+        // Closing bracket
+        let close_start = self.cursor;
+        self.cursor += 1;
+        self.push(
+            self.make_range(close_start, self.cursor),
+            LexSemanticTokenKind::InlineMarkerRefEnd,
+        );
+    }
+
+    /// Advance the raw-text cursor to match unescaped `text` from an InlineNode::Plain.
+    ///
+    /// The inline parser applies escape rules: `\*` → `*`, `\\` → `\`, but `\n` stays `\n`.
+    /// This function mirrors that logic to track how many raw bytes correspond to each
+    /// unescaped character.
+    fn advance_unescaped(&mut self, text: &str) {
+        for expected in text.chars() {
+            if self.cursor >= self.raw.len() {
+                break;
+            }
+            let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
+            if raw_ch == '\\' {
+                let next_ch = self.raw[self.cursor + 1..].chars().next();
+                match next_ch {
+                    Some(nc) if !nc.is_alphanumeric() => {
+                        // Escaped: raw `\X` maps to unescaped `X`
+                        self.cursor += 1 + nc.len_utf8();
+                    }
+                    _ => {
+                        // Literal backslash: raw `\` stays as `\` in the node
+                        self.cursor += 1;
+                    }
+                }
+            } else {
+                self.cursor += raw_ch.len_utf8();
+            }
+            let _ = expected; // cursor already advanced
+        }
+    }
+
+    fn make_range(&self, start: usize, end: usize) -> Range {
+        let start_pos = self.position_at(start);
+        let end_pos = self.position_at(end);
+        Range::new(
+            (self.base_range.span.start + start)..(self.base_range.span.start + end),
+            start_pos,
+            end_pos,
+        )
+    }
+
+    fn position_at(&self, offset: usize) -> Position {
+        let mut line = self.base_range.start.line;
+        let mut column = self.base_range.start.column;
+        for ch in self.raw[..offset].chars() {
+            if ch == '\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += ch.len_utf8();
+            }
+        }
+        Position::new(line, column)
+    }
+
+    fn push(&mut self, range: Range, kind: LexSemanticTokenKind) {
+        if range.span.start < range.span.end {
+            self.tokens.push(LexSemanticToken { kind, range });
         }
     }
 }
@@ -564,5 +789,59 @@ mod tests {
             .expect("failed to parse empty benchmark fixture");
         let tokens = collect_semantic_tokens(&document);
         assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn emits_annotation_content_for_inline_annotation() {
+        let document = sample_document();
+        let tokens = collect_semantic_tokens(&document);
+        let source = sample_source();
+
+        // The fixture starts with `:: doc.note severity=info :: Document preface.`
+        // "Document preface." is inline annotation content — plain text inside annotation context.
+        let annotation_content = snippets(&tokens, LexSemanticTokenKind::AnnotationContent, source);
+        assert!(
+            annotation_content
+                .iter()
+                .any(|snippet| snippet.contains("Document preface")),
+            "AnnotationContent should be emitted for plain text inside annotations, got: {annotation_content:?}"
+        );
+    }
+
+    #[test]
+    fn annotation_content_excludes_formatted_text() {
+        // Inline formatting within annotation context should get its own token type,
+        // not AnnotationContent — only Plain nodes emit AnnotationContent.
+        let source = ":: note :: Some *bold* text.\n";
+        let document = lex_core::lex::parsing::parse_document(source).expect("failed to parse");
+        let tokens = collect_semantic_tokens(&document);
+
+        let annotation_content: Vec<_> = tokens
+            .iter()
+            .filter(|t| t.kind == LexSemanticTokenKind::AnnotationContent)
+            .map(|t| &source[t.range.span.clone()])
+            .collect();
+
+        // "Some " and " text." should be AnnotationContent, but "bold" should not
+        assert!(
+            annotation_content.iter().any(|s| s.contains("Some")),
+            "Plain text before formatting should be AnnotationContent"
+        );
+        assert!(
+            annotation_content.iter().any(|s| s.contains("text.")),
+            "Plain text after formatting should be AnnotationContent"
+        );
+        assert!(
+            !annotation_content.iter().any(|s| s.contains("bold")),
+            "Formatted text should NOT be AnnotationContent"
+        );
+
+        // "bold" should be InlineStrong
+        let strong: Vec<_> = tokens
+            .iter()
+            .filter(|t| t.kind == LexSemanticTokenKind::InlineStrong)
+            .map(|t| &source[t.range.span.clone()])
+            .collect();
+        assert!(strong.contains(&"bold"));
     }
 }

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -619,15 +619,21 @@ impl<'a> InlineWalker<'a> {
             }
             let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
             if raw_ch == '\\' {
-                let next_ch = self.raw[self.cursor + 1..].chars().next();
-                match next_ch {
-                    Some(nc) if !nc.is_alphanumeric() => {
-                        // Escaped: raw `\X` maps to unescaped `X`
-                        self.cursor += 1 + nc.len_utf8();
-                    }
-                    _ => {
-                        // Literal backslash: raw `\` stays as `\` in the node
-                        self.cursor += 1;
+                if self.cursor + 1 >= self.raw.len() {
+                    // Trailing backslash: treat as literal to mirror parser behavior and
+                    // avoid out-of-bounds slicing on `self.raw[self.cursor + 1..]`.
+                    self.cursor += 1;
+                } else {
+                    let next_ch = self.raw[self.cursor + 1..].chars().next();
+                    match next_ch {
+                        Some(nc) if !nc.is_alphanumeric() => {
+                            // Escaped: raw `\X` maps to unescaped `X`
+                            self.cursor += 1 + nc.len_utf8();
+                        }
+                        _ => {
+                            // Literal backslash: raw `\` stays as `\` in the node
+                            self.cursor += 1;
+                        }
                     }
                 }
             } else {

--- a/crates/lex-analysis/src/utils.rs
+++ b/crates/lex-analysis/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::inline::{extract_inline_spans, InlineSpan, InlineSpanKind};
+use crate::inline::{extract_references, PositionedReference};
 use lex_core::lex::ast::traits::AstNode;
 use lex_core::lex::ast::{
     Annotation, ContentItem, Definition, Document, Position, Session, TextContent,
@@ -259,15 +259,18 @@ pub fn session_identifier(session: &Session) -> Option<String> {
     extract_session_identifier(session.title.as_string())
 }
 
-pub fn reference_span_at_position(document: &Document, position: Position) -> Option<InlineSpan> {
+pub fn reference_at_position(
+    document: &Document,
+    position: Position,
+) -> Option<PositionedReference> {
     let mut result = None;
     for_each_text_content(document, &mut |text| {
         if result.is_some() {
             return;
         }
-        for span in extract_inline_spans(text) {
-            if matches!(span.kind, InlineSpanKind::Reference(_)) && span.range.contains(position) {
-                result = Some(span);
+        for reference in extract_references(text) {
+            if reference.range.contains(position) {
+                result = Some(reference);
                 break;
             }
         }

--- a/crates/lex-lsp/src/features/footnotes.rs
+++ b/crates/lex-lsp/src/features/footnotes.rs
@@ -1,4 +1,4 @@
-use lex_analysis::inline::{extract_inline_spans, InlineSpanKind};
+use lex_analysis::inline::extract_references;
 use lex_analysis::utils::{collect_all_annotations, find_notes_session};
 use lex_core::lex::ast::traits::AstNode;
 use lex_core::lex::ast::{ContentItem, Document, Range, Session, TextContent};
@@ -13,10 +13,9 @@ pub fn reorder_footnotes(document: &Document, source: &str) -> String {
     // 1. Collect all footnote references in order
     // Use local traversal to avoid issues with lex-analysis traversal
     traverse_document(document, &mut |text| {
-        let spans = extract_inline_spans(text);
-        for span in spans {
-            if let InlineSpanKind::Reference(ReferenceType::FootnoteNumber { number }) = span.kind {
-                references.push((number, span.range));
+        for reference in extract_references(text) {
+            if let ReferenceType::FootnoteNumber { number } = reference.reference_type {
+                references.push((number, reference.range));
             }
         }
     });


### PR DESCRIPTION
## Summary

Closes #413.

Eliminates the `extract_inline_spans` bypass across the entire `lex-analysis` crate. This parallel regex-based system re-scanned raw text independently of the AST, had no concept of `Plain` text nodes, and produced incorrect results for escape sequences and nested formatting.

### Commit 1: Rewrite semantic token layer

- **Replaces `process_text_content`** with an `InlineWalker` that consumes `TextContent::inline_items()` — the AST's canonical InlineNode tree
- **Fixes `AnnotationContent` never being emitted**: Plain text inside annotation context now produces `AnnotationContent` tokens. The `in_annotation` / `in_definition` context flags (previously set but never read) are now functional
- **Handles escape sequences**: Walks raw text and InlineNode tree in parallel, mirroring the inline parser's escape rules to compute correct byte positions
- **Suppresses context tokens inside formatted containers**: Plain text inside `*bold*` is covered by the `InlineStrong` span, no duplicate tokens

### Commit 2: Remove bypass from all remaining modules

- **Replaces `extract_inline_spans`** with `extract_references` in `inline.rs` — same InlineWalker pattern, focused on positioned references
- **Deletes `InlineSpanKind`, `InlineSpan`**, and all parallel scanning code (`scan_symmetric_pairs`, `scan_bracket_pairs`, `classify_reference`, etc.)
- **Updates 8 files**: inline.rs, utils.rs, hover.rs, go_to_definition.rs, completion.rs, references.rs, diagnostics.rs, lex-lsp/footnotes.rs
- **Simplifies hover**: `inline_hover` reduced from 15 lines of iteration to 4 lines via `reference_at_position`
- **Net result**: -316 lines of bypass code replaced by +197 lines of AST-driven code

## Test plan

- [x] All 6 semantic_tokens tests pass (2 new)
- [x] All analysis module tests pass (hover, go_to_definition, completion, references, diagnostics)
- [x] lex-lsp footnotes tests pass
- [x] Full workspace: 1260 tests, 0 failures
- [x] Clippy clean
- [x] Verified AnnotationContent emission via `lex inspect ... semantic-tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)