### PR TITLE
Tree-sitter highlight parity with LSP semantic tokens

### DIFF
--- a/.claude/skills/tree-sitter-tooling/SKILL.md
+++ b/.claude/skills/tree-sitter-tooling/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: tree-sitter-tooling
+description: |
+  Guide for working with the Lex tree-sitter grammar, running highlight queries,
+  and comparing tree-sitter output against LSP semantic tokens. Use when:
+  (1) Modifying or debugging the tree-sitter grammar (grammar.js, scanner.c)
+  (2) Editing highlight queries (highlights.scm)
+  (3) Comparing tree-sitter captures against LSP semantic tokens
+  (4) Running tree-sitter tests or error-checking .lex files
+---
+
+# Tree-sitter Tooling for Lex
+
+The tree-sitter grammar lives at `tree-sitter/` in the repo root. It is a separate parser from lex-core — tree-sitter provides fast, synchronous CST parsing for editors, while lex-core provides the authoritative AST via the LSP.
+
+## Setup and Configuration
+
+The tree-sitter CLI requires the grammar directory to be discoverable. The grammar is at `tree-sitter/` (not `tree-sitter-lex/`), so the CLI's `parser-directories` config won't find it by default.
+
+**Use a symlink + temp config for all CLI commands:**
+
+```sh
+# One-time setup (persists until reboot)
+ln -sfn /Users/adebert/h/lex/core/tree-sitter /tmp/tree-sitter-lex
+echo '{"parser-directories":["/tmp"]}' > /tmp/ts-config.json
+```
+
+Then all tree-sitter commands use `--config-path /tmp/ts-config.json`. Always run from the `tree-sitter/` directory:
+
+```sh
+cd /Users/adebert/h/lex/core/tree-sitter
+```
+
+## Key Commands
+
+### Parse a file (CST dump)
+
+```sh
+npx tree-sitter parse ../comms/specs/benchmark/010-kitchensink.lex
+```
+
+No config needed — `parse` uses the local grammar directly.
+
+### Run highlight queries (captures with positions)
+
+```sh
+npx tree-sitter query queries/highlights.scm ../path/to/file.lex \
+  --config-path /tmp/ts-config.json --captures
+```
+
+This shows every capture with its pattern number, scope name, position, and matched text. Use this to verify which scope wins when multiple patterns match.
+
+### Run highlight (colored output)
+
+```sh
+npx tree-sitter highlight --config-path /tmp/ts-config.json ../path/to/file.lex
+```
+
+Shows the file with ANSI colors applied by the highlight queries.
+
+### Run grammar tests
+
+```sh
+npx tree-sitter test
+```
+
+Runs all corpus tests in `test/corpus/*.txt`. No config needed.
+
+### Error-check .lex files
+
+```sh
+bash scripts/error-check.sh ../comms/specs/benchmark/010-kitchensink.lex
+# or check all fixtures:
+bash scripts/error-check.sh
+```
+
+Validates no ERROR nodes in the CST.
+
+### Parity check (CST structure vs lex-core AST)
+
+```sh
+bash scripts/parity-check.sh ../path/to/file.lex --verbose
+```
+
+## Comparing Tree-sitter Highlights vs LSP Semantic Tokens
+
+This is the core verification workflow. Both commands should be run from the repo root (`/Users/adebert/h/lex/core`).
+
+### Step 1: Get LSP semantic tokens
+
+```sh
+cargo run -q -p lex-cli -- inspect comms/specs/benchmark/010-kitchensink.lex semantic-tokens
+```
+
+Output format: `line:col-line:col  TokenType  "text"`
+
+### Step 2: Get tree-sitter highlight captures
+
+```sh
+cd tree-sitter
+npx tree-sitter query queries/highlights.scm ../comms/specs/benchmark/010-kitchensink.lex \
+  --config-path /tmp/ts-config.json --captures
+```
+
+Output format: `pattern: N, capture: N - scope.name, start: (row, col), end: (row, col), text: ...`
+
+Note: tree-sitter uses 0-based lines, LSP output uses 1-based lines.
+
+### Step 3: Compare using the mapping table
+
+The canonical mapping from tree-sitter scopes to LSP token types:
+
+| Tree-sitter scope | LSP token types |
+|---|---|
+| `markup.heading` | `SessionTitleText`, `SessionMarker` |
+| `variable.other.definition` | `DefinitionSubject` |
+| `markup.raw.block` | `VerbatimSubject`, `VerbatimLanguage`, `VerbatimAttribute` |
+| `markup.raw` | `VerbatimContent` |
+| `markup.bold` | `InlineStrong` |
+| `markup.italic` | `InlineEmphasis` |
+| `markup.raw.inline` | `InlineCode` |
+| `markup.math` | `InlineMath` |
+| `markup.link` | `Reference`, `ReferenceCitation`, `ReferenceFootnote` |
+| `markup.list` | `ListMarker`, `ListItemText` |
+| `punctuation.special` | `AnnotationLabel` |
+| `comment` | `AnnotationLabel`, `AnnotationParameter`, `AnnotationContent` |
+| `string.escape` | (no LSP equivalent) |
+
+This mapping is also defined in the VSCode integration test at:
+`/Users/adebert/h/lex/vscode/test/integration/treesitter_parity.test.ts`
+
+## File Locations
+
+| What | Where |
+|---|---|
+| Grammar definition | `tree-sitter/grammar.js` |
+| External scanner | `tree-sitter/src/scanner.c` |
+| Highlight queries | `tree-sitter/queries/highlights.scm` |
+| Corpus tests | `tree-sitter/test/corpus/*.txt` |
+| Error-check script | `tree-sitter/scripts/error-check.sh` |
+| Parity-check script | `tree-sitter/scripts/parity-check.sh` |
+| Generated parser | `tree-sitter/src/parser.c` (do not edit) |
+| Node types | `tree-sitter/src/node-types.json` (do not edit) |
+| VSCode parity test | `/Users/adebert/h/lex/vscode/test/integration/treesitter_parity.test.ts` |
+| LSP semantic tokens | `crates/lex-analysis/src/semantic_tokens.rs` |
+| Kitchen-sink benchmark | `comms/specs/benchmark/010-kitchensink.lex` |
+
+## highlights.scm Precedence Rules
+
+In tree-sitter queries, **LATER patterns override earlier ones** when multiple patterns match the same node. This means:
+
+1. Put generic patterns first (e.g., `(annotation_marker) @punctuation.special`)
+2. Put specific overrides after (e.g., `(verbatim_block (annotation_marker)) @markup.raw.block`)
+
+The specific pattern wins because it appears later in the file.
+
+## Known Limitations
+
+These are grammar-level limitations tracked in GitHub issues:
+
+- **#416**: `list_item_line` and `annotation_inline_text` are leaf nodes — inline formatting (`*bold*`, `[ref]`, `` `code` ``) inside them is not parsed
+- **#417**: List markers and session markers are not separated from content text — `- Item` is one `markup.list` span, `1. Title` is one `markup.heading` span
+
+## Regenerating the Parser
+
+After editing `grammar.js`:
+
+```sh
+npx tree-sitter generate
+npx tree-sitter test
+```
+
+After editing `src/scanner.c`, just rebuild and test:
+
+```sh
+npx tree-sitter test
+```

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ comms/specs/**/*.treeviz.*
 
 # Proptest regression files
 **/proptest-regressions/
+.padz

--- a/crates/lex-core/tests/proptest_references.rs
+++ b/crates/lex-core/tests/proptest_references.rs
@@ -83,7 +83,9 @@ fn file_target_strategy() -> impl Strategy<Value = String> {
 fn general_target_strategy() -> impl Strategy<Value = String> {
     "[A-Z][a-zA-Z0-9 ]{1,20}"
         .prop_map(|s| s.trim_end().to_string())
-        .prop_filter("must not be empty", |s| !s.is_empty())
+        .prop_filter("must not be empty or reserved", |s| {
+            !s.is_empty() && !s.eq_ignore_ascii_case("TK")
+        })
 }
 
 // =============================================================================

--- a/tree-sitter/grammar.js
+++ b/tree-sitter/grammar.js
@@ -4,18 +4,19 @@
 /**
  * Tree-sitter grammar for the Lex document format.
  *
- * The external scanner detects line-level tokens (list lines, annotation
+ * The external scanner detects line-level tokens (list markers, annotation
  * markers) because tree-sitter's longest-match lexer rule would otherwise
  * always prefer text_content (/[^\n]+/) over shorter prefixes.
  *
  * Token strategy:
- * - Scanner emits full-line tokens: list_item_line (entire line with marker)
+ * - Scanner emits list_marker (just the marker: "- ", "1. ", etc.)
+ * - Scanner emits full-line token: subject_content (line ending with :)
  * - Scanner emits annotation_marker (:: prefix) and annotation_end_marker
  * - Scanner emits emphasis delimiters: _strong_open, _strong_close,
  *   _emphasis_open, _emphasis_close (with flanking validation)
  * - Scanner emits _session_break: blank line(s) + indent increase (lookahead)
- * - Grammar lexer emits: subject_content (line ending with :), text_content,
- *   inline tokens (code_span, math_span, reference, escape_sequence)
+ * - Grammar lexer emits: text_content (inline-aware), inline tokens
+ *   (code_span, math_span, reference, escape_sequence)
  * - INDENT/DEDENT/NEWLINE are always from scanner
  *
  * Session disambiguation:
@@ -35,7 +36,7 @@ module.exports = grammar({
     $._newline,
     $.annotation_marker, // ":: " at line start
     $.annotation_end_marker, // "::" alone on a line (closing marker)
-    $.list_item_line, // entire line starting with list marker (- , 1. , etc.)
+    $.list_marker, // list marker only: "- ", "1. ", "a) ", etc.
     $.subject_content, // entire line ending with : (scanner verifies EOL)
     $._strong_open, // opening * validated by scanner flanking rules
     $._strong_close, // closing * validated by scanner flanking rules
@@ -47,7 +48,7 @@ module.exports = grammar({
   extras: (_$) => [],
 
   conflicts: ($) => [
-    // list_item_line can start a list_item or line_content (paragraph text)
+    // list_marker can start a list_item or line_content (paragraph/session text)
     [$.list_item, $.line_content],
     // blank_line after dedent: part of list_item's trailing blanks or next block
     [$.list_item],
@@ -133,7 +134,8 @@ module.exports = grammar({
 
     list_item: ($) =>
       seq(
-        $.list_item_line,
+        $.list_marker,
+        optional($.text_content),
         $._newline,
         optional(
           seq(
@@ -182,7 +184,11 @@ module.exports = grammar({
     text_line: ($) => seq($.line_content, $._newline),
 
     line_content: ($) =>
-      choice($.list_item_line, $.subject_content, $.text_content),
+      choice(
+        seq($.list_marker, optional($.text_content)),
+        $.subject_content,
+        $.text_content,
+      ),
 
     // ===== Inline-Aware Text Content =====
     text_content: ($) => repeat1($._inline),

--- a/tree-sitter/grammar.js
+++ b/tree-sitter/grammar.js
@@ -246,7 +246,71 @@ module.exports = grammar({
 
     code_span: (_$) => /`[^`\n]+`/,
     math_span: (_$) => /#[^#\n]+#/,
-    reference: (_$) => /\[[^\]\n]+\]/,
+
+    // Reference types — lexically distinguished by prefix/content.
+    // Mirrors the classification in lex-core/src/lex/inlines/references.rs.
+    // Order matters: token.immediate() alternatives are tried by specificity.
+    reference: ($) =>
+      choice(
+        $.citation_reference,
+        $.footnote_reference,
+        $.url_reference,
+        $.file_reference,
+        $.session_reference,
+        $.tocome_reference,
+        $.number_reference,
+        $.general_reference,
+      ),
+
+    // [@key] or [@key, p.42] — citation
+    citation_reference: (_$) => token(seq("[", "@", /[^\]\n]+/, "]")),
+
+    // [^label] — labeled footnote
+    footnote_reference: (_$) => token(seq("[", "^", /[^\]\n]+/, "]")),
+
+    // [https://...], [http://...], [mailto:...] — URL
+    url_reference: (_$) =>
+      token(
+        choice(
+          seq("[", "https://", /[^\]\n]+/, "]"),
+          seq("[", "http://", /[^\]\n]+/, "]"),
+          seq("[", "mailto:", /[^\]\n]+/, "]"),
+        ),
+      ),
+
+    // [./...], [../...], [/...] — file path
+    file_reference: (_$) =>
+      token(
+        choice(
+          seq("[", "./", /[^\]\n]*/, "]"),
+          seq("[", "../", /[^\]\n]*/, "]"),
+          seq("[", "/", /[^\]\n]+/, "]"),
+        ),
+      ),
+
+    // [#digits.dashes] — session reference
+    session_reference: (_$) => token(seq("[", "#", /[0-9][0-9.\-]*/, "]")),
+
+    // [TK] or [TK-identifier] — to-come placeholder (case insensitive)
+    tocome_reference: (_$) =>
+      token(
+        choice(
+          seq("[", choice("TK", "tk", "Tk", "tK"), "]"),
+          seq(
+            "[",
+            choice("TK-", "tk-", "Tk-", "tK-"),
+            /[a-z0-9]+/,
+            "]",
+          ),
+        ),
+      ),
+
+    // [42] — numbered footnote (digits only)
+    number_reference: (_$) => token(seq("[", /[0-9]+/, "]")),
+
+    // [anything else] — general reference (fallback)
+    general_reference: (_$) => /\[[^\]\n]+\]/,
+
     escape_sequence: (_$) => /\\[^a-zA-Z0-9\n]/,
 
     _word: ($) => choice($._word_alnum, $._word_space, $._word_other),

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -72,5 +72,17 @@
 (emphasis) @markup.italic
 (code_span) @markup.raw.inline
 (math_span) @markup.math
-(reference) @markup.link
 (escape_sequence) @string.escape
+
+; === References (typed) ===
+; Generic fallback — all references are links
+(reference) @markup.link
+
+; Specific reference type overrides (later = higher priority)
+(citation_reference) @markup.link
+(footnote_reference) @markup.link
+(url_reference) @markup.link.url
+(file_reference) @markup.link.url
+(session_reference) @markup.link
+(tocome_reference) @constant.builtin
+(number_reference) @markup.link

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -8,6 +8,10 @@
 ;
 ; Reference: lex-analysis/src/semantic_tokens.rs defines the authoritative
 ; LSP token types. This file mirrors that mapping at CST granularity.
+;
+; PRECEDENCE: In tree-sitter queries, LATER patterns override earlier ones
+; when multiple patterns match the same node. Specific overrides (e.g.
+; verbatim closing markers) must appear AFTER their generic counterparts.
 
 ; === Sessions ===
 ; Session titles are headings (LSP: SessionTitleText)
@@ -33,14 +37,6 @@
 (verbatim_block
   (list) @markup.raw)
 
-; Verbatim closing metadata — annotation nodes inside verbatim_block are
-; the closing `:: label ::` line (LSP: VerbatimLanguage/VerbatimAttribute).
-; These MUST appear before generic annotation captures to take priority.
-(verbatim_block
-  (annotation_marker) @markup.raw.block)
-(verbatim_block
-  (annotation_header) @markup.raw.block)
-
 ; === Lists ===
 ; List item lines — ONLY inside list_item nodes (LSP: ListMarker + ListItemText)
 ; list_item_line also appears as line_content in session titles, where it
@@ -48,7 +44,7 @@
 (list_item
   (list_item_line) @markup.list)
 
-; === Annotations ===
+; === Annotations (generic) ===
 ; Annotation delimiters (LSP: part of AnnotationLabel)
 (annotation_marker) @punctuation.special
 (annotation_end_marker) @punctuation.special
@@ -62,6 +58,15 @@
 ; Annotation block body content (LSP: AnnotationContent)
 (annotation_block
   (_) @comment)
+
+; === Verbatim closing metadata (overrides generic annotation captures) ===
+; Annotation nodes inside verbatim_block are the closing `:: label ::` line
+; (LSP: VerbatimLanguage/VerbatimAttribute). These MUST appear AFTER generic
+; annotation captures so they take priority.
+(verbatim_block
+  (annotation_marker) @markup.raw.block)
+(verbatim_block
+  (annotation_header) @markup.raw.block)
 
 ; === Inline formatting ===
 (strong) @markup.bold

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -18,6 +18,12 @@
 (session
   title: (line_content) @markup.heading)
 
+; Session sequence marker (LSP: SessionMarker) — numbered titles like "1. Title"
+; list_marker inside a session title is structural, not a list item
+(session
+  title: (line_content
+    (list_marker) @punctuation.definition.heading))
+
 ; === Definitions ===
 ; Definition subjects are terms being defined (LSP: DefinitionSubject)
 ; NOT headings — they are variable/term definitions

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -38,11 +38,10 @@
   (list) @markup.raw)
 
 ; === Lists ===
-; List item lines — ONLY inside list_item nodes (LSP: ListMarker + ListItemText)
-; list_item_line also appears as line_content in session titles, where it
-; should NOT be tagged as a list item (it's a heading in that context).
+; List marker (- , 1. , a) , etc.) — captures just the marker portion
+; (LSP: ListMarker). Content is handled by inline captures below.
 (list_item
-  (list_item_line) @markup.list)
+  (list_marker) @markup.list)
 
 ; === Annotations (generic) ===
 ; Annotation delimiters (LSP: part of AnnotationLabel)

--- a/tree-sitter/scripts/cst-to-json.js
+++ b/tree-sitter/scripts/cst-to-json.js
@@ -131,30 +131,9 @@ function extractTitle(node) {
   return extractText(titleNode);
 }
 
-// Extract list marker from list_item_line text (e.g., "- First item" → "-")
-function extractListMarker(text) {
-  if (text.startsWith("- ")) return "-";
-
-  const parenMatch = text.match(/^\(([^)]+)\)\s/);
-  if (parenMatch) return `(${parenMatch[1]})`;
-
-  const orderedMatch = text.match(/^([0-9a-zA-Z.]+[.)]) /);
-  if (orderedMatch) return orderedMatch[1];
-
-  return "";
-}
-
-// Extract list item text (everything after marker)
-function extractListItemText(text) {
-  if (text.startsWith("- ")) return text.substring(2);
-
-  const parenMatch = text.match(/^\([^)]+\)\s(.*)/);
-  if (parenMatch) return parenMatch[1];
-
-  const orderedMatch = text.match(/^[0-9a-zA-Z.]+[.)]\s(.*)/);
-  if (orderedMatch) return orderedMatch[1];
-
-  return text;
+// Extract list marker text, stripping trailing space (e.g., "- " → "-")
+function extractListMarkerText(markerNode) {
+  return extractText(markerNode).replace(/\s+$/, "");
 }
 
 // Convert block children: map blank_lines to BlankLineGroups, convert others
@@ -215,14 +194,17 @@ function convertNode(node) {
     }
 
     case "list_item": {
-      const lineNode = node.children.find((c) => c.tag === "list_item_line");
-      const lineText = lineNode ? extractText(lineNode) : "";
-      const marker = extractListMarker(lineText);
-      const text = extractListItemText(lineText);
+      const markerNode = node.children.find((c) => c.tag === "list_marker");
+      const marker = markerNode ? extractListMarkerText(markerNode) : "";
+      const contentNode = node.children.find((c) => c.tag === "text_content");
+      const text = contentNode ? extractText(contentNode) : "";
 
       const nestedBlocks = convertBlockChildren({
         children: node.children.filter(
-          (c) => c.tag !== "list_item_line" && c.tag !== "blank_line",
+          (c) =>
+            c.tag !== "list_marker" &&
+            c.tag !== "text_content" &&
+            c.tag !== "blank_line",
         ),
       });
 

--- a/tree-sitter/src/grammar.json
+++ b/tree-sitter/src/grammar.json
@@ -645,6 +645,357 @@
       "value": "#[^#\\n]+#"
     },
     "reference": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "citation_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "footnote_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "url_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "file_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "session_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tocome_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "general_reference"
+        }
+      ]
+    },
+    "citation_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "STRING",
+            "value": "@"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\]\\n]+"
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "footnote_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "STRING",
+            "value": "^"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\]\\n]+"
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "url_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "https://"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\]\\n]+"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "http://"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\]\\n]+"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "mailto:"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\]\\n]+"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "file_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "./"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\]\\n]*"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "../"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\]\\n]*"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "/"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\]\\n]+"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "session_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "STRING",
+            "value": "#"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[0-9][0-9.\\-]*"
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "tocome_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "TK"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "tk"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "Tk"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "tK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "TK-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "tk-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "Tk-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "tK-"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[a-z0-9]+"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "number_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "PATTERN",
+            "value": "[0-9]+"
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "general_reference": {
       "type": "PATTERN",
       "value": "\\[[^\\]\\n]+\\]"
     },

--- a/tree-sitter/src/grammar.json
+++ b/tree-sitter/src/grammar.json
@@ -249,7 +249,19 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "list_item_line"
+          "name": "list_marker"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "text_content"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -436,8 +448,25 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "list_item_line"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "list_marker"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "text_content"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -732,7 +761,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "list_item_line"
+      "name": "list_marker"
     },
     {
       "type": "SYMBOL",

--- a/tree-sitter/src/node-types.json
+++ b/tree-sitter/src/node-types.json
@@ -355,6 +355,49 @@
     }
   },
   {
+    "type": "reference",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "citation_reference",
+          "named": true
+        },
+        {
+          "type": "file_reference",
+          "named": true
+        },
+        {
+          "type": "footnote_reference",
+          "named": true
+        },
+        {
+          "type": "general_reference",
+          "named": true
+        },
+        {
+          "type": "number_reference",
+          "named": true
+        },
+        {
+          "type": "session_reference",
+          "named": true
+        },
+        {
+          "type": "tocome_reference",
+          "named": true
+        },
+        {
+          "type": "url_reference",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "session",
     "named": true,
     "fields": {
@@ -564,11 +607,27 @@
     "named": true
   },
   {
+    "type": "citation_reference",
+    "named": true
+  },
+  {
     "type": "code_span",
     "named": true
   },
   {
     "type": "escape_sequence",
+    "named": true
+  },
+  {
+    "type": "file_reference",
+    "named": true
+  },
+  {
+    "type": "footnote_reference",
+    "named": true
+  },
+  {
+    "type": "general_reference",
     "named": true
   },
   {
@@ -580,11 +639,23 @@
     "named": true
   },
   {
-    "type": "reference",
+    "type": "number_reference",
+    "named": true
+  },
+  {
+    "type": "session_reference",
     "named": true
   },
   {
     "type": "subject_content",
+    "named": true
+  },
+  {
+    "type": "tocome_reference",
+    "named": true
+  },
+  {
+    "type": "url_reference",
     "named": true
   }
 ]

--- a/tree-sitter/src/node-types.json
+++ b/tree-sitter/src/node-types.json
@@ -255,11 +255,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
-          "type": "list_item_line",
+          "type": "list_marker",
           "named": true
         },
         {
@@ -317,7 +317,7 @@
           "named": true
         },
         {
-          "type": "list_item_line",
+          "type": "list_marker",
           "named": true
         },
         {
@@ -326,6 +326,10 @@
         },
         {
           "type": "session",
+          "named": true
+        },
+        {
+          "type": "text_content",
           "named": true
         },
         {
@@ -568,7 +572,7 @@
     "named": true
   },
   {
-    "type": "list_item_line",
+    "type": "list_marker",
     "named": true
   },
   {

--- a/tree-sitter/src/scanner.c
+++ b/tree-sitter/src/scanner.c
@@ -4,7 +4,7 @@
  * Handles:
  * - Indentation-based structure (INDENT/DEDENT tokens)
  * - NEWLINE emission at line boundaries and EOF
- * - Line-start detection for annotation markers (::) and list items (full line)
+ * - Line-start detection for annotation markers (::) and list markers
  * - Session boundary detection via lookahead (_session_break)
  * - Emphasis delimiter validation (*strong* and _emphasis_) with flanking rules
  *
@@ -35,7 +35,7 @@
  *   2: _newline
  *   3: annotation_marker
  *   4: annotation_end_marker
- *   5: list_item_line
+ *   5: list_marker
  *   6: subject_content
  *   7: _strong_open
  *   8: _strong_close
@@ -68,7 +68,7 @@ enum TokenType {
     NEWLINE,
     ANNOTATION_MARKER,
     ANNOTATION_END_MARKER,
-    LIST_ITEM_LINE,
+    LIST_MARKER,
     SUBJECT_CONTENT,
     STRONG_OPEN,
     STRONG_CLOSE,
@@ -313,7 +313,7 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
     fprintf(stderr, "] pending=%d lookahead='%c'(%d) valid=[",
             scanner->pending_dedents, lexer->lookahead > 31 ? lexer->lookahead : '?',
             lexer->lookahead);
-    const char *names[] = {"IND","DED","NL","AM","AEM","LIL","SC","SO","SCl","EO","ECl","SB"};
+    const char *names[] = {"IND","DED","NL","AM","AEM","LM","SC","SO","SCl","EO","ECl","SB"};
     for (int i = 0; i <= 11; i++) {
         if (valid_symbols[i]) fprintf(stderr, "%s ", names[i]);
     }
@@ -596,13 +596,15 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
             return false;
         }
 
-        // Try list item line: marker + rest of line (full line token)
-        if (valid_symbols[LIST_ITEM_LINE]) {
+        // Try list marker: just the marker portion (- , 1. , a) , etc.)
+        // Content after the marker is handled by the grammar's text_content
+        // rule, which decomposes inline elements (bold, references, etc.).
+        if (valid_symbols[LIST_MARKER]) {
             if (try_list_marker(lexer)) {
-                // Marker matched — consume the rest of the line
-                consume_rest_of_line(lexer);
                 lexer->mark_end(lexer);
-                lexer->result_symbol = LIST_ITEM_LINE;
+                lexer->result_symbol = LIST_MARKER;
+                // Marker ends with a space — set class for emphasis flanking
+                scanner->last_char_class = CHAR_CLASS_WHITESPACE;
                 return true;
             }
             // Not a list marker — fall through to subject_content check.
@@ -635,13 +637,13 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
 
     // === Not at line start ===
 
-    // Try list item line (e.g., first line after INDENT in a definition body)
-    if (valid_symbols[LIST_ITEM_LINE]) {
+    // Try list marker (e.g., first line after INDENT in a definition body)
+    if (valid_symbols[LIST_MARKER]) {
         lexer->mark_end(lexer);
         if (try_list_marker(lexer)) {
-            consume_rest_of_line(lexer);
             lexer->mark_end(lexer);
-            lexer->result_symbol = LIST_ITEM_LINE;
+            lexer->result_symbol = LIST_MARKER;
+            scanner->last_char_class = CHAR_CLASS_WHITESPACE;
             return true;
         }
         // Not a list marker — fall through

--- a/tree-sitter/test/corpus/annotations.txt
+++ b/tree-sitter/test/corpus/annotations.txt
@@ -103,5 +103,6 @@ Annotation inline text with multiple inlines
     (annotation_header)
     (annotation_marker)
     (annotation_inline_text
-      (reference)
+      (reference
+        (general_reference))
       (code_span))))

--- a/tree-sitter/test/corpus/annotations.txt
+++ b/tree-sitter/test/corpus/annotations.txt
@@ -76,3 +76,32 @@ Block annotation with inline text and body
       (text_line
         (line_content
           (text_content))))))
+
+==================
+Annotation inline text with formatting
+==================
+:: note :: This is *important* text
+---
+
+(document
+  (annotation_single
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)
+    (annotation_inline_text
+      (strong))))
+
+==================
+Annotation inline text with multiple inlines
+==================
+:: note :: See [ref] and `code` here
+---
+
+(document
+  (annotation_single
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)
+    (annotation_inline_text
+      (reference)
+      (code_span))))

--- a/tree-sitter/test/corpus/inlines.txt
+++ b/tree-sitter/test/corpus/inlines.txt
@@ -35,7 +35,8 @@ See [https://example.com] for details
     (text_line
       (line_content
         (text_content
-          (reference))))))
+          (reference
+            (url_reference)))))))
 
 ==================
 Escape sequence
@@ -63,7 +64,8 @@ Text `code` and #math# and [ref]
         (text_content
           (code_span)
           (math_span)
-          (reference))))))
+          (reference
+            (general_reference)))))))
 
 ==================
 Unmatched backtick
@@ -114,8 +116,10 @@ See [Section 1] and [Section 2] for details
     (text_line
       (line_content
         (text_content
-          (reference)
-          (reference))))))
+          (reference
+            (general_reference))
+          (reference
+            (general_reference)))))))
 
 ==================
 Strong (bold)
@@ -197,7 +201,8 @@ Text *bold* _italic_ `code` #math# [ref]
           (emphasis)
           (code_span)
           (math_span)
-          (reference))))))
+          (reference
+            (general_reference)))))))
 
 ==================
 Escaped asterisk not strong
@@ -267,7 +272,8 @@ _see [Section 1] for details_
       (line_content
         (text_content
           (emphasis
-            (reference)))))))
+            (reference
+              (general_reference))))))))
 
 ==================
 Word-adjacent asterisk not strong
@@ -367,3 +373,143 @@ A formula: F = m*a where *a* is acceleration.
       (line_content
         (text_content
           (strong))))))
+
+==================
+Citation reference
+==================
+See [@jones-2023] for details
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (citation_reference)))))))
+
+==================
+Footnote labeled reference
+==================
+As noted [^important] previously
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (footnote_reference)))))))
+
+==================
+URL reference
+==================
+Visit [https://example.com/path] now
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (url_reference)))))))
+
+==================
+File reference
+==================
+See [./data/results.csv] for data
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (file_reference)))))))
+
+==================
+Session reference
+==================
+As discussed in [#3.2] above
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (session_reference)))))))
+
+==================
+ToCome reference bare
+==================
+Add content here [TK] later
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (tocome_reference)))))))
+
+==================
+ToCome reference with identifier
+==================
+Insert [TK-budget] when ready
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (tocome_reference)))))))
+
+==================
+Number reference
+==================
+See footnote [42] for details
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (number_reference)))))))
+
+==================
+All reference types in one line
+==================
+Refs: [@cite] [^fn] [https://url] [./file] [#1] [TK] [42] [General]
+---
+
+(document
+  (paragraph
+    (text_line
+      (line_content
+        (text_content
+          (reference
+            (citation_reference))
+          (reference
+            (footnote_reference))
+          (reference
+            (url_reference))
+          (reference
+            (file_reference))
+          (reference
+            (session_reference))
+          (reference
+            (tocome_reference))
+          (reference
+            (number_reference))
+          (reference
+            (general_reference)))))))

--- a/tree-sitter/test/corpus/lists.txt
+++ b/tree-sitter/test/corpus/lists.txt
@@ -100,7 +100,8 @@ List item with inline formatting
       (list_marker)
       (text_content
         (strong)
-        (reference)))
+        (reference
+          (general_reference))))
     (list_item
       (list_marker)
       (text_content

--- a/tree-sitter/test/corpus/lists.txt
+++ b/tree-sitter/test/corpus/lists.txt
@@ -8,9 +8,11 @@ Simple dash list
 (document
   (list
     (list_item
-      (list_item_line))
+      (list_marker)
+      (text_content))
     (list_item
-      (list_item_line))))
+      (list_marker)
+      (text_content))))
 
 ==================
 Three item dash list
@@ -23,11 +25,14 @@ Three item dash list
 (document
   (list
     (list_item
-      (list_item_line))
+      (list_marker)
+      (text_content))
     (list_item
-      (list_item_line))
+      (list_marker)
+      (text_content))
     (list_item
-      (list_item_line))))
+      (list_marker)
+      (text_content))))
 
 ==================
 Numbered list
@@ -39,9 +44,11 @@ Numbered list
 (document
   (list
     (list_item
-      (list_item_line))
+      (list_marker)
+      (text_content))
     (list_item
-      (list_item_line))))
+      (list_marker)
+      (text_content))))
 
 ==================
 List item with nested content
@@ -54,13 +61,15 @@ List item with nested content
 (document
   (list
     (list_item
-      (list_item_line)
+      (list_marker)
+      (text_content)
       (paragraph
         (text_line
           (line_content
             (text_content)))))
     (list_item
-      (list_item_line))))
+      (list_marker)
+      (text_content))))
 
 ==================
 Alphabetical list
@@ -72,6 +81,62 @@ b. Second
 (document
   (list
     (list_item
-      (list_item_line))
+      (list_marker)
+      (text_content))
     (list_item
-      (list_item_line))))
+      (list_marker)
+      (text_content))))
+
+==================
+List item with inline formatting
+==================
+- Item with *bold* and [ref]
+- Second _italic_ item
+---
+
+(document
+  (list
+    (list_item
+      (list_marker)
+      (text_content
+        (strong)
+        (reference)))
+    (list_item
+      (list_marker)
+      (text_content
+        (emphasis)))))
+
+==================
+List item with code span
+==================
+- Use `command` here
+- Another item
+---
+
+(document
+  (list
+    (list_item
+      (list_marker)
+      (text_content
+        (code_span)))
+    (list_item
+      (list_marker)
+      (text_content))))
+
+==================
+Numbered session title with marker
+==================
+1. Introduction
+
+    Session content here
+---
+
+(document
+  (session
+    title: (line_content
+      (list_marker)
+      (text_content))
+    (paragraph
+      (text_line
+        (line_content
+          (text_content))))))


### PR DESCRIPTION
## Summary

- **Split `list_item_line` into `list_marker` + `text_content`** — the scanner now emits only the marker portion (`- `, `1. `, `a) `), and the grammar's `text_content` rule handles inline decomposition (closes #416, closes #417)
- **Classify reference types lexically** — 8 typed reference variants (`citation_reference`, `footnote_reference`, `url_reference`, `file_reference`, `session_reference`, `tocome_reference`, `number_reference`, `general_reference`) replace the single opaque `reference` regex (closes #409)
- **Add session marker capture** in `highlights.scm` — `list_marker` inside session titles gets `@punctuation.definition.heading` (matches LSP's `SessionMarker`)
- **Fix proptest regression** — `general_target_strategy` excluded `"TK"` which is correctly classified as ToCome per spec
- **Update CST bridge** — `cst-to-json.js` updated for the `list_marker` split
- **Fix verbatim closing marker highlight precedence** (#410)

### Highlight parity status

All visually meaningful LSP semantic token types now have tree-sitter capture equivalents. Remaining gaps are by-design CST limitations (inline delimiter markers, annotation parameter splitting, document title detection) that the LSP overrides in editors anyway.

| Commits | |
|---|---|
| `f1b9cc6c` | Fix verbatim closing marker highlight precedence |
| `414c3df4` | Add tree-sitter-tooling agent skill |
| `4e2c5770` | Fix proptest: exclude "TK" from general reference targets |
| `e57673cf` | Split list_item_line into list_marker + text_content (#416, #417) |
| `6b04c194` | Add test cases for inline formatting in annotation text (#416) |
| `2ef36b49` | Classify reference types lexically (#409) |
| `7fe0b31b` | Update CST bridge, add session marker capture |

## Test plan

- [ ] 69 tree-sitter corpus tests pass (was 55, +14 new)
- [ ] 1332 Rust workspace tests pass
- [ ] 118 spec files parse error-free (1 expected: grammar-inline.lex)
- [ ] Verify inline formatting renders in list items (e.g., `- Item with *bold*`)
- [ ] Verify reference types get distinct highlights (e.g., `[@cite]` vs `[TK]` vs `[#1]`)
- [ ] Verify numbered session titles show marker separately (e.g., `1. Title`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)