### PR TITLE
Tree-sitter: support verbatim groups

### DIFF
--- a/tree-sitter/grammar.js
+++ b/tree-sitter/grammar.js
@@ -55,10 +55,10 @@ module.exports = grammar({
     [$.list_item],
     // subject_content: definition vs verbatim vs line_content (paragraph text)
     [$.verbatim_block, $.definition, $.line_content],
-    // after dedent: session done vs verbatim continues with closing annotation
-    [$.session, $.verbatim_block],
     // verbatim_block shares structure with definition (no blank lines case)
     [$.verbatim_block, $.definition],
+    // blank lines between verbatim groups: body's repeat vs group_item's repeat
+    [$.verbatim_group_item],
   ],
 
   rules: {
@@ -94,6 +94,9 @@ module.exports = grammar({
       ),
 
     // ===== Verbatim Blocks =====
+    // Verbatim blocks can contain multiple subject/content pairs (groups)
+    // sharing a single closing annotation. The first subject/content lives
+    // directly in verbatim_block; additional pairs are verbatim_group_item nodes.
     verbatim_block: ($) =>
       prec.dynamic(
         4,
@@ -112,10 +115,32 @@ module.exports = grammar({
             // emits an opaque multi-line verbatim_content token
             seq(repeat($.blank_line), $.verbatim_content),
           ),
+          repeat($.verbatim_group_item),
           $.annotation_marker,
           $.annotation_header,
           $.annotation_marker,
           $._newline,
+        ),
+      ),
+
+    // Additional subject/content pair in a verbatim group.
+    verbatim_group_item: ($) =>
+      prec.dynamic(
+        4,
+        prec.right(
+          seq(
+            repeat($.blank_line),
+            field("subject", $.subject_content),
+            $._newline,
+            choice(
+              seq($._session_break, repeat1($._block), $._dedent),
+              seq(
+                repeat($.blank_line),
+                optional(seq($._indent, repeat1($._block), $._dedent)),
+              ),
+              seq(repeat($.blank_line), $.verbatim_content),
+            ),
+          ),
         ),
       ),
 

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -45,6 +45,18 @@
 (verbatim_block
   (verbatim_content) @markup.raw)
 
+; Verbatim group item subjects and content
+(verbatim_group_item
+  subject: (subject_content) @markup.raw.block)
+(verbatim_group_item
+  (paragraph) @markup.raw)
+(verbatim_group_item
+  (definition) @markup.raw)
+(verbatim_group_item
+  (list) @markup.raw)
+(verbatim_group_item
+  (verbatim_content) @markup.raw)
+
 ; === Lists ===
 ; List marker (- , 1. , a) , etc.) — captures just the marker portion
 ; (LSP: ListMarker). Content is handled by inline captures below.

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -44,6 +44,8 @@
   (list) @markup.raw)
 (verbatim_block
   (verbatim_content) @markup.raw)
+(verbatim_block
+  (session) @markup.raw)
 
 ; Verbatim group item subjects and content
 (verbatim_group_item
@@ -56,6 +58,8 @@
   (list) @markup.raw)
 (verbatim_group_item
   (verbatim_content) @markup.raw)
+(verbatim_group_item
+  (session) @markup.raw)
 
 ; === Lists ===
 ; List marker (- , 1. , a) , etc.) — captures just the marker portion

--- a/tree-sitter/queries/injections.scm
+++ b/tree-sitter/queries/injections.scm
@@ -39,3 +39,39 @@
   (annotation_header) @injection.language)
  (#gsub! @injection.language "^%s*(%S+).*$" "%1")
  (#set! injection.combined))
+
+; === Verbatim group items ===
+; Content inside group items also gets language injection from the
+; shared closing annotation.
+
+; Group item paragraphs
+((verbatim_block
+  (verbatim_group_item
+    (paragraph) @injection.content)
+  (annotation_header) @injection.language)
+ (#gsub! @injection.language "^%s*(%S+).*$" "%1")
+ (#set! injection.combined))
+
+; Group item definitions
+((verbatim_block
+  (verbatim_group_item
+    (definition) @injection.content)
+  (annotation_header) @injection.language)
+ (#gsub! @injection.language "^%s*(%S+).*$" "%1")
+ (#set! injection.combined))
+
+; Group item lists
+((verbatim_block
+  (verbatim_group_item
+    (list) @injection.content)
+  (annotation_header) @injection.language)
+ (#gsub! @injection.language "^%s*(%S+).*$" "%1")
+ (#set! injection.combined))
+
+; Group item sessions
+((verbatim_block
+  (verbatim_group_item
+    (session) @injection.content)
+  (annotation_header) @injection.language)
+ (#gsub! @injection.language "^%s*(%S+).*$" "%1")
+ (#set! injection.combined))

--- a/tree-sitter/queries/textobjects.scm
+++ b/tree-sitter/queries/textobjects.scm
@@ -45,3 +45,5 @@
 ; === Parameters (@parameter.outer) ===
 ; List items as "parameters" for item-level navigation
 (list_item) @parameter.outer
+; Verbatim group items for navigating between group pairs
+(verbatim_group_item) @parameter.outer

--- a/tree-sitter/src/grammar.json
+++ b/tree-sitter/src/grammar.json
@@ -182,6 +182,13 @@
             ]
           },
           {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "verbatim_group_item"
+            }
+          },
+          {
             "type": "SYMBOL",
             "name": "annotation_marker"
           },
@@ -198,6 +205,119 @@
             "name": "_newline"
           }
         ]
+      }
+    },
+    "verbatim_group_item": {
+      "type": "PREC_DYNAMIC",
+      "value": 4,
+      "content": {
+        "type": "PREC_RIGHT",
+        "value": 0,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "blank_line"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "subject",
+              "content": {
+                "type": "SYMBOL",
+                "name": "subject_content"
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_newline"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_session_break"
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_block"
+                      }
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_dedent"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "blank_line"
+                      }
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_indent"
+                            },
+                            {
+                              "type": "REPEAT1",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "_block"
+                              }
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_dedent"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "blank_line"
+                      }
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "verbatim_content"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
       }
     },
     "definition": {
@@ -1096,12 +1216,11 @@
       "line_content"
     ],
     [
-      "session",
-      "verbatim_block"
-    ],
-    [
       "verbatim_block",
       "definition"
+    ],
+    [
+      "verbatim_group_item"
     ]
   ],
   "precedences": [],

--- a/tree-sitter/src/node-types.json
+++ b/tree-sitter/src/node-types.json
@@ -594,6 +594,68 @@
         {
           "type": "verbatim_content",
           "named": true
+        },
+        {
+          "type": "verbatim_group_item",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "verbatim_group_item",
+    "named": true,
+    "fields": {
+      "subject": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "subject_content",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "annotation_block",
+          "named": true
+        },
+        {
+          "type": "annotation_single",
+          "named": true
+        },
+        {
+          "type": "blank_line",
+          "named": true
+        },
+        {
+          "type": "definition",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "session",
+          "named": true
+        },
+        {
+          "type": "verbatim_block",
+          "named": true
+        },
+        {
+          "type": "verbatim_content",
+          "named": true
         }
       ]
     }

--- a/tree-sitter/test/corpus/verbatim.txt
+++ b/tree-sitter/test/corpus/verbatim.txt
@@ -164,3 +164,142 @@ Empty:
     (annotation_marker)
     (annotation_header)
     (annotation_marker)))
+
+==================
+Verbatim group with two pairs
+==================
+Install:
+    $ brew install lex
+Run:
+    $ lex help
+:: shell ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (paragraph
+      (text_line
+        (line_content
+          (text_content))))
+    (verbatim_group_item
+      subject: (subject_content)
+      (paragraph
+        (text_line
+          (line_content
+            (text_content)))))
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Verbatim group with three pairs
+==================
+Step one:
+    $ ls
+Step two:
+    $ pwd
+Step three:
+    $ whoami
+:: shell ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (paragraph
+      (text_line
+        (line_content
+          (text_content))))
+    (verbatim_group_item
+      subject: (subject_content)
+      (paragraph
+        (text_line
+          (line_content
+            (text_content)))))
+    (verbatim_group_item
+      subject: (subject_content)
+      (paragraph
+        (text_line
+          (line_content
+            (text_content)))))
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Verbatim group with blank lines between pairs
+==================
+First:
+    content1
+
+Second:
+
+    content2
+:: python ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (paragraph
+      (text_line
+        (line_content
+          (text_content))))
+    (blank_line)
+    (verbatim_group_item
+      subject: (subject_content)
+      (paragraph
+        (text_line
+          (line_content
+            (text_content)))))
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Verbatim group with no content
+==================
+Label A:
+Label B:
+:: tag ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (verbatim_group_item
+      subject: (subject_content))
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))
+
+==================
+Verbatim group mixed content and no content
+==================
+Has content:
+    $ echo hello
+No content:
+Also has content:
+    $ echo world
+:: shell ::
+---
+
+(document
+  (verbatim_block
+    subject: (subject_content)
+    (paragraph
+      (text_line
+        (line_content
+          (text_content))))
+    (verbatim_group_item
+      subject: (subject_content))
+    (verbatim_group_item
+      subject: (subject_content)
+      (paragraph
+        (text_line
+          (line_content
+            (text_content)))))
+    (annotation_marker)
+    (annotation_header)
+    (annotation_marker)))


### PR DESCRIPTION
## Summary

- Adds `verbatim_group_item` node for multiple subject/content pairs sharing a single closing `:: label ::` annotation
- Updates highlight queries to mark group item subjects and content as raw/preformatted
- Updates injection queries so group item content gets syntax highlighting from the shared annotation language (e.g., `:: python ::`)
- Updates textobjects for group item navigation in nvim
- 5 new tree-sitter test cases (two pairs, three pairs, blank lines between pairs, no-content groups, mixed)

## Design

The first subject/content pair stays directly on `verbatim_block` (matching lex-core's AST backwards-compatibility). Additional pairs are `verbatim_group_item` children. This mirrors lex-core's `additional_groups` field.

No scanner changes needed — existing `subject_content` and `annotation_marker` detection works for groups as-is. The grammar handles groups via GLR with `prec.dynamic(4)` and a self-conflict declaration on `verbatim_group_item` to resolve blank-line ownership between groups.

## Test plan

- [x] All 78 tree-sitter tests pass (73 existing + 5 new group tests)
- [x] All 1332 Rust workspace tests pass
- [x] All spec `.lex` files parse without errors (no regressions)
- [x] Spec fixtures `verbatim-11-group-shell.lex` and `verbatim-12-document-simple.lex` parse groups correctly
- [ ] Verify injection highlighting in VSCode/nvim with a grouped verbatim block

🤖 Generated with [Claude Code](https://claude.com/claude-code)