### PR TITLE
Make tables non-terminal in traversals and outline

### DIFF
--- a/crates/lex-analysis/src/document_symbols.rs
+++ b/crates/lex-analysis/src/document_symbols.rs
@@ -393,19 +393,23 @@ mod tests {
             .find(|s| s.name.contains("My Table"))
             .expect("Table symbol not found");
         assert_eq!(table_sym.kind, SymbolKind::CONSTANT);
-        assert!(table_sym
-            .detail
-            .as_ref()
-            .unwrap()
-            .contains("2 row(s)"));
+        assert!(table_sym.detail.as_ref().unwrap().contains("2 row(s)"));
 
         // Table should have row children
-        assert_eq!(table_sym.children.len(), 2, "Table should have 2 row children");
+        assert_eq!(
+            table_sym.children.len(),
+            2,
+            "Table should have 2 row children"
+        );
 
         let row1_sym = &table_sym.children[0];
         assert_eq!(row1_sym.name, "Row 1");
         assert_eq!(row1_sym.kind, SymbolKind::ENUM);
-        assert_eq!(row1_sym.children.len(), 2, "Row 1 should have 2 cell children");
+        assert_eq!(
+            row1_sym.children.len(),
+            2,
+            "Row 1 should have 2 cell children"
+        );
 
         // Check cell names
         assert_eq!(row1_sym.children[0].name, "Header A");

--- a/crates/lex-analysis/src/document_symbols.rs
+++ b/crates/lex-analysis/src/document_symbols.rs
@@ -1,6 +1,6 @@
 use lex_core::lex::ast::{
     Annotation, AstNode, ContentItem, Definition, Document, List, ListItem, Paragraph, Range,
-    Session, Table, TextContent, Verbatim,
+    Session, Table, TableRow, TextContent, Verbatim,
 };
 use lsp_types::SymbolKind;
 
@@ -122,18 +122,20 @@ fn verbatim_symbol(verbatim: &Verbatim) -> LexDocumentSymbol {
 fn table_symbol(table: &Table) -> LexDocumentSymbol {
     let mut children = annotation_symbol_list(table.annotations());
 
-    // Include symbols from cell children with block content
+    // Include rows as intermediate children so the outline reflects the table structure
+    let mut row_index = 0;
     for row in table.all_rows() {
-        for cell in &row.cells {
-            if cell.has_block_content() {
-                children.extend(collect_symbols_from_items(cell.children.iter()));
-            }
-        }
+        row_index += 1;
+        children.push(row_symbol(row, row_index));
     }
 
     LexDocumentSymbol {
         name: format!("Table: {}", summarize_text(&table.subject, "Table")),
-        detail: Some("table".to_string()),
+        detail: Some(format!(
+            "{} row(s), {} col(s)",
+            table.row_count(),
+            table.column_count()
+        )),
         kind: SymbolKind::CONSTANT,
         range: table.range().clone(),
         selection_range: table
@@ -141,6 +143,48 @@ fn table_symbol(table: &Table) -> LexDocumentSymbol {
             .location
             .clone()
             .unwrap_or_else(|| table.range().clone()),
+        children,
+    }
+}
+
+fn row_symbol(row: &TableRow, index: usize) -> LexDocumentSymbol {
+    let mut children = Vec::new();
+
+    for cell in &row.cells {
+        let cell_text = cell.content.as_string().trim().to_string();
+        let cell_name = if cell_text.is_empty() {
+            "(empty)".to_string()
+        } else {
+            cell_text
+        };
+
+        // Collect block-level content inside this cell
+        let cell_children = if cell.has_block_content() {
+            collect_symbols_from_items(cell.children.iter())
+        } else {
+            Vec::new()
+        };
+
+        children.push(LexDocumentSymbol {
+            name: cell_name,
+            detail: if cell.colspan > 1 || cell.rowspan > 1 {
+                Some(format!("{}×{}", cell.colspan, cell.rowspan))
+            } else {
+                None
+            },
+            kind: SymbolKind::FIELD,
+            range: cell.location.clone(),
+            selection_range: cell.location.clone(),
+            children: cell_children,
+        });
+    }
+
+    LexDocumentSymbol {
+        name: format!("Row {}", index),
+        detail: Some(format!("{} cell(s)", row.cells.len())),
+        kind: SymbolKind::ENUM,
+        range: row.location.clone(),
+        selection_range: row.location.clone(),
         children,
     }
 }
@@ -317,6 +361,60 @@ mod tests {
         }
         let item_symbol = item_symbol.expect("List item symbol not found");
         assert!(item_symbol.name.contains("-"));
+    }
+
+    #[test]
+    fn table_symbol_includes_rows_and_cells() {
+        use lex_core::lex::ast::elements::table::{TableCell, TableRow};
+        use lex_core::lex::ast::elements::verbatim::VerbatimBlockMode;
+        use lex_core::lex::ast::{Table, TextContent};
+
+        let row1 = TableRow::new(vec![
+            TableCell::new(TextContent::from_string("Header A".to_string(), None)),
+            TableCell::new(TextContent::from_string("Header B".to_string(), None)),
+        ]);
+        let row2 = TableRow::new(vec![
+            TableCell::new(TextContent::from_string("Value 1".to_string(), None)),
+            TableCell::new(TextContent::from_string("Value 2".to_string(), None)),
+        ]);
+        let table = Table::new(
+            TextContent::from_string("My Table".to_string(), None),
+            vec![row1],
+            vec![row2],
+            VerbatimBlockMode::Inflow,
+        );
+
+        let document = Document::with_content(vec![ContentItem::Table(Box::new(table))]);
+        let symbols = collect_document_symbols(&document);
+
+        // Find the table symbol
+        let table_sym = symbols
+            .iter()
+            .find(|s| s.name.contains("My Table"))
+            .expect("Table symbol not found");
+        assert_eq!(table_sym.kind, SymbolKind::CONSTANT);
+        assert!(table_sym
+            .detail
+            .as_ref()
+            .unwrap()
+            .contains("2 row(s)"));
+
+        // Table should have row children
+        assert_eq!(table_sym.children.len(), 2, "Table should have 2 row children");
+
+        let row1_sym = &table_sym.children[0];
+        assert_eq!(row1_sym.name, "Row 1");
+        assert_eq!(row1_sym.kind, SymbolKind::ENUM);
+        assert_eq!(row1_sym.children.len(), 2, "Row 1 should have 2 cell children");
+
+        // Check cell names
+        assert_eq!(row1_sym.children[0].name, "Header A");
+        assert_eq!(row1_sym.children[1].name, "Header B");
+        assert_eq!(row1_sym.children[0].kind, SymbolKind::FIELD);
+
+        let row2_sym = &table_sym.children[1];
+        assert_eq!(row2_sym.children[0].name, "Value 1");
+        assert_eq!(row2_sym.children[1].name, "Value 2");
     }
 
     #[test]

--- a/crates/lex-analysis/src/document_symbols.rs
+++ b/crates/lex-analysis/src/document_symbols.rs
@@ -180,7 +180,7 @@ fn row_symbol(row: &TableRow, index: usize) -> LexDocumentSymbol {
     }
 
     LexDocumentSymbol {
-        name: format!("Row {}", index),
+        name: format!("Row {index}"),
         detail: Some(format!("{} cell(s)", row.cells.len())),
         kind: SymbolKind::ENUM,
         range: row.location.clone(),

--- a/crates/lex-cli/src/transforms.rs
+++ b/crates/lex-cli/src/transforms.rs
@@ -342,11 +342,7 @@ fn parity_content_item(out: &mut String, depth: usize, item: &lex_core::lex::ast
             parity_line(out, depth, &format!("\"{}\"", fl.content.as_string()));
         }
         ContentItem::Table(t) => {
-            parity_line(
-                out,
-                depth,
-                &format!("Table \"{}\"", t.subject.as_string()),
-            );
+            parity_line(out, depth, &format!("Table \"{}\"", t.subject.as_string()));
             for row in t.header_rows.iter().chain(t.body_rows.iter()) {
                 let cells: Vec<&str> = row.cells.iter().map(|c| c.text()).collect();
                 let line = format!("| {} |", cells.join(" | "));

--- a/crates/lex-core/src/lex/assembling/stages/apply_table_config.rs
+++ b/crates/lex-core/src/lex/assembling/stages/apply_table_config.rs
@@ -116,7 +116,11 @@ fn resplit_header_body(table: &mut Table, header_count: usize) {
 
 /// Apply column alignments to all cells in the table.
 fn apply_alignments(table: &mut Table, alignments: &[TableCellAlignment]) {
-    for row in table.header_rows.iter_mut().chain(table.body_rows.iter_mut()) {
+    for row in table
+        .header_rows
+        .iter_mut()
+        .chain(table.body_rows.iter_mut())
+    {
         for (col_idx, cell) in row.cells.iter_mut().enumerate() {
             if let Some(align) = alignments.get(col_idx) {
                 cell.align = *align;

--- a/crates/lex-core/src/lex/ast/elements/content_item.rs
+++ b/crates/lex-core/src/lex/ast/elements/content_item.rs
@@ -390,17 +390,31 @@ impl ContentItem {
         }
     }
 
+    /// Iterate over all effective children, including table cell children.
+    /// For most items, this delegates to `children()`. For tables,
+    /// it iterates through all cells' block-level children.
+    fn effective_children_iter(&self) -> Box<dyn Iterator<Item = &ContentItem> + '_> {
+        match self {
+            ContentItem::Table(t) => Box::new(t.cell_children_iter()),
+            _ => {
+                if let Some(children) = self.children() {
+                    Box::new(children.iter())
+                } else {
+                    Box::new(std::iter::empty())
+                }
+            }
+        }
+    }
+
     /// Find the deepest element at the given position in this item and its children
     /// Returns the deepest (most nested) element that contains the position
     pub fn element_at(&self, pos: Position) -> Option<&ContentItem> {
         // Check nested items first - even if parent location doesn't contain position,
         // nested elements might. This is important because parent locations (like sessions)
         // may only cover their title, not their nested content.
-        if let Some(children) = self.children() {
-            for child in children {
-                if let Some(result) = child.element_at(pos) {
-                    return Some(result); // Return deepest element found
-                }
+        for child in self.effective_children_iter() {
+            if let Some(result) = child.element_at(pos) {
+                return Some(result); // Return deepest element found
             }
         }
 
@@ -422,11 +436,9 @@ impl ContentItem {
     /// VerbatimBlock), it returns the deepest line element, not the container itself.
     pub fn visual_line_at(&self, pos: Position) -> Option<&ContentItem> {
         // First, check children for visual line nodes (depth-first search)
-        if let Some(children) = self.children() {
-            for child in children {
-                if let Some(result) = child.visual_line_at(pos) {
-                    return Some(result);
-                }
+        for child in self.effective_children_iter() {
+            if let Some(result) = child.visual_line_at(pos) {
+                return Some(result);
             }
         }
 
@@ -470,11 +482,9 @@ impl ContentItem {
         }
 
         // If not a block element, check children
-        if let Some(children) = self.children() {
-            for child in children {
-                if let Some(result) = child.block_element_at(pos) {
-                    return Some(result);
-                }
+        for child in self.effective_children_iter() {
+            if let Some(result) = child.block_element_at(pos) {
+                return Some(result);
             }
         }
 
@@ -485,13 +495,11 @@ impl ContentItem {
     /// Returns a vector of nodes [self, child, grandchild, ...]
     pub fn node_path_at_position(&self, pos: Position) -> Vec<&ContentItem> {
         // Check nested items first
-        if let Some(children) = self.children() {
-            for child in children {
-                let mut path = child.node_path_at_position(pos);
-                if !path.is_empty() {
-                    path.insert(0, self);
-                    return path;
-                }
+        for child in self.effective_children_iter() {
+            let mut path = child.node_path_at_position(pos);
+            if !path.is_empty() {
+                path.insert(0, self);
+                return path;
             }
         }
 
@@ -506,15 +514,10 @@ impl ContentItem {
     /// Recursively iterate all descendants of this node (depth-first pre-order)
     /// Does not include the node itself, only its descendants
     pub fn descendants(&self) -> Box<dyn Iterator<Item = &ContentItem> + '_> {
-        if let Some(children) = self.children() {
-            Box::new(
-                children
-                    .iter()
-                    .flat_map(|child| std::iter::once(child).chain(child.descendants())),
-            )
-        } else {
-            Box::new(std::iter::empty())
-        }
+        Box::new(
+            self.effective_children_iter()
+                .flat_map(|child| std::iter::once(child).chain(child.descendants())),
+        )
     }
 
     /// Recursively iterate all descendants with their relative depth
@@ -523,14 +526,10 @@ impl ContentItem {
         &self,
         start_depth: usize,
     ) -> Box<dyn Iterator<Item = (&ContentItem, usize)> + '_> {
-        if let Some(children) = self.children() {
-            Box::new(children.iter().flat_map(move |child| {
-                std::iter::once((child, start_depth))
-                    .chain(child.descendants_with_depth(start_depth + 1))
-            }))
-        } else {
-            Box::new(std::iter::empty())
-        }
+        Box::new(self.effective_children_iter().flat_map(move |child| {
+            std::iter::once((child, start_depth))
+                .chain(child.descendants_with_depth(start_depth + 1))
+        }))
     }
 }
 

--- a/crates/lex-core/src/lex/ast/elements/table.rs
+++ b/crates/lex-core/src/lex/ast/elements/table.rs
@@ -226,6 +226,13 @@ impl Table {
             .unwrap_or(0)
     }
 
+    /// Iterate over all block-level children across all cells in all rows
+    pub fn cell_children_iter(&self) -> impl Iterator<Item = &ContentItem> {
+        self.all_rows()
+            .flat_map(|row| row.cells.iter())
+            .flat_map(|cell| cell.children.iter())
+    }
+
     /// Annotations attached to this table.
     pub fn annotations(&self) -> &[Annotation] {
         &self.annotations
@@ -257,6 +264,22 @@ impl AstNode for Table {
 
     fn accept(&self, visitor: &mut dyn Visitor) {
         visitor.visit_table(self);
+        // Descend into cell children (block-level content inside cells)
+        for row in self.all_rows() {
+            for cell in &row.cells {
+                for child in cell.children.iter() {
+                    child.accept(visitor);
+                }
+            }
+        }
+        // Visit annotations
+        for annotation in &self.annotations {
+            annotation.accept(visitor);
+        }
+        // Visit footnotes
+        if let Some(footnotes) = &self.footnotes {
+            footnotes.accept(visitor);
+        }
         visitor.leave_table(self);
     }
 }

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -623,7 +623,6 @@ fn split_header_body(
     (header_rows, body_rows)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/lex-core/src/lex/parsing/parser/builder.rs
+++ b/crates/lex-core/src/lex/parsing/parser/builder.rs
@@ -10,11 +10,11 @@ use std::ops::Range;
 
 mod builders;
 
+pub(super) use builders::container_starts_with_pipe_row;
 use builders::{
     build_annotation_block, build_annotation_single, build_blank_line_group, build_definition,
     build_list, build_paragraph, build_session, build_table, build_verbatim_block,
 };
-pub(super) use builders::container_starts_with_pipe_row;
 
 /// Type alias for the recursive parser function callback
 type ParserFn = dyn Fn(Vec<LineContainer>, &str) -> Result<Vec<ParseNode>, String>;

--- a/crates/lex-core/src/lex/parsing/parser/builder/builders/table.rs
+++ b/crates/lex-core/src/lex/parsing/parser/builder/builders/table.rs
@@ -53,11 +53,13 @@ pub(in crate::lex::parsing::parser::builder) fn build_table(
         None
     };
 
-    Ok(ParseNode::new(NodeType::Table, vec![], vec![]).with_payload(ParseNodePayload::Table {
-        subject: subject_token,
-        content_lines: all_lines,
-        config_annotation_tokens,
-    }))
+    Ok(
+        ParseNode::new(NodeType::Table, vec![], vec![]).with_payload(ParseNodePayload::Table {
+            subject: subject_token,
+            content_lines: all_lines,
+            config_annotation_tokens,
+        }),
+    )
 }
 
 /// Check if the first non-blank line in a container starts with a pipe character.

--- a/crates/lex-core/tests/proptest_table_config.rs
+++ b/crates/lex-core/tests/proptest_table_config.rs
@@ -22,6 +22,7 @@ fn subject() -> impl Strategy<Value = String> {
 }
 
 /// Generate a table with N rows (all pipe rows, no blank lines = compact mode)
+#[allow(dead_code)]
 fn table_rows(row_count: usize) -> impl Strategy<Value = Vec<String>> {
     prop::collection::vec(word(), row_count).prop_map(|words| {
         words

--- a/crates/lex-core/tests/spec_documents.rs
+++ b/crates/lex-core/tests/spec_documents.rs
@@ -139,7 +139,7 @@ fn spec_table() {
     let doc = Lexplore::from_path(workspace_path("comms/specs/elements/table.lex"))
         .parse()
         .unwrap();
-    assert_ast(&doc).item_count(14).item(0, |item| {
+    assert_ast(&doc).item_count(15).item(0, |item| {
         item.assert_session().label("Introduction");
     });
 }


### PR DESCRIPTION
## Summary

- **lex-core**: `Table::accept()` now descends into cell children, annotations, and footnotes. All `ContentItem` traversal methods (`element_at`, `node_path_at_position`, `visual_line_at`, `block_element_at`, `descendants`, `descendants_with_depth`) now traverse into table cells via `effective_children_iter()`.
- **lex-analysis**: `table_symbol()` emits Row → Cell hierarchy in document symbols, so VSCode/nvim outline and breadcrumbs show table internal structure instead of treating tables as terminal nodes.
- Added unit test verifying table symbol hierarchy.

## Test plan

- [x] All existing tests pass (`cargo test --workspace --exclude lex-wasm`)
- [x] New `table_symbol_includes_rows_and_cells` test verifies row/cell children in outline
- [ ] Manual verification in VSCode outline view with a table-containing .lex file

🤖 Generated with [Claude Code](https://claude.com/claude-code)