### PR TITLE
Fix remaining audit issues: verbatim multi-group, definition hover

### DIFF
--- a/crates/lex-analysis/src/hover.rs
+++ b/crates/lex-analysis/src/hover.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    find_annotation_at_position, find_definition_by_subject, find_session_at_position,
-    reference_at_position, session_identifier,
+    find_annotation_at_position, find_definition_at_position, find_definition_by_subject,
+    find_session_at_position, reference_at_position, session_identifier,
 };
 use lex_core::lex::ast::{Annotation, ContentItem, Document, Position, Range};
 use lex_core::lex::inlines::ReferenceType;
@@ -14,6 +14,7 @@ pub struct HoverResult {
 pub fn hover(document: &Document, position: Position) -> Option<HoverResult> {
     inline_hover(document, position)
         .or_else(|| annotation_hover(document, position))
+        .or_else(|| definition_subject_hover(document, position))
         .or_else(|| session_hover(document, position))
 }
 
@@ -144,6 +145,31 @@ fn annotation_hover_result(annotation: &Annotation) -> HoverResult {
     }
 }
 
+fn definition_subject_hover(document: &Document, position: Position) -> Option<HoverResult> {
+    let definition = find_definition_at_position(document, position)?;
+    let header = definition.header_location()?;
+    if !header.contains(position) {
+        return None;
+    }
+    let subject = definition.subject.as_string().trim().to_string();
+    let mut body_lines = Vec::new();
+    if let Some(preview) = preview_from_items(definition.children.iter()) {
+        body_lines.push(preview);
+    }
+    Some(HoverResult {
+        range: header.clone(),
+        contents: format!(
+            "**Definition: {}**\n\n{}",
+            subject,
+            if body_lines.is_empty() {
+                "(no content)".to_string()
+            } else {
+                body_lines.join("\n\n")
+            }
+        ),
+    })
+}
+
 fn session_hover(document: &Document, position: Position) -> Option<HoverResult> {
     let session = find_session_at_position(document, position)?;
     let header = session.header_location()?;
@@ -237,9 +263,14 @@ fn collect_preview<'a>(
                 collect_preview(session.children.iter(), lines, limit);
             }
             ContentItem::VerbatimBlock(verbatim) => {
-                let subject = verbatim.subject.as_string().trim().to_string();
-                if !subject.is_empty() {
-                    lines.push(subject);
+                for group in verbatim.group() {
+                    if lines.len() >= limit {
+                        break;
+                    }
+                    let subject = group.subject.as_string().trim().to_string();
+                    if !subject.is_empty() {
+                        lines.push(subject);
+                    }
                 }
             }
             ContentItem::TextLine(_)
@@ -344,5 +375,26 @@ mod tests {
         let hover = hover(&document, position).expect("hover expected for session");
         assert!(hover.contents.contains("Session"));
         assert!(hover.contents.contains("Intro"));
+    }
+
+    #[test]
+    fn hover_on_definition_subject_shows_body_preview() {
+        use lex_core::lex::parsing;
+        let doc = parsing::parse_document("Term:\n    The definition body.\n").unwrap();
+        // Position on the subject line "Term"
+        let result =
+            hover(&doc, Position::new(0, 1)).expect("hover expected on definition subject");
+        assert!(result.contents.contains("Definition"));
+        assert!(result.contents.contains("Term"));
+        assert!(result.contents.contains("definition body"));
+    }
+
+    #[test]
+    fn hover_on_definition_body_returns_none() {
+        use lex_core::lex::parsing;
+        let doc = parsing::parse_document("Term:\n    The definition body.\n").unwrap();
+        // Position inside the body, not on the subject
+        let result = hover(&doc, Position::new(1, 6));
+        assert!(result.is_none());
     }
 }

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -352,6 +352,11 @@ impl TokenCollector {
             if let Some(location) = &group.subject.location {
                 self.push_range(location, LexSemanticTokenKind::VerbatimSubject);
             }
+            for child in group.children {
+                if let ContentItem::VerbatimLine(line) = child {
+                    self.push_range(&line.location, LexSemanticTokenKind::VerbatimContent);
+                }
+            }
         }
 
         self.push_range(
@@ -360,13 +365,6 @@ impl TokenCollector {
         );
         for parameter in &verbatim.closing_data.parameters {
             self.push_range(&parameter.location, LexSemanticTokenKind::VerbatimAttribute);
-        }
-
-        // Highlight verbatim content lines
-        for child in &verbatim.children {
-            if let ContentItem::VerbatimLine(line) = child {
-                self.push_range(&line.location, LexSemanticTokenKind::VerbatimContent);
-            }
         }
 
         self.process_annotations(verbatim.annotations());


### PR DESCRIPTION
## Summary

Fixes remaining code quality issues from the cross-layer compliance audit (#422).

- **Verbatim multi-group semantic tokens**: `VerbatimContent` tokens were only emitted for the first group's content lines. Additional groups were invisible to editor syntax highlighting. Now iterates all groups via `group()`.
- **Verbatim multi-group hover**: Preview only showed the first group's subject. Now shows all group subjects.
- **Definition subject hover**: Hovering on a definition subject line (e.g., `Term:`) showed nothing. Now displays body preview, matching the behavior of annotations and sessions which already support header hover.

**Not addressed (feature gaps, not code smells):**
- Annotation `::` marker tokens: tree-sitter handles via `@punctuation.special`; adding to LSP would require AST structural changes for low visual impact
- Annotation parameter completion: new feature, not a regression

## Test plan

- [x] All workspace tests pass (1335 tests, 0 failures)
- [x] New tests: `hover_on_definition_subject_shows_body_preview`, `hover_on_definition_body_returns_none`
- [x] Pre-commit hook passes (fmt + clippy + build + test)

Refs #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)