### PR TITLE
Fix parity: annotation params, inline text, subtitles, trailing whitespace, wall stripping

### DIFF
--- a/crates/lex-cli/src/transforms.rs
+++ b/crates/lex-cli/src/transforms.rs
@@ -291,7 +291,8 @@ fn parity_content_item(out: &mut String, depth: usize, item: &lex_core::lex::ast
             }
         }
         ContentItem::TextLine(tl) => {
-            parity_line(out, depth, &format!("\"{}\"", tl.text()));
+            let text = tl.text().trim_end();
+            parity_line(out, depth, &format!("\"{text}\""));
         }
         ContentItem::Definition(d) => {
             parity_line(

--- a/tree-sitter/scripts/parity-known-failures.txt
+++ b/tree-sitter/scripts/parity-known-failures.txt
@@ -22,9 +22,7 @@ comms/specs/elements/annotation.docs/annotation-29-attachment-example-k-session-
 # --- Subtitle detection ---
 # Lex-core detects subtitle (trailing colon on title + second line); tree-sitter
 # CST doesn't have subtitle support — emits the colon as part of the title text.
-comms/specs/elements/document.docs/document-07-title-with-subtitle.lex
 comms/specs/elements/document.docs/document-08-subtitle-with-inlines.lex
-comms/specs/elements/document.docs/document-12-subtitle-then-session.lex
 
 # --- DocumentTitle vs Paragraph for single-line documents ---
 # Tree-sitter classifies any first line followed by blank as DocumentTitle.

--- a/tree-sitter/scripts/parity-known-failures.txt
+++ b/tree-sitter/scripts/parity-known-failures.txt
@@ -7,23 +7,6 @@
 # Format: relative path from repo root, followed by # comment with reason.
 # Empty lines and lines starting with # are ignored.
 
-# --- Annotation parameters ---
-# Tree-sitter includes parameters in annotation label text ("warning severity=high"),
-# lex-core separates label from parameters ("warning"). Structural difference in how
-# annotations are represented in CST vs AST.
-comms/specs/elements/annotation.docs/annotation-02-flat-marker-with-params.lex
-comms/specs/elements/annotation.docs/annotation-06-flat-block-multi-paragraph.lex
-comms/specs/elements/annotation.docs/annotation-07-flat-block-with-list.lex
-comms/specs/elements/annotation.docs/annotation-08-nested-with-list-and-paragraph.lex
-comms/specs/elements/annotation.docs/annotation-10-nested-complex.lex
-comms/specs/elements/annotation.docs/annotation-11-quoted-parameter.lex
-
-# --- Annotation inline text ---
-# Lex-core includes inline text after annotation label as a paragraph child;
-# tree-sitter handles annotation_inline_text differently.
-comms/specs/elements/annotation.docs/annotation-03-flat-inline-text.lex
-comms/specs/elements/annotation.docs/annotation-04-flat-inline-with-params.lex
-
 # --- Annotation attachment ---
 # Lex-core attaches annotations to adjacent elements (post-parse assembly stage).
 # Tree-sitter emits annotations as standalone CST nodes. This is a fundamental
@@ -41,7 +24,6 @@ comms/specs/elements/annotation.docs/annotation-29-attachment-example-k-session-
 # CST doesn't have subtitle support — emits the colon as part of the title text.
 comms/specs/elements/document.docs/document-07-title-with-subtitle.lex
 comms/specs/elements/document.docs/document-08-subtitle-with-inlines.lex
-comms/specs/elements/document.docs/document-09-subtitle-with-annotations.lex
 comms/specs/elements/document.docs/document-12-subtitle-then-session.lex
 
 # --- DocumentTitle vs Paragraph for single-line documents ---
@@ -51,7 +33,6 @@ comms/specs/elements/document.docs/document-12-subtitle-then-session.lex
 # sees them as paragraphs (no blank line after) or titles (with blank).
 comms/specs/elements/document.docs/document-02-title-no-blank.lex
 comms/specs/elements/document.docs/document-03-title-multiline.lex
-comms/specs/elements/document.docs/document-04-title-with-annotations.lex
 comms/specs/elements/paragraph.docs/paragraph-01-flat-oneline.lex
 comms/specs/elements/paragraph.docs/paragraph-03-flat-special-chars.lex
 comms/specs/elements/paragraph.docs/paragraph-04-flat-numbers.lex
@@ -142,34 +123,3 @@ comms/specs/elements/paragraph.docs/paragraph-09-dialog.lex
 
 # --- Verbatim document-level (numbered session issue) ---
 comms/specs/elements/verbatim.docs/verbatim-12-document-simple.lex
-
-# --- Full spec files ---
-# Large spec documents with multiple divergence categories combined.
-# These contain examples of all the issues listed above.
-comms/specs/elements/annotation.lex
-comms/specs/elements/data.lex
-comms/specs/elements/definition.lex
-comms/specs/elements/document.lex
-comms/specs/elements/escaping.lex
-comms/specs/elements/footnotes.lex
-comms/specs/elements/inlines.lex
-comms/specs/elements/label.lex
-comms/specs/elements/list.lex
-comms/specs/elements/paragraph.lex
-comms/specs/elements/parameter.lex
-comms/specs/elements/session.lex
-comms/specs/elements/table.lex
-comms/specs/elements/verbatim.lex
-comms/specs/elements/XXX-document-simple.lex
-comms/specs/elements/XXX-document-tricky.lex
-comms/specs/elements/inlines.docs/specs/formatting/formatting.lex
-comms/specs/elements/inlines.docs/specs/formatting/inlines-general.lex
-comms/specs/elements/inlines.docs/specs/references/citations.lex
-comms/specs/elements/inlines.docs/specs/references/references-general.lex
-comms/specs/elements/data.docs/data-01-simple.lex
-comms/specs/elements/data.docs/data-02-with-params.lex
-comms/specs/elements/data.docs/data-03-with-quoted-params.lex
-comms/specs/elements/data.docs/data-04-standalone.lex
-comms/specs/elements/label.docs/label-01-simple-valid.lex
-comms/specs/elements/label.docs/label-02-complex-valid.lex
-comms/specs/elements/label.docs/label-03-invalid-start.lex

--- a/tree-sitter/scripts/parity-print.js
+++ b/tree-sitter/scripts/parity-print.js
@@ -227,9 +227,16 @@ function printParity(node, depth) {
 
     case "document_title": {
       const titleNode = findField(node, "title");
-      const title = titleNode ? leafText(titleNode) : "";
+      const subtitleNode = node.children.find(
+        (c) => c.tag === "document_subtitle",
+      );
+      let title = titleNode ? leafText(titleNode) : "";
+      // When subtitle is present, the trailing colon on the title is structural
+      // (delimiter between title and subtitle) — lex-core strips it
+      if (subtitleNode) {
+        title = title.replace(/:$/, "");
+      }
       console.log(`${ind(depth)}DocumentTitle "${title}"`);
-      const subtitleNode = findField(node, "subtitle");
       if (subtitleNode) {
         const subtitle = leafText(subtitleNode);
         console.log(`${ind(depth + 1)}DocumentSubtitle "${subtitle}"`);

--- a/tree-sitter/scripts/parity-print.js
+++ b/tree-sitter/scripts/parity-print.js
@@ -300,7 +300,7 @@ function printParity(node, depth) {
       break;
 
     case "text_line": {
-      const text = leafText(node).trimStart();
+      const text = leafText(node).trimStart().trimEnd();
       console.log(`${ind(depth)}"${text}"`);
       break;
     }
@@ -328,16 +328,28 @@ function printParity(node, depth) {
       const headerNode = node.children.find(
         (c) => c.tag === "annotation_header",
       );
-      const label = headerNode ? leafText(headerNode).trim() : "";
+      // annotation_header contains "label params..." — extract just the label (first word).
+      // Strip trailing colon from label (in ":: label: value ::", the colon is a separator)
+      const headerText = headerNode ? leafText(headerNode).trim() : "";
+      const label = (headerText.split(/\s+/)[0] || "").replace(/:$/, "");
       console.log(`${ind(depth)}Annotation "${label}"`);
       for (const child of node.children) {
         if (
           child.tag === "annotation_marker" ||
           child.tag === "annotation_header" ||
-          child.tag === "annotation_end_marker" ||
-          child.tag === "annotation_inline_text"
+          child.tag === "annotation_end_marker"
         )
           continue;
+        // Annotation inline text becomes a Paragraph child in lex-core.
+        // The space between closing :: and text is part of the content in lex-core.
+        if (child.tag === "annotation_inline_text") {
+          const inlineText = leafText(child);
+          if (inlineText) {
+            console.log(`${ind(depth + 1)}Paragraph`);
+            console.log(`${ind(depth + 2)}" ${inlineText}"`);
+          }
+          continue;
+        }
         printParity(child, depth + 1);
       }
       break;
@@ -347,8 +359,20 @@ function printParity(node, depth) {
       const headerNode = node.children.find(
         (c) => c.tag === "annotation_header",
       );
-      const label = headerNode ? leafText(headerNode).trim() : "";
+      const headerText = headerNode ? leafText(headerNode).trim() : "";
+      const label = (headerText.split(/\s+/)[0] || "").replace(/:$/, "");
       console.log(`${ind(depth)}Annotation "${label}"`);
+      // Inline text in single-line annotations
+      const inlineNode = node.children.find(
+        (c) => c.tag === "annotation_inline_text",
+      );
+      if (inlineNode) {
+        const inlineText = leafText(inlineNode);
+        if (inlineText) {
+          console.log(`${ind(depth + 1)}Paragraph`);
+          console.log(`${ind(depth + 2)}" ${inlineText}"`);
+        }
+      }
       break;
     }
 

--- a/tree-sitter/scripts/parity-print.js
+++ b/tree-sitter/scripts/parity-print.js
@@ -136,8 +136,10 @@ function detectWallCol(verbatimNode) {
 
 /**
  * Strip wall indentation from a raw text line.
- * Tree-sitter reports continuation lines from column 0 (absolute),
+ * Tree-sitter reports continuation lines from character 0 (absolute),
  * while lex-core stores content relative to the wall.
+ * scol is character-based (not column-based), so we strip exactly
+ * wallCol characters of leading whitespace.
  */
 function stripWall(text, wallCol, lineScol) {
   const col = parseInt(lineScol || "0", 10);
@@ -145,17 +147,10 @@ function stripWall(text, wallCol, lineScol) {
     // Line starts at or past the wall — text is already wall-relative
     return text;
   }
-  // Line starts before the wall — strip leading whitespace up to wallCol
-  let stripped = 0;
+  // Strip exactly wallCol characters of leading whitespace
   let i = 0;
-  while (i < text.length && stripped < wallCol) {
-    if (text[i] === "\t") {
-      stripped += 4 - (stripped % 4);
-    } else if (text[i] === " ") {
-      stripped++;
-    } else {
-      break;
-    }
+  while (i < text.length && i < wallCol) {
+    if (text[i] !== " " && text[i] !== "\t") break;
     i++;
   }
   return text.substring(i);


### PR DESCRIPTION
## Summary

Fixes parity tooling extraction bugs and improves tree-sitter parity from 41/115 to 53/115 passing fixtures.

### Changes

- **Annotation label**: extract first word only from header text, strip trailing colon separator
- **Annotation inline text**: emit as Paragraph child matching lex-core
- **Trailing whitespace**: trim on both sides
- **Verbatim wall stripping**: character-based (not column-based) for tab-indented files  
- **Subtitle detection**: find `document_subtitle` node by tag name, strip structural colon from title

### Impact analysis of remaining 62 known failures

The key question: does the user see wrong behavior? Tree-sitter drives highlighting/injections/textobjects. LSP (lex-core) drives outline/breadcrumbs/hover/formatting.

| Group | Files | User-visible impact? | What breaks |
|-------|-------|---------------------|-------------|
| **G. Numbered session→list** | 11 | **Yes — wrong colors** | `1. Title` highlighted as list item instead of session heading |
| **L. Extended list markers** | 1 | **Yes — broken highlighting** | `1.a.` markers not recognized as list structure |
| H. DocumentTitle vs Paragraph | 11 | Mild | First line gets heading style in edge cases |
| E. Verbatim leading blank | 9 | None | Zero characters affected |
| F. Nested list boundaries | 5 | None | Trailing blank placement, no visual difference |
| I. Subtitle (remaining) | 2 | None | Inline parsing issue, separate from subtitle detection |
| J–K. Verbatim groups/fullwidth | 5 | None | Content highlighting identical |
| M. Annotation attachment | 7 | None | Both highlight as `comment` regardless |
| N–O. Table merge/complex cells | 14 | None | Cell content appearance identical |

### Group G investigation (not in this PR)

Investigated the trifecta disambiguation. Root cause: scanner's `peek_next_line_has_list_marker` crosses session boundaries. Fixing the lookahead alone causes a regression (paragraph/dialog_line wins over session). Solution requires a new scanner token for session-titled markers. Documented in #441.

### Results

53 pass (+12 from infrastructure PR), 62 known failures (-12), 0 unexpected.

## Test plan

- [x] `cargo test --workspace` — 1432 tests pass
- [x] `tree-sitter/scripts/parity-check.sh` — 0 unexpected failures
- [x] Pre-commit passes
- [x] `tree-sitter test` — 97/97 corpus tests pass

Contributes to #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)