### PR TITLE
Ignored / review tests 

### DIFF
--- a/crates/lex-babel/tests/markdown/import.rs
+++ b/crates/lex-babel/tests/markdown/import.rs
@@ -615,11 +615,7 @@ Final paragraph.
     assert_lex_output_valid(md, "complex_document");
 }
 
-/// lex-core <= 0.2.2 panics on empty-subject definitions ("Cannot compute
-/// bounding box from empty token list"). Fixed in lex-fmt/core@c7c78591.
-/// Remove #[ignore] once lex-core is updated past 0.2.2.
 #[test]
-#[ignore = "needs lex-core > 0.2.2 (fix: lex-fmt/core#c7c78591)"]
 fn test_lex_validity_reference_fixtures() {
     let commonmark = read_fixture("markdown-reference-commonmark.md");
     assert_lex_output_valid(&commonmark, "commonmark_reference");
@@ -628,9 +624,7 @@ fn test_lex_validity_reference_fixtures() {
     assert_lex_output_valid(&comrak, "comrak_reference");
 }
 
-/// See `test_lex_validity_reference_fixtures` for details.
 #[test]
-#[ignore = "needs lex-core > 0.2.2 (fix: lex-fmt/core#c7c78591)"]
 fn test_lex_validity_comrak_readme() {
     let readme = read_fixture("comrak-readme.md");
     assert_lex_output_valid(&readme, "comrak_readme");

--- a/crates/lex-core/tests/doc_collections.rs
+++ b/crates/lex-core/tests/doc_collections.rs
@@ -1,59 +1,152 @@
+use lex_core::lex::testing::assert_ast;
 use lex_core::lex::testing::lexplore::Lexplore;
 
-fn assert_not_empty(doc: &lex_core::lex::ast::Document, label: &str) {
-    assert!(!doc.root.children.is_empty(), "{label} should have content");
-}
+// ============================================================================
+// Trifecta documents
+// ============================================================================
 
 #[test]
 fn trifecta_000_paragraphs() {
     let doc = Lexplore::trifecta(0).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_000_paragraphs");
+    assert_ast(&doc).item_count(6);
 }
 
 #[test]
 fn trifecta_010_paragraphs_sessions_flat_single() {
     let doc = Lexplore::trifecta(10).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_010_paragraphs_sessions_flat_single");
+    assert_ast(&doc).item_count(5);
 }
 
 #[test]
 fn trifecta_020_paragraphs_sessions_flat_multiple() {
     let doc = Lexplore::trifecta(20).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_020_paragraphs_sessions_flat_multiple");
+    assert_ast(&doc).item_count(8);
 }
 
 #[test]
 fn trifecta_030_paragraphs_sessions_nested_multiple() {
     let doc = Lexplore::trifecta(30).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_030_paragraphs_sessions_nested_multiple");
+    assert_ast(&doc).item_count(4);
 }
 
 #[test]
 fn trifecta_040_lists() {
     let doc = Lexplore::trifecta(40).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_040_lists");
+    assert_ast(&doc).item_count(15);
 }
 
 #[test]
 fn trifecta_050_paragraph_lists() {
     let doc = Lexplore::trifecta(50).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_050_paragraph_lists");
+    assert_ast(&doc).item_count(24);
+}
+
+#[test]
+fn trifecta_051_definitions_no_blank() {
+    let doc = Lexplore::trifecta(51).parse().unwrap();
+    assert_ast(&doc).item_count(8);
 }
 
 #[test]
 fn trifecta_060_trifecta_nesting() {
     let doc = Lexplore::trifecta(60).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_060_trifecta_nesting");
+    assert_ast(&doc).item_count(4);
 }
 
 #[test]
 fn trifecta_070_trifecta_flat_simple() {
     let doc = Lexplore::trifecta(70).parse().unwrap();
-    assert_not_empty(&doc, "trifecta_070_trifecta_flat_simple");
+    assert_ast(&doc).item_count(8);
+}
+
+// ============================================================================
+// Benchmark documents
+// ============================================================================
+
+#[test]
+fn benchmark_000_empty() {
+    let doc = Lexplore::benchmark(0).parse().unwrap();
+    assert_ast(&doc).item_count(0);
 }
 
 #[test]
 fn benchmark_010_kitchensink() {
     let doc = Lexplore::benchmark(10).parse().unwrap();
-    assert_not_empty(&doc, "benchmark_010_kitchensink");
+    assert_ast(&doc).item_count(7);
+}
+
+#[test]
+fn benchmark_020_ideas_naked() {
+    let doc = Lexplore::benchmark(20).parse().unwrap();
+    assert_ast(&doc).item_count(6);
+}
+
+#[test]
+fn benchmark_030_a_place_for_ideas() {
+    let doc = Lexplore::benchmark(30).parse().unwrap();
+    assert_ast(&doc).item_count(4);
+}
+
+#[test]
+fn benchmark_040_on_parsing() {
+    let doc = Lexplore::benchmark(40).parse().unwrap();
+    assert_ast(&doc).item_count(10);
+}
+
+#[test]
+fn benchmark_050_lsp_fixture() {
+    let doc = Lexplore::benchmark(50).parse().unwrap();
+    assert_ast(&doc).item_count(3);
+}
+
+#[test]
+fn benchmark_060_injection_multilang() {
+    let doc = Lexplore::benchmark(60).parse().unwrap();
+    assert_ast(&doc).item_count(7);
+}
+
+#[test]
+fn benchmark_070_semantic_tokens() {
+    let doc = Lexplore::benchmark(70).parse().unwrap();
+    assert_ast(&doc).item_count(4);
+}
+
+#[test]
+fn benchmark_080_gentle_introduction() {
+    let doc = Lexplore::benchmark(80).parse().unwrap();
+    assert_ast(&doc).item_count(16);
+}
+
+// ============================================================================
+// Discovery: ensure all spec files are covered by tests above
+// ============================================================================
+
+#[test]
+fn all_trifecta_files_covered() {
+    let numbers =
+        lex_core::lex::testing::lexplore::specfile_finder::list_available_numbers("trifecta", None)
+            .unwrap();
+    let tested: Vec<usize> = vec![0, 10, 20, 30, 40, 50, 51, 60, 70];
+    for n in &numbers {
+        assert!(
+            tested.contains(n),
+            "Trifecta file #{n:03} exists but has no test — add one above"
+        );
+    }
+}
+
+#[test]
+fn all_benchmark_files_covered() {
+    let numbers = lex_core::lex::testing::lexplore::specfile_finder::list_available_numbers(
+        "benchmark",
+        None,
+    )
+    .unwrap();
+    let tested: Vec<usize> = vec![0, 10, 20, 30, 40, 50, 60, 70, 80];
+    for n in &numbers {
+        assert!(
+            tested.contains(n),
+            "Benchmark file #{n:03} exists but has no test — add one above"
+        );
+    }
 }

--- a/crates/lex-core/tests/spec_documents.rs
+++ b/crates/lex-core/tests/spec_documents.rs
@@ -1,16 +1,89 @@
-//! Tests for spec/overview documents that don't map to numbered element loaders
+//! Tests for spec/overview documents in comms/specs/elements/
 
 use lex_core::lex::testing::assert_ast;
 use lex_core::lex::testing::lexplore::Lexplore;
 use lex_core::lex::testing::workspace_path;
 
+// ============================================================================
+// Element spec documents
+// ============================================================================
+
 #[test]
-fn test_labels_spec_document() {
+fn spec_annotation() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/annotation.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(4).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_data() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/data.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(6).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_definition() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/definition.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(6).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_document() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/document.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(1).item(0, |item| {
+        item.assert_session().label("Document Title");
+    });
+}
+
+#[test]
+fn spec_escaping() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/escaping.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(5).item(0, |item| {
+        item.assert_session().label("Feature: Escaping");
+    });
+}
+
+#[test]
+fn spec_footnotes() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/footnotes.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(5).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_inlines() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/inlines.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(5).item(0, |item| {
+        item.assert_session().label("Feature: Inlines");
+    });
+}
+
+#[test]
+fn spec_label() {
     let doc = Lexplore::from_path(workspace_path("comms/specs/elements/label.lex"))
         .parse()
         .unwrap();
-
-    assert_ast(&doc).item(0, |item| {
+    assert_ast(&doc).item_count(4).item(0, |item| {
         item.assert_session()
             .label_contains("Introduction")
             .child(0, |child| {
@@ -22,23 +95,62 @@ fn test_labels_spec_document() {
 }
 
 #[test]
-fn test_parameters_spec_document() {
-    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/parameter.lex"))
+fn spec_list() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/list.lex"))
         .parse()
         .unwrap();
-
-    assert_ast(&doc).item(0, |item| {
+    assert_ast(&doc).item_count(10).item(0, |item| {
         item.assert_session().label("Introduction");
     });
 }
 
 #[test]
-fn test_verbatim_spec_document() {
+fn spec_paragraph() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/paragraph.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(9).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_parameter() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/parameter.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(6).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_session() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/session.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(8).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_table() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/table.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(14).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
+fn spec_verbatim() {
     let doc = Lexplore::from_path(workspace_path("comms/specs/elements/verbatim.lex"))
         .parse()
         .unwrap();
-
     assert_ast(&doc)
+        .item_count(10)
         .item(0, |item| {
             item.assert_session().label("Introduction");
         })
@@ -47,15 +159,19 @@ fn test_verbatim_spec_document() {
         });
 }
 
+// ============================================================================
+// Template documents
+// ============================================================================
+
 #[test]
-fn test_template_document_simple() {
+fn spec_template_document_simple() {
     let doc = Lexplore::from_path(workspace_path(
         "comms/specs/elements/XXX-document-simple.lex",
     ))
     .parse()
     .unwrap();
 
-    assert_ast(&doc).item(1, |item| {
+    assert_ast(&doc).item_count(10).item(1, |item| {
         item.assert_session()
             .label("1. Session with Paragraph Content {{session-title}}")
             .child(2, |child| {
@@ -65,14 +181,14 @@ fn test_template_document_simple() {
 }
 
 #[test]
-fn test_template_document_tricky() {
+fn spec_template_document_tricky() {
     let doc = Lexplore::from_path(workspace_path(
         "comms/specs/elements/XXX-document-tricky.lex",
     ))
     .parse()
     .unwrap();
 
-    assert_ast(&doc).item(1, |item| {
+    assert_ast(&doc).item_count(4).item(1, |item| {
         item.assert_session()
             .label("1. Root Session {{session-title}}")
             .child(1, |child| {
@@ -84,4 +200,51 @@ fn test_template_document_tricky() {
                     });
             });
     });
+}
+
+// ============================================================================
+// Discovery: ensure all element spec files are tested
+// ============================================================================
+
+#[test]
+fn all_element_spec_files_covered() {
+    let dir = workspace_path("comms/specs/elements");
+    let tested = [
+        "annotation.lex",
+        "data.lex",
+        "definition.lex",
+        "document.lex",
+        "escaping.lex",
+        "footnotes.lex",
+        "inlines.lex",
+        "label.lex",
+        "list.lex",
+        "paragraph.lex",
+        "parameter.lex",
+        "session.lex",
+        "table.lex",
+        "verbatim.lex",
+        "XXX-document-simple.lex",
+        "XXX-document-tricky.lex",
+    ];
+
+    let entries: Vec<String> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| {
+            let e = e.ok()?;
+            let name = e.file_name().to_string_lossy().to_string();
+            if name.ends_with(".lex") {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for name in &entries {
+        assert!(
+            tested.contains(&name.as_str()),
+            "Element spec file {name} exists but has no test — add one above"
+        );
+    }
 }


### PR DESCRIPTION

- Un-ignore lex-babel validity tests for reference fixtures**
- Strengthen doc_collections: item_count assertions + full coverage**
- Cover all 16 element spec files with item_count + label assertions**
