### PR TITLE
Rename binaries: lex -> lexd, lex-lsp -> lexd-lsp

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,19 +34,19 @@ jobs:
           bundler-cache: true
           working-directory: comms/docs
 
-      - name: Build lex-cli from source
+      - name: Build lexd from source
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Build lex binary
-        run: cargo build --release -p lex-cli
+      - name: Build lexd binary
+        run: cargo build --release -p lexd
 
       - name: Generate Lex HTML
         working-directory: comms/docs
         env:
-          LEX_BIN: ${{ github.workspace }}/target/release/lex
+          LEX_BIN: ${{ github.workspace }}/target/release/lexd
         run: ./build
 
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # Release workflow
-# Builds lex-cli and lex-lsp binaries for multiple platforms, publishes crates to crates.io
+# Builds lexd and lexd-lsp binaries for multiple platforms, publishes crates to crates.io
 
 name: Release
 permissions:
@@ -57,13 +57,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Build lex-cli
-        run: cargo build --release --target ${{ matrix.target }} -p lex-cli
+      - name: Build lexd
+        run: cargo build --release --target ${{ matrix.target }} -p lexd
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Build lex-lsp
-        run: cargo build --release --target ${{ matrix.target }} -p lex-lsp
+      - name: Build lexd-lsp
+        run: cargo build --release --target ${{ matrix.target }} -p lexd-lsp
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
@@ -71,29 +71,29 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar -czvf ../../../lex-${{ matrix.target }}.tar.gz lex
-          tar -czvf ../../../lex-lsp-${{ matrix.target }}.tar.gz lex-lsp
+          tar -czvf ../../../lexd-${{ matrix.target }}.tar.gz lexd
+          tar -czvf ../../../lexd-lsp-${{ matrix.target }}.tar.gz lexd-lsp
           cd ../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          7z a ../../../lex-${{ matrix.target }}.zip lex.exe
-          7z a ../../../lex-lsp-${{ matrix.target }}.zip lex-lsp.exe
+          7z a ../../../lexd-${{ matrix.target }}.zip lexd.exe
+          7z a ../../../lexd-lsp-${{ matrix.target }}.zip lexd-lsp.exe
           cd ../../..
 
-      - name: Upload lex-cli artifact
+      - name: Upload lexd artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lex-${{ matrix.target }}
-          path: lex-${{ matrix.target }}.*
+          name: lexd-${{ matrix.target }}
+          path: lexd-${{ matrix.target }}.*
 
-      - name: Upload lex-lsp artifact
+      - name: Upload lexd-lsp artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lex-lsp-${{ matrix.target }}
-          path: lex-lsp-${{ matrix.target }}.*
+          name: lexd-lsp-${{ matrix.target }}
+          path: lexd-lsp-${{ matrix.target }}.*
 
   release:
     name: Create Release
@@ -159,7 +159,15 @@ jobs:
       - name: Wait for crates.io to index lex-analysis
         run: sleep 30
 
-      - name: Publish lex-lsp
-        run: cargo publish -p lex-lsp || echo "lex-lsp already published"
+      - name: Publish lexd-lsp
+        run: cargo publish -p lexd-lsp || echo "lexd-lsp already published"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io to index lexd-lsp
+        run: sleep 30
+
+      - name: Publish lexd
+        run: cargo publish -p lexd || echo "lexd already published"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+### Breaking
+
+- Rename CLI binary and package: `lex-cli` -> `lexd` (binary: `lex` -> `lexd`)
+- Rename LSP binary and package: `lex-lsp` -> `lexd-lsp` (binary: `lex-lsp` -> `lexd-lsp`)
+- Installation is now `cargo install lexd` and `cargo install lexd-lsp`
+- Release artifacts renamed: `lexd-{target}.tar.gz`, `lexd-lsp-{target}.tar.gz`
+- `lexd` is now published to crates.io (previously `lex-cli` was not published)
+
+The rename avoids conflicts with the Unix `lex` lexical analyzer generator, which shadows the binary on many systems. Internal library crates (`lex-core`, `lex-babel`, `lex-config`, `lex-analysis`) are unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ This is the unified Rust workspace containing all Lex crates and specifications.
 crates/
   lex-core/       Parser crate (crates.io)
   lex-analysis/   Stateless semantic analysis (crates.io)
-  lex-lsp/        LSP server, tower-lsp (crates.io)
+  lex-lsp/        LSP server, tower-lsp — package: lexd-lsp (crates.io)
   lex-babel/      Format conversion via IR (crates.io)
   lex-config/     Configuration loader (crates.io)
-  lex-cli/        Command-line interface (crates.io)
+  lex-cli/        Command-line interface — package: lexd (crates.io)
   lex-wasm/       WebAssembly bindings (not published)
 comms/
   specs/          Grammar specs and test fixtures
@@ -45,9 +45,9 @@ comms/
 ## Releasing
 
 Tag with `vX.Y.Z` and push. CI publishes crates in dependency order:
-lex-core → lex-config → lex-babel → lex-analysis → lex-lsp
+lex-core → lex-config → lex-babel → lex-analysis → lexd-lsp → lexd
 
-CI also builds lex-cli and lex-lsp binaries for 6 platforms.
+CI also builds lexd and lexd-lsp binaries for 6 platforms.
 
 ## Related repos
 
@@ -56,24 +56,24 @@ CI also builds lex-cli and lex-lsp binaries for 6 platforms.
 - [nvim](https://github.com/lex-fmt/nvim) — Neovim plugin
 - [vscode](https://github.com/lex-fmt/vscode) — VSCode extension
 
-Editor UIs download pre-built lex-lsp binaries from this repo's releases,
+Editor UIs download pre-built lexd-lsp binaries from this repo's releases,
 and tree-sitter artifacts from lex-fmt/tree-sitter-lex releases.
 
 For local development, set `LEX_LSP_PATH` to point editors at a local build:
 ```sh
-cargo build -p lex-lsp
-LEX_LSP_PATH=./target/debug/lex-lsp
+cargo build -p lexd-lsp
+LEX_LSP_PATH=./target/debug/lexd-lsp
 ```
 
 ## CLI Quick Reference
 
 ```sh
-lex inspect file.lex                    # AST tree visualization (default)
-lex inspect file.lex ast-tag            # XML-like AST
-lex inspect file.lex ast-json           # JSON AST
-lex inspect file.lex --ast-full         # Full AST with all properties
-lex inspect file.lex token-line-simple  # Token stream (line-classified)
-lex inspect file.lex ir-json            # Intermediate representation
-lex file.lex --to markdown              # Convert formats
-lex format file.lex                     # Auto-format
+lexd inspect file.lex                    # AST tree visualization (default)
+lexd inspect file.lex ast-tag            # XML-like AST
+lexd inspect file.lex ast-json           # JSON AST
+lexd inspect file.lex --ast-full         # Full AST with all properties
+lexd inspect file.lex token-line-simple  # Token stream (line-classified)
+lexd inspect file.lex ir-json            # Intermediate representation
+lexd file.lex --to markdown              # Convert formats
+lexd format file.lex                     # Auto-format
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,23 +1048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lex-cli"
-version = "0.7.0"
-dependencies = [
- "assert_cmd",
- "clap",
- "clap_complete",
- "clapfig",
- "lex-analysis",
- "lex-babel",
- "lex-config",
- "lex-core",
- "predicates",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
 name = "lex-config"
 version = "0.7.0"
 dependencies = [
@@ -1091,24 +1074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lex-lsp"
-version = "0.7.0"
-dependencies = [
- "clapfig",
- "lex-analysis",
- "lex-babel",
- "lex-config",
- "lex-core",
- "lsp-types",
- "proptest",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "tower-lsp",
-]
-
-[[package]]
 name = "lex-wasm"
 version = "0.1.0"
 dependencies = [
@@ -1124,6 +1089,41 @@ dependencies = [
  "spellbook",
  "wasm-bindgen",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "lexd"
+version = "0.7.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "clap_complete",
+ "clapfig",
+ "lex-analysis",
+ "lex-babel",
+ "lex-config",
+ "lex-core",
+ "predicates",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "lexd-lsp"
+version = "0.7.0"
+dependencies = [
+ "clapfig",
+ "lex-analysis",
+ "lex-babel",
+ "lex-config",
+ "lex-core",
+ "lsp-types",
+ "proptest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower-lsp",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repo is the unified Rust workspace containing all backend crates:
 | `lex-core` | Parser and AST |
 | `lex-babel` | Format conversion (Markdown, HTML, PDF, PNG, Pandoc JSON, RFC XML) |
 | `lex-analysis` | Semantic analysis |
-| `lex-lsp` | LSP server (semantic highlighting, symbols, formatting, completion, diagnostics, hover, go-to-definition, references, folding, document links) |
+| `lexd-lsp` | LSP server (semantic highlighting, symbols, formatting, completion, diagnostics, hover, go-to-definition, references, folding, document links) |
 | `lex-config` | Configuration (clapfig) |
-| `lex-cli` | Command-line interface |
+| `lexd` | Command-line interface |
 | `lex-wasm` | WebAssembly bindings |
 
 Specs and docs live in [`lex-fmt/comms`](https://github.com/lex-fmt/comms) (submoduled as `comms/`).
@@ -28,13 +28,13 @@ Specs and docs live in [`lex-fmt/comms`](https://github.com/lex-fmt/comms) (subm
 - [Neovim](https://github.com/lex-fmt/nvim)
 - [LexEd](https://github.com/lex-fmt/lexed) — standalone desktop editor (Electron)
 
-All editors use `lex-lsp` for language features and ship a monochrome theme optimized for prose.
+All editors use `lexd-lsp` for language features and ship a monochrome theme optimized for prose.
 
 ## Install
 
 ```sh
-cargo install lex-cli
-cargo install lex-lsp
+cargo install lexd
+cargo install lexd-lsp
 ```
 
 Editor plugins have their own installation instructions.

--- a/crates/lex-babel/src/lib.rs
+++ b/crates/lex-babel/src/lib.rs
@@ -18,7 +18,7 @@
 //!     conversions into a format agnostic layer. This is done by using the IR representation (./ir/mod.rs),
 //!     and having the common code in ./common/mod.rs. This allows for the format specific code to be focused on the data format transformations, while having a strong, focused core that can be well tested in isolation.
 //!
-//!     This is a pure lib, that is, it powers the lex-cli but is shell agnostic, that is no code
+//!     This is a pure lib, that is, it powers the lexd CLI but is shell agnostic, that is no code
 //!     should be written that supposes a shell environment, be it to std print, env vars etc.
 //!
 //!     The file structure:

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lex-cli"
+name = "lexd"
 version = "0.7.0"
 edition = "2021"
 authors = ["lex contributors"]
@@ -10,10 +10,10 @@ keywords = ["cli", "format", "lex"]
 categories = ["command-line-utilities"]
 
 [package.metadata.dist]
-display-name = "lex"
+display-name = "lexd"
 
 [[bin]]
-name = "lex"
+name = "lexd"
 path = "src/main.rs"
 doctest = false
 

--- a/crates/lex-cli/build.rs
+++ b/crates/lex-cli/build.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         Some(outdir) => outdir,
     };
 
-    let mut cmd = Command::new("lex")
+    let mut cmd = Command::new("lexd")
         .version(env!("CARGO_PKG_VERSION"))
         .about("A tool for inspecting and processing lex files")
         .arg_required_else_help(true)
@@ -55,13 +55,13 @@ fn main() -> Result<(), Error> {
         );
 
     // Generate completions for bash
-    generate_to(Bash, &mut cmd, "lex", &outdir)?;
+    generate_to(Bash, &mut cmd, "lexd", &outdir)?;
 
     // Generate completions for zsh
-    generate_to(Zsh, &mut cmd, "lex", &outdir)?;
+    generate_to(Zsh, &mut cmd, "lexd", &outdir)?;
 
     // Generate completions for fish
-    generate_to(Fish, &mut cmd, "lex", &outdir)?;
+    generate_to(Fish, &mut cmd, "lexd", &outdir)?;
 
     println!("cargo:warning=Shell completions generated in {outdir:?}");
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -4,25 +4,25 @@
 //
 // The inspect command is an internal tool for aid in the development of the lex ecosystem, and is bound to be be extracted to it's own crate in the future.
 //
-// The main role for the lex program is to interface with lex content. Be it converting to and fro, linting or formatting it.
+// The main role for the lexd program is to interface with lex content. Be it converting to and fro, linting or formatting it.
 // The core capabilities use the lex-babel crate. This crate being a interface for the lex-babel library, which is a collection of formats and transformers.
 //
 // Converting:
 //
 // The conversion needs a to and from pair. The to can be auto-detected from the file extension, while being overwrittable by an explicit --from flag.
 // Usage:
-//  lex <input> --to <format> [--from <format>] [--output <file>]  - Convert between formats (default)
-//  lex convert <input> --to <format> [--from <format>] [--output <file>]  - Same as above (explicit)
-//  lex inspect <path> [<transform>]      - Execute a transform (defaults to "ast-treeviz")
-//  lex --list-transforms                 - List available transforms
-//  lex config [list|gen|get|set|unset]   - Manage configuration
+//  lexd <input> --to <format> [--from <format>] [--output <file>]  - Convert between formats (default)
+//  lexd convert <input> --to <format> [--from <format>] [--output <file>]  - Same as above (explicit)
+//  lexd inspect <path> [<transform>]      - Execute a transform (defaults to "ast-treeviz")
+//  lexd --list-transforms                 - List available transforms
+//  lexd config [list|gen|get|set|unset]   - Manage configuration
 //
 // Configuration:
 //
 // Settings are loaded from .lex.toml files (CWD, project root, platform config dir),
 // environment variables (LEX__*), and CLI flags. Use `lex config` to manage settings.
 
-use lex_cli::transforms;
+use lexd::transforms;
 
 use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint};
 use clapfig::{Boundary, Clapfig, ClapfigBuilder, ConfigCommand, SearchPath};
@@ -37,26 +37,26 @@ use std::collections::HashMap;
 use std::fs;
 
 fn build_cli() -> Command {
-    Command::new("lex")
+    Command::new("lexd")
         .version(env!("CARGO_PKG_VERSION"))
         .about("A tool for inspecting and converting lex files")
         .long_about(
-            "lex is a command-line tool for working with lex document files.\n\n\
+            "lexd is a command-line tool for working with lex document files.\n\n\
             Commands:\n  \
             - inspect: View internal representations (tokens, AST, etc.)\n  \
             - convert: Transform between document formats (lex, markdown, HTML, etc.)\n  \
             - config:  Manage configuration (list, get, set, gen)\n\n\
             Configuration:\n  \
             Settings are loaded from .lex.toml files, LEX__* env vars, and CLI flags.\n  \
-            Use `lex config list` to see resolved settings.\n\n\
+            Use `lexd config list` to see resolved settings.\n\n\
             Examples:\n  \
-            lex inspect file.lex                    # View AST tree visualization\n  \
-            lex inspect file.lex ast-tag            # View AST as XML tags\n  \
-            lex inspect file.lex --ast-full         # Show complete AST (all node properties)\n  \
-            lex file.lex --to markdown              # Convert to markdown (outputs to stdout)\n  \
-            lex file.lex --to html -o output.html   # Convert to HTML file\n  \
-            lex config list                         # Show all resolved settings\n  \
-            lex config set convert.html.theme fancy-serif  # Persist a setting"
+            lexd inspect file.lex                    # View AST tree visualization\n  \
+            lexd inspect file.lex ast-tag            # View AST as XML tags\n  \
+            lexd inspect file.lex --ast-full         # Show complete AST (all node properties)\n  \
+            lexd file.lex --to markdown              # Convert to markdown (outputs to stdout)\n  \
+            lexd file.lex --to html -o output.html   # Convert to HTML file\n  \
+            lexd config list                         # Show all resolved settings\n  \
+            lexd config set convert.html.theme fancy-serif  # Persist a setting"
         )
         .arg_required_else_help(true)
         .subcommand_required(false)
@@ -89,10 +89,10 @@ fn build_cli() -> Command {
                     - token-*:      Token stream representations\n  \
                     - ir-json:      Intermediate representation\n\n\
                     Examples:\n  \
-                    lex inspect file.lex                     # Tree visualization (default)\n  \
-                    lex inspect file.lex ast-tag             # XML-like output\n  \
-                    lex inspect file.lex --ast-full          # Complete AST with all properties\n  \
-                    lex inspect file.lex token-core-json     # View token stream"
+                    lexd inspect file.lex                     # Tree visualization (default)\n  \
+                    lexd inspect file.lex ast-tag             # XML-like output\n  \
+                    lexd inspect file.lex --ast-full          # Complete AST with all properties\n  \
+                    lexd inspect file.lex token-core-json     # View token stream"
                 )
                 .arg(
                     Arg::new("path")
@@ -165,10 +165,10 @@ fn build_cli() -> Command {
                     The source format is auto-detected from the file extension.\n\
                     Output goes to stdout by default, or use -o to specify a file.\n\n\
                     Examples:\n  \
-                    lex convert input.lex --to markdown          # Convert to markdown (stdout)\n  \
-                    lex convert input.md --to lex -o output.lex  # Markdown to lex file\n  \
-                    lex convert doc.lex --to html -o out.html    # Generate HTML\n  \
-                    lex input.lex --to markdown                  # 'convert' is optional"
+                    lexd convert input.lex --to markdown          # Convert to markdown (stdout)\n  \
+                    lexd convert input.md --to lex -o output.lex  # Markdown to lex file\n  \
+                    lexd convert doc.lex --to html -o out.html    # Generate HTML\n  \
+                    lexd input.lex --to markdown                  # 'convert' is optional"
                 )
                 .arg(
                     Arg::new("input")
@@ -241,8 +241,8 @@ fn build_cli() -> Command {
                     applying standard indentation and spacing rules.\n\n\
                     Output is always written to stdout.\n\n\
                     Examples:\n  \
-                    lex format input.lex                  # Format to stdout\n  \
-                    lex format input.lex > formatted.lex  # Redirect to file"
+                    lexd format input.lex                  # Format to stdout\n  \
+                    lexd format input.lex > formatted.lex  # Redirect to file"
                 )
                 .arg(
                     Arg::new("input")
@@ -317,8 +317,8 @@ fn build_cli() -> Command {
                     saved to a file and customized, then referenced via the\n\
                     convert.html.custom_css config setting.\n\n\
                     Examples:\n  \
-                    lex generate-lex-css                    # Print CSS to stdout\n  \
-                    lex generate-lex-css > custom.css       # Save to file for editing"
+                    lexd generate-lex-css                    # Print CSS to stdout\n  \
+                    lexd generate-lex-css > custom.css       # Save to file for editing"
                 ),
         )
 }

--- a/crates/lex-cli/tests/element_at.rs
+++ b/crates/lex-cli/tests/element_at.rs
@@ -5,7 +5,7 @@ use std::fs;
 #[allow(deprecated)]
 #[test]
 fn test_element_at_basic() {
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at")
         .arg("../../comms/specs/benchmark/010-kitchensink.lex")
         .arg("18")
@@ -18,7 +18,7 @@ fn test_element_at_basic() {
 
 #[test]
 fn test_element_at_with_all_flag() {
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at")
         .arg("../../comms/specs/benchmark/010-kitchensink.lex")
         .arg("18")
@@ -33,7 +33,7 @@ fn test_element_at_with_all_flag() {
 
 #[test]
 fn test_element_at_no_element_found() {
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at")
         .arg("../../comms/specs/benchmark/010-kitchensink.lex")
         .arg("10000")
@@ -47,7 +47,7 @@ fn test_element_at_no_element_found() {
 
 #[test]
 fn test_element_at_missing_arguments() {
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at")
         .arg("comms/specs/benchmark/010-kitchensink.lex");
 
@@ -56,7 +56,7 @@ fn test_element_at_missing_arguments() {
 
 #[test]
 fn test_element_at_file_not_found() {
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at")
         .arg("nonexistent.lex")
         .arg("1")
@@ -74,7 +74,7 @@ fn test_element_at_on_paragraph() {
     let test_file = "test_element_at_paragraph.lex";
     fs::write(test_file, test_content).unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at").arg(test_file).arg("1").arg("5");
 
     cmd.assert()
@@ -92,7 +92,7 @@ fn test_element_at_shows_deepest_element() {
     let test_file = "test_element_at_nested.lex";
     fs::write(test_file, test_content).unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at").arg(test_file).arg("3").arg("5");
 
     // Without --all, should show only the deepest element
@@ -111,7 +111,7 @@ fn test_element_at_all_shows_ancestors() {
     let test_file = "test_element_at_all.lex";
     fs::write(test_file, test_content).unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("element-at")
         .arg(test_file)
         .arg("3")

--- a/crates/lex-cli/tests/format_config.rs
+++ b/crates/lex-cli/tests/format_config.rs
@@ -17,7 +17,7 @@ indent_string = "  "
     )
     .unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("format")
         .arg(input_path.as_os_str())
         .arg("--config")

--- a/crates/lex-cli/tests/markdown_import.rs
+++ b/crates/lex-cli/tests/markdown_import.rs
@@ -14,7 +14,7 @@ fn fixture_path(name: &str) -> PathBuf {
 #[test]
 fn convert_markdown_to_tag_via_cli() {
     let fixture = fixture_path("markdown-reference-commonmark.md");
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("convert").arg(&fixture).arg("--to").arg("tag");
 
     // Verify comprehensive output structure from markdown import

--- a/crates/lex-cli/tests/nodemap.rs
+++ b/crates/lex-cli/tests/nodemap.rs
@@ -8,7 +8,7 @@ fn test_inspect_nodemap_basic() {
     let file = "test_nodemap.lex";
     fs::write(file, content).unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("inspect").arg(file).arg("ast-nodemap");
 
     cmd.assert()
@@ -35,7 +35,7 @@ fn test_inspect_nodemap_color() {
     let file = "test_nodemap_color.lex";
     fs::write(file, content).unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("inspect")
         .arg(file)
         .arg("ast-nodemap")
@@ -54,7 +54,7 @@ fn test_inspect_nodemap_summary() {
     let file = "test_nodemap_summary.lex";
     fs::write(file, content).unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("inspect")
         .arg(file)
         .arg("ast-nodemap")

--- a/crates/lex-cli/tests/pdf.rs
+++ b/crates/lex-cli/tests/pdf.rs
@@ -32,7 +32,7 @@ printf '%%PDF-1.7\n%%%%EOF\n' > "$OUTPUT"
         let output_dir = tempdir().unwrap();
         let output_pdf = output_dir.path().join("out.pdf");
 
-        let mut cmd = cargo_bin_cmd!("lex");
+        let mut cmd = cargo_bin_cmd!("lexd");
         cmd.env("LEX_CHROME_BIN", &chrome_stub)
             .arg("../../comms/specs/benchmark/010-kitchensink.lex")
             .arg("--to")
@@ -51,7 +51,7 @@ printf '%%PDF-1.7\n%%%%EOF\n' > "$OUTPUT"
     #[test]
     fn cli_pdf_requires_output_path() {
         let (_dir, chrome_stub) = write_stub_chrome();
-        let mut cmd = cargo_bin_cmd!("lex");
+        let mut cmd = cargo_bin_cmd!("lexd");
         cmd.env("LEX_CHROME_BIN", &chrome_stub)
             .arg("../../comms/specs/benchmark/010-kitchensink.lex")
             .arg("--to")

--- a/crates/lex-cli/tests/theme_config.rs
+++ b/crates/lex-cli/tests/theme_config.rs
@@ -18,7 +18,7 @@ theme = "dark"
     )
     .unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("convert")
         .arg(input_path.as_os_str())
         .arg("--to")
@@ -49,7 +49,7 @@ theme = "fancy-serif"
     )
     .unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("convert")
         .arg(input_path.as_os_str())
         .arg("--to")
@@ -90,7 +90,7 @@ theme = "modern"
     )
     .unwrap();
 
-    let mut cmd = cargo_bin_cmd!("lex");
+    let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("convert")
         .arg(input_path.as_os_str())
         .arg("--to")

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lex-lsp"
+name = "lexd-lsp"
 version = "0.7.0"
 edition = "2021"
 authors = ["lex contributors"]
@@ -13,8 +13,8 @@ categories = ["development-tools", "text-editors"]
 doctest = false
 
 [[bin]]
-name = "lex-lsp"
-path = "src/bin/lex-lsp.rs"
+name = "lexd-lsp"
+path = "src/bin/lexd-lsp.rs"
 
 [dependencies]
 lex-core = { workspace = true }

--- a/crates/lex-lsp/src/bin/lexd-lsp.rs
+++ b/crates/lex-lsp/src/bin/lexd-lsp.rs
@@ -1,4 +1,4 @@
-use lex_lsp::LexLanguageServer;
+use lexd_lsp::LexLanguageServer;
 use std::env;
 use std::fs;
 use std::process::ExitCode;
@@ -7,7 +7,7 @@ use tower_lsp::{LspService, Server};
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    eprintln!("DEBUG: lex-lsp starting up (Commit 1)...");
+    eprintln!("DEBUG: lexd-lsp starting up...");
     let args: Vec<String> = env::args().collect();
 
     // If called with "convert" subcommand, handle it and exit

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -134,7 +134,7 @@
 //!
 //!     3. Error Propagation:
 //!         - The `lex-parser` crate returns `Result` types for all parsing operations.
-//!         - The `lex-lsp` server maps these internal errors to appropriate LSP error codes
+//!         - The `lexd-lsp` server maps these internal errors to appropriate LSP error codes
 //!           (e.g., `InternalError`, `InvalidRequest`) when communicating with the client.
 //!
 //!     4. Property-Based Testing:
@@ -147,7 +147,7 @@
 //!
 //!     Library:
 //!         ```rust
-//!         use lex_lsp::LexLanguageServer;
+//!         use lexd_lsp::LexLanguageServer;
 //!         use tower_lsp::Server;
 //!
 //!         #[tokio::main]
@@ -161,7 +161,7 @@
 //!         ```
 //!
 //!     Binary:
-//!         $ lex-lsp
+//!         $ lexd-lsp
 //!         Starts the language server on stdin/stdout for editor integration.
 //!
 

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -774,7 +774,7 @@ where
         Ok(InitializeResult {
             capabilities,
             server_info: Some(ServerInfo {
-                name: "lex-lsp".to_string(),
+                name: "lexd-lsp".to_string(),
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
         })

--- a/crates/lex-lsp/tests/cli.rs
+++ b/crates/lex-lsp/tests/cli.rs
@@ -2,15 +2,15 @@ use std::process::{Command, Stdio};
 
 #[test]
 fn lex_lsp_binary_starts_and_stops() {
-    let exe = env!("CARGO_BIN_EXE_lex-lsp");
+    let exe = env!("CARGO_BIN_EXE_lexd-lsp");
     let mut child = Command::new(exe)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("failed to start lex-lsp binary");
+        .expect("failed to start lexd-lsp binary");
 
     // Immediately terminate the server; we only need to ensure it starts.
-    child.kill().expect("failed to stop lex-lsp binary");
+    child.kill().expect("failed to stop lexd-lsp binary");
     let _ = child.wait();
 }

--- a/crates/lex-lsp/tests/robustness_proptest.rs
+++ b/crates/lex-lsp/tests/robustness_proptest.rs
@@ -1,5 +1,5 @@
-use lex_lsp::server::{DefaultFeatureProvider, LspClient};
-use lex_lsp::LexLanguageServer;
+use lexd_lsp::server::{DefaultFeatureProvider, LspClient};
+use lexd_lsp::LexLanguageServer;
 use proptest::prelude::*;
 use std::sync::Arc;
 use tower_lsp::lsp_types::{

--- a/readme.lex
+++ b/readme.lex
@@ -109,7 +109,7 @@ It's flexible and permissive so that you can go from free text to more structure
     - Format conversion (lex-babel): markdown, html, pdf, png, pandoc JSON (enabling LaTeX, DOCX, EPUB, RST, and 30+ formats through Pandoc), and RFC XML
     - Inspectors for internal phases, from tokens to final AST, with several visualizations (treeviz, tag, nodemap, JSON)
     - Semantic analysis library (lex-analysis)
-    - An LSP server (lex-lsp) for editors, with semantic highlighting, document symbols, formatting, completion, diagnostics, hover, go to definition, references, folding, and document links
+    - An LSP server (lexd-lsp) for editors, with semantic highlighting, document symbols, formatting, completion, diagnostics, hover, go to definition, references, folding, and document links
     - Editor integrations:  nvim [https://github.com/lex-fmt/nvim],  the VSCode Extension [https://github.com/lex-fmt/vscode], and lexed [https://github.com/lex-fmt/lexed], a standalone desktop editor
 
 6. Installation
@@ -117,8 +117,8 @@ It's flexible and permissive so that you can go from free text to more structure
     All Rust tools can be installed via cargo.
 
     Install:
-        cargo install lex-cli
-        cargo install lex-lsp
+        cargo install lexd
+        cargo install lexd-lsp
     :: shell ::
 
     Each editor plugin has its own installation instructions in its respective repository.


### PR DESCRIPTION
## Summary

- Rename `lex-cli` package to `lexd` (binary: `lex` -> `lexd`)
- Rename `lex-lsp` package to `lexd-lsp` (binary: `lex-lsp` -> `lexd-lsp`)
- Add `cargo publish -p lexd` to release workflow (was missing)
- Update documentation and CI workflows

Avoids conflicts with the Unix `lex` lexical analyzer generator. Users install with `cargo install lexd` / `cargo install lexd-lsp`. Internal library crates (`lex-core`, `lex-babel`, `lex-config`, `lex-analysis`) are unchanged.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` passes
- [x] `cargo nextest run --workspace --exclude lex-wasm` — 1444 tests pass
- [x] `target/debug/lexd --help` shows `lexd` command name
- [x] `target/debug/lexd-lsp` binary exists and starts
- [ ] Release workflow produces correctly named artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)