### PR TITLE
Cross-layer compliance audit: fix labeled footnotes, remove dead TextNode

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -98,6 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -139,6 +143,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -160,6 +166,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -61,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -23,33 +23,53 @@ pub fn analyze(document: &Document) -> Vec<AnalysisDiagnostic> {
 }
 
 fn check_footnotes(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-    // 1. Collect all footnote references
-    let mut references = Vec::new();
+    // 1. Collect all footnote references (both numbered and labeled)
+    let mut numbered_refs = Vec::new();
+    let mut labeled_refs = Vec::new();
     for_each_text_content(document, &mut |text| {
         for reference in extract_references(text) {
-            if let ReferenceType::FootnoteNumber { number } = reference.reference_type {
-                references.push((number, reference.range));
+            match &reference.reference_type {
+                ReferenceType::FootnoteNumber { number } => {
+                    numbered_refs.push((*number, reference.range));
+                }
+                ReferenceType::FootnoteLabeled { label } => {
+                    labeled_refs.push((label.clone(), reference.range));
+                }
+                _ => {}
             }
         }
     });
 
     // 2. Collect all footnote definitions (annotations and list items)
     let definitions_list = crate::utils::collect_footnote_definitions(document);
-    let mut definitions = std::collections::HashSet::new();
+    let mut numeric_definitions = std::collections::HashSet::new();
+    let mut label_definitions = std::collections::HashSet::new();
 
-    for (label, _) in definitions_list {
+    for (label, _) in &definitions_list {
+        label_definitions.insert(label.to_lowercase());
         if let Ok(number) = label.parse::<u32>() {
-            definitions.insert(number);
+            numeric_definitions.insert(number);
         }
     }
 
-    // 3. Check for missing definitions
-    for (number, range) in &references {
-        if !definitions.contains(number) {
+    // 3. Check for missing definitions (numbered)
+    for (number, range) in &numbered_refs {
+        if !numeric_definitions.contains(number) {
             diagnostics.push(AnalysisDiagnostic {
                 range: range.clone(),
                 kind: DiagnosticKind::MissingFootnoteDefinition,
                 message: format!("Footnote [{number}] is referenced but not defined"),
+            });
+        }
+    }
+
+    // 4. Check for missing definitions (labeled)
+    for (label, range) in &labeled_refs {
+        if !label_definitions.contains(&label.to_lowercase()) {
+            diagnostics.push(AnalysisDiagnostic {
+                range: range.clone(),
+                kind: DiagnosticKind::MissingFootnoteDefinition,
+                message: format!("Footnote [^{label}] is referenced but not defined"),
             });
         }
     }
@@ -85,6 +105,29 @@ mod tests {
     fn ignores_valid_list_footnote() {
         // "Notes" session with list item "1."
         let doc = parse("Text [1].\n\nNotes\n\n1. Note.\n");
+        let diags = analyze(&doc);
+        assert_eq!(diags.len(), 0);
+    }
+
+    #[test]
+    fn detects_missing_labeled_footnote_definition() {
+        let doc = parse("Text with [^source] reference.");
+        let diags = analyze(&doc);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].kind, DiagnosticKind::MissingFootnoteDefinition);
+        assert!(diags[0].message.contains("[^source]"));
+    }
+
+    #[test]
+    fn ignores_valid_labeled_footnote() {
+        let doc = parse("Text [^source].\n\n:: source :: The source material.\n");
+        let diags = analyze(&doc);
+        assert_eq!(diags.len(), 0);
+    }
+
+    #[test]
+    fn labeled_footnote_match_is_case_insensitive() {
+        let doc = parse("Text [^Source].\n\n:: source :: The source material.\n");
         let diags = analyze(&doc);
         assert_eq!(diags.len(), 0);
     }

--- a/crates/lex-core/src/lex/ast.rs
+++ b/crates/lex-core/src/lex/ast.rs
@@ -90,7 +90,7 @@
 //!
 //! - `range` - Position and Range types for source code locations
 //! - `elements` - AST node type definitions organized by element type
-//! - `traits` - Common traits for AST nodes (AstNode, Container, TextNode, Visitor)
+//! - `traits` - Common traits for AST nodes (AstNode, Container, Visitor)
 //! - `lookup` - Position-based AST node lookup functionality
 //! - `snapshot` - Normalized intermediate representation for serialization
 //! - `error` - Error types for AST operations
@@ -126,7 +126,7 @@ pub use snapshot::{
     snapshot_from_document_with_options, snapshot_node, AstSnapshot,
 };
 pub use text_content::TextContent;
-pub use traits::{AstNode, Container, TextNode, Visitor, VisualStructure};
+pub use traits::{AstNode, Container, Visitor, VisualStructure};
 
 // Convenience functions that delegate to Document methods
 // These are provided for backwards compatibility with existing code

--- a/crates/lex-core/src/lex/ast/elements/paragraph.rs
+++ b/crates/lex-core/src/lex/ast/elements/paragraph.rs
@@ -24,7 +24,7 @@
 
 use super::super::range::{Position, Range};
 use super::super::text_content::TextContent;
-use super::super::traits::{AstNode, Container, TextNode, Visitor, VisualStructure};
+use super::super::traits::{AstNode, Container, Visitor, VisualStructure};
 use super::annotation::Annotation;
 use super::content_item::ContentItem;
 use std::fmt;
@@ -209,27 +209,6 @@ impl AstNode for Paragraph {
         // Visit child TextLines
         super::super::traits::visit_children(visitor, &self.lines);
         visitor.leave_paragraph(self);
-    }
-}
-
-impl TextNode for Paragraph {
-    fn text(&self) -> String {
-        self.lines
-            .iter()
-            .filter_map(|item| {
-                if let super::content_item::ContentItem::TextLine(tl) = item {
-                    Some(tl.text().to_string())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-    fn lines(&self) -> &[TextContent] {
-        // This is a compatibility method - we no longer store raw TextContent
-        // Return empty slice since we've moved to ContentItem::TextLine
-        &[]
     }
 }
 

--- a/crates/lex-core/src/lex/ast/traits.rs
+++ b/crates/lex-core/src/lex/ast/traits.rs
@@ -6,7 +6,6 @@
 use super::elements::ContentItem;
 use super::elements::VerbatimLine;
 use super::range::{Position, Range};
-use super::text_content::TextContent;
 
 /// Visitor trait for traversing the AST
 ///
@@ -97,12 +96,6 @@ pub trait Container: AstNode {
     fn label(&self) -> &str;
     fn children(&self) -> &[ContentItem];
     fn children_mut(&mut self) -> &mut Vec<ContentItem>;
-}
-
-/// Trait for leaf nodes that contain text
-pub trait TextNode: AstNode {
-    fn text(&self) -> String;
-    fn lines(&self) -> &[TextContent];
 }
 
 /// Trait describing visual/structural properties of nodes for line-oriented rendering

--- a/crates/lex-core/src/lex/parsing.rs
+++ b/crates/lex-core/src/lex/parsing.rs
@@ -78,8 +78,7 @@ pub use common::{ParseError, ParserInput};
 // Re-export AST types and utilities from the ast module
 pub use crate::lex::ast::{
     format_at_position, Annotation, AstNode, Container, ContentItem, Definition, Document, Label,
-    List, ListItem, Paragraph, Parameter, Position, Range, Session, SourceLocation, TextNode,
-    Verbatim,
+    List, ListItem, Paragraph, Parameter, Position, Range, Session, SourceLocation, Verbatim,
 };
 
 pub use crate::lex::formats::{serialize_ast_tag, to_treeviz_str};

--- a/crates/lex-core/src/lex/testing/lexplore/extraction.rs
+++ b/crates/lex-core/src/lex/testing/lexplore/extraction.rs
@@ -7,7 +7,7 @@
 //!   - doc.root.find_paragraphs(|p| ...)
 //!     etc.
 
-use crate::lex::ast::traits::{Container, TextNode};
+use crate::lex::ast::traits::Container;
 use crate::lex::ast::{ContentItem, Document, Paragraph};
 
 // ===== Assertion helpers =====
@@ -39,7 +39,7 @@ pub fn documents_match(doc1: &Document, doc2: &Document) -> bool {
 pub fn content_items_match(item1: &ContentItem, item2: &ContentItem) -> bool {
     use ContentItem::*;
     match (item1, item2) {
-        (Paragraph(p1), Paragraph(p2)) => p1.lines().len() == p2.lines().len(),
+        (Paragraph(p1), Paragraph(p2)) => p1.lines.len() == p2.lines.len(),
         (Session(s1), Session(s2)) => {
             s1.label() == s2.label()
                 && s1.children().len() == s2.children().len()


### PR DESCRIPTION
## Summary

Phase 1 of the cross-layer compliance audit (#422). Traced every element (inline, annotation, verbatim, definition, list, session, paragraph, document) through all 7 layers (spec → token → AST → parser → tree-sitter → semantic tokens → LSP features).

**Bugs fixed:**
- Labeled footnote references (`[^label]`) were never checked for missing definitions in diagnostics — only numbered `[1]` footnotes were validated. Now both forms are checked with case-insensitive matching.
- `TextNode` trait was a dead abstraction: `Paragraph::lines()` returned `&[]` because Paragraph moved to `Vec<ContentItem>`. This made `content_items_match()` always return true for paragraph comparisons. Removed the trait entirely and fixed the comparison.

**Audit findings (no code changes needed):**
- Inlines: clean after #413 — all layers consistent
- Annotations: `::` markers not emitted as semantic tokens (consistent, low impact); tree-sitter closing `::` optional vs spec required (permissive by design)
- Verbatim: well-structured; LSP features incomplete for multi-group (feature gap, not bug)
- Definition: no hover on subject line itself (feature gap)
- List/Session: list footnotes only recognized in hardcoded "Notes" session (design limitation)
- Paragraph/Document: two-parser CST/AST differences are intentional

Full matrix documented in #422.

## Test plan

- [x] All workspace tests pass (0 failures)
- [x] New tests: `detects_missing_labeled_footnote_definition`, `ignores_valid_labeled_footnote`, `labeled_footnote_match_is_case_insensitive`
- [x] Pre-commit hook passes (fmt + clippy + build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)