### PR TITLE
Add Table element with block cell content

### DIFF
--- a/crates/lex-analysis/src/completion.rs
+++ b/crates/lex-analysis/src/completion.rs
@@ -331,8 +331,10 @@ fn collect_definitions_in_item(item: &ContentItem, subjects: &mut BTreeSet<Strin
                 collect_definitions_in_item(line, subjects);
             }
         }
-        ContentItem::VerbatimBlock(_) | ContentItem::TextLine(_) | ContentItem::VerbatimLine(_) => {
-        }
+        ContentItem::VerbatimBlock(_)
+        | ContentItem::Table(_)
+        | ContentItem::TextLine(_)
+        | ContentItem::VerbatimLine(_) => {}
         ContentItem::BlankLineGroup(_) => {}
     }
 }

--- a/crates/lex-analysis/src/document_symbols.rs
+++ b/crates/lex-analysis/src/document_symbols.rs
@@ -120,7 +120,17 @@ fn verbatim_symbol(verbatim: &Verbatim) -> LexDocumentSymbol {
 }
 
 fn table_symbol(table: &Table) -> LexDocumentSymbol {
-    let children = annotation_symbol_list(table.annotations());
+    let mut children = annotation_symbol_list(table.annotations());
+
+    // Include symbols from cell children with block content
+    for row in table.all_rows() {
+        for cell in &row.cells {
+            if cell.has_block_content() {
+                children.extend(collect_symbols_from_items(cell.children.iter()));
+            }
+        }
+    }
+
     LexDocumentSymbol {
         name: format!("Table: {}", summarize_text(&table.subject, "Table")),
         detail: Some("table".to_string()),

--- a/crates/lex-analysis/src/document_symbols.rs
+++ b/crates/lex-analysis/src/document_symbols.rs
@@ -1,6 +1,6 @@
 use lex_core::lex::ast::{
     Annotation, AstNode, ContentItem, Definition, Document, List, ListItem, Paragraph, Range,
-    Session, TextContent, Verbatim,
+    Session, Table, TextContent, Verbatim,
 };
 use lsp_types::SymbolKind;
 
@@ -58,6 +58,7 @@ fn collect_symbols_from_items<'a>(
             ContentItem::List(list) => symbols.push(list_symbol(list)),
             ContentItem::Annotation(annotation) => symbols.push(annotation_symbol(annotation)),
             ContentItem::VerbatimBlock(verbatim) => symbols.push(verbatim_symbol(verbatim)),
+            ContentItem::Table(table) => symbols.push(table_symbol(table)),
             ContentItem::Paragraph(paragraph) => symbols.push(paragraph_symbol(paragraph)),
             ContentItem::ListItem(list_item) => symbols.push(list_item_symbol(list_item)),
             ContentItem::TextLine(_)
@@ -114,6 +115,22 @@ fn verbatim_symbol(verbatim: &Verbatim) -> LexDocumentSymbol {
             .location
             .clone()
             .unwrap_or_else(|| verbatim.range().clone()),
+        children,
+    }
+}
+
+fn table_symbol(table: &Table) -> LexDocumentSymbol {
+    let children = annotation_symbol_list(table.annotations());
+    LexDocumentSymbol {
+        name: format!("Table: {}", summarize_text(&table.subject, "Table")),
+        detail: Some("table".to_string()),
+        kind: SymbolKind::CONSTANT,
+        range: table.range().clone(),
+        selection_range: table
+            .subject
+            .location
+            .clone()
+            .unwrap_or_else(|| table.range().clone()),
         children,
     }
 }

--- a/crates/lex-analysis/src/folding_ranges.rs
+++ b/crates/lex-analysis/src/folding_ranges.rs
@@ -138,6 +138,14 @@ impl FoldingCollector {
 
     fn process_table(&mut self, table: &Table) {
         self.process_annotations(table.annotations());
+        // Process cell children with block content
+        for row in table.all_rows() {
+            for cell in &row.cells {
+                for child in cell.children.iter() {
+                    self.process_content_item(child);
+                }
+            }
+        }
         if let Some(subject_range) = &table.subject.location {
             if subject_range.start.line < table.range().end.line {
                 self.push_fold(

--- a/crates/lex-analysis/src/folding_ranges.rs
+++ b/crates/lex-analysis/src/folding_ranges.rs
@@ -1,5 +1,5 @@
 use lex_core::lex::ast::{
-    Annotation, AstNode, ContentItem, Definition, Document, List, ListItem, Range, Session,
+    Annotation, AstNode, ContentItem, Definition, Document, List, ListItem, Range, Session, Table,
     Verbatim,
 };
 use lsp_types::FoldingRangeKind;
@@ -58,6 +58,7 @@ impl FoldingCollector {
             ContentItem::Definition(definition) => self.process_definition(definition),
             ContentItem::Annotation(annotation) => self.process_annotation(annotation),
             ContentItem::VerbatimBlock(verbatim) => self.process_verbatim(verbatim),
+            ContentItem::Table(table) => self.process_table(table),
             ContentItem::TextLine(_)
             | ContentItem::VerbatimLine(_)
             | ContentItem::BlankLineGroup(_) => {}
@@ -129,6 +130,19 @@ impl FoldingCollector {
                 self.push_fold(
                     Some(subject_range),
                     verbatim.range(),
+                    Some(FoldingRangeKind::Region),
+                );
+            }
+        }
+    }
+
+    fn process_table(&mut self, table: &Table) {
+        self.process_annotations(table.annotations());
+        if let Some(subject_range) = &table.subject.location {
+            if subject_range.start.line < table.range().end.line {
+                self.push_fold(
+                    Some(subject_range),
+                    table.range(),
                     Some(FoldingRangeKind::Region),
                 );
             }

--- a/crates/lex-analysis/src/hover.rs
+++ b/crates/lex-analysis/src/hover.rs
@@ -273,7 +273,8 @@ fn collect_preview<'a>(
                     }
                 }
             }
-            ContentItem::TextLine(_)
+            ContentItem::Table(_)
+            | ContentItem::TextLine(_)
             | ContentItem::VerbatimLine(_)
             | ContentItem::BlankLineGroup(_) => {}
         }

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -377,6 +377,15 @@ impl TokenCollector {
             self.push_range(location, LexSemanticTokenKind::VerbatimSubject);
         }
 
+        // Process cell children for block content tokens
+        for row in table.all_rows() {
+            for cell in &row.cells {
+                for child in cell.children.iter() {
+                    self.process_content_item(child);
+                }
+            }
+        }
+
         self.push_range(
             &table.closing_data.label.location,
             LexSemanticTokenKind::VerbatimLanguage,

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -40,7 +40,7 @@
 //! tests and so forth.
 use lex_core::lex::ast::{
     Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Position, Range,
-    Session, TextContent, Verbatim,
+    Session, Table, TextContent, Verbatim,
 };
 use lex_core::lex::inlines::{InlineNode, ReferenceType};
 
@@ -289,6 +289,7 @@ impl TokenCollector {
             ContentItem::Definition(definition) => self.process_definition(definition),
             ContentItem::Annotation(annotation) => self.process_annotation(annotation),
             ContentItem::VerbatimBlock(verbatim) => self.process_verbatim(verbatim),
+            ContentItem::Table(table) => self.process_table(table),
             ContentItem::TextLine(text_line) => self.process_text_content(&text_line.content),
             ContentItem::VerbatimLine(_) => {}
             ContentItem::BlankLineGroup(_) => {}
@@ -368,6 +369,23 @@ impl TokenCollector {
         }
 
         self.process_annotations(verbatim.annotations());
+    }
+
+    fn process_table(&mut self, table: &Table) {
+        self.process_text_content(&table.subject);
+        if let Some(location) = &table.subject.location {
+            self.push_range(location, LexSemanticTokenKind::VerbatimSubject);
+        }
+
+        self.push_range(
+            &table.closing_data.label.location,
+            LexSemanticTokenKind::VerbatimLanguage,
+        );
+        for parameter in &table.closing_data.parameters {
+            self.push_range(&parameter.location, LexSemanticTokenKind::VerbatimAttribute);
+        }
+
+        self.process_annotations(table.annotations());
     }
 
     fn process_annotation(&mut self, annotation: &Annotation) {

--- a/crates/lex-analysis/src/utils.rs
+++ b/crates/lex-analysis/src/utils.rs
@@ -112,6 +112,11 @@ fn collect_content_annotations<'a>(item: &'a ContentItem, out: &mut Vec<&'a Anno
                 collect_annotation_recursive(annotation, out);
             }
         }
+        ContentItem::Table(table) => {
+            for annotation in table.annotations() {
+                collect_annotation_recursive(annotation, out);
+            }
+        }
         ContentItem::TextLine(_)
         | ContentItem::VerbatimLine(_)
         | ContentItem::BlankLineGroup(_) => {}
@@ -183,6 +188,11 @@ where
         ContentItem::Session(session) => visit_session_annotations(session, f),
         ContentItem::VerbatimBlock(verbatim) => {
             for annotation in verbatim.annotations() {
+                visit_annotation_recursive(annotation, f);
+            }
+        }
+        ContentItem::Table(table) => {
+            for annotation in table.annotations() {
                 visit_annotation_recursive(annotation, f);
             }
         }
@@ -360,6 +370,12 @@ where
         ContentItem::VerbatimBlock(verbatim) => {
             f(&verbatim.subject);
             for annotation in verbatim.annotations() {
+                visit_annotation_text(annotation, f);
+            }
+        }
+        ContentItem::Table(table) => {
+            f(&table.subject);
+            for annotation in table.annotations() {
                 visit_annotation_text(annotation, f);
             }
         }

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -8,7 +8,7 @@ use lex_core::lex::ast::TextContent;
 
 use super::nodes::{
     Annotation, Definition, DocNode, Document, Heading, InlineContent, List, ListForm, ListItem,
-    ListStyle, Paragraph, Table, TableCell, TableCellAlignment, TableRow, Verbatim,
+    ListStyle, Paragraph, Verbatim,
 };
 
 /// Converts a lex document to the IR.
@@ -132,6 +132,7 @@ fn extract_attached_annotations(item: &LexContentItem, level: usize) -> Vec<DocN
         LexContentItem::ListItem(list_item) => list_item.annotations(),
         LexContentItem::Definition(definition) => definition.annotations(),
         LexContentItem::VerbatimBlock(verbatim) => verbatim.annotations(),
+        LexContentItem::Table(table) => table.annotations(),
         _ => &[],
     };
 
@@ -183,6 +184,7 @@ fn from_lex_content_item_with_level(item: &LexContentItem, level: usize) -> DocN
         LexContentItem::ListItem(list_item) => from_lex_list_item(list_item, level),
         LexContentItem::Definition(definition) => from_lex_definition(definition, level),
         LexContentItem::VerbatimBlock(verbatim) => from_lex_verbatim(verbatim),
+        LexContentItem::Table(table) => from_lex_table(table),
         LexContentItem::Annotation(annotation) => from_lex_annotation(annotation, level),
         LexContentItem::TextLine(text_line) => from_lex_text_line(text_line),
         LexContentItem::VerbatimLine(verbatim_line) => from_lex_verbatim_line(verbatim_line),
@@ -365,9 +367,6 @@ fn from_lex_verbatim(verbatim: &LexVerbatim) -> DocNode {
 
 /// Converts a lex annotation to an IR annotation.
 fn from_lex_annotation(annotation: &LexAnnotation, level: usize) -> DocNode {
-    if annotation.data.label.value == "table" {
-        return from_lex_table(annotation, level);
-    }
     let label = annotation.data.label.value.clone();
     let parameters = annotation
         .data
@@ -383,76 +382,6 @@ fn from_lex_annotation(annotation: &LexAnnotation, level: usize) -> DocNode {
     })
 }
 
-fn from_lex_table(annotation: &LexAnnotation, level: usize) -> DocNode {
-    // Parse children to find thead and tbody
-    let mut header = Vec::new();
-    let mut rows = Vec::new();
-
-    for child in &annotation.children {
-        if let LexContentItem::Annotation(ann) = child {
-            if ann.data.label.value == "thead" {
-                for row_item in &ann.children {
-                    if let LexContentItem::Annotation(row_ann) = row_item {
-                        if row_ann.data.label.value == "tr" {
-                            header.push(from_lex_table_row(row_ann, level));
-                        }
-                    }
-                }
-            } else if ann.data.label.value == "tbody" {
-                for row_item in &ann.children {
-                    if let LexContentItem::Annotation(row_ann) = row_item {
-                        if row_ann.data.label.value == "tr" {
-                            rows.push(from_lex_table_row(row_ann, level));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    DocNode::Table(Table {
-        rows,
-        header,
-        caption: None,
-    })
-}
-
-fn from_lex_table_row(annotation: &LexAnnotation, level: usize) -> TableRow {
-    let mut cells = Vec::new();
-    for child in &annotation.children {
-        if let LexContentItem::Annotation(ann) = child {
-            if ann.data.label.value == "th" || ann.data.label.value == "td" {
-                cells.push(from_lex_table_cell(ann, level));
-            }
-        }
-    }
-    TableRow { cells }
-}
-
-fn from_lex_table_cell(annotation: &LexAnnotation, level: usize) -> TableCell {
-    let header = annotation.data.label.value == "th";
-
-    let mut align = TableCellAlignment::None;
-    for param in &annotation.data.parameters {
-        if param.key == "align" {
-            align = match param.value.as_str() {
-                "left" => TableCellAlignment::Left,
-                "center" => TableCellAlignment::Center,
-                "right" => TableCellAlignment::Right,
-                _ => TableCellAlignment::None,
-            };
-        }
-    }
-
-    let content = convert_children(&annotation.children, level);
-
-    TableCell {
-        content,
-        header,
-        align,
-    }
-}
-
 /// Converts a standalone TextLine to an IR paragraph.
 /// TextLines are typically parts of paragraphs, but can appear standalone.
 fn from_lex_text_line(text_line: &LexTextLine) -> DocNode {
@@ -462,6 +391,53 @@ fn from_lex_text_line(text_line: &LexTextLine) -> DocNode {
 
 /// Converts a VerbatimLine to an IR verbatim block.
 /// VerbatimLines are typically parts of VerbatimBlocks, but can appear standalone.
+/// Converts a native lex Table AST node to an IR Table node.
+fn from_lex_table(table: &lex_core::lex::ast::Table) -> DocNode {
+    use crate::ir::nodes::{
+        Table as IrTable, TableCell as IrTableCell, TableCellAlignment as IrAlign,
+        TableRow as IrTableRow,
+    };
+
+    let convert_align = |a: lex_core::lex::ast::TableCellAlignment| -> IrAlign {
+        match a {
+            lex_core::lex::ast::TableCellAlignment::Left => IrAlign::Left,
+            lex_core::lex::ast::TableCellAlignment::Center => IrAlign::Center,
+            lex_core::lex::ast::TableCellAlignment::Right => IrAlign::Right,
+            lex_core::lex::ast::TableCellAlignment::None => IrAlign::None,
+        }
+    };
+
+    let convert_row = |row: &lex_core::lex::ast::TableRow| -> IrTableRow {
+        IrTableRow {
+            cells: row
+                .cells
+                .iter()
+                .map(|cell| IrTableCell {
+                    content: vec![DocNode::Paragraph(Paragraph {
+                        content: convert_inline_content(&cell.content),
+                    })],
+                    header: cell.header,
+                    align: convert_align(cell.align),
+                })
+                .collect(),
+        }
+    };
+
+    let header: Vec<IrTableRow> = table.header_rows.iter().map(convert_row).collect();
+    let rows: Vec<IrTableRow> = table.body_rows.iter().map(convert_row).collect();
+    let caption = if table.subject.as_string().is_empty() {
+        None
+    } else {
+        Some(convert_inline_content(&table.subject))
+    };
+
+    DocNode::Table(IrTable {
+        rows,
+        header,
+        caption,
+    })
+}
+
 fn from_lex_verbatim_line(verbatim_line: &LexVerbatimLine) -> DocNode {
     let content = verbatim_line.content.as_string().to_string();
     DocNode::Verbatim(Verbatim {

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -412,12 +412,19 @@ fn from_lex_table(table: &lex_core::lex::ast::Table) -> DocNode {
             cells: row
                 .cells
                 .iter()
-                .map(|cell| IrTableCell {
-                    content: vec![DocNode::Paragraph(Paragraph {
-                        content: convert_inline_content(&cell.content),
-                    })],
-                    header: cell.header,
-                    align: convert_align(cell.align),
+                .map(|cell| {
+                    let content = if cell.has_block_content() {
+                        convert_children(&cell.children, 2)
+                    } else {
+                        vec![DocNode::Paragraph(Paragraph {
+                            content: convert_inline_content(&cell.content),
+                        })]
+                    };
+                    IrTableCell {
+                        content,
+                        header: cell.header,
+                        align: convert_align(cell.align),
+                    }
                 })
                 .collect(),
         }

--- a/crates/lex-cli/src/transforms.rs
+++ b/crates/lex-cli/src/transforms.rs
@@ -485,6 +485,50 @@ fn content_item_to_json(item: &lex_core::lex::ast::ContentItem) -> serde_json::V
                 "content": fl.content.as_string(),
             })
         }
+        ContentItem::Table(t) => {
+            let header_rows: Vec<serde_json::Value> = t
+                .header_rows
+                .iter()
+                .map(|row| {
+                    json!({
+                        "cells": row.cells.iter().map(|cell| json!({
+                            "content": cell.content.as_string(),
+                            "header": cell.header,
+                            "align": format!("{:?}", cell.align),
+                        })).collect::<Vec<_>>(),
+                    })
+                })
+                .collect();
+            let body_rows: Vec<serde_json::Value> = t
+                .body_rows
+                .iter()
+                .map(|row| {
+                    json!({
+                        "cells": row.cells.iter().map(|cell| json!({
+                            "content": cell.content.as_string(),
+                            "header": cell.header,
+                            "align": format!("{:?}", cell.align),
+                        })).collect::<Vec<_>>(),
+                    })
+                })
+                .collect();
+            let mut node = json!({
+                "type": "Table",
+                "subject": t.subject.as_string(),
+                "mode": format!("{:?}", t.mode),
+                "closing_label": t.closing_data.label.value,
+                "header_rows": header_rows,
+                "body_rows": body_rows,
+            });
+            if !t.annotations.is_empty() {
+                node["annotations"] = json!(t
+                    .annotations
+                    .iter()
+                    .map(annotation_to_json)
+                    .collect::<Vec<_>>());
+            }
+            node
+        }
         ContentItem::BlankLineGroup(blg) => {
             json!({
                 "type": "BlankLineGroup",

--- a/crates/lex-core/src/lex/ast.rs
+++ b/crates/lex-core/src/lex/ast.rs
@@ -116,7 +116,7 @@ pub mod traits;
 pub use diagnostics::{validate_references, validate_structure, Diagnostic, DiagnosticSeverity};
 pub use elements::{
     Annotation, ContentItem, Data, Definition, Document, Label, List, ListItem, Paragraph,
-    Parameter, Session, TextLine, Verbatim,
+    Parameter, Session, Table, TableCell, TableCellAlignment, TableRow, TextLine, Verbatim,
 };
 pub use error::PositionLookupError;
 pub use links::{DocumentLink, LinkType};

--- a/crates/lex-core/src/lex/ast/elements.rs
+++ b/crates/lex-core/src/lex/ast/elements.rs
@@ -31,6 +31,7 @@
 //!         - Definitions: have a subject (term) and their content. See [definition](definition).
 //!         - Annotations: metadata, have a data tag and optional content. See [annotation](annotation).
 //!         - Verbatim Blocks: has a subject, optional content and data tag. See [verbatim](verbatim).
+//!         - Tables: structured tabular data with pipe-delimited cells. See [table](table).
 //!
 //! Structure, Children, Indentation and the AST
 //!
@@ -141,6 +142,7 @@ pub mod paragraph;
 pub mod parameter;
 pub mod sequence_marker;
 pub mod session;
+pub mod table;
 pub mod typed_content;
 pub mod verbatim;
 pub mod verbatim_line;
@@ -158,6 +160,7 @@ pub use paragraph::{Paragraph, TextLine};
 pub use parameter::Parameter;
 pub use sequence_marker::{DecorationStyle, Form, Separator, SequenceMarker};
 pub use session::Session;
+pub use table::{Table, TableCell, TableCellAlignment, TableRow};
 pub use typed_content::{ContentElement, ListContent, SessionContent, VerbatimContent};
 pub use verbatim::Verbatim;
 pub use verbatim_line::VerbatimLine;

--- a/crates/lex-core/src/lex/ast/elements/container.rs
+++ b/crates/lex-core/src/lex/ast/elements/container.rs
@@ -140,6 +140,7 @@ use super::definition::Definition;
 use super::list::{List, ListItem};
 use super::paragraph::Paragraph;
 use super::session::Session;
+use super::table::Table;
 use super::typed_content::{ContentElement, ListContent, SessionContent, VerbatimContent};
 use super::verbatim::Verbatim;
 use std::fmt;
@@ -588,6 +589,12 @@ impl<P: ContainerPolicy> Container<P> {
         as_annotation,
         "Recursively iterate all annotations at any depth in the container"
     );
+    impl_recursive_iterator!(
+        iter_tables_recursive,
+        Table,
+        as_table,
+        "Recursively iterate all tables at any depth in the container"
+    );
 
     // ========================================================================
     // CONVENIENCE "FIRST" METHODS
@@ -629,6 +636,12 @@ impl<P: ContainerPolicy> Container<P> {
         iter_verbatim_blocks_recursive,
         "Get the first verbatim block in the container (returns None if not found)"
     );
+    impl_first_method!(
+        first_table,
+        Table,
+        iter_tables_recursive,
+        "Get the first table in the container (returns None if not found)"
+    );
 
     // ========================================================================
     // "EXPECT" METHODS (panic if not found)
@@ -667,6 +680,11 @@ impl<P: ContainerPolicy> Container<P> {
     pub fn expect_verbatim(&self) -> &Verbatim {
         self.first_verbatim()
             .expect("No verbatim block found in container")
+    }
+
+    /// Get the first table, panicking if none found
+    pub fn expect_table(&self) -> &Table {
+        self.first_table().expect("No table found in container")
     }
 
     // ========================================================================

--- a/crates/lex-core/src/lex/ast/elements/content_item.rs
+++ b/crates/lex-core/src/lex/ast/elements/content_item.rs
@@ -16,6 +16,7 @@ use super::definition::Definition;
 use super::list::{List, ListItem};
 use super::paragraph::{Paragraph, TextLine};
 use super::session::Session;
+use super::table::Table;
 use super::verbatim::Verbatim;
 use super::verbatim_line::VerbatimLine;
 use std::fmt;
@@ -31,6 +32,7 @@ pub enum ContentItem {
     Definition(Definition),
     Annotation(Annotation),
     VerbatimBlock(Box<Verbatim>),
+    Table(Box<Table>),
     VerbatimLine(VerbatimLine),
     BlankLineGroup(BlankLineGroup),
 }
@@ -46,6 +48,7 @@ impl AstNode for ContentItem {
             ContentItem::Definition(d) => d.node_type(),
             ContentItem::Annotation(a) => a.node_type(),
             ContentItem::VerbatimBlock(fb) => fb.node_type(),
+            ContentItem::Table(t) => t.node_type(),
             ContentItem::VerbatimLine(fl) => fl.node_type(),
             ContentItem::BlankLineGroup(blg) => blg.node_type(),
         }
@@ -61,6 +64,7 @@ impl AstNode for ContentItem {
             ContentItem::Definition(d) => d.display_label(),
             ContentItem::Annotation(a) => a.display_label(),
             ContentItem::VerbatimBlock(fb) => fb.display_label(),
+            ContentItem::Table(t) => t.display_label(),
             ContentItem::VerbatimLine(fl) => fl.display_label(),
             ContentItem::BlankLineGroup(blg) => blg.display_label(),
         }
@@ -76,6 +80,7 @@ impl AstNode for ContentItem {
             ContentItem::Definition(d) => d.range(),
             ContentItem::Annotation(a) => a.range(),
             ContentItem::VerbatimBlock(fb) => fb.range(),
+            ContentItem::Table(t) => t.range(),
             ContentItem::VerbatimLine(fl) => fl.range(),
             ContentItem::BlankLineGroup(blg) => blg.range(),
         }
@@ -91,6 +96,7 @@ impl AstNode for ContentItem {
             ContentItem::Definition(d) => d.accept(visitor),
             ContentItem::Annotation(a) => a.accept(visitor),
             ContentItem::VerbatimBlock(fb) => fb.accept(visitor),
+            ContentItem::Table(t) => t.accept(visitor),
             ContentItem::VerbatimLine(fl) => fl.accept(visitor),
             ContentItem::BlankLineGroup(blg) => blg.accept(visitor),
         }
@@ -108,6 +114,7 @@ impl VisualStructure for ContentItem {
             ContentItem::Definition(d) => d.is_source_line_node(),
             ContentItem::Annotation(a) => a.is_source_line_node(),
             ContentItem::VerbatimBlock(fb) => fb.is_source_line_node(),
+            ContentItem::Table(t) => t.is_source_line_node(),
             ContentItem::VerbatimLine(fl) => fl.is_source_line_node(),
             ContentItem::BlankLineGroup(blg) => blg.is_source_line_node(),
         }
@@ -123,6 +130,7 @@ impl VisualStructure for ContentItem {
             ContentItem::Definition(d) => d.has_visual_header(),
             ContentItem::Annotation(a) => a.has_visual_header(),
             ContentItem::VerbatimBlock(fb) => fb.has_visual_header(),
+            ContentItem::Table(t) => t.has_visual_header(),
             ContentItem::VerbatimLine(fl) => fl.has_visual_header(),
             ContentItem::BlankLineGroup(blg) => blg.has_visual_header(),
         }
@@ -138,6 +146,7 @@ impl VisualStructure for ContentItem {
             ContentItem::Definition(d) => d.collapses_with_children(),
             ContentItem::Annotation(a) => a.collapses_with_children(),
             ContentItem::VerbatimBlock(fb) => fb.collapses_with_children(),
+            ContentItem::Table(t) => t.collapses_with_children(),
             ContentItem::VerbatimLine(fl) => fl.collapses_with_children(),
             ContentItem::BlankLineGroup(blg) => blg.collapses_with_children(),
         }
@@ -152,6 +161,7 @@ impl ContentItem {
             ContentItem::Annotation(a) => Some(a.label()),
             ContentItem::ListItem(li) => Some(li.label()),
             ContentItem::VerbatimBlock(fb) => Some(fb.subject.as_string()),
+            ContentItem::Table(t) => Some(t.subject.as_string()),
             _ => None,
         }
     }
@@ -165,6 +175,7 @@ impl ContentItem {
             ContentItem::ListItem(li) => Some(&li.children),
             ContentItem::Paragraph(p) => Some(&p.lines),
             ContentItem::VerbatimBlock(fb) => Some(&fb.children),
+            ContentItem::Table(_) => None, // Tables use structured rows/cells, not generic children
             ContentItem::TextLine(_) => None,
             ContentItem::VerbatimLine(_) => None,
             _ => None,
@@ -180,6 +191,7 @@ impl ContentItem {
             ContentItem::ListItem(li) => Some(li.children.as_mut_vec()),
             ContentItem::Paragraph(p) => Some(&mut p.lines),
             ContentItem::VerbatimBlock(fb) => Some(fb.children.as_mut_vec()),
+            ContentItem::Table(_) => None,
             ContentItem::TextLine(_) => None,
             ContentItem::VerbatimLine(_) => None,
             _ => None,
@@ -216,6 +228,10 @@ impl ContentItem {
     }
     pub fn is_verbatim_block(&self) -> bool {
         matches!(self, ContentItem::VerbatimBlock(_))
+    }
+
+    pub fn is_table(&self) -> bool {
+        matches!(self, ContentItem::Table(_))
     }
 
     pub fn is_verbatim_line(&self) -> bool {
@@ -271,6 +287,14 @@ impl ContentItem {
     pub fn as_verbatim_block(&self) -> Option<&Verbatim> {
         if let ContentItem::VerbatimBlock(fb) = self {
             Some(fb)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_table(&self) -> Option<&Table> {
+        if let ContentItem::Table(t) = self {
+            Some(t)
         } else {
             None
         }
@@ -337,6 +361,14 @@ impl ContentItem {
     pub fn as_verbatim_block_mut(&mut self) -> Option<&mut Verbatim> {
         if let ContentItem::VerbatimBlock(fb) = self {
             Some(fb)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_table_mut(&mut self) -> Option<&mut Table> {
+        if let ContentItem::Table(t) = self {
+            Some(t)
         } else {
             None
         }
@@ -430,6 +462,7 @@ impl ContentItem {
                 | ContentItem::Paragraph(_)
                 | ContentItem::Annotation(_)
                 | ContentItem::VerbatimBlock(_)
+                | ContentItem::Table(_)
         );
 
         if is_block && self.range().contains(pos) {
@@ -537,6 +570,14 @@ impl fmt::Display for ContentItem {
             ),
             ContentItem::VerbatimBlock(fb) => {
                 write!(f, "VerbatimBlock('{}')", fb.subject.as_string())
+            }
+            ContentItem::Table(t) => {
+                write!(
+                    f,
+                    "Table('{}', {} rows)",
+                    t.subject.as_string(),
+                    t.row_count()
+                )
             }
             ContentItem::VerbatimLine(fl) => {
                 write!(f, "VerbatimLine('{}')", fl.content.as_string())

--- a/crates/lex-core/src/lex/ast/elements/session.rs
+++ b/crates/lex-core/src/lex/ast/elements/session.rs
@@ -66,6 +66,7 @@ use super::content_item::ContentItem;
 use super::definition::Definition;
 use super::list::{List, ListItem};
 use super::paragraph::Paragraph;
+use super::table::Table;
 use super::typed_content::SessionContent;
 use super::verbatim::Verbatim;
 use std::fmt;
@@ -319,6 +320,11 @@ impl Session {
     /// Get the first verbatim block, panicking if none found
     pub fn expect_verbatim(&self) -> &Verbatim {
         self.children.expect_verbatim()
+    }
+
+    /// Get the first table, panicking if none found
+    pub fn expect_table(&self) -> &Table {
+        self.children.expect_table()
     }
 
     /// Find all paragraphs matching a predicate

--- a/crates/lex-core/src/lex/ast/elements/table.rs
+++ b/crates/lex-core/src/lex/ast/elements/table.rs
@@ -1,0 +1,295 @@
+//! Table element
+//!
+//!     Tables are a native element for structured, tabular data. They share the outer
+//!     structure of verbatim blocks (subject line, indented content, closing annotation)
+//!     but with inline-parsed pipe-delimited content instead of raw text.
+//!
+//! Structure
+//!
+//!     - subject: The table caption (inline-parsed)
+//!     - header_rows: Header rows (default: first row)
+//!     - body_rows: Body/data rows
+//!     - footnotes: Optional scoped footnote list
+//!     - closing_data: The closing annotation (:: table params? ::)
+//!     - mode: Inflow or Fullwidth (inherited from verbatim wall logic)
+//!
+//! Syntax
+//!
+//!     <subject-line>
+//!         | cell | cell | cell |
+//!         | cell | cell | cell |
+//!     :: table params? ::
+//!
+//! Cell Merging
+//!
+//!     Merge markers (`>>` for colspan, `^^` for rowspan) are resolved during AST
+//!     assembly. The content cell gets its colspan/rowspan incremented, and absorbed
+//!     cells are removed. The final AST contains only content cells with span counts.
+//!
+//! Multi-line Mode
+//!
+//!     When blank lines separate pipe groups, consecutive pipe lines within a group
+//!     form a single row. Auto-detected; no flags needed.
+//!
+//! Learn More:
+//!
+//!     - Table element spec: specs/elements/table.lex
+//!     - Table proposal: specs/proposals/table.lex
+
+use super::super::range::Range;
+use super::super::text_content::TextContent;
+use super::super::traits::{AstNode, Container, Visitor, VisualStructure};
+use super::annotation::Annotation;
+use super::content_item::ContentItem;
+use super::data::Data;
+use super::list::List;
+use super::verbatim::VerbatimBlockMode;
+use std::fmt;
+
+/// Alignment hint for a table cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableCellAlignment {
+    /// Left-aligned (default)
+    Left,
+    /// Center-aligned
+    Center,
+    /// Right-aligned
+    Right,
+    /// No explicit alignment
+    None,
+}
+
+/// A single cell in a table row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TableCell {
+    /// The cell's inline content (trimmed text, inline-parsed)
+    pub content: TextContent,
+    /// Number of columns this cell spans (1 = no merge)
+    pub colspan: usize,
+    /// Number of rows this cell spans (1 = no merge)
+    pub rowspan: usize,
+    /// Column alignment for this cell
+    pub align: TableCellAlignment,
+    /// Whether this cell is in a header row
+    pub header: bool,
+    /// Byte range location
+    pub location: Range,
+}
+
+impl TableCell {
+    pub fn new(content: TextContent) -> Self {
+        Self {
+            content,
+            colspan: 1,
+            rowspan: 1,
+            align: TableCellAlignment::None,
+            header: false,
+            location: Range::default(),
+        }
+    }
+
+    pub fn with_span(mut self, colspan: usize, rowspan: usize) -> Self {
+        self.colspan = colspan;
+        self.rowspan = rowspan;
+        self
+    }
+
+    pub fn with_align(mut self, align: TableCellAlignment) -> Self {
+        self.align = align;
+        self
+    }
+
+    pub fn with_header(mut self, header: bool) -> Self {
+        self.header = header;
+        self
+    }
+
+    pub fn at(mut self, location: Range) -> Self {
+        self.location = location;
+        self
+    }
+
+    /// The text content of this cell
+    pub fn text(&self) -> &str {
+        self.content.as_string()
+    }
+
+    /// Whether this cell is empty (whitespace-only or no content)
+    pub fn is_empty(&self) -> bool {
+        self.content.as_string().trim().is_empty()
+    }
+}
+
+/// A row in a table.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TableRow {
+    /// The cells in this row
+    pub cells: Vec<TableCell>,
+    /// Byte range location
+    pub location: Range,
+}
+
+impl TableRow {
+    pub fn new(cells: Vec<TableCell>) -> Self {
+        Self {
+            cells,
+            location: Range::default(),
+        }
+    }
+
+    pub fn at(mut self, location: Range) -> Self {
+        self.location = location;
+        self
+    }
+
+    /// Number of cells in this row
+    pub fn cell_count(&self) -> usize {
+        self.cells.len()
+    }
+}
+
+/// A table element with structured, pipe-delimited content.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Table {
+    /// Caption/subject line (inline-parsed)
+    pub subject: TextContent,
+    /// Header rows (typically first row; controlled by header=N parameter)
+    pub header_rows: Vec<TableRow>,
+    /// Body/data rows
+    pub body_rows: Vec<TableRow>,
+    /// Optional scoped footnote definitions
+    pub footnotes: Option<Box<List>>,
+    /// Closing annotation (:: table params? ::)
+    pub closing_data: Data,
+    /// Annotations attached to this table
+    pub annotations: Vec<Annotation>,
+    /// Location spanning the entire table element
+    pub location: Range,
+    /// Rendering mode (Inflow or Fullwidth, same as verbatim blocks)
+    pub mode: VerbatimBlockMode,
+}
+
+impl Table {
+    pub fn new(
+        subject: TextContent,
+        header_rows: Vec<TableRow>,
+        body_rows: Vec<TableRow>,
+        closing_data: Data,
+        mode: VerbatimBlockMode,
+    ) -> Self {
+        Self {
+            subject,
+            header_rows,
+            body_rows,
+            footnotes: None,
+            closing_data,
+            annotations: Vec::new(),
+            location: Range::default(),
+            mode,
+        }
+    }
+
+    pub fn with_footnotes(mut self, footnotes: List) -> Self {
+        self.footnotes = Some(Box::new(footnotes));
+        self
+    }
+
+    pub fn at(mut self, location: Range) -> Self {
+        self.location = location;
+        self
+    }
+
+    /// All rows (header + body) in document order
+    pub fn all_rows(&self) -> impl Iterator<Item = &TableRow> {
+        self.header_rows.iter().chain(self.body_rows.iter())
+    }
+
+    /// Total number of rows (header + body)
+    pub fn row_count(&self) -> usize {
+        self.header_rows.len() + self.body_rows.len()
+    }
+
+    /// Maximum column count across all rows
+    pub fn column_count(&self) -> usize {
+        self.all_rows()
+            .map(|row| row.cells.len())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Annotations attached to this table.
+    pub fn annotations(&self) -> &[Annotation] {
+        &self.annotations
+    }
+
+    /// Mutable access to table annotations.
+    pub fn annotations_mut(&mut self) -> &mut Vec<Annotation> {
+        &mut self.annotations
+    }
+}
+
+impl AstNode for Table {
+    fn node_type(&self) -> &'static str {
+        "Table"
+    }
+
+    fn display_label(&self) -> String {
+        let subject_text = self.subject.as_string();
+        if subject_text.chars().count() > 50 {
+            format!("{}…", subject_text.chars().take(50).collect::<String>())
+        } else {
+            subject_text.to_string()
+        }
+    }
+
+    fn range(&self) -> &Range {
+        &self.location
+    }
+
+    fn accept(&self, visitor: &mut dyn Visitor) {
+        visitor.visit_table(self);
+        visitor.leave_table(self);
+    }
+}
+
+impl VisualStructure for Table {
+    fn is_source_line_node(&self) -> bool {
+        true
+    }
+
+    fn has_visual_header(&self) -> bool {
+        true
+    }
+}
+
+impl Container for Table {
+    fn label(&self) -> &str {
+        self.subject.as_string()
+    }
+
+    fn children(&self) -> &[ContentItem] {
+        // Tables don't use the generic ContentItem children pattern;
+        // their structure is rows/cells. Return empty slice.
+        &[]
+    }
+
+    fn children_mut(&mut self) -> &mut Vec<ContentItem> {
+        // Tables don't use generic children. This is a design tension with
+        // the Container trait but is consistent with how they work.
+        // For now, panic - callers should use the typed row/cell API.
+        panic!("Tables use structured rows/cells, not generic children")
+    }
+}
+
+impl fmt::Display for Table {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Table('{}', {} header + {} body rows, {} cols)",
+            self.subject.as_string(),
+            self.header_rows.len(),
+            self.body_rows.len(),
+            self.column_count()
+        )
+    }
+}

--- a/crates/lex-core/src/lex/ast/elements/table.rs
+++ b/crates/lex-core/src/lex/ast/elements/table.rs
@@ -40,9 +40,11 @@ use super::super::range::Range;
 use super::super::text_content::TextContent;
 use super::super::traits::{AstNode, Container, Visitor, VisualStructure};
 use super::annotation::Annotation;
+use super::container::GeneralContainer;
 use super::content_item::ContentItem;
 use super::data::Data;
 use super::list::List;
+use super::typed_content::ContentElement;
 use super::verbatim::VerbatimBlockMode;
 use std::fmt;
 
@@ -64,6 +66,8 @@ pub enum TableCellAlignment {
 pub struct TableCell {
     /// The cell's inline content (trimmed text, inline-parsed)
     pub content: TextContent,
+    /// Block-level children (lists, definitions, etc.) when cell has block content
+    pub children: GeneralContainer,
     /// Number of columns this cell spans (1 = no merge)
     pub colspan: usize,
     /// Number of rows this cell spans (1 = no merge)
@@ -80,12 +84,23 @@ impl TableCell {
     pub fn new(content: TextContent) -> Self {
         Self {
             content,
+            children: GeneralContainer::empty(),
             colspan: 1,
             rowspan: 1,
             align: TableCellAlignment::None,
             header: false,
             location: Range::default(),
         }
+    }
+
+    pub fn with_children(mut self, children: Vec<ContentElement>) -> Self {
+        self.children = GeneralContainer::from_typed(children);
+        self
+    }
+
+    /// Whether this cell has block-level content (lists, definitions, etc.)
+    pub fn has_block_content(&self) -> bool {
+        !self.children.is_empty()
     }
 
     pub fn with_span(mut self, colspan: usize, rowspan: usize) -> Self {

--- a/crates/lex-core/src/lex/ast/elements/typed_content.rs
+++ b/crates/lex-core/src/lex/ast/elements/typed_content.rs
@@ -43,6 +43,7 @@ use super::definition::Definition;
 use super::list::{List, ListItem};
 use super::paragraph::{Paragraph, TextLine};
 use super::session::Session;
+use super::table::Table;
 use super::verbatim::Verbatim;
 use super::verbatim_line::VerbatimLine;
 
@@ -62,6 +63,7 @@ pub enum ContentElement {
     List(List),
     Definition(Definition),
     VerbatimBlock(Box<Verbatim>),
+    Table(Box<Table>),
     TextLine(TextLine),
     VerbatimLine(VerbatimLine),
     BlankLineGroup(BlankLineGroup),
@@ -78,6 +80,7 @@ impl TryFrom<ContentItem> for ContentElement {
             ContentItem::List(l) => Ok(ContentElement::List(l)),
             ContentItem::Definition(d) => Ok(ContentElement::Definition(d)),
             ContentItem::VerbatimBlock(vb) => Ok(ContentElement::VerbatimBlock(vb)),
+            ContentItem::Table(t) => Ok(ContentElement::Table(t)),
             ContentItem::TextLine(tl) => Ok(ContentElement::TextLine(tl)),
             ContentItem::VerbatimLine(vl) => Ok(ContentElement::VerbatimLine(vl)),
             ContentItem::BlankLineGroup(blg) => Ok(ContentElement::BlankLineGroup(blg)),
@@ -94,6 +97,7 @@ impl From<ContentElement> for ContentItem {
             ContentElement::List(l) => ContentItem::List(l),
             ContentElement::Definition(d) => ContentItem::Definition(d),
             ContentElement::VerbatimBlock(vb) => ContentItem::VerbatimBlock(vb),
+            ContentElement::Table(t) => ContentItem::Table(t),
             ContentElement::TextLine(tl) => ContentItem::TextLine(tl),
             ContentElement::VerbatimLine(vl) => ContentItem::VerbatimLine(vl),
             ContentElement::BlankLineGroup(blg) => ContentItem::BlankLineGroup(blg),

--- a/crates/lex-core/src/lex/ast/snapshot.rs
+++ b/crates/lex-core/src/lex/ast/snapshot.rs
@@ -114,6 +114,7 @@ pub fn snapshot_from_content_with_options(item: &ContentItem, include_all: bool)
         ContentItem::ListItem(li) => build_list_item_snapshot(li, include_all),
         ContentItem::Definition(def) => build_definition_snapshot(def, include_all),
         ContentItem::VerbatimBlock(fb) => build_verbatim_block_snapshot(fb, include_all),
+        ContentItem::Table(t) => build_table_snapshot(t, include_all),
         ContentItem::VerbatimLine(fl) => AstSnapshot::new(
             "VerbatimLine".to_string(),
             fl.display_label(),
@@ -358,6 +359,17 @@ fn build_annotation_snapshot(ann: &Annotation, include_all: bool) -> AstSnapshot
             .children
             .push(snapshot_from_content_with_options(child, include_all));
     }
+    snapshot
+}
+
+fn build_table_snapshot(t: &super::Table, _include_all: bool) -> AstSnapshot {
+    let label = format!(
+        "{} ({} header + {} body rows)",
+        t.display_label(),
+        t.header_rows.len(),
+        t.body_rows.len()
+    );
+    let snapshot = AstSnapshot::new("Table".to_string(), label, t.range().clone());
     snapshot
 }
 

--- a/crates/lex-core/src/lex/ast/snapshot.rs
+++ b/crates/lex-core/src/lex/ast/snapshot.rs
@@ -362,14 +362,36 @@ fn build_annotation_snapshot(ann: &Annotation, include_all: bool) -> AstSnapshot
     snapshot
 }
 
-fn build_table_snapshot(t: &super::Table, _include_all: bool) -> AstSnapshot {
+fn build_table_snapshot(t: &super::Table, include_all: bool) -> AstSnapshot {
     let label = format!(
         "{} ({} header + {} body rows)",
         t.display_label(),
         t.header_rows.len(),
         t.body_rows.len()
     );
-    let snapshot = AstSnapshot::new("Table".to_string(), label, t.range().clone());
+    let mut snapshot = AstSnapshot::new("Table".to_string(), label, t.range().clone());
+
+    // Include cell children with block content
+    if include_all {
+        for row in t.all_rows() {
+            for cell in &row.cells {
+                if cell.has_block_content() {
+                    let mut cell_snapshot = AstSnapshot::new(
+                        "TableCell".to_string(),
+                        cell.content.as_string().to_string(),
+                        cell.location.clone(),
+                    );
+                    for child in cell.children.iter() {
+                        cell_snapshot
+                            .children
+                            .push(snapshot_from_content_with_options(child, include_all));
+                    }
+                    snapshot.children.push(cell_snapshot);
+                }
+            }
+        }
+    }
+
     snapshot
 }
 

--- a/crates/lex-core/src/lex/ast/traits.rs
+++ b/crates/lex-core/src/lex/ast/traits.rs
@@ -50,6 +50,9 @@ pub trait Visitor {
     fn visit_verbatim_block(&mut self, _verbatim_block: &super::Verbatim) {}
     fn leave_verbatim_block(&mut self, _verbatim_block: &super::Verbatim) {}
 
+    fn visit_table(&mut self, _table: &super::Table) {}
+    fn leave_table(&mut self, _table: &super::Table) {}
+
     fn visit_verbatim_group(&mut self, _group: &super::elements::verbatim::VerbatimGroupItemRef) {}
     fn leave_verbatim_group(&mut self, _group: &super::elements::verbatim::VerbatimGroupItemRef) {}
 

--- a/crates/lex-core/src/lex/building/api.rs
+++ b/crates/lex-core/src/lex/building/api.rs
@@ -274,6 +274,42 @@ pub fn verbatim_block_from_lines(
 }
 
 // ============================================================================
+// TABLE BUILDING
+// ============================================================================
+
+/// Build a Table AST node from subject, content, and closing data.
+///
+/// Reuses verbatim block's outer structure handling (mode detection, wall stripping)
+/// and adds pipe-row parsing, merge resolution, and header/alignment extraction.
+///
+/// # Arguments
+///
+/// * `subject_token` - LineToken for the table subject/caption
+/// * `content_tokens` - LineTokens for each content line (pipe rows)
+/// * `closing_data` - The closing data node (:: table params? ::)
+/// * `source` - Original source string
+///
+/// # Returns
+///
+/// A Table ContentItem
+pub fn table_from_lines(
+    subject_token: &LineToken,
+    content_tokens: &[LineToken],
+    closing_data: Data,
+    source: &str,
+    source_location: &SourceLocation,
+) -> ContentItem {
+    // 1. Extract (reuses verbatim wall stripping + parses pipe rows)
+    let data = extraction::extract_table_data(subject_token, content_tokens, &closing_data, source);
+
+    // 2. Extract alignment hints from closing annotation
+    let alignments = extraction::table::extract_alignments(&closing_data);
+
+    // 3. Create
+    ast_nodes::table_node(data, closing_data, &alignments, source_location)
+}
+
+// ============================================================================
 // NORMALIZED TOKEN API (tokens already normalized)
 // ============================================================================
 //

--- a/crates/lex-core/src/lex/building/ast_nodes.rs
+++ b/crates/lex-core/src/lex/building/ast_nodes.rs
@@ -29,8 +29,8 @@
 //! conversion happens here using `byte_range_to_ast_range()`.
 
 use super::extraction::{
-    DataExtraction, DefinitionData, ListItemData, ParagraphData, SessionData, VerbatimBlockData,
-    VerbatimGroupData,
+    DataExtraction, DefinitionData, ListItemData, ParagraphData, SessionData, TableCellData,
+    TableData, TableRowData, VerbatimBlockData, VerbatimGroupData,
 };
 use super::location::{
     aggregate_locations, byte_range_to_ast_range, compute_location_from_locations, default_location,
@@ -44,8 +44,8 @@ use crate::lex::ast::elements::SequenceMarker;
 use crate::lex::ast::range::SourceLocation;
 use crate::lex::ast::traits::AstNode;
 use crate::lex::ast::{
-    Annotation, Data, Definition, Label, List, ListItem, Paragraph, Range, Session, TextContent,
-    TextLine, Verbatim,
+    Annotation, Data, Definition, Label, List, ListItem, Paragraph, Range, Session, Table,
+    TableCell, TableCellAlignment, TableRow, TextContent, TextLine, Verbatim,
 };
 use crate::lex::parsing::ContentItem;
 use crate::lex::token::Token;
@@ -392,6 +392,92 @@ fn build_verbatim_group(
 
     // Children are all VerbatimLines by construction - no validation needed
     (subject, children, locations)
+}
+
+// ============================================================================
+// TABLE CREATION
+// ============================================================================
+
+/// Create a Table AST node from extracted table data.
+///
+/// Converts byte ranges to AST Ranges, creates TextContent for subject and cells,
+/// and aggregates location from all components.
+pub(super) fn table_node(
+    data: TableData,
+    closing_data: Data,
+    alignments: &[TableCellAlignment],
+    source_location: &SourceLocation,
+) -> ContentItem {
+    let subject_location = byte_range_to_ast_range(data.subject_byte_range, source_location);
+    let subject = TextContent::from_string(data.subject_text, Some(subject_location.clone()));
+
+    let mut location_sources = vec![subject_location];
+
+    let header_rows: Vec<TableRow> = data
+        .header_rows
+        .into_iter()
+        .map(|row_data| {
+            let row = build_table_row(row_data, alignments, source_location);
+            location_sources.push(row.location.clone());
+            row
+        })
+        .collect();
+
+    let body_rows: Vec<TableRow> = data
+        .body_rows
+        .into_iter()
+        .map(|row_data| {
+            let row = build_table_row(row_data, alignments, source_location);
+            location_sources.push(row.location.clone());
+            row
+        })
+        .collect();
+
+    location_sources.push(closing_data.location.clone());
+    let location = compute_location_from_locations(&location_sources);
+
+    let table = Table::new(subject, header_rows, body_rows, closing_data, data.mode).at(location);
+    ContentItem::Table(Box::new(table))
+}
+
+fn build_table_row(
+    row_data: TableRowData,
+    alignments: &[TableCellAlignment],
+    source_location: &SourceLocation,
+) -> TableRow {
+    let row_location = byte_range_to_ast_range(row_data.byte_range, source_location);
+
+    let cells: Vec<TableCell> = row_data
+        .cells
+        .into_iter()
+        .enumerate()
+        .map(|(col_idx, cell_data)| {
+            build_table_cell(cell_data, col_idx, alignments, source_location)
+        })
+        .collect();
+
+    TableRow::new(cells).at(row_location)
+}
+
+fn build_table_cell(
+    cell_data: TableCellData,
+    col_idx: usize,
+    alignments: &[TableCellAlignment],
+    source_location: &SourceLocation,
+) -> TableCell {
+    let cell_location = byte_range_to_ast_range(cell_data.byte_range, source_location);
+    let content = TextContent::from_string(cell_data.text, Some(cell_location.clone()));
+
+    let align = alignments
+        .get(col_idx)
+        .copied()
+        .unwrap_or(TableCellAlignment::None);
+
+    TableCell::new(content)
+        .with_span(cell_data.colspan, cell_data.rowspan)
+        .with_align(align)
+        .with_header(cell_data.is_header)
+        .at(cell_location)
 }
 
 // ============================================================================

--- a/crates/lex-core/src/lex/building/ast_nodes.rs
+++ b/crates/lex-core/src/lex/building/ast_nodes.rs
@@ -29,8 +29,8 @@
 //! conversion happens here using `byte_range_to_ast_range()`.
 
 use super::extraction::{
-    DataExtraction, DefinitionData, ListItemData, ParagraphData, SessionData, TableCellData,
-    TableData, TableRowData, VerbatimBlockData, VerbatimGroupData,
+    DataExtraction, DefinitionData, FootnoteLineData, ListItemData, ParagraphData, SessionData,
+    TableCellData, TableData, TableRowData, VerbatimBlockData, VerbatimGroupData,
 };
 use super::location::{
     aggregate_locations, byte_range_to_ast_range, compute_location_from_locations, default_location,
@@ -433,10 +433,21 @@ pub(super) fn table_node(
         })
         .collect();
 
+    // Build footnotes if present
+    let footnotes = if data.footnotes.is_empty() {
+        None
+    } else {
+        Some(build_footnote_list(data.footnotes, source_location))
+    };
+
     location_sources.push(closing_data.location.clone());
     let location = compute_location_from_locations(&location_sources);
 
-    let table = Table::new(subject, header_rows, body_rows, closing_data, data.mode).at(location);
+    let mut table =
+        Table::new(subject, header_rows, body_rows, closing_data, data.mode).at(location);
+    if let Some(list) = footnotes {
+        table = table.with_footnotes(list);
+    }
     ContentItem::Table(Box::new(table))
 }
 
@@ -478,6 +489,17 @@ fn build_table_cell(
         .with_align(align)
         .with_header(cell_data.is_header)
         .at(cell_location)
+}
+
+fn build_footnote_list(footnotes: Vec<FootnoteLineData>, source_location: &SourceLocation) -> List {
+    let items: Vec<ListItem> = footnotes
+        .into_iter()
+        .map(|f| {
+            let location = byte_range_to_ast_range(f.byte_range, source_location);
+            ListItem::new(f.marker, f.text).at(location)
+        })
+        .collect();
+    List::new(items)
 }
 
 // ============================================================================

--- a/crates/lex-core/src/lex/building/ast_nodes.rs
+++ b/crates/lex-core/src/lex/building/ast_nodes.rs
@@ -484,11 +484,17 @@ fn build_table_cell(
         .copied()
         .unwrap_or(TableCellAlignment::None);
 
-    TableCell::new(content)
+    let mut cell = TableCell::new(content)
         .with_span(cell_data.colspan, cell_data.rowspan)
         .with_align(align)
         .with_header(cell_data.is_header)
-        .at(cell_location)
+        .at(cell_location);
+
+    if let Some(block_content) = cell_data.block_content {
+        cell = cell.with_children(block_content);
+    }
+
+    cell
 }
 
 fn build_footnote_list(footnotes: Vec<FootnoteLineData>, source_location: &SourceLocation) -> List {

--- a/crates/lex-core/src/lex/building/ast_tree.rs
+++ b/crates/lex-core/src/lex/building/ast_tree.rs
@@ -139,6 +139,7 @@ impl<'a> AstTreeBuilder<'a> {
             NodeType::Definition => self.build_definition(node),
             NodeType::Annotation => self.build_annotation(node),
             NodeType::VerbatimBlock => Ok(self.build_verbatim_block(node)),
+            NodeType::Table => Ok(self.build_table(node)),
             NodeType::BlankLineGroup => Ok(self.build_blank_line_group(node)),
             _ => panic!("Unexpected node type"),
         }
@@ -211,12 +212,41 @@ impl<'a> AstTreeBuilder<'a> {
             subject,
             content_lines,
             closing_data_tokens,
-        } = payload;
+        } = payload
+        else {
+            panic!("Expected VerbatimBlock payload for VerbatimBlock node");
+        };
 
         let closing_data =
             ast_api::data_from_tokens(closing_data_tokens, self.source, &self.source_location);
 
         ast_api::verbatim_block_from_lines(
+            &subject,
+            &content_lines,
+            closing_data,
+            self.source,
+            &self.source_location,
+        )
+    }
+
+    fn build_table(&self, mut node: ParseNode) -> ContentItem {
+        let payload = node
+            .payload
+            .take()
+            .expect("Parser must attach table payload");
+        let ParseNodePayload::Table {
+            subject,
+            content_lines,
+            closing_data_tokens,
+        } = payload
+        else {
+            panic!("Expected Table payload for Table node");
+        };
+
+        let closing_data =
+            ast_api::data_from_tokens(closing_data_tokens, self.source, &self.source_location);
+
+        ast_api::table_from_lines(
             &subject,
             &content_lines,
             closing_data,

--- a/crates/lex-core/src/lex/building/extraction.rs
+++ b/crates/lex-core/src/lex/building/extraction.rs
@@ -44,7 +44,9 @@ pub(super) use definition::{extract_definition_data, DefinitionData};
 pub(super) use list_item::{extract_list_item_data, ListItemData};
 pub(super) use paragraph::{extract_paragraph_data, ParagraphData};
 pub(super) use session::{extract_session_data, SessionData};
-pub(super) use table::{extract_table_data, TableCellData, TableData, TableRowData};
+pub(super) use table::{
+    extract_table_data, FootnoteLineData, TableCellData, TableData, TableRowData,
+};
 pub(super) use verbatim::{extract_verbatim_block_data, VerbatimBlockData, VerbatimGroupData};
 
 // Re-export VerbatimGroupTokenLines as public for use in ast_tree.rs

--- a/crates/lex-core/src/lex/building/extraction.rs
+++ b/crates/lex-core/src/lex/building/extraction.rs
@@ -35,6 +35,7 @@ mod list_item;
 mod paragraph;
 mod parameter;
 mod session;
+pub(in crate::lex::building) mod table;
 mod verbatim;
 
 // Re-export data structures and functions
@@ -43,6 +44,7 @@ pub(super) use definition::{extract_definition_data, DefinitionData};
 pub(super) use list_item::{extract_list_item_data, ListItemData};
 pub(super) use paragraph::{extract_paragraph_data, ParagraphData};
 pub(super) use session::{extract_session_data, SessionData};
+pub(super) use table::{extract_table_data, TableCellData, TableData, TableRowData};
 pub(super) use verbatim::{extract_verbatim_block_data, VerbatimBlockData, VerbatimGroupData};
 
 // Re-export VerbatimGroupTokenLines as public for use in ast_tree.rs

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -23,10 +23,14 @@ use std::ops::Range as ByteRange;
 #[derive(Debug, Clone)]
 pub(in crate::lex::building) struct TableCellData {
     pub text: String,
+    /// Raw text preserving indentation (for block content parsing in multi-line mode)
+    pub raw_text: Option<String>,
     pub byte_range: ByteRange<usize>,
     pub colspan: usize,
     pub rowspan: usize,
     pub is_header: bool,
+    /// Block content parsed from multi-line cell text, if any.
+    pub block_content: Option<Vec<crate::lex::ast::elements::typed_content::ContentElement>>,
 }
 
 /// Extracted data for a single table row (pre-AST).
@@ -91,6 +95,16 @@ pub(in crate::lex::building) fn extract_table_data(
     // Resolve merge markers
     let mut rows = resolve_merges(raw_rows);
 
+    // Parse block content in multi-line cells
+    if is_multiline {
+        for row in &mut rows {
+            for cell in &mut row.cells {
+                let parse_text = cell.raw_text.as_deref().unwrap_or(&cell.text);
+                cell.block_content = parse_cell_content(parse_text);
+            }
+        }
+    }
+
     // Split into header/body based on closing annotation parameters
     let header_count = extract_header_count(closing_data);
     let (header_rows, body_rows) = split_header_body(&mut rows, header_count);
@@ -124,7 +138,10 @@ fn parse_pipe_rows(content_lines: &[(String, ByteRange<usize>)]) -> Vec<TableRow
 enum LineKind<'a> {
     /// A pipe row with parsed cell texts
     PipeRow {
+        /// Trimmed cell texts (for merge markers, compact mode)
         cells: Vec<&'a str>,
+        /// Raw cell texts preserving leading whitespace (for block content in multi-line mode)
+        raw_cells: Vec<&'a str>,
         line_range: &'a ByteRange<usize>,
     },
     /// A blank line (row group separator in multi-line mode)
@@ -156,9 +173,12 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
                 } else {
                     segments.len()
                 };
-                let cells = segments[start..end].iter().map(|s| s.trim()).collect();
+                let cells: Vec<&str> = segments[start..end].iter().map(|s| s.trim()).collect();
+                let raw_cells: Vec<&str> =
+                    segments[start..end].iter().map(|s| s.trim_end()).collect();
                 LineKind::PipeRow {
                     cells,
+                    raw_cells,
                     line_range: range,
                 }
             } else {
@@ -200,15 +220,20 @@ fn parse_compact_rows(lines: &[LineKind]) -> Vec<TableRowData> {
     lines
         .iter()
         .filter_map(|line| {
-            if let LineKind::PipeRow { cells, line_range } = line {
+            if let LineKind::PipeRow {
+                cells, line_range, ..
+            } = line
+            {
                 let cell_data = cells
                     .iter()
                     .map(|text| TableCellData {
                         text: text.to_string(),
+                        raw_text: None,
                         byte_range: (*line_range).clone(),
                         colspan: 1,
                         rowspan: 1,
                         is_header: false,
+                        block_content: None,
                     })
                     .collect();
                 Some(TableRowData {
@@ -259,7 +284,12 @@ fn parse_multiline_rows(lines: &[LineKind]) -> Vec<TableRowData> {
 ///
 /// The first line establishes the cells. Continuation lines append to the
 /// corresponding cell's text (joined with newline). Whitespace-only
-/// continuation cells add nothing.
+/// continuation cells represent blank lines (paragraph separators) when the
+/// cell already has content.
+///
+/// Two texts are built per cell:
+/// - `merged_texts`: trimmed cell content (for inline use and merge markers)
+/// - `merged_raw`: raw cell content preserving leading whitespace (for block parsing)
 fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
     if group.is_empty() {
         return None;
@@ -268,6 +298,7 @@ fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
     // Extract the first line's cells as the base
     let LineKind::PipeRow {
         cells: first_cells,
+        raw_cells: first_raw,
         line_range: first_range,
     } = group[0]
     else {
@@ -275,12 +306,14 @@ fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
     };
 
     let mut merged_texts: Vec<String> = first_cells.iter().map(|s| s.to_string()).collect();
+    let mut merged_raw: Vec<String> = first_raw.iter().map(|s| s.to_string()).collect();
     let mut row_range = (*first_range).clone();
 
     // Append continuation lines
     for line in &group[1..] {
         let LineKind::PipeRow {
             cells: cont_cells,
+            raw_cells: cont_raw,
             line_range: cont_range,
         } = line
         else {
@@ -292,26 +325,49 @@ fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
 
         for (col, cell_text) in cont_cells.iter().enumerate() {
             if col < merged_texts.len() {
-                // Whitespace-only continuation cells add nothing
                 if !cell_text.is_empty() {
+                    // Non-empty continuation: append with newline
                     if !merged_texts[col].is_empty() {
                         merged_texts[col].push('\n');
                     }
                     merged_texts[col].push_str(cell_text);
+                } else if !merged_texts[col].is_empty() {
+                    // Whitespace-only continuation on a non-empty cell: blank line
+                    // (This creates paragraph separators for block content)
+                    merged_raw[col].push('\n');
                 }
             }
-            // Extra columns in continuation lines are ignored
+
+            // Build raw text for all columns
+            if col < merged_raw.len() {
+                let raw = cont_raw.get(col).copied().unwrap_or("");
+                if !raw.trim().is_empty() {
+                    merged_raw[col].push('\n');
+                    merged_raw[col].push_str(raw);
+                } else if !merged_raw[col].is_empty() {
+                    // Blank line separator in raw text
+                    merged_raw[col].push('\n');
+                }
+            }
         }
+    }
+
+    // Dedent raw text: compute per-cell indentation baseline and strip it
+    for raw in &mut merged_raw {
+        dedent_cell_text(raw);
     }
 
     let cells = merged_texts
         .into_iter()
-        .map(|text| TableCellData {
+        .zip(merged_raw)
+        .map(|(text, raw)| TableCellData {
             text,
+            raw_text: if group.len() > 1 { Some(raw) } else { None },
             byte_range: row_range.clone(),
             colspan: 1,
             rowspan: 1,
             is_header: false,
+            block_content: None,
         })
         .collect();
 
@@ -319,6 +375,85 @@ fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
         cells,
         byte_range: row_range,
     })
+}
+
+/// Dedent cell text by stripping the common leading whitespace from all non-empty lines.
+fn dedent_cell_text(text: &mut String) {
+    let baseline = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    if baseline > 0 {
+        let dedented: String = text
+            .lines()
+            .map(|line| {
+                if line.trim().is_empty() {
+                    ""
+                } else if line.len() > baseline {
+                    &line[baseline..]
+                } else {
+                    line.trim_start()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        *text = dedented;
+    }
+}
+
+/// Parse cell text to detect block-level content.
+///
+/// For multi-line cells, re-parses the merged text as a standalone document.
+/// Returns `None` if the cell is inline-only (single paragraph matching original text).
+/// Returns `Some(children)` if the cell contains block content.
+fn parse_cell_content(
+    text: &str,
+) -> Option<Vec<crate::lex::ast::elements::typed_content::ContentElement>> {
+    use crate::lex::ast::elements::typed_content::ContentElement;
+    use crate::lex::ast::ContentItem;
+    use crate::lex::parsing::parse_document;
+
+    // Single-line cells are always inline
+    if !text.contains('\n') {
+        return None;
+    }
+
+    // Try to parse the cell text as a standalone document
+    let cell_source = format!("{text}\n");
+    let mut doc = parse_document(&cell_source).ok()?;
+
+    let items: Vec<&ContentItem> = doc
+        .root
+        .children
+        .iter()
+        .filter(|item| !matches!(item, ContentItem::BlankLineGroup(_)))
+        .collect();
+
+    // If it's a single paragraph, check if it matches the original text
+    if items.len() == 1 {
+        if let ContentItem::Paragraph(p) = items[0] {
+            let para_text = p.text();
+            if para_text.trim() == text.trim() {
+                return None; // Just a plain paragraph — stay inline
+            }
+        }
+    }
+
+    // Convert to ContentElement (filtering out blank lines and sessions)
+    let children: Vec<ContentElement> = std::mem::take(doc.root.children.as_mut_vec())
+        .into_iter()
+        .filter_map(|item| ContentElement::try_from(item).ok())
+        .filter(|item| !matches!(item, ContentElement::BlankLineGroup(_)))
+        .collect();
+
+    if children.is_empty() {
+        None
+    } else {
+        Some(children)
+    }
 }
 
 /// Check if a line is a separator (cosmetic) line.
@@ -545,6 +680,8 @@ mod tests {
                     colspan: 1,
                     rowspan: 1,
                     is_header: false,
+                    raw_text: None,
+                    block_content: None,
                 },
                 TableCellData {
                     text: ">>".to_string(),
@@ -552,6 +689,8 @@ mod tests {
                     colspan: 1,
                     rowspan: 1,
                     is_header: false,
+                    raw_text: None,
+                    block_content: None,
                 },
                 TableCellData {
                     text: "normal".to_string(),
@@ -559,6 +698,8 @@ mod tests {
                     colspan: 1,
                     rowspan: 1,
                     is_header: false,
+                    raw_text: None,
+                    block_content: None,
                 },
             ],
             byte_range: 0..20,
@@ -578,17 +719,21 @@ mod tests {
                 cells: vec![
                     TableCellData {
                         text: "tall".to_string(),
+                        raw_text: None,
                         byte_range: 0..4,
                         colspan: 1,
                         rowspan: 1,
                         is_header: false,
+                        block_content: None,
                     },
                     TableCellData {
                         text: "b".to_string(),
+                        raw_text: None,
                         byte_range: 0..1,
                         colspan: 1,
                         rowspan: 1,
                         is_header: false,
+                        block_content: None,
                     },
                 ],
                 byte_range: 0..10,
@@ -597,17 +742,21 @@ mod tests {
                 cells: vec![
                     TableCellData {
                         text: "^^".to_string(),
+                        raw_text: None,
                         byte_range: 0..2,
                         colspan: 1,
                         rowspan: 1,
                         is_header: false,
+                        block_content: None,
                     },
                     TableCellData {
                         text: "d".to_string(),
+                        raw_text: None,
                         byte_range: 0..1,
                         colspan: 1,
                         rowspan: 1,
                         is_header: false,
+                        block_content: None,
                     },
                 ],
                 byte_range: 0..10,

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -36,6 +36,14 @@ pub(in crate::lex::building) struct TableRowData {
     pub byte_range: ByteRange<usize>,
 }
 
+/// Extracted data for a footnote line (pre-AST).
+#[derive(Debug, Clone)]
+pub(in crate::lex::building) struct FootnoteLineData {
+    pub marker: String,
+    pub text: String,
+    pub byte_range: ByteRange<usize>,
+}
+
 /// Extracted data for building a Table AST node.
 #[derive(Debug, Clone)]
 pub(in crate::lex::building) struct TableData {
@@ -43,6 +51,7 @@ pub(in crate::lex::building) struct TableData {
     pub subject_byte_range: ByteRange<usize>,
     pub header_rows: Vec<TableRowData>,
     pub body_rows: Vec<TableRowData>,
+    pub footnotes: Vec<FootnoteLineData>,
     pub mode: VerbatimBlockMode,
 }
 
@@ -69,8 +78,15 @@ pub(in crate::lex::building) fn extract_table_data(
     let subject_text = group.subject_text;
     let subject_byte_range = group.subject_byte_range;
 
-    // Parse the wall-stripped content lines into rows
-    let raw_rows = parse_pipe_rows(&group.content_lines);
+    // Parse the wall-stripped content lines into rows and extract footnotes
+    let classified = classify_lines(&group.content_lines);
+    let is_multiline = detect_multiline(&classified);
+    let raw_rows = if is_multiline {
+        parse_multiline_rows(&classified)
+    } else {
+        parse_compact_rows(&classified)
+    };
+    let footnotes = extract_footnote_lines(&classified);
 
     // Resolve merge markers
     let mut rows = resolve_merges(raw_rows);
@@ -84,23 +100,13 @@ pub(in crate::lex::building) fn extract_table_data(
         subject_byte_range,
         header_rows,
         body_rows,
+        footnotes,
         mode,
     }
 }
 
-/// Parse wall-stripped content lines into raw table rows.
-///
-/// Supports two modes:
-///
-/// **Compact mode** (default): Each pipe line is an independent row.
-///
-/// **Multi-line mode**: When blank lines appear between pipe groups,
-/// consecutive pipe lines within a group form a single row with multi-line
-/// cell content. Each continuation line appends to the corresponding cell
-/// (joined with newline). Whitespace-only continuation cells add nothing.
-///
-/// Mode is auto-detected: if any blank lines separate pipe groups, the
-/// table is in multi-line mode.
+/// Parse wall-stripped content lines into raw table rows (test helper).
+#[cfg(test)]
 fn parse_pipe_rows(content_lines: &[(String, ByteRange<usize>)]) -> Vec<TableRowData> {
     // First, classify lines and check for multi-line mode
     let classified = classify_lines(content_lines);
@@ -123,8 +129,11 @@ enum LineKind<'a> {
     },
     /// A blank line (row group separator in multi-line mode)
     Blank,
-    /// A non-pipe, non-blank line (currently skipped)
-    Other,
+    /// A non-pipe, non-blank line (potential footnote)
+    Other {
+        text: &'a str,
+        line_range: &'a ByteRange<usize>,
+    },
 }
 
 /// Classify all content lines into pipe rows, blanks, or other.
@@ -153,7 +162,10 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
                     line_range: range,
                 }
             } else {
-                LineKind::Other
+                LineKind::Other {
+                    text: trimmed,
+                    line_range: range,
+                }
             }
         })
         .collect()
@@ -177,7 +189,7 @@ fn detect_multiline(lines: &[LineKind]) -> bool {
                     seen_blank_after_pipe = true;
                 }
             }
-            LineKind::Other => {}
+            LineKind::Other { .. } => {}
         }
     }
     false
@@ -229,7 +241,7 @@ fn parse_multiline_rows(lines: &[LineKind]) -> Vec<TableRowData> {
             LineKind::PipeRow { .. } => {
                 current_group.push(line);
             }
-            LineKind::Other => {}
+            LineKind::Other { .. } => {}
         }
     }
 
@@ -316,6 +328,57 @@ fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
 fn is_separator_line(line: &str) -> bool {
     line.chars()
         .all(|c| matches!(c, '|' | '-' | ':' | '+' | ' ' | '='))
+}
+
+/// Extract footnote lines from trailing non-pipe content.
+///
+/// Footnotes are non-pipe lines that appear after the last pipe row.
+/// They follow the pattern `N. text` (numbered list items).
+/// Blank lines between the last pipe row and footnotes are skipped.
+fn extract_footnote_lines(lines: &[LineKind]) -> Vec<FootnoteLineData> {
+    // Find the last pipe row index
+    let last_pipe_idx = lines
+        .iter()
+        .rposition(|l| matches!(l, LineKind::PipeRow { .. }));
+
+    let Some(last_pipe_idx) = last_pipe_idx else {
+        return Vec::new();
+    };
+
+    let mut footnotes = Vec::new();
+    for line in &lines[last_pipe_idx + 1..] {
+        if let LineKind::Other { text, line_range } = line {
+            if let Some(footnote) = parse_footnote_line(text, line_range) {
+                footnotes.push(footnote);
+            }
+        }
+    }
+    footnotes
+}
+
+/// Try to parse a line as a footnote item (e.g. "1. Some text").
+fn parse_footnote_line(text: &str, range: &ByteRange<usize>) -> Option<FootnoteLineData> {
+    // Match pattern: digits followed by . or ) then space and text
+    let text = text.trim();
+    let marker_end = text.find(|c: char| !c.is_ascii_digit())?;
+    if marker_end == 0 {
+        return None;
+    }
+    let rest = &text[marker_end..];
+    let separator = if rest.starts_with(". ") {
+        "."
+    } else if rest.starts_with(") ") {
+        ")"
+    } else {
+        return None;
+    };
+    let marker = format!("{}{}", &text[..marker_end], separator);
+    let body = rest[2..].to_string(); // skip separator + space
+    Some(FootnoteLineData {
+        marker,
+        text: body,
+        byte_range: range.clone(),
+    })
 }
 
 /// Resolve merge markers (`>>` for colspan, `^^` for rowspan).
@@ -658,6 +721,55 @@ mod tests {
         assert_eq!(rows[1].cells[1].text, "line1\nline2");
         assert_eq!(rows[2].cells[0].text, "b");
         assert_eq!(rows[2].cells[1].text, "single");
+    }
+
+    #[test]
+    fn test_parse_footnote_line_numbered_period() {
+        let f = parse_footnote_line("1. Some text here", &(0..17)).unwrap();
+        assert_eq!(f.marker, "1.");
+        assert_eq!(f.text, "Some text here");
+    }
+
+    #[test]
+    fn test_parse_footnote_line_numbered_paren() {
+        let f = parse_footnote_line("2) Another note", &(0..15)).unwrap();
+        assert_eq!(f.marker, "2)");
+        assert_eq!(f.text, "Another note");
+    }
+
+    #[test]
+    fn test_parse_footnote_line_not_a_footnote() {
+        assert!(parse_footnote_line("Just plain text", &(0..15)).is_none());
+        assert!(parse_footnote_line("- a dash item", &(0..13)).is_none());
+    }
+
+    #[test]
+    fn test_extract_footnote_lines_from_classified() {
+        let lines = vec![
+            ("| a | b |".to_string(), 0..9),
+            ("| c | d |".to_string(), 10..19),
+            ("".to_string(), 20..20),
+            ("1. First note".to_string(), 21..34),
+            ("2. Second note".to_string(), 35..49),
+        ];
+        let classified = classify_lines(&lines);
+        let footnotes = extract_footnote_lines(&classified);
+        assert_eq!(footnotes.len(), 2);
+        assert_eq!(footnotes[0].marker, "1.");
+        assert_eq!(footnotes[0].text, "First note");
+        assert_eq!(footnotes[1].marker, "2.");
+        assert_eq!(footnotes[1].text, "Second note");
+    }
+
+    #[test]
+    fn test_extract_footnote_lines_none_when_no_trailing() {
+        let lines = vec![
+            ("| a | b |".to_string(), 0..9),
+            ("| c | d |".to_string(), 10..19),
+        ];
+        let classified = classify_lines(&lines);
+        let footnotes = extract_footnote_lines(&classified);
+        assert!(footnotes.is_empty());
     }
 
     #[test]

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -442,8 +442,16 @@ fn parse_cell_content(
         }
     }
 
+    // Include document-level annotations (these end up outside root.children)
+    let mut all_items: Vec<ContentItem> = doc
+        .annotations
+        .drain(..)
+        .map(ContentItem::Annotation)
+        .collect();
+    all_items.extend(std::mem::take(doc.root.children.as_mut_vec()));
+
     // Convert to ContentElement (filtering out blank lines and sessions)
-    let children: Vec<ContentElement> = std::mem::take(doc.root.children.as_mut_vec())
+    let children: Vec<ContentElement> = all_items
         .into_iter()
         .filter_map(|item| ContentElement::try_from(item).ok())
         .filter(|item| !matches!(item, ContentElement::BlankLineGroup(_)))

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -1,0 +1,683 @@
+//! Table Data Extraction
+//!
+//! This module handles the extraction of table content from line tokens,
+//! reusing the verbatim block's outer structure handling (mode detection,
+//! indentation wall stripping) and adding pipe-row parsing on top.
+//!
+//! # Pipeline
+//!
+//! 1. Reuse verbatim extraction for mode detection and wall stripping
+//! 2. Parse wall-stripped lines into pipe rows
+//! 3. Detect separator lines (cosmetic, discarded)
+//! 4. Detect multi-line mode (blank lines between pipe groups)
+//! 5. Resolve merge markers (>> for colspan, ^^ for rowspan)
+//! 6. Apply header/align hints from closing annotation parameters
+
+use super::verbatim::extract_verbatim_block_data;
+use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+use crate::lex::ast::Data;
+use crate::lex::token::LineToken;
+use std::ops::Range as ByteRange;
+
+/// Extracted data for a single table cell (pre-AST).
+#[derive(Debug, Clone)]
+pub(in crate::lex::building) struct TableCellData {
+    pub text: String,
+    pub byte_range: ByteRange<usize>,
+    pub colspan: usize,
+    pub rowspan: usize,
+    pub is_header: bool,
+}
+
+/// Extracted data for a single table row (pre-AST).
+#[derive(Debug, Clone)]
+pub(in crate::lex::building) struct TableRowData {
+    pub cells: Vec<TableCellData>,
+    pub byte_range: ByteRange<usize>,
+}
+
+/// Extracted data for building a Table AST node.
+#[derive(Debug, Clone)]
+pub(in crate::lex::building) struct TableData {
+    pub subject_text: String,
+    pub subject_byte_range: ByteRange<usize>,
+    pub header_rows: Vec<TableRowData>,
+    pub body_rows: Vec<TableRowData>,
+    pub mode: VerbatimBlockMode,
+}
+
+/// Extract table data from the verbatim-like outer structure.
+///
+/// Reuses verbatim extraction for wall stripping, then parses pipe rows.
+pub(in crate::lex::building) fn extract_table_data(
+    subject_token: &LineToken,
+    content_tokens: &[LineToken],
+    closing_data: &Data,
+    source: &str,
+) -> TableData {
+    // Reuse verbatim extraction for mode detection + wall stripping
+    let verbatim_data = extract_verbatim_block_data(subject_token, content_tokens, source);
+    let mode = verbatim_data.mode;
+
+    // Tables don't support groups (no multiple subject lines) — use only the first group
+    let group = verbatim_data
+        .groups
+        .into_iter()
+        .next()
+        .expect("Table must have at least one group");
+
+    let subject_text = group.subject_text;
+    let subject_byte_range = group.subject_byte_range;
+
+    // Parse the wall-stripped content lines into rows
+    let raw_rows = parse_pipe_rows(&group.content_lines);
+
+    // Resolve merge markers
+    let mut rows = resolve_merges(raw_rows);
+
+    // Split into header/body based on closing annotation parameters
+    let header_count = extract_header_count(closing_data);
+    let (header_rows, body_rows) = split_header_body(&mut rows, header_count);
+
+    TableData {
+        subject_text,
+        subject_byte_range,
+        header_rows,
+        body_rows,
+        mode,
+    }
+}
+
+/// Parse wall-stripped content lines into raw table rows.
+///
+/// Supports two modes:
+///
+/// **Compact mode** (default): Each pipe line is an independent row.
+///
+/// **Multi-line mode**: When blank lines appear between pipe groups,
+/// consecutive pipe lines within a group form a single row with multi-line
+/// cell content. Each continuation line appends to the corresponding cell
+/// (joined with newline). Whitespace-only continuation cells add nothing.
+///
+/// Mode is auto-detected: if any blank lines separate pipe groups, the
+/// table is in multi-line mode.
+fn parse_pipe_rows(content_lines: &[(String, ByteRange<usize>)]) -> Vec<TableRowData> {
+    // First, classify lines and check for multi-line mode
+    let classified = classify_lines(content_lines);
+    let is_multiline = detect_multiline(&classified);
+
+    if is_multiline {
+        parse_multiline_rows(&classified)
+    } else {
+        parse_compact_rows(&classified)
+    }
+}
+
+/// A classified content line.
+#[derive(Debug)]
+enum LineKind<'a> {
+    /// A pipe row with parsed cell texts
+    PipeRow {
+        cells: Vec<&'a str>,
+        line_range: &'a ByteRange<usize>,
+    },
+    /// A blank line (row group separator in multi-line mode)
+    Blank,
+    /// A non-pipe, non-blank line (currently skipped)
+    Other,
+}
+
+/// Classify all content lines into pipe rows, blanks, or other.
+fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<LineKind<'a>> {
+    content_lines
+        .iter()
+        .map(|(text, range)| {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                LineKind::Blank
+            } else if trimmed.starts_with('|') && !is_separator_line(trimmed) {
+                let segments: Vec<&str> = trimmed.split('|').collect();
+                let start = if segments.first().is_some_and(|s| s.trim().is_empty()) {
+                    1
+                } else {
+                    0
+                };
+                let end = if segments.last().is_some_and(|s| s.trim().is_empty()) {
+                    segments.len() - 1
+                } else {
+                    segments.len()
+                };
+                let cells = segments[start..end].iter().map(|s| s.trim()).collect();
+                LineKind::PipeRow {
+                    cells,
+                    line_range: range,
+                }
+            } else {
+                LineKind::Other
+            }
+        })
+        .collect()
+}
+
+/// Detect multi-line mode: true if any blank line appears between two pipe rows.
+fn detect_multiline(lines: &[LineKind]) -> bool {
+    let mut seen_pipe = false;
+    let mut seen_blank_after_pipe = false;
+
+    for line in lines {
+        match line {
+            LineKind::PipeRow { .. } => {
+                if seen_blank_after_pipe {
+                    return true;
+                }
+                seen_pipe = true;
+            }
+            LineKind::Blank => {
+                if seen_pipe {
+                    seen_blank_after_pipe = true;
+                }
+            }
+            LineKind::Other => {}
+        }
+    }
+    false
+}
+
+/// Compact mode: each pipe line is an independent row.
+fn parse_compact_rows(lines: &[LineKind]) -> Vec<TableRowData> {
+    lines
+        .iter()
+        .filter_map(|line| {
+            if let LineKind::PipeRow { cells, line_range } = line {
+                let cell_data = cells
+                    .iter()
+                    .map(|text| TableCellData {
+                        text: text.to_string(),
+                        byte_range: (*line_range).clone(),
+                        colspan: 1,
+                        rowspan: 1,
+                        is_header: false,
+                    })
+                    .collect();
+                Some(TableRowData {
+                    cells: cell_data,
+                    byte_range: (*line_range).clone(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Multi-line mode: blank lines delimit row groups. Consecutive pipe lines
+/// within a group form a single row with multi-line cell content.
+fn parse_multiline_rows(lines: &[LineKind]) -> Vec<TableRowData> {
+    let mut rows = Vec::new();
+    let mut current_group: Vec<&LineKind> = Vec::new();
+
+    for line in lines {
+        match line {
+            LineKind::Blank => {
+                if !current_group.is_empty() {
+                    if let Some(row) = merge_group(&current_group) {
+                        rows.push(row);
+                    }
+                    current_group.clear();
+                }
+            }
+            LineKind::PipeRow { .. } => {
+                current_group.push(line);
+            }
+            LineKind::Other => {}
+        }
+    }
+
+    // Flush final group
+    if !current_group.is_empty() {
+        if let Some(row) = merge_group(&current_group) {
+            rows.push(row);
+        }
+    }
+
+    rows
+}
+
+/// Merge a group of pipe lines into a single row.
+///
+/// The first line establishes the cells. Continuation lines append to the
+/// corresponding cell's text (joined with newline). Whitespace-only
+/// continuation cells add nothing.
+fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
+    if group.is_empty() {
+        return None;
+    }
+
+    // Extract the first line's cells as the base
+    let LineKind::PipeRow {
+        cells: first_cells,
+        line_range: first_range,
+    } = group[0]
+    else {
+        return None;
+    };
+
+    let mut merged_texts: Vec<String> = first_cells.iter().map(|s| s.to_string()).collect();
+    let mut row_range = (*first_range).clone();
+
+    // Append continuation lines
+    for line in &group[1..] {
+        let LineKind::PipeRow {
+            cells: cont_cells,
+            line_range: cont_range,
+        } = line
+        else {
+            continue;
+        };
+
+        // Extend the row's byte range to cover all continuation lines
+        row_range = row_range.start..cont_range.end;
+
+        for (col, cell_text) in cont_cells.iter().enumerate() {
+            if col < merged_texts.len() {
+                // Whitespace-only continuation cells add nothing
+                if !cell_text.is_empty() {
+                    if !merged_texts[col].is_empty() {
+                        merged_texts[col].push('\n');
+                    }
+                    merged_texts[col].push_str(cell_text);
+                }
+            }
+            // Extra columns in continuation lines are ignored
+        }
+    }
+
+    let cells = merged_texts
+        .into_iter()
+        .map(|text| TableCellData {
+            text,
+            byte_range: row_range.clone(),
+            colspan: 1,
+            rowspan: 1,
+            is_header: false,
+        })
+        .collect();
+
+    Some(TableRowData {
+        cells,
+        byte_range: row_range,
+    })
+}
+
+/// Check if a line is a separator (cosmetic) line.
+///
+/// Separator lines contain only pipes, dashes, colons, pluses, and spaces.
+/// Examples: `|---|---|`, `|:---:|---:|`, `+---+---+`
+fn is_separator_line(line: &str) -> bool {
+    line.chars()
+        .all(|c| matches!(c, '|' | '-' | ':' | '+' | ' ' | '='))
+}
+
+/// Resolve merge markers (`>>` for colspan, `^^` for rowspan).
+///
+/// - `>>` means "this cell is absorbed by the cell to the left" (colspan)
+/// - `^^` means "this cell is absorbed by the cell above" (rowspan)
+///
+/// After resolution, absorbed cells are removed and the spanning cell's
+/// colspan/rowspan is incremented.
+fn resolve_merges(mut rows: Vec<TableRowData>) -> Vec<TableRowData> {
+    // First pass: resolve colspan (>> markers)
+    for row in &mut rows {
+        let mut i = 0;
+        while i < row.cells.len() {
+            if row.cells[i].text == ">>" && i > 0 {
+                // Find the cell to the left that isn't a merge marker
+                let mut target = i - 1;
+                while target > 0 && row.cells[target].text == ">>" {
+                    target -= 1;
+                }
+                row.cells[target].colspan += 1;
+                row.cells.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    // Second pass: resolve rowspan (^^ markers)
+    for row_idx in 0..rows.len() {
+        let mut col_idx = 0;
+        while col_idx < rows[row_idx].cells.len() {
+            if rows[row_idx].cells[col_idx].text == "^^" && row_idx > 0 {
+                // Find the cell above in the same column position
+                if col_idx < rows[row_idx - 1].cells.len() {
+                    rows[row_idx - 1].cells[col_idx].rowspan += 1;
+                }
+                rows[row_idx].cells.remove(col_idx);
+            } else {
+                col_idx += 1;
+            }
+        }
+    }
+
+    rows
+}
+
+/// Extract the header count from closing annotation parameters.
+///
+/// Looks for `header=N` parameter. Default is 1 (first row is header).
+fn extract_header_count(closing_data: &Data) -> usize {
+    for param in &closing_data.parameters {
+        if param.key == "header" {
+            if let Ok(n) = param.value.parse::<usize>() {
+                return n;
+            }
+        }
+    }
+    1 // Default: first row is header
+}
+
+/// Split rows into header and body based on header count.
+fn split_header_body(
+    rows: &mut Vec<TableRowData>,
+    header_count: usize,
+) -> (Vec<TableRowData>, Vec<TableRowData>) {
+    let split_at = header_count.min(rows.len());
+    let body_rows = rows.split_off(split_at);
+    let mut header_rows = std::mem::take(rows);
+
+    // Mark header cells
+    for row in &mut header_rows {
+        for cell in &mut row.cells {
+            cell.is_header = true;
+        }
+    }
+
+    (header_rows, body_rows)
+}
+
+/// Extract column alignment hints from closing annotation parameters.
+///
+/// Looks for `align=lcr` parameter where l=left, c=center, r=right.
+/// Returns alignment per column index.
+pub(in crate::lex::building) fn extract_alignments(
+    closing_data: &Data,
+) -> Vec<crate::lex::ast::TableCellAlignment> {
+    use crate::lex::ast::TableCellAlignment;
+
+    for param in &closing_data.parameters {
+        if param.key == "align" {
+            return param
+                .value
+                .chars()
+                .map(|c| match c {
+                    'l' | 'L' => TableCellAlignment::Left,
+                    'c' | 'C' => TableCellAlignment::Center,
+                    'r' | 'R' => TableCellAlignment::Right,
+                    _ => TableCellAlignment::None,
+                })
+                .collect();
+        }
+    }
+
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_separator_line() {
+        assert!(is_separator_line("|---|---|"));
+        assert!(is_separator_line("|:---:|---:|"));
+        assert!(is_separator_line("+---+---+"));
+        assert!(is_separator_line("| --- | --- |"));
+        assert!(!is_separator_line("| hello | world |"));
+        assert!(!is_separator_line("| --- | data |"));
+    }
+
+    #[test]
+    fn test_classify_lines_cell_splitting() {
+        let lines = vec![("| a | b | c |".to_string(), 0..13)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells, &["a", "b", "c"]);
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_no_trailing_pipe() {
+        let lines = vec![("| a | b | c".to_string(), 0..11)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells.len(), 3);
+            assert_eq!(cells[2], "c");
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_empty_cells() {
+        let lines = vec![("| a | | c |".to_string(), 0..11)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells.len(), 3);
+            assert_eq!(cells[1], "");
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_resolve_merges_colspan() {
+        let rows = vec![TableRowData {
+            cells: vec![
+                TableCellData {
+                    text: "wide".to_string(),
+                    byte_range: 0..4,
+                    colspan: 1,
+                    rowspan: 1,
+                    is_header: false,
+                },
+                TableCellData {
+                    text: ">>".to_string(),
+                    byte_range: 0..2,
+                    colspan: 1,
+                    rowspan: 1,
+                    is_header: false,
+                },
+                TableCellData {
+                    text: "normal".to_string(),
+                    byte_range: 0..6,
+                    colspan: 1,
+                    rowspan: 1,
+                    is_header: false,
+                },
+            ],
+            byte_range: 0..20,
+        }];
+
+        let resolved = resolve_merges(rows);
+        assert_eq!(resolved[0].cells.len(), 2);
+        assert_eq!(resolved[0].cells[0].text, "wide");
+        assert_eq!(resolved[0].cells[0].colspan, 2);
+        assert_eq!(resolved[0].cells[1].text, "normal");
+    }
+
+    #[test]
+    fn test_resolve_merges_rowspan() {
+        let rows = vec![
+            TableRowData {
+                cells: vec![
+                    TableCellData {
+                        text: "tall".to_string(),
+                        byte_range: 0..4,
+                        colspan: 1,
+                        rowspan: 1,
+                        is_header: false,
+                    },
+                    TableCellData {
+                        text: "b".to_string(),
+                        byte_range: 0..1,
+                        colspan: 1,
+                        rowspan: 1,
+                        is_header: false,
+                    },
+                ],
+                byte_range: 0..10,
+            },
+            TableRowData {
+                cells: vec![
+                    TableCellData {
+                        text: "^^".to_string(),
+                        byte_range: 0..2,
+                        colspan: 1,
+                        rowspan: 1,
+                        is_header: false,
+                    },
+                    TableCellData {
+                        text: "d".to_string(),
+                        byte_range: 0..1,
+                        colspan: 1,
+                        rowspan: 1,
+                        is_header: false,
+                    },
+                ],
+                byte_range: 0..10,
+            },
+        ];
+
+        let resolved = resolve_merges(rows);
+        assert_eq!(resolved[0].cells[0].rowspan, 2);
+        assert_eq!(resolved[1].cells.len(), 1);
+        assert_eq!(resolved[1].cells[0].text, "d");
+    }
+
+    #[test]
+    fn test_parse_pipe_rows_skips_separators() {
+        let lines = vec![
+            ("| a | b |".to_string(), 0..9),
+            ("|---|---|".to_string(), 10..18),
+            ("| c | d |".to_string(), 19..28),
+        ];
+        let rows = parse_pipe_rows(&lines);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_pipe_rows_blanks_trigger_multiline() {
+        // Blank between pipe rows → multi-line mode, but each group has 1 line → 2 rows
+        let lines = vec![
+            ("| a | b |".to_string(), 0..9),
+            ("".to_string(), 10..10),
+            ("| c | d |".to_string(), 11..20),
+        ];
+        let rows = parse_pipe_rows(&lines);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].cells[0].text, "a");
+        assert_eq!(rows[1].cells[0].text, "c");
+    }
+
+    #[test]
+    fn test_detect_multiline_false_for_compact() {
+        let lines = vec![
+            ("| a | b |".to_string(), 0..9),
+            ("| c | d |".to_string(), 10..19),
+        ];
+        let classified = classify_lines(&lines);
+        assert!(!detect_multiline(&classified));
+    }
+
+    #[test]
+    fn test_detect_multiline_true_with_blanks() {
+        let lines = vec![
+            ("| a | b |".to_string(), 0..9),
+            ("".to_string(), 10..10),
+            ("| c | d |".to_string(), 11..20),
+        ];
+        let classified = classify_lines(&lines);
+        assert!(detect_multiline(&classified));
+    }
+
+    #[test]
+    fn test_merge_group_single_line() {
+        let lines = vec![("| x | y |".to_string(), 0..9)];
+        let classified = classify_lines(&lines);
+        let refs: Vec<&LineKind> = classified.iter().collect();
+        let row = merge_group(&refs).unwrap();
+        assert_eq!(row.cells.len(), 2);
+        assert_eq!(row.cells[0].text, "x");
+        assert_eq!(row.cells[1].text, "y");
+    }
+
+    #[test]
+    fn test_merge_group_continuation() {
+        let lines = vec![
+            ("| hello | world |".to_string(), 0..17),
+            ("|       | again |".to_string(), 18..35),
+        ];
+        let classified = classify_lines(&lines);
+        let refs: Vec<&LineKind> = classified.iter().collect();
+        let row = merge_group(&refs).unwrap();
+        assert_eq!(row.cells.len(), 2);
+        assert_eq!(row.cells[0].text, "hello");
+        assert_eq!(row.cells[1].text, "world\nagain");
+    }
+
+    #[test]
+    fn test_merge_group_whitespace_only_continuation_ignored() {
+        let lines = vec![
+            ("| base | val |".to_string(), 0..14),
+            ("|      |     |".to_string(), 15..29),
+        ];
+        let classified = classify_lines(&lines);
+        let refs: Vec<&LineKind> = classified.iter().collect();
+        let row = merge_group(&refs).unwrap();
+        assert_eq!(row.cells[0].text, "base");
+        assert_eq!(row.cells[1].text, "val");
+    }
+
+    #[test]
+    fn test_multiline_rows_grouping() {
+        let lines = vec![
+            ("| H1 | H2 |".to_string(), 0..11),
+            ("".to_string(), 12..12),
+            ("| a  | line1 |".to_string(), 13..27),
+            ("|    | line2 |".to_string(), 28..42),
+            ("".to_string(), 43..43),
+            ("| b  | single |".to_string(), 44..59),
+        ];
+        let rows = parse_pipe_rows(&lines);
+        assert_eq!(rows.len(), 3); // header group, row group 1, row group 2
+        assert_eq!(rows[0].cells[0].text, "H1");
+        assert_eq!(rows[1].cells[0].text, "a");
+        assert_eq!(rows[1].cells[1].text, "line1\nline2");
+        assert_eq!(rows[2].cells[0].text, "b");
+        assert_eq!(rows[2].cells[1].text, "single");
+    }
+
+    #[test]
+    fn test_extract_alignments() {
+        use crate::lex::ast::{Label, TableCellAlignment};
+
+        let label = Label::new("table".to_string());
+        let data = Data::new(
+            label,
+            vec![crate::lex::ast::Parameter {
+                key: "align".to_string(),
+                value: "lcr".to_string(),
+                location: crate::lex::ast::Range::default(),
+            }],
+        );
+
+        let aligns = extract_alignments(&data);
+        assert_eq!(aligns.len(), 3);
+        assert_eq!(aligns[0], TableCellAlignment::Left);
+        assert_eq!(aligns[1], TableCellAlignment::Center);
+        assert_eq!(aligns[2], TableCellAlignment::Right);
+    }
+}

--- a/crates/lex-core/src/lex/parsing/ir.rs
+++ b/crates/lex-core/src/lex/parsing/ir.rs
@@ -23,6 +23,7 @@ pub enum NodeType {
     Definition,
     Annotation,
     VerbatimBlock,
+    Table,
     BlankLineGroup,
 }
 
@@ -31,6 +32,12 @@ pub enum NodeType {
 pub enum ParseNodePayload {
     /// Raw line tokens needed to build a verbatim block (subject + content lines + closing data)
     VerbatimBlock {
+        subject: LineToken,
+        content_lines: Vec<LineToken>,
+        closing_data_tokens: Vec<TokenLocation>,
+    },
+    /// Raw line tokens needed to build a table (same outer structure as verbatim)
+    Table {
         subject: LineToken,
         content_lines: Vec<LineToken>,
         closing_data_tokens: Vec<TokenLocation>,

--- a/crates/lex-core/src/lex/parsing/parser/builder/builders/verbatim.rs
+++ b/crates/lex-core/src/lex/parsing/parser/builder/builders/verbatim.rs
@@ -28,7 +28,7 @@
 
 use super::helpers::{collect_line_tokens, extract_annotation_header_tokens, extract_line_token};
 use crate::lex::parsing::ir::{NodeType, ParseNode, ParseNodePayload};
-use crate::lex::token::{LineContainer, LineType};
+use crate::lex::token::{LineContainer, LineType, Token};
 use std::ops::Range;
 
 /// Build a verbatim block node from a subject, arbitrary content lines, and a closing annotation.
@@ -53,13 +53,32 @@ pub(in crate::lex::parsing::parser::builder) fn build_verbatim_block(
     }
     let header_tokens = extract_annotation_header_tokens(closing_token)?;
 
-    let verbatim_node = ParseNode::new(NodeType::VerbatimBlock, vec![], vec![]).with_payload(
-        ParseNodePayload::VerbatimBlock {
-            subject: subject_token,
-            content_lines,
-            closing_data_tokens: header_tokens,
-        },
-    );
+    // Detect whether this is a table or a verbatim block by checking the label.
+    // The label is the first non-whitespace text token in the header.
+    let is_table = header_tokens.iter().find_map(|(token, _)| match token {
+        Token::Text(text) => Some(text.as_str()),
+        _ => None,
+    }) == Some("table");
 
-    Ok(verbatim_node)
+    let (node_type, payload) = if is_table {
+        (
+            NodeType::Table,
+            ParseNodePayload::Table {
+                subject: subject_token,
+                content_lines,
+                closing_data_tokens: header_tokens,
+            },
+        )
+    } else {
+        (
+            NodeType::VerbatimBlock,
+            ParseNodePayload::VerbatimBlock {
+                subject: subject_token,
+                content_lines,
+                closing_data_tokens: header_tokens,
+            },
+        )
+    };
+
+    Ok(ParseNode::new(node_type, vec![], vec![]).with_payload(payload))
 }

--- a/crates/lex-core/src/lex/testing/ast_assertions.rs
+++ b/crates/lex-core/src/lex/testing/ast_assertions.rs
@@ -86,7 +86,7 @@ mod assertions;
 pub use assertions::{
     AnnotationAssertion, ChildrenAssertion, DefinitionAssertion, DocumentAssertion,
     InlineAssertion, InlineExpectation, ListAssertion, ListItemAssertion, ParagraphAssertion,
-    ReferenceExpectation, SessionAssertion, VerbatimBlockkAssertion,
+    ReferenceExpectation, SessionAssertion, TableAssertion, VerbatimBlockkAssertion,
 };
 
 use crate::lex::ast::traits::AstNode;
@@ -180,6 +180,21 @@ impl<'a> ContentItemAssertion<'a> {
             },
             _ => panic!(
                 "{}: Expected Annotation, found {}",
+                self.context,
+                self.item.node_type()
+            ),
+        }
+    }
+
+    /// Assert this item is a Table and return table-specific assertions
+    pub fn assert_table(self) -> TableAssertion<'a> {
+        match self.item {
+            ContentItem::Table(t) => TableAssertion {
+                table: t,
+                context: self.context,
+            },
+            _ => panic!(
+                "{}: Expected Table, found {}",
                 self.context,
                 self.item.node_type()
             ),

--- a/crates/lex-core/src/lex/testing/ast_assertions/assertions.rs
+++ b/crates/lex-core/src/lex/testing/ast_assertions/assertions.rs
@@ -11,6 +11,7 @@ mod inlines;
 mod list;
 mod paragraph;
 mod session;
+mod table;
 mod verbatim;
 
 pub use annotation::AnnotationAssertion;
@@ -24,6 +25,7 @@ pub use inlines::{InlineAssertion, InlineExpectation, ReferenceExpectation};
 pub use list::{ListAssertion, ListItemAssertion};
 pub use paragraph::ParagraphAssertion;
 pub use session::SessionAssertion;
+pub use table::TableAssertion;
 pub use verbatim::VerbatimBlockkAssertion;
 
 use crate::lex::ast::traits::AstNode;

--- a/crates/lex-core/src/lex/testing/ast_assertions/assertions/table.rs
+++ b/crates/lex-core/src/lex/testing/ast_assertions/assertions/table.rs
@@ -1,0 +1,247 @@
+//! Table assertions
+
+use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+use crate::lex::ast::{Table, TableCellAlignment};
+
+pub struct TableAssertion<'a> {
+    pub(crate) table: &'a Table,
+    pub(crate) context: String,
+}
+
+impl<'a> TableAssertion<'a> {
+    pub fn subject(self, expected: &str) -> Self {
+        let actual = self.table.subject.as_string();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected table subject '{}', got '{}'",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn mode(self, expected: VerbatimBlockMode) -> Self {
+        assert_eq!(
+            self.table.mode, expected,
+            "{}: Expected table mode {:?}, got {:?}",
+            self.context, expected, self.table.mode
+        );
+        self
+    }
+
+    pub fn closing_label(self, expected: &str) -> Self {
+        let actual = &self.table.closing_data.label.value;
+        assert_eq!(
+            actual, expected,
+            "{}: Expected closing label '{}', got '{}'",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn header_row_count(self, expected: usize) -> Self {
+        let actual = self.table.header_rows.len();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} header rows, got {}",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn body_row_count(self, expected: usize) -> Self {
+        let actual = self.table.body_rows.len();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} body rows, got {}",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn row_count(self, expected: usize) -> Self {
+        let actual = self.table.row_count();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} total rows, got {}",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn column_count(self, expected: usize) -> Self {
+        let actual = self.table.column_count();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} columns, got {}",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    /// Assert a specific header row's cell contents
+    pub fn header_row(self, row_index: usize, assertion: impl FnOnce(RowAssertion<'a>)) -> Self {
+        assert!(
+            row_index < self.table.header_rows.len(),
+            "{}: Header row index {} out of bounds ({} header rows)",
+            self.context,
+            row_index,
+            self.table.header_rows.len()
+        );
+        assertion(RowAssertion {
+            row: &self.table.header_rows[row_index],
+            context: format!("{}::header[{}]", self.context, row_index),
+        });
+        self
+    }
+
+    /// Assert a specific body row's cell contents
+    pub fn body_row(self, row_index: usize, assertion: impl FnOnce(RowAssertion<'a>)) -> Self {
+        assert!(
+            row_index < self.table.body_rows.len(),
+            "{}: Body row index {} out of bounds ({} body rows)",
+            self.context,
+            row_index,
+            self.table.body_rows.len()
+        );
+        assertion(RowAssertion {
+            row: &self.table.body_rows[row_index],
+            context: format!("{}::body[{}]", self.context, row_index),
+        });
+        self
+    }
+
+    /// Assert all header cell texts for a header row
+    pub fn header_cells(self, row_index: usize, expected: &[&str]) -> Self {
+        assert!(
+            row_index < self.table.header_rows.len(),
+            "{}: Header row index {} out of bounds",
+            self.context,
+            row_index
+        );
+        let row = &self.table.header_rows[row_index];
+        let actual: Vec<&str> = row.cells.iter().map(|c| c.content.as_string()).collect();
+        assert_eq!(
+            actual, expected,
+            "{}: Header row {} cells mismatch",
+            self.context, row_index
+        );
+        self
+    }
+
+    /// Assert all body cell texts for a body row
+    pub fn body_cells(self, row_index: usize, expected: &[&str]) -> Self {
+        assert!(
+            row_index < self.table.body_rows.len(),
+            "{}: Body row index {} out of bounds",
+            self.context,
+            row_index
+        );
+        let row = &self.table.body_rows[row_index];
+        let actual: Vec<&str> = row.cells.iter().map(|c| c.content.as_string()).collect();
+        assert_eq!(
+            actual, expected,
+            "{}: Body row {} cells mismatch",
+            self.context, row_index
+        );
+        self
+    }
+
+    pub fn has_closing_parameter_with_value(self, key: &str, value: &str) -> Self {
+        let found = self
+            .table
+            .closing_data
+            .parameters
+            .iter()
+            .any(|p| p.key == key && p.value == value);
+        assert!(
+            found,
+            "{}: Expected closing parameter '{}={}'",
+            self.context, key, value
+        );
+        self
+    }
+
+    pub fn annotation_count(self, expected: usize) -> Self {
+        let actual = self.table.annotations.len();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} annotations, got {}",
+            self.context, expected, actual
+        );
+        self
+    }
+}
+
+pub struct RowAssertion<'a> {
+    row: &'a crate::lex::ast::TableRow,
+    context: String,
+}
+
+impl<'a> RowAssertion<'a> {
+    pub fn cell_count(self, expected: usize) -> Self {
+        let actual = self.row.cells.len();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} cells, got {}",
+            self.context, expected, actual
+        );
+        self
+    }
+
+    pub fn cell_text(self, col: usize, expected: &str) -> Self {
+        assert!(
+            col < self.row.cells.len(),
+            "{}: Cell index {} out of bounds ({} cells)",
+            self.context,
+            col,
+            self.row.cells.len()
+        );
+        let actual = self.row.cells[col].content.as_string();
+        assert_eq!(
+            actual, expected,
+            "{}: Cell {} text mismatch",
+            self.context, col
+        );
+        self
+    }
+
+    pub fn cell_colspan(self, col: usize, expected: usize) -> Self {
+        assert!(col < self.row.cells.len());
+        assert_eq!(
+            self.row.cells[col].colspan, expected,
+            "{}: Cell {} colspan mismatch",
+            self.context, col
+        );
+        self
+    }
+
+    pub fn cell_rowspan(self, col: usize, expected: usize) -> Self {
+        assert!(col < self.row.cells.len());
+        assert_eq!(
+            self.row.cells[col].rowspan, expected,
+            "{}: Cell {} rowspan mismatch",
+            self.context, col
+        );
+        self
+    }
+
+    pub fn cell_align(self, col: usize, expected: TableCellAlignment) -> Self {
+        assert!(col < self.row.cells.len());
+        assert_eq!(
+            self.row.cells[col].align, expected,
+            "{}: Cell {} alignment mismatch",
+            self.context, col
+        );
+        self
+    }
+
+    pub fn cell_is_header(self, col: usize, expected: bool) -> Self {
+        assert!(col < self.row.cells.len());
+        assert_eq!(
+            self.row.cells[col].header, expected,
+            "{}: Cell {} header flag mismatch",
+            self.context, col
+        );
+        self
+    }
+}

--- a/crates/lex-core/src/lex/testing/ast_assertions/assertions/table.rs
+++ b/crates/lex-core/src/lex/testing/ast_assertions/assertions/table.rs
@@ -161,6 +161,73 @@ impl<'a> TableAssertion<'a> {
         self
     }
 
+    pub fn has_footnotes(self) -> Self {
+        assert!(
+            self.table.footnotes.is_some(),
+            "{}: Expected table to have footnotes",
+            self.context
+        );
+        self
+    }
+
+    pub fn no_footnotes(self) -> Self {
+        assert!(
+            self.table.footnotes.is_none(),
+            "{}: Expected table to have no footnotes",
+            self.context
+        );
+        self
+    }
+
+    pub fn footnote_count(self, expected: usize) -> Self {
+        let list = self
+            .table
+            .footnotes
+            .as_ref()
+            .unwrap_or_else(|| panic!("{}: Expected table to have footnotes", self.context));
+        let items: Vec<_> = list.items.iter().collect();
+        assert_eq!(
+            items.len(),
+            expected,
+            "{}: Expected {} footnotes, got {}",
+            self.context,
+            expected,
+            items.len()
+        );
+        self
+    }
+
+    pub fn footnote_text(self, index: usize, expected: &str) -> Self {
+        let list = self
+            .table
+            .footnotes
+            .as_ref()
+            .unwrap_or_else(|| panic!("{}: Expected table to have footnotes", self.context));
+        let items: Vec<_> = list.items.iter().collect();
+        assert!(
+            index < items.len(),
+            "{}: Footnote index {} out of bounds ({} footnotes)",
+            self.context,
+            index,
+            items.len()
+        );
+        let item = items[index]
+            .as_list_item()
+            .expect("Footnote should be a ListItem");
+        let actual: String = item
+            .text
+            .iter()
+            .map(|t| t.as_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_eq!(
+            actual, expected,
+            "{}: Footnote {} text mismatch",
+            self.context, index
+        );
+        self
+    }
+
     pub fn annotation_count(self, expected: usize) -> Self {
         let actual = self.table.annotations.len();
         assert_eq!(

--- a/crates/lex-core/src/lex/testing/ast_assertions/assertions/table.rs
+++ b/crates/lex-core/src/lex/testing/ast_assertions/assertions/table.rs
@@ -237,6 +237,96 @@ impl<'a> TableAssertion<'a> {
         );
         self
     }
+
+    /// Assert that a cell has (or doesn't have) block content
+    pub fn cell_has_block_content(
+        self,
+        row_type: &str,
+        row_idx: usize,
+        col: usize,
+        expected: bool,
+    ) -> Self {
+        let rows = match row_type {
+            "header" => &self.table.header_rows,
+            "body" => &self.table.body_rows,
+            _ => panic!("row_type must be 'header' or 'body'"),
+        };
+        assert!(
+            row_idx < rows.len(),
+            "{}: {} row {} out of bounds",
+            self.context,
+            row_type,
+            row_idx
+        );
+        assert!(
+            col < rows[row_idx].cells.len(),
+            "{}: Cell {} out of bounds in {} row {}",
+            self.context,
+            col,
+            row_type,
+            row_idx
+        );
+        let actual = rows[row_idx].cells[col].has_block_content();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {}[{}] cell {} has_block_content={}, got {}",
+            self.context, row_type, row_idx, col, expected, actual
+        );
+        self
+    }
+
+    /// Assert specific child element within a cell using a callback
+    pub fn cell_child(
+        self,
+        row_type: &str,
+        row_idx: usize,
+        col: usize,
+        child_idx: usize,
+        assertion: impl FnOnce(&crate::lex::ast::ContentItem),
+    ) -> Self {
+        let rows = match row_type {
+            "header" => &self.table.header_rows,
+            "body" => &self.table.body_rows,
+            _ => panic!("row_type must be 'header' or 'body'"),
+        };
+        let cell = &rows[row_idx].cells[col];
+        let children: Vec<&crate::lex::ast::ContentItem> = cell.children.iter().collect();
+        assert!(
+            child_idx < children.len(),
+            "{}: Child index {} out of bounds ({} children in {}[{}] cell {})",
+            self.context,
+            child_idx,
+            children.len(),
+            row_type,
+            row_idx,
+            col
+        );
+        assertion(children[child_idx]);
+        self
+    }
+
+    /// Count block children in a cell
+    pub fn cell_child_count(
+        self,
+        row_type: &str,
+        row_idx: usize,
+        col: usize,
+        expected: usize,
+    ) -> Self {
+        let rows = match row_type {
+            "header" => &self.table.header_rows,
+            "body" => &self.table.body_rows,
+            _ => panic!("row_type must be 'header' or 'body'"),
+        };
+        let cell = &rows[row_idx].cells[col];
+        let actual = cell.children.len();
+        assert_eq!(
+            actual, expected,
+            "{}: Expected {} children in {}[{}] cell {}, got {}",
+            self.context, expected, row_type, row_idx, col, actual
+        );
+        self
+    }
 }
 
 pub struct RowAssertion<'a> {
@@ -307,6 +397,28 @@ impl<'a> RowAssertion<'a> {
         assert_eq!(
             self.row.cells[col].header, expected,
             "{}: Cell {} header flag mismatch",
+            self.context, col
+        );
+        self
+    }
+
+    pub fn cell_has_block_content(self, col: usize, expected: bool) -> Self {
+        assert!(col < self.row.cells.len());
+        let actual = self.row.cells[col].has_block_content();
+        assert_eq!(
+            actual, expected,
+            "{}: Cell {} has_block_content mismatch",
+            self.context, col
+        );
+        self
+    }
+
+    pub fn cell_child_count(self, col: usize, expected: usize) -> Self {
+        assert!(col < self.row.cells.len());
+        let actual = self.row.cells[col].children.len();
+        assert_eq!(
+            actual, expected,
+            "{}: Cell {} child count mismatch",
             self.context, col
         );
         self

--- a/crates/lex-core/src/lex/testing/lexplore/loader.rs
+++ b/crates/lex-core/src/lex/testing/lexplore/loader.rs
@@ -6,7 +6,9 @@
 //! The Lexplore API now returns `DocumentLoader` which provides a fluent interface
 //! for running transforms on test files.
 
-use crate::lex::ast::elements::{Annotation, Definition, List, Paragraph, Session, Verbatim};
+use crate::lex::ast::elements::{
+    Annotation, Definition, List, Paragraph, Session, Table, Verbatim,
+};
 use crate::lex::ast::Document;
 use crate::lex::loader::DocumentLoader;
 use crate::lex::parsing::parse_document;
@@ -213,6 +215,12 @@ impl Lexplore {
         doc.root.expect_verbatim()
     }
 
+    /// Load a table element file and return the table directly
+    pub fn get_table(number: usize) -> &'static Table {
+        let doc = Box::leak(Box::new(load_isolated_element(ElementType::Table, number)));
+        doc.root.expect_table()
+    }
+
     // ===== Convenience shortcuts for element files (fluent API) =====
 
     element_shortcuts! {
@@ -222,6 +230,7 @@ impl Lexplore {
         definition => Definition, "definition";
         annotation => Annotation, "annotation";
         verbatim => Verbatim, "verbatim";
+        table => Table, "table";
         document => Document, "document";
     }
 

--- a/crates/lex-core/src/lex/testing/lexplore/specfile_finder.rs
+++ b/crates/lex-core/src/lex/testing/lexplore/specfile_finder.rs
@@ -41,6 +41,7 @@ pub enum ElementType {
     Definition,
     Annotation,
     Verbatim,
+    Table,
     Document,
 }
 
@@ -61,6 +62,7 @@ impl ElementType {
             ElementType::Definition => "definition",
             ElementType::Annotation => "annotation",
             ElementType::Verbatim => "verbatim",
+            ElementType::Table => "table",
             ElementType::Document => "document",
         }
     }

--- a/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
+++ b/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
@@ -83,6 +83,22 @@ impl InlineProcessor {
         self.process_text_content(&mut line.content);
     }
 
+    fn process_table(&self, table: &mut crate::lex::ast::elements::table::Table) {
+        self.process_text_content(&mut table.subject);
+        for row in table
+            .header_rows
+            .iter_mut()
+            .chain(table.body_rows.iter_mut())
+        {
+            for cell in &mut row.cells {
+                self.process_text_content(&mut cell.content);
+            }
+        }
+        for annotation in &mut table.annotations {
+            self.process_annotation(annotation);
+        }
+    }
+
     fn process_verbatim(&self, verbatim: &mut Verbatim) {
         self.process_text_content(&mut verbatim.subject);
         for group in verbatim.additional_groups_mut() {
@@ -110,6 +126,7 @@ impl InlineProcessor {
             ContentItem::Definition(definition) => self.process_definition(definition),
             ContentItem::Annotation(annotation) => self.process_annotation(annotation),
             ContentItem::VerbatimBlock(verbatim) => self.process_verbatim(verbatim),
+            ContentItem::Table(table) => self.process_table(table),
             ContentItem::VerbatimLine(_) => {}
             ContentItem::BlankLineGroup(_) => {}
         }

--- a/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
+++ b/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
@@ -92,6 +92,10 @@ impl InlineProcessor {
         {
             for cell in &mut row.cells {
                 self.process_text_content(&mut cell.content);
+                // Process block children if present
+                for child in cell.children.iter_mut() {
+                    self.process_content_item(child);
+                }
             }
         }
         if let Some(footnotes) = &mut table.footnotes {

--- a/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
+++ b/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
@@ -94,6 +94,9 @@ impl InlineProcessor {
                 self.process_text_content(&mut cell.content);
             }
         }
+        if let Some(footnotes) = &mut table.footnotes {
+            self.process_list(footnotes);
+        }
         for annotation in &mut table.annotations {
             self.process_annotation(annotation);
         }

--- a/crates/lex-core/tests/elements_table.rs
+++ b/crates/lex-core/tests/elements_table.rs
@@ -67,6 +67,37 @@ fn test_table_03_flat_header_count() {
 }
 
 // ============================================================================
+// Footnotes
+// ============================================================================
+
+#[test]
+fn test_table_06_flat_with_footnotes() {
+    // table-06: Table with trailing numbered footnotes
+    let doc = Lexplore::table(6).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Comparative Analysis of Retrieval Methods")
+            .header_row_count(1)
+            .body_row_count(3)
+            .has_footnotes()
+            .footnote_count(2)
+            .footnote_text(0, "Precision measured at k=10")
+            .footnote_text(1, "Weighted combination of BM25 and Dense");
+    });
+}
+
+#[test]
+fn test_table_no_footnotes() {
+    // table-01: Simple table should have no footnotes
+    let doc = Lexplore::table(1).parse().unwrap();
+
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table().no_footnotes();
+    });
+}
+
+// ============================================================================
 // Cell Merging
 // ============================================================================
 

--- a/crates/lex-core/tests/elements_table.rs
+++ b/crates/lex-core/tests/elements_table.rs
@@ -1,0 +1,322 @@
+//! Table element tests
+//!
+//! Tests the Table element using Lexplore fixtures from `table.docs/`.
+//! Covers: basic tables, alignment, header count, cell merging (colspan/rowspan),
+//! separator lines, fullwidth mode, empty cells, no-header mode, and combined spans.
+
+use lex_core::lex::ast::elements::verbatim::VerbatimBlockMode;
+use lex_core::lex::ast::TableCellAlignment;
+use lex_core::lex::testing::assert_ast;
+use lex_core::lex::testing::lexplore::Lexplore;
+
+// ============================================================================
+// Basic Tables
+// ============================================================================
+
+#[test]
+fn test_table_01_flat_minimal() {
+    // table-01: Simple 3-row table with 2 columns, default header=1
+    let doc = Lexplore::table(1).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Favorite Pets")
+            .closing_label("table")
+            .mode(VerbatimBlockMode::Inflow)
+            .header_row_count(1)
+            .body_row_count(2)
+            .column_count(2)
+            .header_cells(0, &["Person", "Pet"])
+            .body_cells(0, &["Bob", "Cats"])
+            .body_cells(1, &["Alice", "Dogs"]);
+    });
+}
+
+#[test]
+fn test_table_02_flat_with_alignment() {
+    // table-02: 4-row table with align=lcr parameter
+    let doc = Lexplore::table(2).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Test Scores")
+            .has_closing_parameter_with_value("align", "lcr")
+            .header_row_count(1)
+            .body_row_count(3)
+            .column_count(3)
+            .header_row(0, |row| {
+                row.cell_align(0, TableCellAlignment::Left)
+                    .cell_align(1, TableCellAlignment::Center)
+                    .cell_align(2, TableCellAlignment::Right);
+            });
+    });
+}
+
+#[test]
+fn test_table_03_flat_header_count() {
+    // table-03: header=2 with merge markers in header rows
+    let doc = Lexplore::table(3).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Quarterly Revenue")
+            .has_closing_parameter_with_value("header", "2")
+            .header_row_count(2)
+            .body_row_count(2);
+    });
+}
+
+// ============================================================================
+// Cell Merging
+// ============================================================================
+
+#[test]
+fn test_table_04_flat_cell_merging() {
+    // table-04: Colspan (>>) merge markers in header
+    let doc = Lexplore::table(4).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Experiment Summary")
+            .header_row_count(2)
+            .body_row_count(2)
+            .header_row(0, |row| {
+                // "Experiment Results | >> | Control" -> first cell has colspan=2
+                row.cell_text(0, "Experiment Results")
+                    .cell_colspan(0, 2)
+                    .cell_text(1, "Control");
+            });
+    });
+}
+
+#[test]
+fn test_table_17_flat_rowspan() {
+    // table-17: Rowspan (^^) merge markers
+    let doc = Lexplore::table(17).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Category Breakdown")
+            .header_row_count(1)
+            .body_row_count(3)
+            .body_row(0, |row| {
+                // "Group A" with ^^ below -> rowspan=2
+                row.cell_text(0, "Group A").cell_rowspan(0, 2);
+            });
+    });
+}
+
+#[test]
+fn test_table_18_flat_combined_spans() {
+    // table-18: Both colspan (>>) and rowspan (^^) in one table
+    let doc = Lexplore::table(18).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Matrix")
+            .header_row_count(2)
+            .body_row_count(2)
+            .header_row(0, |row| {
+                // "Q1 | >> | >> | Q2 | >> | >>" -> two cells with colspan=3 each
+                row.cell_count(2)
+                    .cell_text(0, "Q1")
+                    .cell_colspan(0, 3)
+                    .cell_text(1, "Q2")
+                    .cell_colspan(1, 3);
+            });
+    });
+}
+
+// ============================================================================
+// Multi-line Cells
+// ============================================================================
+
+#[test]
+fn test_table_05_flat_multiline() {
+    // table-05: Blank lines between pipe groups trigger multi-line mode.
+    // Consecutive pipe lines within a group form a single row with joined cell content.
+    let doc = Lexplore::table(5).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Experiment Log")
+            .header_row_count(1)
+            .body_row_count(2)
+            .column_count(3)
+            .header_cells(0, &["Trial", "Conditions", "Result"])
+            .body_row(0, |row| {
+                row.cell_text(0, "Trial 1")
+                    .cell_text(1, "20°C, pH 7.2")
+                    .cell_text(2, "Successful growth\nobserved after 48hrs.");
+            })
+            .body_row(1, |row| {
+                row.cell_text(0, "Trial 2")
+                    .cell_text(1, "25°C, pH 6.8")
+                    .cell_text(2, "No growth detected.");
+            });
+    });
+}
+
+#[test]
+fn test_table_multiline_from_string() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source = "Notes:\n    | Key | Value |\n\n    | A   | line1 |\n    |     | line2 |\n\n    | B   | solo  |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .body_row_count(2)
+            .header_cells(0, &["Key", "Value"])
+            .body_row(0, |row| {
+                row.cell_text(0, "A").cell_text(1, "line1\nline2");
+            })
+            .body_row(1, |row| {
+                row.cell_text(0, "B").cell_text(1, "solo");
+            });
+    });
+}
+
+// ============================================================================
+// Separator Lines
+// ============================================================================
+
+#[test]
+fn test_table_07_flat_separator_lines() {
+    // table-07: Separator lines (|---|---|) should be skipped
+    let doc = Lexplore::table(7).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Migration Example")
+            .row_count(3) // 1 header + 2 body, separator line is skipped
+            .header_cells(0, &["Name", "Score"])
+            .body_cells(0, &["Alice", "95"])
+            .body_cells(1, &["Bob", "87"]);
+    });
+}
+
+// ============================================================================
+// Empty Cells and No-Header
+// ============================================================================
+
+#[test]
+fn test_table_14_flat_empty_cells() {
+    // table-14: Some cells are empty
+    let doc = Lexplore::table(14).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Status Matrix")
+            .header_row_count(1)
+            .body_row_count(3)
+            .column_count(4)
+            .body_row(0, |row| {
+                // Review | (empty) | Done | (empty)
+                row.cell_text(0, "Review")
+                    .cell_text(1, "")
+                    .cell_text(2, "Done");
+            });
+    });
+}
+
+#[test]
+fn test_table_16_flat_no_header() {
+    // table-16: header=0, all rows are body
+    let doc = Lexplore::table(16).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Quick Reference")
+            .has_closing_parameter_with_value("header", "0")
+            .header_row_count(0)
+            .body_row_count(2)
+            .body_cells(0, &["Alice", "95"])
+            .body_cells(1, &["Bob", "87"]);
+    });
+}
+
+// ============================================================================
+// Fullwidth Mode
+// ============================================================================
+
+#[test]
+fn test_table_11_fullwidth() {
+    // table-11: Content starting at column 1 triggers fullwidth mode
+    let doc = Lexplore::table(11).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Fullwidth Comparison Table")
+            .mode(VerbatimBlockMode::Fullwidth)
+            .header_row_count(1)
+            .body_row_count(4)
+            .column_count(4);
+    });
+}
+
+// ============================================================================
+// Parsing from String
+// ============================================================================
+
+#[test]
+fn test_table_from_string() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source = "Simple Table:\n    | A | B |\n    | 1 | 2 |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Simple Table")
+            .header_row_count(1)
+            .body_row_count(1)
+            .header_cells(0, &["A", "B"])
+            .body_cells(0, &["1", "2"]);
+    });
+}
+
+#[test]
+fn test_table_header_cells_marked_as_header() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source = "T:\n    | H1 | H2 |\n    | B1 | B2 |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row(0, |row| {
+                row.cell_is_header(0, true).cell_is_header(1, true);
+            })
+            .body_row(0, |row| {
+                row.cell_is_header(0, false).cell_is_header(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_separator_only_dashes() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source = "T:\n    | A | B |\n    |---|---|\n    | 1 | 2 |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    // Separator should be ignored
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table().row_count(2);
+    });
+}
+
+#[test]
+fn test_table_inline_parsing_of_cells() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source = "T:\n    | *bold* | normal |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    // Cell content should be inline-parsed (TextContent with potential inlines)
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table().header_cells(0, &["*bold*", "normal"]);
+    });
+}

--- a/crates/lex-core/tests/elements_table.rs
+++ b/crates/lex-core/tests/elements_table.rs
@@ -339,6 +339,141 @@ fn test_table_separator_only_dashes() {
     });
 }
 
+// ============================================================================
+// Block Cell Content
+// ============================================================================
+
+#[test]
+fn test_table_19_cell_with_list() {
+    let doc = Lexplore::table(19).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Data")
+            .header_row_count(1)
+            .body_row_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "Alice")
+                    .cell_has_block_content(0, false)
+                    .cell_has_block_content(1, true)
+                    .cell_child_count(1, 1); // One list
+            })
+            .body_row(1, |row| {
+                row.cell_text(0, "Bob").cell_has_block_content(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_20_cell_with_definition() {
+    let doc = Lexplore::table(20).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Data")
+            .header_row_count(1)
+            .body_row_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "Cache").cell_has_block_content(1, true);
+            })
+            .body_row(1, |row| {
+                row.cell_has_block_content(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_21_cell_with_verbatim() {
+    let doc = Lexplore::table(21).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Data")
+            .header_row_count(1)
+            .body_row_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "Python").cell_has_block_content(1, true);
+            })
+            .body_row(1, |row| {
+                row.cell_has_block_content(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_22_cell_with_mixed_content() {
+    let doc = Lexplore::table(22).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Data")
+            .header_row_count(1)
+            .body_row_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "Alice").cell_has_block_content(1, true);
+            })
+            .body_row(1, |row| {
+                row.cell_text(0, "Bob").cell_has_block_content(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_23_cell_with_annotation() {
+    let doc = Lexplore::table(23).parse().unwrap();
+
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_table()
+            .subject("Data")
+            .header_row_count(1)
+            .body_row_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "Alpha").cell_has_block_content(1, true);
+            })
+            .body_row(1, |row| {
+                row.cell_has_block_content(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_block_content_from_string() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source = "T:\n    | Key | Value |\n\n    | A   | - item1 |\n    |     | - item2 |\n\n    | B   | plain   |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .body_row_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "A")
+                    .cell_has_block_content(1, true)
+                    .cell_child_count(1, 1); // One list
+            })
+            .body_row(1, |row| {
+                row.cell_text(0, "B").cell_has_block_content(1, false);
+            });
+    });
+}
+
+#[test]
+fn test_table_compact_mode_no_block_content() {
+    use lex_core::lex::parsing::parse_document;
+
+    // Compact mode (no blank lines) should never produce block content
+    let source = "T:\n    | A | - item |\n    | B | plain  |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table().body_row(0, |row| {
+            row.cell_has_block_content(0, false)
+                .cell_has_block_content(1, false);
+        });
+    });
+}
+
 #[test]
 fn test_table_inline_parsing_of_cells() {
     use lex_core::lex::parsing::parse_document;

--- a/crates/lex-core/tests/elements_verbatim.rs
+++ b/crates/lex-core/tests/elements_verbatim.rs
@@ -389,7 +389,7 @@ fn test_verbatim_17_fullwidth_preserves_leading_blank_line() {
     assert_ast(&doc).item_count(1).item(0, |item| {
         item.assert_verbatim_block()
             .subject("Fullwidth Leading Blank")
-            .closing_label("table")
+            .closing_label("data")
             .mode(VerbatimBlockMode::Fullwidth)
             .line_count(3)
             .line_eq(0, "")

--- a/crates/lex-core/tests/location_integrity.rs
+++ b/crates/lex-core/tests/location_integrity.rs
@@ -111,6 +111,12 @@ fn validate_item(item: &ContentItem, source: &str) {
             assert_range_in_source(&line.location, source);
             validate_text_content(&line.content, source);
         }
+        ContentItem::Table(table) => {
+            validate_text_content(&table.subject, source);
+            for annotation in &table.annotations {
+                validate_annotation(annotation, source);
+            }
+        }
         ContentItem::BlankLineGroup(_) => {}
     }
 }

--- a/crates/lex-core/tests/location_integrity.rs
+++ b/crates/lex-core/tests/location_integrity.rs
@@ -116,6 +116,14 @@ fn validate_item(item: &ContentItem, source: &str) {
             for annotation in &table.annotations {
                 validate_annotation(annotation, source);
             }
+            // Validate cell children locations
+            for row in table.all_rows() {
+                for cell in &row.cells {
+                    for child in cell.children.iter() {
+                        validate_item(child, source);
+                    }
+                }
+            }
         }
         ContentItem::BlankLineGroup(_) => {}
     }

--- a/crates/lex-core/tests/proptest_invariants.rs
+++ b/crates/lex-core/tests/proptest_invariants.rs
@@ -105,6 +105,14 @@ fn collect_text(item: &ContentItem, out: &mut String) {
         ContentItem::VerbatimLine(vl) => {
             out.push_str(vl.content.as_string());
         }
+        ContentItem::Table(t) => {
+            out.push_str(t.subject.as_string());
+            for row in t.all_rows() {
+                for cell in &row.cells {
+                    out.push_str(cell.content.as_string());
+                }
+            }
+        }
         ContentItem::BlankLineGroup(_) => {}
         ContentItem::Annotation(_) => {}
     }

--- a/crates/lex-core/tests/proptest_invariants.rs
+++ b/crates/lex-core/tests/proptest_invariants.rs
@@ -48,6 +48,10 @@ fn valid_document_strategy() -> impl Strategy<Value = String> {
         // Verbatim
         (subject_strategy(), label_strategy(), "[a-zA-Z0-9]+")
             .prop_map(|(s, l, c)| format!("{s}:\n    {c}\n:: {l} ::\n")),
+        // Table (compact)
+        (subject_strategy(), list_text(), list_text()).prop_map(|(s, a, b)| {
+            format!("{s}:\n    | H1 | H2 |\n    | {a} | {b} |\n:: table ::\n")
+        }),
     ]
 }
 
@@ -110,6 +114,10 @@ fn collect_text(item: &ContentItem, out: &mut String) {
             for row in t.all_rows() {
                 for cell in &row.cells {
                     out.push_str(cell.content.as_string());
+                    // Recurse into block children
+                    for child in cell.children.iter() {
+                        collect_text(child, out);
+                    }
                 }
             }
         }

--- a/crates/lex-core/tests/proptest_table_cells.rs
+++ b/crates/lex-core/tests/proptest_table_cells.rs
@@ -1,0 +1,118 @@
+//! Property-based tests for table cell block content
+//!
+//! Tests that multi-line tables with block content parse correctly
+//! and maintain structural invariants.
+
+use lex_core::lex::ast::ContentItem;
+use lex_core::lex::parsing::parse_document;
+use proptest::prelude::*;
+
+fn word() -> impl Strategy<Value = String> {
+    "[A-Z][a-z]{2,8}"
+}
+
+fn list_cell() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(word(), 2..=4)
+        .prop_map(|words| words.into_iter().map(|w| format!("| - {w:<13}|")).collect())
+}
+
+/// Generate a multi-line table with optional list content in cells
+fn table_with_list_strategy() -> impl Strategy<Value = String> {
+    (word(), word(), list_cell()).prop_map(|(subject, header, list_lines)| {
+        let mut lines = Vec::new();
+        lines.push(format!("{subject}:"));
+        lines.push("    | Name | Items           |".to_string());
+        lines.push(String::new()); // blank line for multi-line mode
+        lines.push(format!("    | {:<4} {}", header, list_lines[0]));
+        for line in &list_lines[1..] {
+            lines.push(format!("    |      {line}"));
+        }
+        lines.push(String::new()); // blank line
+        lines.push("    | Solo | Plain text      |".to_string());
+        lines.push(":: table ::".to_string());
+        lines.push(String::new());
+        lines.join("\n")
+    })
+}
+
+/// Generate a simple multi-line table with paragraph content
+fn table_with_paragraphs_strategy() -> impl Strategy<Value = String> {
+    (word(), word(), word()).prop_map(|(subject, w1, w2)| {
+        format!(
+            "{subject}:\n    | Key | Value |\n\n    | {w1} | Line one. |\n    |     | Line two. |\n\n    | {w2} | Single.   |\n:: table ::\n"
+        )
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn table_with_list_parses_successfully(source in table_with_list_strategy()) {
+        let result = parse_document(&source);
+        prop_assert!(result.is_ok(), "Failed to parse: {:?}\nSource:\n{}", result.err(), source);
+    }
+
+    #[test]
+    fn table_with_paragraphs_parses_successfully(source in table_with_paragraphs_strategy()) {
+        let result = parse_document(&source);
+        prop_assert!(result.is_ok(), "Failed to parse: {:?}\nSource:\n{}", result.err(), source);
+    }
+
+    #[test]
+    fn table_with_list_has_block_content(source in table_with_list_strategy()) {
+        let doc = parse_document(&source).unwrap();
+        let items: Vec<&ContentItem> = doc.root.children.iter()
+            .filter(|i| !matches!(i, ContentItem::BlankLineGroup(_)))
+            .collect();
+
+        // Should have at least one table
+        let has_table = items.iter().any(|i| matches!(i, ContentItem::Table(_)));
+        prop_assert!(has_table, "No table found in parsed document\nSource:\n{}", source);
+
+        // The first body row's second cell should have block content (list)
+        for item in &items {
+            if let ContentItem::Table(t) = item {
+                if let Some(row) = t.body_rows.first() {
+                    if row.cells.len() > 1 {
+                        let cell = &row.cells[1];
+                        prop_assert!(
+                            cell.has_block_content(),
+                            "Expected block content in first body row cell 1\nSource:\n{}",
+                            source
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn no_sessions_in_cell_children(source in table_with_list_strategy()) {
+        let doc = parse_document(&source).unwrap();
+        for item in doc.root.children.iter() {
+            if let ContentItem::Table(t) = item {
+                for row in t.all_rows() {
+                    for cell in &row.cells {
+                        for child in cell.children.iter() {
+                            prop_assert!(
+                                !matches!(child, ContentItem::Session(_)),
+                                "Session found in cell children (should be impossible)"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parse_is_deterministic_for_tables(source in table_with_paragraphs_strategy()) {
+        let doc1 = parse_document(&source).unwrap();
+        let doc2 = parse_document(&source).unwrap();
+
+        let count1 = doc1.root.children.iter().count();
+        let count2 = doc2.root.children.iter().count();
+        prop_assert_eq!(count1, count2, "Different child counts on same source");
+    }
+}


### PR DESCRIPTION
## Summary
- Native table element: pipe-delimited rows with subject/closing-annotation pattern
- Cell merging (colspan `>>`, rowspan `^^`), multi-line cells, footnotes, alignment/header params
- Block content in cells: lists, definitions, verbatim blocks, annotations
- Downstream updates: analysis (semantic tokens, symbols, folding, completion), babel IR conversion, CLI transforms

## Test plan
- [x] 25 element tests covering all table features (fixtures 01-23)
- [x] Proptests for cell parsing invariants
- [x] Location integrity and proptest invariant coverage
- [x] Full workspace passes (1386 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)