### PR TITLE
Align marker terminology across codebase

### DIFF
--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -65,8 +65,8 @@ pub enum LexSemanticTokenKind {
     ReferenceCitation,
     ReferenceFootnote,
     VerbatimSubject,
-    VerbatimLanguage,
-    VerbatimAttribute,
+    DataLabel,
+    DataParameter,
     VerbatimContent,
     InlineMarkerStrongStart,
     InlineMarkerStrongEnd,
@@ -118,8 +118,8 @@ impl LexSemanticTokenKind {
             LexSemanticTokenKind::ReferenceCitation => "ReferenceCitation",
             LexSemanticTokenKind::ReferenceFootnote => "ReferenceFootnote",
             LexSemanticTokenKind::VerbatimSubject => "VerbatimSubject",
-            LexSemanticTokenKind::VerbatimLanguage => "VerbatimLanguage",
-            LexSemanticTokenKind::VerbatimAttribute => "VerbatimAttribute",
+            LexSemanticTokenKind::DataLabel => "DataLabel",
+            LexSemanticTokenKind::DataParameter => "DataParameter",
             LexSemanticTokenKind::VerbatimContent => "VerbatimContent",
             LexSemanticTokenKind::InlineMarkerStrongStart => "InlineMarker_strong_start",
             LexSemanticTokenKind::InlineMarkerStrongEnd => "InlineMarker_strong_end",
@@ -155,8 +155,8 @@ pub const SEMANTIC_TOKEN_KINDS: &[LexSemanticTokenKind] = &[
     LexSemanticTokenKind::ReferenceCitation,
     LexSemanticTokenKind::ReferenceFootnote,
     LexSemanticTokenKind::VerbatimSubject,
-    LexSemanticTokenKind::VerbatimLanguage,
-    LexSemanticTokenKind::VerbatimAttribute,
+    LexSemanticTokenKind::DataLabel,
+    LexSemanticTokenKind::DataParameter,
     LexSemanticTokenKind::VerbatimContent,
     LexSemanticTokenKind::InlineMarkerStrongStart,
     LexSemanticTokenKind::InlineMarkerStrongEnd,
@@ -379,10 +379,10 @@ impl TokenCollector {
 
         self.push_range(
             &verbatim.closing_data.label.location,
-            LexSemanticTokenKind::VerbatimLanguage,
+            LexSemanticTokenKind::DataLabel,
         );
         for parameter in &verbatim.closing_data.parameters {
-            self.push_range(&parameter.location, LexSemanticTokenKind::VerbatimAttribute);
+            self.push_range(&parameter.location, LexSemanticTokenKind::DataParameter);
         }
 
         self.process_annotations(verbatim.annotations());
@@ -406,10 +406,10 @@ impl TokenCollector {
 
         self.push_range(
             &table.closing_data.label.location,
-            LexSemanticTokenKind::VerbatimLanguage,
+            LexSemanticTokenKind::DataLabel,
         );
         for parameter in &table.closing_data.parameters {
-            self.push_range(&parameter.location, LexSemanticTokenKind::VerbatimAttribute);
+            self.push_range(&parameter.location, LexSemanticTokenKind::DataParameter);
         }
 
         self.process_annotations(table.annotations());
@@ -776,11 +776,9 @@ mod tests {
         assert!(verbatim_subjects
             .iter()
             .any(|snippet| snippet.contains("CLI Example")));
-        assert!(
-            snippets(&tokens, LexSemanticTokenKind::VerbatimLanguage, source)
-                .iter()
-                .any(|snippet| snippet.contains("shell"))
-        );
+        assert!(snippets(&tokens, LexSemanticTokenKind::DataLabel, source)
+            .iter()
+            .any(|snippet| snippet.contains("shell")));
     }
 
     #[test]

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -8,30 +8,27 @@ use lex_core::lex::ast::{
     Annotation, Definition, Document, List, ListItem, Paragraph, Session, Verbatim,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum MarkerType {
-    Bullet,
-    Numeric,
-    AlphaLower,
-    AlphaUpper,
-    RomanUpper,
-}
+use lex_core::lex::ast::elements::sequence_marker::DecorationStyle;
 
 struct ListContext {
     index: usize,
-    marker_type: MarkerType,
+    style: DecorationStyle,
+    upper_case: bool,
     marker_form: Option<Form>,
 }
 
-impl MarkerType {}
-
-fn format_marker_index(marker_type: MarkerType, index: usize) -> String {
-    match marker_type {
-        MarkerType::Bullet => "-".to_string(),
-        MarkerType::Numeric => index.to_string(),
-        MarkerType::AlphaLower => to_alpha_lower(index),
-        MarkerType::AlphaUpper => to_alpha_upper(index),
-        MarkerType::RomanUpper => to_roman_upper(index),
+fn format_marker_index(style: DecorationStyle, upper_case: bool, index: usize) -> String {
+    match style {
+        DecorationStyle::Plain => "-".to_string(),
+        DecorationStyle::Numerical => index.to_string(),
+        DecorationStyle::Alphabetical => {
+            if upper_case {
+                to_alpha_upper(index)
+            } else {
+                to_alpha_lower(index)
+            }
+        }
+        DecorationStyle::Roman => to_roman_upper(index),
     }
 }
 
@@ -152,7 +149,7 @@ impl LexSerializer {
                 // Current level: not yet incremented
                 ctx.index
             };
-            parts.push(format_marker_index(ctx.marker_type, idx));
+            parts.push(format_marker_index(ctx.style, ctx.upper_case, idx));
         }
         format!("{}.", parts.join("."))
     }
@@ -208,31 +205,23 @@ impl Visitor for LexSerializer {
     }
 
     fn visit_list(&mut self, list: &List) {
-        // Use the SequenceMarker to determine marker type
-        let marker_type = if let Some(marker) = &list.marker {
-            use lex_core::lex::ast::elements::DecorationStyle;
-            match marker.style {
-                DecorationStyle::Plain => MarkerType::Bullet,
-                DecorationStyle::Numerical => MarkerType::Numeric,
-                DecorationStyle::Alphabetical => {
-                    let text = marker.as_str();
-                    if text.chars().next().is_some_and(|c| c.is_uppercase()) {
-                        MarkerType::AlphaUpper
-                    } else {
-                        MarkerType::AlphaLower
-                    }
-                }
-                DecorationStyle::Roman => MarkerType::RomanUpper,
-            }
+        let (style, upper_case) = if let Some(marker) = &list.marker {
+            let upper = marker.style == DecorationStyle::Alphabetical
+                && marker
+                    .as_str()
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_uppercase());
+            (marker.style, upper)
         } else {
-            MarkerType::Bullet
+            (DecorationStyle::Plain, false)
         };
 
-        // Determine marker form (Standard vs Extended)
         let marker_form = list.marker.as_ref().map(|marker| marker.form);
 
         self.list_stack.push(ListContext {
-            marker_type,
+            style,
+            upper_case,
             marker_form,
             index: 1,
         });
@@ -257,12 +246,13 @@ impl Visitor for LexSerializer {
                     .list_stack
                     .last()
                     .expect("List stack empty in list item");
-                match context.marker_type {
-                    MarkerType::Bullet => self.rules.unordered_seq_marker.to_string(),
-                    MarkerType::Numeric => format!("{}.", context.index),
-                    MarkerType::AlphaLower => format!("{}.", to_alpha_lower(context.index)),
-                    MarkerType::AlphaUpper => format!("{}.", to_alpha_upper(context.index)),
-                    MarkerType::RomanUpper => format!("{}.", to_roman_upper(context.index)),
+                if context.style == DecorationStyle::Plain {
+                    self.rules.unordered_seq_marker.to_string()
+                } else {
+                    format!(
+                        "{}.",
+                        format_marker_index(context.style, context.upper_case, context.index)
+                    )
                 }
             }
         } else {

--- a/crates/lex-core/src/lex/ast/elements/annotation.rs
+++ b/crates/lex-core/src/lex/ast/elements/annotation.rs
@@ -25,7 +25,7 @@
 //!
 //! | Element    | Prec. Blank | Head                | Blank | Content | Tail          |
 //! |------------|-------------|---------------------|-------|---------|---------------|
-//! | Annotation | Optional    | AnnotationStartLine | Yes   | Yes     | dedent        |
+//! | Annotation | Optional    | DataMarkerLine | Yes   | Yes     | dedent        |
 //!
 //! Special Case: Short form annotations are one-liners without content or dedent.
 //!

--- a/crates/lex-core/src/lex/lexing/line_classification.rs
+++ b/crates/lex-core/src/lex/lexing/line_classification.rs
@@ -20,14 +20,14 @@
 //!
 //!     Classification follows this specific order (important for correctness):
 //!         1. Blank lines
-//!         2. Annotation start lines (follows annotation grammar)
+//!         2. Data marker lines (:: label params? ::, closed form)
 //!         3. Data lines (:: label params? without closing ::)
 //!         4. List lines starting with list marker AND ending with colon -> SubjectOrListItemLine
 //!         5. List lines (starting with list marker)
 //!         6. Subject lines (ending with colon)
 //!         7. Default to paragraph
 //!
-//!     This ordering ensures that more specific patterns (like annotation lines) are matched before
+//!     This ordering ensures that more specific patterns (like data marker lines) are matched before
 //!     more general ones (like subject lines).
 
 use crate::lex::annotation::analyze_annotation_header_tokens;
@@ -56,7 +56,7 @@ pub struct ParsedListMarker {
 ///
 /// Classification follows this specific order (important for correctness):
 /// 1. Blank lines
-/// 2. Annotation start lines (follows annotation grammar)
+/// 2. Data marker lines (:: label params? ::, closed form)
 /// 3. Data lines (:: label params? without closing ::)
 /// 4. List lines starting with list marker AND ending with colon -> SubjectOrListItemLine
 /// 5. List lines (starting with list marker)
@@ -72,9 +72,9 @@ pub fn classify_line_tokens(tokens: &[Token]) -> LineType {
         return LineType::BlankLine;
     }
 
-    // ANNOTATION_START_LINE: Follows annotation grammar with :: markers
-    if is_annotation_start_line(tokens) {
-        return LineType::AnnotationStartLine;
+    // DATA_MARKER_LINE: Data marker in closed form (:: label params? ::)
+    if is_data_marker_line(tokens) {
+        return LineType::DataMarkerLine;
     }
 
     // DATA_LINE: :: label params? without closing ::
@@ -117,13 +117,13 @@ fn is_blank_line(tokens: &[Token]) -> bool {
     })
 }
 
-/// Check if line is an annotation start line: follows annotation grammar
+/// Check if line is a data marker line in closed form: :: label params? ::
 /// Grammar: <lex-marker><space><label>(<space><parameters>)? <lex-marker> <content>?
 ///
 /// Uses quote-aware marker detection so that `::` inside quoted parameter
 /// values (e.g., `:: note msg=":: value" ::`) is not misidentified as a
 /// structural delimiter.
-fn is_annotation_start_line(tokens: &[Token]) -> bool {
+fn is_data_marker_line(tokens: &[Token]) -> bool {
     if tokens.is_empty() {
         return false;
     }
@@ -447,7 +447,7 @@ mod tests {
             Token::LexMarker,
             Token::BlankLine(Some("\n".to_string())),
         ];
-        assert_eq!(classify_line_tokens(&tokens), LineType::AnnotationStartLine);
+        assert_eq!(classify_line_tokens(&tokens), LineType::DataMarkerLine);
     }
 
     #[test]
@@ -607,7 +607,7 @@ mod tests {
             Token::LexMarker, // closing ::
             Token::BlankLine(Some("\n".to_string())),
         ];
-        assert_eq!(classify_line_tokens(&tokens), LineType::AnnotationStartLine);
+        assert_eq!(classify_line_tokens(&tokens), LineType::DataMarkerLine);
     }
 
     #[test]

--- a/crates/lex-core/src/lex/lexing/transformations/document_start.rs
+++ b/crates/lex-core/src/lex/lexing/transformations/document_start.rs
@@ -29,7 +29,7 @@ impl DocumentStartMarker {
     /// - At position 0 if there are no document-level annotations
     /// - Immediately after the last document-level annotation otherwise
     ///
-    /// Document-level annotations are identified as AnnotationStartLine at indentation
+    /// Document-level annotations are identified as DataMarkerLine at indentation
     /// level 0 (not nested within any container).
     pub fn mark(line_tokens: Vec<LineToken>) -> Vec<LineToken> {
         if line_tokens.is_empty() {
@@ -58,7 +58,7 @@ impl DocumentStartMarker {
     ///
     /// This scans for the pattern of document-level annotations at the start.
     /// Document-level annotations are:
-    /// - AnnotationStartLine at root level
+    /// - DataMarkerLine at root level
     /// - Followed by their content (possibly including Indent/Dedent for nested content)
     /// - Possibly followed by BlankLines
     fn find_content_start(tokens: &[LineToken]) -> usize {
@@ -80,7 +80,7 @@ impl DocumentStartMarker {
                 }
 
                 // Annotation at root level - skip it and its content
-                LineType::AnnotationStartLine if indent_depth == 0 => {
+                LineType::DataMarkerLine if indent_depth == 0 => {
                     pos += 1;
                     // Continue to consume the annotation's content
                 }
@@ -97,7 +97,7 @@ impl DocumentStartMarker {
 
                     // If next non-blank is an annotation, skip all blanks
                     if lookahead < tokens.len()
-                        && tokens[lookahead].line_type == LineType::AnnotationStartLine
+                        && tokens[lookahead].line_type == LineType::DataMarkerLine
                     {
                         pos = lookahead;
                     } else {
@@ -206,9 +206,9 @@ mod tests {
 
     #[test]
     fn test_single_annotation_then_content() {
-        // Document: AnnotationStartLine, Indent, ParagraphLine, Dedent, ParagraphLine
+        // Document: DataMarkerLine, Indent, ParagraphLine, Dedent, ParagraphLine
         let tokens = vec![
-            make_line(LineType::AnnotationStartLine),
+            make_line(LineType::DataMarkerLine),
             make_indent(),
             make_line(LineType::ParagraphLine),
             make_dedent(),
@@ -219,7 +219,7 @@ mod tests {
 
         // DocumentStart should be after the annotation block (position 4)
         assert_eq!(result.len(), 6);
-        assert_eq!(result[0].line_type, LineType::AnnotationStartLine);
+        assert_eq!(result[0].line_type, LineType::DataMarkerLine);
         assert_eq!(result[1].line_type, LineType::Indent);
         assert_eq!(result[2].line_type, LineType::ParagraphLine);
         assert_eq!(result[3].line_type, LineType::Dedent);
@@ -231,12 +231,12 @@ mod tests {
     fn test_multiple_annotations() {
         // Document: Annotation1, BlankLine, Annotation2, content
         let tokens = vec![
-            make_line(LineType::AnnotationStartLine),
+            make_line(LineType::DataMarkerLine),
             make_indent(),
             make_line(LineType::ParagraphLine),
             make_dedent(),
             make_blank(),
-            make_line(LineType::AnnotationStartLine),
+            make_line(LineType::DataMarkerLine),
             make_indent(),
             make_line(LineType::ParagraphLine),
             make_dedent(),
@@ -253,9 +253,9 @@ mod tests {
 
     #[test]
     fn test_blank_lines_before_content() {
-        // Document: AnnotationStartLine, content, BlankLine, ParagraphLine
+        // Document: DataMarkerLine, content, BlankLine, ParagraphLine
         let tokens = vec![
-            make_line(LineType::AnnotationStartLine),
+            make_line(LineType::DataMarkerLine),
             make_indent(),
             make_line(LineType::ParagraphLine),
             make_dedent(),
@@ -277,7 +277,7 @@ mod tests {
     fn test_only_annotations() {
         // Document: only annotations, no content
         let tokens = vec![
-            make_line(LineType::AnnotationStartLine),
+            make_line(LineType::DataMarkerLine),
             make_indent(),
             make_line(LineType::ParagraphLine),
             make_dedent(),

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -387,7 +387,7 @@ impl GrammarMatcher {
         start_idx: usize,
     ) -> Option<(PatternMatch, Range<usize>)> {
         use LineType::{
-            AnnotationStartLine, BlankLine, DocumentStart, SubjectLine, SubjectOrListItemLine,
+            BlankLine, DataMarkerLine, DocumentStart, SubjectLine, SubjectOrListItemLine,
         };
 
         let len = tokens.len();
@@ -468,7 +468,7 @@ impl GrammarMatcher {
 
                     match &tokens[cursor] {
                         LineContainer::Token(line) => {
-                            if matches!(line.line_type, AnnotationStartLine) {
+                            if matches!(line.line_type, DataMarkerLine) {
                                 // Container followed by closing annotation (:: label ::) - this IS verbatim!
                                 // Continue loop to match it
                                 continue;
@@ -488,7 +488,7 @@ impl GrammarMatcher {
                     }
                 }
                 LineContainer::Token(line) => {
-                    if matches!(line.line_type, AnnotationStartLine) {
+                    if matches!(line.line_type, DataMarkerLine) {
                         // Found closing annotation (:: label ::) - success!
                         // But only if we haven't mixed containers with flat content in a problematic way
                         return Some((

--- a/crates/lex-core/src/lex/parsing/parser/builder/builders/verbatim.rs
+++ b/crates/lex-core/src/lex/parsing/parser/builder/builders/verbatim.rs
@@ -48,7 +48,7 @@ pub(in crate::lex::parsing::parser::builder) fn build_verbatim_block(
     }
 
     let closing_token = extract_line_token(&tokens[closing_idx])?;
-    if !matches!(closing_token.line_type, LineType::AnnotationStartLine) {
+    if !matches!(closing_token.line_type, LineType::DataMarkerLine) {
         return Err("Verbatim blocks must end with a closing annotation (:: label ::)".to_string());
     }
     let header_tokens = extract_annotation_header_tokens(closing_token)?;

--- a/crates/lex-core/src/lex/parsing/parser/grammar.rs
+++ b/crates/lex-core/src/lex/parsing/parser/grammar.rs
@@ -44,7 +44,7 @@
 //!     a few consequential marks in lines (blank, data, subject, list) having them
 //!     denormalized is required to have parsing simpler.
 //!
-//!     The definitive set is the LineType enum (blank, annotation start, data, subject,
+//!     The definitive set is the LineType enum (blank, data marker, data, subject,
 //!     list, subject-or-list-item, paragraph, dialog, indent, dedent), and containers are
 //!     a separate structural node, not a line token.
 //!
@@ -84,7 +84,7 @@ pub(super) static LIST_ITEM_REGEX: Lazy<Regex> =
 /// # Pattern Structure
 ///
 /// - Named capture groups (e.g., `(?P<start>...)`) allow extracting specific parts
-/// - Token types in angle brackets (e.g., `<annotation-start-line>`) match grammar symbols
+/// - Token types in angle brackets (e.g., `<data-marker-line>`) match grammar symbols
 /// - `<container>` represents a nested indented block
 /// - Quantifiers like `+` (one or more) and `{2,}` (two or more) enforce grammar rules
 pub(super) const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
@@ -107,13 +107,13 @@ pub(super) const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
     // Document start marker: synthetic boundary between metadata and content
     // Only matched when there's no document title (fallback)
     ("document_start", r"^<document-start-line>"),
-    // Annotation (multi-line): <annotation-start-line><container>
+    // Annotation (multi-line): <data-marker-line><container>
     (
         "annotation_block",
-        r"^(?P<start><annotation-start-line>)(?P<content><container>)",
+        r"^(?P<start><data-marker-line>)(?P<content><container>)",
     ),
-    // Annotation (single-line): <annotation-start-line><content>
-    ("annotation_single", r"^(?P<start><annotation-start-line>)"),
+    // Annotation (single-line): <data-marker-line><content>
+    ("annotation_single", r"^(?P<start><data-marker-line>)"),
     // List without preceding blank line (matches anywhere — paragraph lookaheads yield)
     (
         "list_no_blank",

--- a/crates/lex-core/src/lex/token/line.rs
+++ b/crates/lex-core/src/lex/token/line.rs
@@ -23,7 +23,7 @@
 //!     These are the line tokens:
 //!
 //!         - BlankLine: empty or whitespace only
-//!         - AnnotationStartLine: a data node + lex marker
+//!         - DataMarkerLine: a data marker in closed form (:: label params? ::)
 //!         - DataLine: :: label params? (no closing :: marker)
 //!         - SubjectLine: Line ending with colon (could be subject/definition/session title)
 //!         - ListLine: Line starting with list marker (-, 1., a., I., etc.)
@@ -93,8 +93,9 @@ pub enum LineType {
     /// Blank line (empty or whitespace only)
     BlankLine,
 
-    /// Annotation start line: follows annotation grammar <lex-marker><space><label>(<space><parameters>)? <lex-marker> <content>?
-    AnnotationStartLine,
+    /// Data marker line: a data marker in closed form (:: label params? ::).
+    /// Used for both annotation headers and verbatim closing lines.
+    DataMarkerLine,
 
     /// Data line: :: label params? (no closing :: marker)
     DataLine,
@@ -135,7 +136,7 @@ impl fmt::Display for LineType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             LineType::BlankLine => "BLANK_LINE",
-            LineType::AnnotationStartLine => "ANNOTATION_START_LINE",
+            LineType::DataMarkerLine => "DATA_MARKER_LINE",
             LineType::DataLine => "DATA_LINE",
             LineType::SubjectLine => "SUBJECT_LINE",
             LineType::ListLine => "LIST_LINE",
@@ -157,12 +158,12 @@ impl LineType {
     ///
     /// Examples:
     /// - BlankLine -> `<blank-line>`
-    /// - AnnotationStartLine -> `<annotation-start-line>`
+    /// - DataMarkerLine -> `<data-marker-line>`
     /// - SubjectLine -> `<subject-line>`
     pub fn to_grammar_string(&self) -> String {
         let name = match self {
             LineType::BlankLine => "blank-line",
-            LineType::AnnotationStartLine => "annotation-start-line",
+            LineType::DataMarkerLine => "data-marker-line",
             LineType::DataLine => "data-line",
             LineType::SubjectLine => "subject-line",
             LineType::ListLine => "list-line",
@@ -228,8 +229,8 @@ mod tests {
     fn test_token_type_to_grammar_string() {
         assert_eq!(LineType::BlankLine.to_grammar_string(), "<blank-line>");
         assert_eq!(
-            LineType::AnnotationStartLine.to_grammar_string(),
-            "<annotation-start-line>"
+            LineType::DataMarkerLine.to_grammar_string(),
+            "<data-marker-line>"
         );
         assert_eq!(LineType::SubjectLine.to_grammar_string(), "<subject-line>");
         assert_eq!(LineType::ListLine.to_grammar_string(), "<list-line>");

--- a/crates/lex-core/tests/elements_annotations.rs
+++ b/crates/lex-core/tests/elements_annotations.rs
@@ -334,6 +334,6 @@ fn test_annotations_overview_document() {
                 });
         })
         .item(1, |item| {
-            item.assert_session().label("Syntax Forms:");
+            item.assert_session().label("Syntax Forms");
         });
 }

--- a/tree-sitter/scripts/error-check.sh
+++ b/tree-sitter/scripts/error-check.sh
@@ -38,6 +38,9 @@ ALLOWLIST=(
     # annotation.lex has :: label :: fragments inside definition bodies that
     # look like annotations but aren't valid verbatim block structures
     "comms/specs/elements/annotation.lex"
+    # data.lex shows data marker syntax examples (:: label params? ::) that
+    # tree-sitter interprets as annotation nodes
+    "comms/specs/elements/data.lex"
     # 040-on-parsing.lex is a complex benchmark with structures beyond current
     # tree-sitter grammar coverage (deeply nested mixed elements)
     "comms/specs/benchmark/040-on-parsing.lex"


### PR DESCRIPTION
## Summary

Consistency review for the two shared data models (sequence markers and data markers) across all layers. Aligns naming between specs and code.

- **Rename `AnnotationStartLine` → `DataMarkerLine`** in `LineType` enum and all references (7 files). This line type classifies both annotation headers and verbatim closing lines — the name now reflects that.
- **Remove `MarkerType` from lex-babel** — use `DecorationStyle` directly from lex-core, handling alpha casing at format time. Eliminates a redundant enum.
- **Rename LSP semantic tokens** `VerbatimLanguage` → `DataLabel`, `VerbatimAttribute` → `DataParameter`. Same syntactic pattern (data markers) now gets consistent token names regardless of context.
- **Grammar patterns** updated to use `<data-marker-line>` token name
- **Tree-sitter error-check** allowlist updated for new data.lex spec
- **Comms submodule** updated to consistency-review-markers-v2 (lex-fmt/comms#13)

## Test plan

- [x] All 1407 tests pass (`cargo nextest run`)
- [x] Clippy clean
- [x] Tree-sitter: 97/97 grammar tests pass, error-check clean
- [x] Pre-commit hook passes
- [ ] Editor plugins (vscode, nvim) will need `DataLabel`/`DataParameter` token mapping after merge

Resolves #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)