### PR TITLE
Tree-sitter: support fullwidth verbatim blocks

### DIFF
--- a/tree-sitter/grammar.js
+++ b/tree-sitter/grammar.js
@@ -43,6 +43,7 @@ module.exports = grammar({
     $._emphasis_open, // opening _ validated by scanner flanking rules
     $._emphasis_close, // closing _ validated by scanner flanking rules
     $._session_break, // blank line(s) + indent increase (scanner lookahead)
+    $.verbatim_content, // fullwidth verbatim: opaque multi-line content block
   ],
 
   extras: (_$) => [],
@@ -107,6 +108,9 @@ module.exports = grammar({
               repeat($.blank_line),
               optional(seq($._indent, repeat1($._block), $._dedent)),
             ),
+            // Fullwidth: content at column 1 (sub-indent-width), scanner
+            // emits an opaque multi-line verbatim_content token
+            seq(repeat($.blank_line), $.verbatim_content),
           ),
           $.annotation_marker,
           $.annotation_header,

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -42,6 +42,8 @@
   (definition) @markup.raw)
 (verbatim_block
   (list) @markup.raw)
+(verbatim_block
+  (verbatim_content) @markup.raw)
 
 ; === Lists ===
 ; List marker (- , 1. , a) , etc.) — captures just the marker portion

--- a/tree-sitter/src/grammar.json
+++ b/tree-sitter/src/grammar.json
@@ -162,6 +162,22 @@
                     ]
                   }
                 ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "blank_line"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "verbatim_content"
+                  }
+                ]
               }
             ]
           },
@@ -1137,6 +1153,10 @@
     {
       "type": "SYMBOL",
       "name": "_session_break"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "verbatim_content"
     }
   ],
   "inline": [],

--- a/tree-sitter/src/node-types.json
+++ b/tree-sitter/src/node-types.json
@@ -590,6 +590,10 @@
         {
           "type": "verbatim_block",
           "named": true
+        },
+        {
+          "type": "verbatim_content",
+          "named": true
         }
       ]
     }
@@ -656,6 +660,10 @@
   },
   {
     "type": "url_reference",
+    "named": true
+  },
+  {
+    "type": "verbatim_content",
     "named": true
   }
 ]

--- a/tree-sitter/src/scanner.c
+++ b/tree-sitter/src/scanner.c
@@ -502,7 +502,9 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
                     } else {
                         line_indent++;
                     }
-                    lexer->advance(lexer, false);
+                    // Skip leading indentation so it is not part of VERBATIM_CONTENT,
+                    // matching how the first content line's indent is handled.
+                    lexer->advance(lexer, true);
                 }
 
                 // Blank line — include in content

--- a/tree-sitter/src/scanner.c
+++ b/tree-sitter/src/scanner.c
@@ -42,6 +42,7 @@
  *   9: _emphasis_open
  *  10: _emphasis_close
  *  11: _session_break
+ *  12: verbatim_content
  *
  * Flanking validation for emphasis delimiters:
  *   Opening: prev char must not be alphanumeric (WORD class), next must be WORD.
@@ -75,6 +76,7 @@ enum TokenType {
     EMPHASIS_OPEN,
     EMPHASIS_CLOSE,
     SESSION_BREAK,
+    VERBATIM_CONTENT,
 };
 
 // Character class for flanking rule context tracking.
@@ -313,8 +315,8 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
     fprintf(stderr, "] pending=%d lookahead='%c'(%d) valid=[",
             scanner->pending_dedents, lexer->lookahead > 31 ? lexer->lookahead : '?',
             lexer->lookahead);
-    const char *names[] = {"IND","DED","NL","AM","AEM","LM","SC","SO","SCl","EO","ECl","SB"};
-    for (int i = 0; i <= 11; i++) {
+    const char *names[] = {"IND","DED","NL","AM","AEM","LM","SC","SO","SCl","EO","ECl","SB","VC"};
+    for (int i = 0; i <= 12; i++) {
         if (valid_symbols[i]) fprintf(stderr, "%s ", names[i]);
     }
     fprintf(stderr, "]\n");
@@ -405,6 +407,19 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
                 int current_indent =
                     scanner->indent_stack[scanner->indent_depth];
                 if (next_indent > current_indent) {
+                    // Fullwidth suppression: if the indent increase is
+                    // sub-INDENT_WIDTH (1-3 spaces) and VERBATIM_CONTENT
+                    // is valid, this is fullwidth verbatim content, not a
+                    // session break. Emit NEWLINE for just the blank line
+                    // so the grammar's fullwidth branch can match.
+                    if (next_indent < INDENT_WIDTH &&
+                        valid_symbols[VERBATIM_CONTENT]) {
+                        lexer->result_symbol = NEWLINE;
+                        scanner->at_line_start = true;
+                        scanner->indent_measured = false;
+                        scanner->last_char_class = CHAR_CLASS_NONE;
+                        return true;
+                    }
                     // Session break confirmed! Update mark_end to include
                     // all blank lines + indent whitespace.
                     lexer->mark_end(lexer);
@@ -458,6 +473,78 @@ bool tree_sitter_lex_external_scanner_scan(void *payload, TSLexer *lexer,
         }
 
         int current_indent = scanner->indent_stack[scanner->indent_depth];
+
+        // Fullwidth verbatim content: indent 1-3 (sub-INDENT_WIDTH) is never
+        // valid normal lex indentation. When VERBATIM_CONTENT is valid (the
+        // grammar is exploring the fullwidth branch of verbatim_block), consume
+        // all lines until :: at subject indent level as an opaque token.
+        // This MUST run before indent handling to prevent spurious DEDENT/INDENT.
+        if (indent > 0 && indent < INDENT_WIDTH &&
+            valid_symbols[VERBATIM_CONTENT]) {
+            int subject_indent = current_indent;
+
+            // Consume the rest of the current line
+            while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
+                lexer->advance(lexer, false);
+            }
+            if (!lexer->eof(lexer)) {
+                lexer->advance(lexer, false); // consume \n
+            }
+            lexer->mark_end(lexer);
+
+            // Consume subsequent lines until closing :: at subject indent
+            while (!lexer->eof(lexer)) {
+                // Measure indent of this line
+                int line_indent = 0;
+                while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+                    if (lexer->lookahead == '\t') {
+                        line_indent += INDENT_WIDTH;
+                    } else {
+                        line_indent++;
+                    }
+                    lexer->advance(lexer, false);
+                }
+
+                // Blank line — include in content
+                if (lexer->lookahead == '\n') {
+                    lexer->advance(lexer, false);
+                    lexer->mark_end(lexer);
+                    continue;
+                }
+
+                if (lexer->eof(lexer)) break;
+
+                // Check for closing :: at subject indent
+                if (line_indent == subject_indent && lexer->lookahead == ':') {
+                    lexer->advance(lexer, false);
+                    if (lexer->lookahead == ':') {
+                        // Found closing annotation — stop.
+                        // mark_end is after the last content line's \n.
+                        break;
+                    }
+                    // Single colon at subject indent — still content
+                    consume_rest_of_line(lexer);
+                    if (!lexer->eof(lexer)) {
+                        lexer->advance(lexer, false); // \n
+                    }
+                    lexer->mark_end(lexer);
+                    continue;
+                }
+
+                // Regular content line
+                consume_rest_of_line(lexer);
+                if (!lexer->eof(lexer)) {
+                    lexer->advance(lexer, false); // \n
+                }
+                lexer->mark_end(lexer);
+            }
+
+            scanner->at_line_start = true;
+            scanner->indent_measured = false;
+            scanner->last_char_class = CHAR_CLASS_NONE;
+            lexer->result_symbol = VERBATIM_CONTENT;
+            return true;
+        }
 
         // Handle indentation changes
         if (indent > current_indent) {

--- a/tree-sitter/test/corpus/verbatim.txt
+++ b/tree-sitter/test/corpus/verbatim.txt
@@ -96,3 +96,71 @@ API Response:
     (annotation_marker)
     (annotation_header)
     (annotation_marker)))
+
+==================
+Fullwidth verbatim block
+==================
+Table:
+ Header | Value
+ Data   | More
+:: table ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (verbatim_content)
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Fullwidth with blank line after subject
+==================
+Table:
+
+ Header | Value
+ Data   | More
+:: table ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (blank_line)
+    (verbatim_content)
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Fullwidth with mixed indent content
+==================
+Wide Table:
+ Alpha  | 10    | baseline
+Beta   | 25    | extended
+ Gamma  | 30    | final
+:: data ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (verbatim_content)
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Fullwidth without content
+==================
+Empty:
+:: label ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))


### PR DESCRIPTION
## Summary

- **New `verbatim_content` scanner token** — opaque multi-line token that captures fullwidth (stretched) verbatim content, bypassing INDENT/DEDENT tracking entirely
- **Session break suppression** — prevents the inflow branch from claiming blank-line-before-fullwidth content (sub-INDENT_WIDTH indent triggers NEWLINE instead of SESSION_BREAK)
- **Highlight query** — `(verbatim_block (verbatim_content) @markup.raw)` for consistent raw styling

### Why a scanner token?

Fullwidth verbatim content sits at column 1 (or even 0), which is below the 4-space indent unit. The standard INDENT/DEDENT machinery can't frame this content — lines at column 0 would trigger spurious DEDENTs in nested contexts. The scanner detects `indent ∈ [1, INDENT_WIDTH)` when `VERBATIM_CONTENT` is valid, then consumes all lines until `::` at the subject's indent level.

### Before / After

| Fixture | Before | After |
|---|---|---|
| `verbatim-14-fullwidth.lex` | `definition` + `paragraph` + `annotation_single` | `verbatim_block` |
| `verbatim-16-fullwidth-nested.lex` | `paragraph` + `definition` + `paragraph` + `annotation_single` + `paragraph` | `paragraph` + `verbatim_block` + `paragraph` |
| `verbatim-17-fullwidth-leading-blank.lex` | `definition` + `annotation_single` | `verbatim_block` |

## Test plan

- [x] 73 tree-sitter corpus tests pass (was 69, +4 new fullwidth tests)
- [x] 1332 Rust workspace tests pass
- [x] 118 spec files parse error-free (1 expected: grammar-inline.lex)
- [x] All 3 fullwidth fixtures (14, 16, 17) produce `verbatim_block` nodes
- [x] Pre-commit hook passes (fmt, clippy, build, test, tree-sitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)