### PR TITLE
Escape-aware structural scanners — fix \| in tables, \, in citations (#451)

### DIFF
--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -15,7 +15,9 @@
 
 use super::verbatim::extract_verbatim_block_data;
 use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+use crate::lex::escape::split_respecting_escape_with_ranges;
 use crate::lex::token::LineToken;
+use std::borrow::Cow;
 use std::ops::Range as ByteRange;
 
 /// Extracted data for a single table cell (pre-AST).
@@ -137,10 +139,11 @@ fn parse_pipe_rows(content_lines: &[(String, ByteRange<usize>)]) -> Vec<TableRow
 enum LineKind<'a> {
     /// A pipe row with parsed cell texts
     PipeRow {
-        /// Trimmed cell texts (for merge markers, compact mode)
-        cells: Vec<&'a str>,
+        /// Trimmed cell texts (for merge markers, compact mode).
+        /// `Cow::Owned` when backslash escapes were stripped (e.g. `\|`), otherwise borrowed.
+        cells: Vec<Cow<'a, str>>,
         /// Raw cell texts preserving leading whitespace (for block content in multi-line mode)
-        raw_cells: Vec<&'a str>,
+        raw_cells: Vec<Cow<'a, str>>,
         /// Per-cell byte ranges (of trimmed text) in the source
         cell_ranges: Vec<ByteRange<usize>>,
         line_range: &'a ByteRange<usize>,
@@ -155,6 +158,16 @@ enum LineKind<'a> {
 }
 
 /// Classify all content lines into pipe rows, blanks, or other.
+///
+/// Pipe-row parsing honors the Lex structural escape convention:
+/// - `\|` inside a cell is a literal pipe (not a cell boundary); the backslash
+///   is stripped in the returned cell text.
+/// - Content inside balanced backticks (`` `...` ``) is a literal region:
+///   pipes inside it do not split, and backslashes are passed through verbatim
+///   (so that code spans like `` `a|b` `` survive as a single cell).
+///
+/// Byte ranges point to source positions of the trimmed segment text,
+/// regardless of whether the cell text had backslashes stripped.
 fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<LineKind<'a>> {
     content_lines
         .iter()
@@ -166,39 +179,46 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
                 // Offset of trimmed text within the full line text
                 let trim_offset = text.len() - text.trim_start().len();
 
-                let segments: Vec<&str> = trimmed.split('|').collect();
-                let start = if segments.first().is_some_and(|s| s.trim().is_empty()) {
+                // Escape-aware split: respects `\|` and backtick literal regions.
+                let segments = split_respecting_escape_with_ranges(trimmed, '|', Some('`'));
+
+                // Leading/trailing fully-empty segments come from the `|` at row start/end.
+                let start = if segments
+                    .first()
+                    .is_some_and(|(cow, _)| cow.trim().is_empty())
+                {
                     1
                 } else {
                     0
                 };
-                let end = if segments.last().is_some_and(|s| s.trim().is_empty()) {
+                let end = if segments
+                    .last()
+                    .is_some_and(|(cow, _)| cow.trim().is_empty())
+                {
                     segments.len() - 1
                 } else {
                     segments.len()
                 };
 
-                // Compute per-cell byte ranges by walking through the trimmed line
-                let mut cell_ranges = Vec::with_capacity(end - start);
-                let mut pos = 0; // position within trimmed
-                for (seg_idx, segment) in segments.iter().enumerate() {
-                    if seg_idx > 0 {
-                        pos += 1; // skip the `|` delimiter
-                    }
-                    if seg_idx >= start && seg_idx < end {
-                        // Find the trimmed content within this segment
-                        let seg_trim_start = segment.len() - segment.trim_start().len();
-                        let seg_trim_end = segment.trim_end().len();
-                        let cell_start = range.start + trim_offset + pos + seg_trim_start;
-                        let cell_end = range.start + trim_offset + pos + seg_trim_end;
-                        cell_ranges.push(cell_start..cell_end);
-                    }
-                    pos += segment.len();
+                let mut cell_ranges = Vec::with_capacity(end.saturating_sub(start));
+                let mut cells: Vec<Cow<'a, str>> = Vec::with_capacity(end.saturating_sub(start));
+                let mut raw_cells: Vec<Cow<'a, str>> =
+                    Vec::with_capacity(end.saturating_sub(start));
+
+                for (cow, seg_range) in &segments[start..end] {
+                    // Byte range computation uses the ORIGINAL source segment (pre-strip),
+                    // so diagnostic spans always point to real source positions.
+                    let src_seg = &trimmed[seg_range.clone()];
+                    let lead_ws = src_seg.len() - src_seg.trim_start().len();
+                    let trail_ws = src_seg.len() - src_seg.trim_end().len();
+                    let cell_start = range.start + trim_offset + seg_range.start + lead_ws;
+                    let cell_end = range.start + trim_offset + seg_range.end - trail_ws;
+                    cell_ranges.push(cell_start..cell_end);
+
+                    cells.push(trim_cow(cow));
+                    raw_cells.push(trim_end_cow(cow));
                 }
 
-                let cells: Vec<&str> = segments[start..end].iter().map(|s| s.trim()).collect();
-                let raw_cells: Vec<&str> =
-                    segments[start..end].iter().map(|s| s.trim_end()).collect();
                 LineKind::PipeRow {
                     cells,
                     raw_cells,
@@ -213,6 +233,36 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
             }
         })
         .collect()
+}
+
+/// Trim whitespace from both ends of a `Cow<str>`, preserving Borrowed status when possible.
+fn trim_cow<'a>(cow: &Cow<'a, str>) -> Cow<'a, str> {
+    match cow {
+        Cow::Borrowed(s) => Cow::Borrowed(s.trim()),
+        Cow::Owned(s) => {
+            let t = s.trim();
+            if t.len() == s.len() {
+                Cow::Owned(s.clone())
+            } else {
+                Cow::Owned(t.to_string())
+            }
+        }
+    }
+}
+
+/// Trim only trailing whitespace from a `Cow<str>`.
+fn trim_end_cow<'a>(cow: &Cow<'a, str>) -> Cow<'a, str> {
+    match cow {
+        Cow::Borrowed(s) => Cow::Borrowed(s.trim_end()),
+        Cow::Owned(s) => {
+            let t = s.trim_end();
+            if t.len() == s.len() {
+                Cow::Owned(s.clone())
+            } else {
+                Cow::Owned(t.to_string())
+            }
+        }
+    }
 }
 
 /// Detect multi-line mode: true if any blank line appears between two pipe rows.
@@ -371,7 +421,7 @@ fn merge_group(group: &[&LineKind]) -> Option<TableRowData> {
 
             // Build raw text for all columns
             if col < merged_raw.len() {
-                let raw = cont_raw.get(col).copied().unwrap_or("");
+                let raw: &str = cont_raw.get(col).map(|c| c.as_ref()).unwrap_or("");
                 if !raw.trim().is_empty() {
                     merged_raw[col].push('\n');
                     merged_raw[col].push_str(raw);
@@ -643,6 +693,84 @@ mod tests {
         let classified = classify_lines(&lines);
         if let LineKind::PipeRow { cells, .. } = &classified[0] {
             assert_eq!(cells, &["a", "b", "c"]);
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_escaped_pipe_in_cell() {
+        // `\|` should not split the cell; the backslash is stripped in the cell text.
+        let lines = vec![(r"| a\|b | c |".to_string(), 0..12)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow {
+            cells, cell_ranges, ..
+        } = &classified[0]
+        {
+            assert_eq!(cells.len(), 2, "expected 2 cells, got {cells:?}");
+            assert_eq!(cells[0], "a|b");
+            assert_eq!(cells[1], "c");
+            // Byte range of cell 0 spans "a\|b" in source (4 bytes), pointing at the
+            // trimmed content inside the segment, not the stripped cell text.
+            assert_eq!(cell_ranges[0].end - cell_ranges[0].start, 4);
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_backtick_protects_pipe() {
+        // Pipes inside balanced backticks must not split cells.
+        let lines = vec![("| a | `x|y|z` | c |".to_string(), 0..19)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells.len(), 3, "expected 3 cells, got {cells:?}");
+            assert_eq!(cells[0], "a");
+            assert_eq!(cells[1], "`x|y|z`");
+            assert_eq!(cells[2], "c");
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_multiple_escaped_pipes() {
+        let lines = vec![(r"| a\|b\|c | d |".to_string(), 0..15)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells.len(), 2);
+            assert_eq!(cells[0], "a|b|c");
+            assert_eq!(cells[1], "d");
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_double_backslash_then_pipe_splits() {
+        // `\\|` = literal backslash + structural pipe (even backslashes → not escaped).
+        let lines = vec![(r"| a\\|b |".to_string(), 0..9)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells.len(), 2, "expected 2 cells, got {cells:?}");
+            assert_eq!(cells[0], r"a\\");
+            assert_eq!(cells[1], "b");
+        } else {
+            panic!("Expected PipeRow");
+        }
+    }
+
+    #[test]
+    fn test_classify_lines_escape_inside_backticks_preserved() {
+        // Inside backtick literal region, backslashes pass through verbatim —
+        // no split AND no stripping.
+        let lines = vec![(r"| a | `code\|here` | b |".to_string(), 0..24)];
+        let classified = classify_lines(&lines);
+        if let LineKind::PipeRow { cells, .. } = &classified[0] {
+            assert_eq!(cells.len(), 3);
+            assert_eq!(cells[0], "a");
+            assert_eq!(cells[1], r"`code\|here`");
+            assert_eq!(cells[2], "b");
         } else {
             panic!("Expected PipeRow");
         }

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -205,7 +205,10 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
                 let mut raw_cells: Vec<Cow<'a, str>> =
                     Vec::with_capacity(end.saturating_sub(start));
 
-                for (cow, seg_range) in &segments[start..end] {
+                for (i, (cow, seg_range)) in segments.into_iter().enumerate() {
+                    if i < start || i >= end {
+                        continue;
+                    }
                     // Byte range computation uses the ORIGINAL source segment (pre-strip),
                     // so diagnostic spans always point to real source positions.
                     let src_seg = &trimmed[seg_range.clone()];
@@ -215,8 +218,9 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
                     let cell_end = range.start + trim_offset + seg_range.end - trail_ws;
                     cell_ranges.push(cell_start..cell_end);
 
-                    cells.push(trim_cow(cow));
-                    raw_cells.push(trim_end_cow(cow));
+                    let (cell, raw) = trim_cell_pair(cow);
+                    cells.push(cell);
+                    raw_cells.push(raw);
                 }
 
                 LineKind::PipeRow {
@@ -235,31 +239,36 @@ fn classify_lines<'a>(content_lines: &'a [(String, ByteRange<usize>)]) -> Vec<Li
         .collect()
 }
 
-/// Trim whitespace from both ends of a `Cow<str>`, preserving Borrowed status when possible.
-fn trim_cow<'a>(cow: &Cow<'a, str>) -> Cow<'a, str> {
+/// Consume a segment `Cow` and produce both `(trimmed, trim_end_only)` variants.
+///
+/// Borrowed inputs produce two sub-slices — zero allocations. Owned inputs reuse
+/// the existing `String` whenever a trim would be a no-op, allocating only for
+/// the variants that actually differ.
+fn trim_cell_pair<'a>(cow: Cow<'a, str>) -> (Cow<'a, str>, Cow<'a, str>) {
     match cow {
-        Cow::Borrowed(s) => Cow::Borrowed(s.trim()),
+        Cow::Borrowed(s) => (Cow::Borrowed(s.trim()), Cow::Borrowed(s.trim_end())),
         Cow::Owned(s) => {
-            let t = s.trim();
-            if t.len() == s.len() {
-                Cow::Owned(s.clone())
-            } else {
-                Cow::Owned(t.to_string())
-            }
-        }
-    }
-}
-
-/// Trim only trailing whitespace from a `Cow<str>`.
-fn trim_end_cow<'a>(cow: &Cow<'a, str>) -> Cow<'a, str> {
-    match cow {
-        Cow::Borrowed(s) => Cow::Borrowed(s.trim_end()),
-        Cow::Owned(s) => {
-            let t = s.trim_end();
-            if t.len() == s.len() {
-                Cow::Owned(s.clone())
-            } else {
-                Cow::Owned(t.to_string())
+            let full_noop = s.trim().len() == s.len();
+            let end_noop = s.trim_end().len() == s.len();
+            match (full_noop, end_noop) {
+                (true, true) => {
+                    // Neither trim modifies the string; share via one clone.
+                    let clone = s.clone();
+                    (Cow::Owned(s), Cow::Owned(clone))
+                }
+                (true, false) => {
+                    let te = s.trim_end().to_string();
+                    (Cow::Owned(s), Cow::Owned(te))
+                }
+                (false, true) => {
+                    let t = s.trim().to_string();
+                    (Cow::Owned(t), Cow::Owned(s))
+                }
+                (false, false) => {
+                    let t = s.trim().to_string();
+                    let te = s.trim_end().to_string();
+                    (Cow::Owned(t), Cow::Owned(te))
+                }
             }
         }
     }

--- a/crates/lex-core/src/lex/escape.rs
+++ b/crates/lex-core/src/lex/escape.rs
@@ -240,6 +240,18 @@ pub fn split_respecting_escape_and_literals(
     split_inner(s, sep, Some(literal_delim))
 }
 
+/// Like [`split_respecting_escape_and_literals`] but also returns the byte range
+/// of each segment within the input (pre-strip, pre-trim positions).
+///
+/// Useful for parsers that need source-position tracking (e.g. diagnostic spans).
+pub fn split_respecting_escape_with_ranges<'a>(
+    s: &'a str,
+    sep: char,
+    literal_delim: Option<char>,
+) -> Vec<(Cow<'a, str>, std::ops::Range<usize>)> {
+    split_with_ranges_inner(s, sep, literal_delim)
+}
+
 /// Find the first position of `needle` in `s` that is structural — i.e.,
 /// not preceded by an odd number of backslashes and (if `literal_delim` is
 /// provided) not inside a balanced literal region.
@@ -473,6 +485,76 @@ fn strip_escapes_char(slice: &str, sep: char, literal_delim: Option<char>) -> St
         i += 1;
     }
     out
+}
+
+fn split_with_ranges_inner<'a>(
+    s: &'a str,
+    sep: char,
+    literal_delim: Option<char>,
+) -> Vec<(Cow<'a, str>, std::ops::Range<usize>)> {
+    if s.is_empty() {
+        return vec![(Cow::Borrowed(""), 0..0)];
+    }
+    let bytes = s.as_bytes();
+    let sep_is_ascii = sep.is_ascii();
+    let literal_is_ascii = literal_delim.is_none_or(|c| c.is_ascii());
+    if sep_is_ascii && literal_is_ascii {
+        let mut segments = Vec::new();
+        let mut seg_start = 0usize;
+        let mut in_literal = false;
+        let mut i = 0usize;
+        let sep_byte = sep as u8;
+        let literal_byte = literal_delim.map(|c| c as u8);
+        while i < bytes.len() {
+            let b = bytes[i];
+            if let Some(delim) = literal_byte {
+                if b == delim && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                    in_literal = !in_literal;
+                    i += 1;
+                    continue;
+                }
+            }
+            if !in_literal && b == sep_byte && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                let seg = extract_segment(s, seg_start, i, sep_byte, literal_byte);
+                segments.push((seg, seg_start..i));
+                seg_start = i + 1;
+            }
+            i += 1;
+        }
+        let seg = extract_segment(s, seg_start, bytes.len(), sep_byte, literal_byte);
+        segments.push((seg, seg_start..bytes.len()));
+        segments
+    } else {
+        let mut segments = Vec::new();
+        let mut seg_start = 0usize;
+        let mut in_literal = false;
+        let mut prev_backslashes = 0usize;
+        for (i, ch) in s.char_indices() {
+            let is_escaped = prev_backslashes % 2 == 1;
+            if let Some(delim) = literal_delim {
+                if ch == delim && !is_escaped {
+                    in_literal = !in_literal;
+                    prev_backslashes = 0;
+                    continue;
+                }
+            }
+            if !in_literal && ch == sep && !is_escaped {
+                let seg = extract_segment_char(s, seg_start, i, sep, literal_delim);
+                segments.push((seg, seg_start..i));
+                seg_start = i + ch.len_utf8();
+                prev_backslashes = 0;
+                continue;
+            }
+            if ch == '\\' {
+                prev_backslashes += 1;
+            } else {
+                prev_backslashes = 0;
+            }
+        }
+        let seg = extract_segment_char(s, seg_start, s.len(), sep, literal_delim);
+        segments.push((seg, seg_start..s.len()));
+        segments
+    }
 }
 
 fn find_inner(s: &str, needle: char, literal_delim: Option<char>) -> Option<usize> {

--- a/crates/lex-core/src/lex/escape.rs
+++ b/crates/lex-core/src/lex/escape.rs
@@ -11,7 +11,17 @@
 //!   - `\\` inside a quoted value: literal backslash
 //!   - Only `"` and `\` can be escaped; other backslashes are literal
 //!
+//! Structural Scanner Rules (for split/find on structural delimiters like `|`, `,`, `;`):
+//!   - `\<sep>` is treated as a literal character (not a split point);
+//!     the escaping backslash is stripped in the returned segment text.
+//!   - `\\<sep>` counts as an escaped backslash followed by a structural `<sep>`
+//!     (even number of backslashes → `<sep>` is structural).
+//!   - Optionally, content inside balanced `literal_delim` pairs (e.g. backticks)
+//!     is passed through verbatim: no split, no backslash stripping.
+//!
 //! Verbatim blocks and labels have no character-level escaping.
+
+use std::borrow::Cow;
 
 /// Result of processing a backslash at position `i` in a character stream.
 pub enum EscapeAction {
@@ -156,6 +166,330 @@ pub fn find_structural_lex_marker_pairs<R>(tokens: &[(crate::lex::token::Token, 
         }
     }
     markers
+}
+
+// --- Escape-aware structural scanners ---
+
+/// Count trailing backslashes immediately preceding byte position `pos` in `bytes`.
+///
+/// Returns 0 if `pos == 0` or the byte at `pos - 1` is not `\`.
+fn trailing_backslashes_before(bytes: &[u8], pos: usize) -> usize {
+    let mut n = 0usize;
+    let mut i = pos;
+    while i > 0 && bytes[i - 1] == b'\\' {
+        n += 1;
+        i -= 1;
+    }
+    n
+}
+
+/// Check whether the byte at `pos` in `bytes` is a structural delimiter — i.e.,
+/// not preceded by an odd number of backslashes and (if `literal_delim` is provided)
+/// not inside a balanced pair of literal delimiters starting from byte 0.
+///
+/// Literal delimiters nest flat (balanced pairs, no nesting), matching how
+/// backtick-delimited inline code behaves in Lex.
+pub fn is_structural_at(bytes: &[u8], pos: usize, literal_delim: Option<u8>) -> bool {
+    if pos >= bytes.len() {
+        return false;
+    }
+    // Escape check: odd backslashes before pos → escaped.
+    if trailing_backslashes_before(bytes, pos) % 2 == 1 {
+        return false;
+    }
+    // Literal-region check: scan from start, toggling on unescaped literal_delim.
+    if let Some(delim) = literal_delim {
+        let mut in_literal = false;
+        let mut i = 0;
+        while i < pos {
+            if bytes[i] == delim && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                in_literal = !in_literal;
+            }
+            i += 1;
+        }
+        if in_literal {
+            return false;
+        }
+    }
+    true
+}
+
+/// Splits `s` on `sep`, treating `\<sep>` as a literal character (not a split point)
+/// and stripping the escaping backslash from the returned segment text.
+///
+/// Returns `Cow::Borrowed` for segments with no escapes to strip (no allocation),
+/// `Cow::Owned` otherwise.
+///
+/// Semantics:
+/// - `\<sep>` → literal `<sep>` inside a segment, no split.
+/// - `\\<sep>` → literal `\` followed by structural `<sep>` → splits.
+/// - Other `\X` sequences inside a segment are preserved as-is (this scanner
+///   only resolves `\<sep>`; inline-level escape resolution is a separate pass).
+pub fn split_respecting_escape(s: &str, sep: char) -> Vec<Cow<'_, str>> {
+    split_inner(s, sep, None)
+}
+
+/// Like [`split_respecting_escape`] but additionally treats content inside
+/// balanced `literal_delim` pairs as non-splittable. Separators and escapes
+/// inside literal regions are passed through verbatim.
+pub fn split_respecting_escape_and_literals(
+    s: &str,
+    sep: char,
+    literal_delim: char,
+) -> Vec<Cow<'_, str>> {
+    split_inner(s, sep, Some(literal_delim))
+}
+
+/// Find the first position of `needle` in `s` that is structural — i.e.,
+/// not preceded by an odd number of backslashes and (if `literal_delim` is
+/// provided) not inside a balanced literal region.
+///
+/// Returns a byte offset into `s`.
+pub fn find_respecting_escape(s: &str, needle: char) -> Option<usize> {
+    find_inner(s, needle, None)
+}
+
+/// Like [`find_respecting_escape`] but respects balanced `literal_delim` regions.
+pub fn find_respecting_escape_and_literals(
+    s: &str,
+    needle: char,
+    literal_delim: char,
+) -> Option<usize> {
+    find_inner(s, needle, Some(literal_delim))
+}
+
+fn split_inner(s: &str, sep: char, literal_delim: Option<char>) -> Vec<Cow<'_, str>> {
+    if s.is_empty() {
+        return vec![Cow::Borrowed("")];
+    }
+    let bytes = s.as_bytes();
+    let sep_is_ascii = sep.is_ascii();
+    let literal_is_ascii = literal_delim.is_none_or(|c| c.is_ascii());
+    // Fast path: if sep and literal_delim are ASCII, we can scan bytes directly.
+    // Otherwise, fall back to char iteration.
+    if sep_is_ascii && literal_is_ascii {
+        split_inner_ascii(s, bytes, sep as u8, literal_delim.map(|c| c as u8))
+    } else {
+        split_inner_chars(s, sep, literal_delim)
+    }
+}
+
+fn split_inner_ascii<'a>(
+    s: &'a str,
+    bytes: &[u8],
+    sep: u8,
+    literal_delim: Option<u8>,
+) -> Vec<Cow<'a, str>> {
+    let mut segments = Vec::new();
+    let mut seg_start = 0usize;
+    let mut in_literal = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(delim) = literal_delim {
+            if b == delim && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                in_literal = !in_literal;
+                i += 1;
+                continue;
+            }
+        }
+        if !in_literal && b == sep && trailing_backslashes_before(bytes, i) % 2 == 0 {
+            segments.push(extract_segment(s, seg_start, i, sep, literal_delim));
+            seg_start = i + 1;
+        }
+        i += 1;
+    }
+    segments.push(extract_segment(
+        s,
+        seg_start,
+        bytes.len(),
+        sep,
+        literal_delim,
+    ));
+    segments
+}
+
+fn split_inner_chars<'a>(s: &'a str, sep: char, literal_delim: Option<char>) -> Vec<Cow<'a, str>> {
+    let mut segments = Vec::new();
+    let mut seg_start = 0usize;
+    let mut in_literal = false;
+    let mut prev_backslashes = 0usize;
+    for (i, ch) in s.char_indices() {
+        let is_escaped = prev_backslashes % 2 == 1;
+        if let Some(delim) = literal_delim {
+            if ch == delim && !is_escaped {
+                in_literal = !in_literal;
+                prev_backslashes = 0;
+                continue;
+            }
+        }
+        if !in_literal && ch == sep && !is_escaped {
+            segments.push(extract_segment_char(s, seg_start, i, sep, literal_delim));
+            seg_start = i + ch.len_utf8();
+            prev_backslashes = 0;
+            continue;
+        }
+        if ch == '\\' {
+            prev_backslashes += 1;
+        } else {
+            prev_backslashes = 0;
+        }
+    }
+    segments.push(extract_segment_char(
+        s,
+        seg_start,
+        s.len(),
+        sep,
+        literal_delim,
+    ));
+    segments
+}
+
+/// Extract `s[start..end]` and strip escaping backslashes for `\<sep>` sequences
+/// that occur outside literal regions.
+fn extract_segment<'a>(
+    s: &'a str,
+    start: usize,
+    end: usize,
+    sep: u8,
+    literal_delim: Option<u8>,
+) -> Cow<'a, str> {
+    let slice = &s[start..end];
+    // Quick check: only need to strip if we find `\<sep>` outside any literal region.
+    if !needs_strip_ascii(slice.as_bytes(), sep, literal_delim) {
+        return Cow::Borrowed(slice);
+    }
+    Cow::Owned(strip_escapes_ascii(slice.as_bytes(), sep, literal_delim))
+}
+
+fn extract_segment_char<'a>(
+    s: &'a str,
+    start: usize,
+    end: usize,
+    sep: char,
+    literal_delim: Option<char>,
+) -> Cow<'a, str> {
+    let slice = &s[start..end];
+    if !needs_strip_char(slice, sep, literal_delim) {
+        return Cow::Borrowed(slice);
+    }
+    Cow::Owned(strip_escapes_char(slice, sep, literal_delim))
+}
+
+fn needs_strip_ascii(bytes: &[u8], sep: u8, literal_delim: Option<u8>) -> bool {
+    let mut in_literal = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(delim) = literal_delim {
+            if b == delim && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                in_literal = !in_literal;
+                i += 1;
+                continue;
+            }
+        }
+        if !in_literal && b == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == sep {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+fn strip_escapes_ascii(bytes: &[u8], sep: u8, literal_delim: Option<u8>) -> String {
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut in_literal = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(delim) = literal_delim {
+            if b == delim && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                in_literal = !in_literal;
+                out.push(b);
+                i += 1;
+                continue;
+            }
+        }
+        if !in_literal && b == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == sep {
+            out.push(sep);
+            i += 2;
+            continue;
+        }
+        out.push(b);
+        i += 1;
+    }
+    // Safe: input was valid UTF-8 and we only delete whole ASCII `\` bytes or
+    // replace ASCII `\<sep>` with ASCII `<sep>`. Non-ASCII multi-byte sequences
+    // are copied byte-for-byte intact, so the result stays valid UTF-8.
+    String::from_utf8(out).expect("byte-level manipulations preserve UTF-8 validity")
+}
+
+fn needs_strip_char(slice: &str, sep: char, literal_delim: Option<char>) -> bool {
+    let chars: Vec<char> = slice.chars().collect();
+    let mut in_literal = false;
+    let mut prev_backslashes = 0usize;
+    for (i, &ch) in chars.iter().enumerate() {
+        let is_escaped = prev_backslashes % 2 == 1;
+        if let Some(delim) = literal_delim {
+            if ch == delim && !is_escaped {
+                in_literal = !in_literal;
+                prev_backslashes = 0;
+                continue;
+            }
+        }
+        if !in_literal && ch == '\\' && chars.get(i + 1).copied() == Some(sep) {
+            return true;
+        }
+        if ch == '\\' {
+            prev_backslashes += 1;
+        } else {
+            prev_backslashes = 0;
+        }
+    }
+    false
+}
+
+fn strip_escapes_char(slice: &str, sep: char, literal_delim: Option<char>) -> String {
+    let chars: Vec<char> = slice.chars().collect();
+    let mut out = String::with_capacity(slice.len());
+    let mut in_literal = false;
+    let mut i = 0;
+    while i < chars.len() {
+        let ch = chars[i];
+        if let Some(delim) = literal_delim {
+            if ch == delim {
+                in_literal = !in_literal;
+                out.push(ch);
+                i += 1;
+                continue;
+            }
+        }
+        if !in_literal && ch == '\\' && chars.get(i + 1).copied() == Some(sep) {
+            out.push(sep);
+            i += 2;
+            continue;
+        }
+        out.push(ch);
+        i += 1;
+    }
+    out
+}
+
+fn find_inner(s: &str, needle: char, literal_delim: Option<char>) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut in_literal = false;
+    for (i, ch) in s.char_indices() {
+        if let Some(delim) = literal_delim {
+            if ch == delim && trailing_backslashes_before(bytes, i) % 2 == 0 {
+                in_literal = !in_literal;
+                continue;
+            }
+        }
+        if !in_literal && ch == needle && trailing_backslashes_before(bytes, i) % 2 == 0 {
+            return Some(i);
+        }
+    }
+    None
 }
 
 // --- Quoted parameter value escaping ---
@@ -594,6 +928,292 @@ mod tests {
             Token::LexMarker, // 10: structural
         ];
         assert_eq!(find_structural_lex_markers(&tokens), vec![0, 10]);
+    }
+
+    // --- split_respecting_escape ---
+
+    fn collect(segments: Vec<Cow<'_, str>>) -> Vec<String> {
+        segments.into_iter().map(|s| s.into_owned()).collect()
+    }
+
+    #[test]
+    fn split_no_separator() {
+        assert_eq!(
+            collect(split_respecting_escape("hello", '|')),
+            vec!["hello"]
+        );
+    }
+
+    #[test]
+    fn split_empty_input() {
+        assert_eq!(collect(split_respecting_escape("", '|')), vec![""]);
+    }
+
+    #[test]
+    fn split_simple() {
+        assert_eq!(
+            collect(split_respecting_escape("a|b|c", '|')),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn split_trailing_empty() {
+        assert_eq!(
+            collect(split_respecting_escape("a|b|", '|')),
+            vec!["a", "b", ""]
+        );
+    }
+
+    #[test]
+    fn split_leading_empty() {
+        assert_eq!(
+            collect(split_respecting_escape("|a|b", '|')),
+            vec!["", "a", "b"]
+        );
+    }
+
+    #[test]
+    fn split_only_separators() {
+        assert_eq!(
+            collect(split_respecting_escape("|||", '|')),
+            vec!["", "", "", ""]
+        );
+    }
+
+    #[test]
+    fn split_escaped_separator() {
+        assert_eq!(
+            collect(split_respecting_escape("a\\|b|c", '|')),
+            vec!["a|b", "c"]
+        );
+    }
+
+    #[test]
+    fn split_double_backslash_then_sep_splits() {
+        // \\| → literal \ + structural |
+        assert_eq!(
+            collect(split_respecting_escape("a\\\\|b", '|')),
+            vec!["a\\\\", "b"]
+        );
+    }
+
+    #[test]
+    fn split_triple_backslash_then_sep_is_escaped() {
+        // \\\| → literal \ + escaped |
+        assert_eq!(
+            collect(split_respecting_escape("a\\\\\\|b", '|')),
+            vec!["a\\\\|b"]
+        );
+    }
+
+    #[test]
+    fn split_multiple_escapes_in_one_segment() {
+        assert_eq!(
+            collect(split_respecting_escape("\\|a\\|b\\|", '|')),
+            vec!["|a|b|"]
+        );
+    }
+
+    #[test]
+    fn split_trailing_backslash_no_sep() {
+        assert_eq!(
+            collect(split_respecting_escape("abc\\", '|')),
+            vec!["abc\\"]
+        );
+    }
+
+    #[test]
+    fn split_preserves_unrelated_backslashes() {
+        // `\n` is unrelated to `|`, preserved verbatim (inline-level escaping handles that).
+        assert_eq!(
+            collect(split_respecting_escape("a\\n|b", '|')),
+            vec!["a\\n", "b"]
+        );
+    }
+
+    #[test]
+    fn split_different_separator() {
+        assert_eq!(
+            collect(split_respecting_escape("a,b\\,c,d", ',')),
+            vec!["a", "b,c", "d"]
+        );
+    }
+
+    #[test]
+    fn split_borrowed_when_no_strip() {
+        // No escapes → segments should be Cow::Borrowed (no allocation).
+        let segments = split_respecting_escape("a|b|c", '|');
+        for seg in &segments {
+            assert!(
+                matches!(seg, Cow::Borrowed(_)),
+                "expected Borrowed, got {seg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn split_owned_when_strip_happens() {
+        let segments = split_respecting_escape("a\\|b|c", '|');
+        assert!(matches!(segments[0], Cow::Owned(_)));
+        assert!(matches!(segments[1], Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn split_unicode_content() {
+        assert_eq!(
+            collect(split_respecting_escape("α|β|γ", '|')),
+            vec!["α", "β", "γ"]
+        );
+    }
+
+    #[test]
+    fn split_unicode_with_escape() {
+        assert_eq!(
+            collect(split_respecting_escape("α\\|β|γ", '|')),
+            vec!["α|β", "γ"]
+        );
+    }
+
+    #[test]
+    fn split_non_ascii_separator() {
+        assert_eq!(
+            collect(split_respecting_escape("a→b→c", '→')),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn split_non_ascii_separator_with_escape() {
+        assert_eq!(
+            collect(split_respecting_escape("a\\→b→c", '→')),
+            vec!["a→b", "c"]
+        );
+    }
+
+    // --- split_respecting_escape_and_literals ---
+
+    #[test]
+    fn split_literal_region_protects_separator() {
+        assert_eq!(
+            collect(split_respecting_escape_and_literals("a|`b|c`|d", '|', '`')),
+            vec!["a", "`b|c`", "d"]
+        );
+    }
+
+    #[test]
+    fn split_literal_region_multiple_pipes() {
+        assert_eq!(
+            collect(split_respecting_escape_and_literals(
+                "a|`x|y|z`|b",
+                '|',
+                '`'
+            )),
+            vec!["a", "`x|y|z`", "b"]
+        );
+    }
+
+    #[test]
+    fn split_escape_outside_literal_still_works() {
+        assert_eq!(
+            collect(split_respecting_escape_and_literals(
+                "a\\|b|`c|d`|e",
+                '|',
+                '`'
+            )),
+            vec!["a|b", "`c|d`", "e"]
+        );
+    }
+
+    #[test]
+    fn split_unbalanced_literal_delim() {
+        // Only one backtick → rest of input is treated as inside literal region.
+        assert_eq!(
+            collect(split_respecting_escape_and_literals("a|`b|c", '|', '`')),
+            vec!["a", "`b|c"]
+        );
+    }
+
+    #[test]
+    fn split_escaped_literal_delim_does_not_open_region() {
+        // `\` before backtick means the backtick is not a structural literal delimiter.
+        assert_eq!(
+            collect(split_respecting_escape_and_literals("a|\\`b|c", '|', '`')),
+            vec!["a", "\\`b", "c"]
+        );
+    }
+
+    #[test]
+    fn split_empty_cells_between_literal_regions() {
+        assert_eq!(
+            collect(split_respecting_escape_and_literals("`a`|`b`", '|', '`')),
+            vec!["`a`", "`b`"]
+        );
+    }
+
+    // --- find_respecting_escape ---
+
+    #[test]
+    fn find_first_unescaped() {
+        assert_eq!(find_respecting_escape("a|b|c", '|'), Some(1));
+    }
+
+    #[test]
+    fn find_skips_escaped() {
+        assert_eq!(find_respecting_escape("a\\|b|c", '|'), Some(4));
+    }
+
+    #[test]
+    fn find_none_when_only_escaped() {
+        assert_eq!(find_respecting_escape("a\\|b\\|c", '|'), None);
+    }
+
+    #[test]
+    fn find_respects_literal_region() {
+        assert_eq!(
+            find_respecting_escape_and_literals("`a|b`|c", '|', '`'),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn find_empty() {
+        assert_eq!(find_respecting_escape("", '|'), None);
+    }
+
+    // --- is_structural_at ---
+
+    #[test]
+    fn structural_at_unescaped() {
+        assert!(is_structural_at(b"a|b", 1, None));
+    }
+
+    #[test]
+    fn structural_at_escaped() {
+        assert!(!is_structural_at(b"a\\|b", 2, None));
+    }
+
+    #[test]
+    fn structural_at_double_escape() {
+        // \\| at pos 2 means "|" at pos 2, preceded by two backslashes → structural
+        assert!(is_structural_at(b"a\\\\|b", 3, None));
+    }
+
+    #[test]
+    fn structural_at_inside_literal() {
+        // backtick-a-pipe-b-backtick: pipe at pos 2 is inside literal region
+        assert!(!is_structural_at(b"`a|b`", 2, Some(b'`')));
+    }
+
+    #[test]
+    fn structural_at_outside_literal() {
+        assert!(is_structural_at(b"`a`|b", 3, Some(b'`')));
+    }
+
+    #[test]
+    fn structural_at_out_of_bounds() {
+        assert!(!is_structural_at(b"abc", 3, None));
+        assert!(!is_structural_at(b"", 0, None));
     }
 
     #[test]

--- a/crates/lex-core/src/lex/escape.rs
+++ b/crates/lex-core/src/lex/escape.rs
@@ -465,23 +465,32 @@ fn strip_escapes_char(slice: &str, sep: char, literal_delim: Option<char>) -> St
     let chars: Vec<char> = slice.chars().collect();
     let mut out = String::with_capacity(slice.len());
     let mut in_literal = false;
+    let mut prev_backslashes = 0usize;
     let mut i = 0;
     while i < chars.len() {
         let ch = chars[i];
+        let is_escaped = prev_backslashes % 2 == 1;
         if let Some(delim) = literal_delim {
-            if ch == delim {
+            if ch == delim && !is_escaped {
                 in_literal = !in_literal;
                 out.push(ch);
+                prev_backslashes = 0;
                 i += 1;
                 continue;
             }
         }
         if !in_literal && ch == '\\' && chars.get(i + 1).copied() == Some(sep) {
             out.push(sep);
+            prev_backslashes = 0;
             i += 2;
             continue;
         }
         out.push(ch);
+        if ch == '\\' {
+            prev_backslashes += 1;
+        } else {
+            prev_backslashes = 0;
+        }
         i += 1;
     }
     out
@@ -1222,6 +1231,26 @@ mod tests {
         assert_eq!(
             collect(split_respecting_escape_and_literals("a|\\`b|c", '|', '`')),
             vec!["a", "\\`b", "c"]
+        );
+    }
+
+    #[test]
+    fn split_escaped_literal_delim_before_escaped_sep_non_ascii() {
+        // Regression: char-path `strip_escapes_char` used to toggle `in_literal`
+        // on every literal_delim occurrence, including escaped ones. With a
+        // non-ASCII literal_delim that forces the char path, an escaped `\α`
+        // inside a segment falsely "opened" a literal region, which then
+        // swallowed the following `\|` and blocked escape stripping.
+        let segments = split_respecting_escape_and_literals("a\\α\\|b", '|', 'α');
+        assert_eq!(
+            segments.len(),
+            1,
+            "escaped pipe must not split; got segments={segments:?}"
+        );
+        assert_eq!(
+            segments[0].as_ref(),
+            "a\\α|b",
+            "escaped pipe must be stripped; escaped alpha must not open a literal region"
         );
     }
 

--- a/crates/lex-core/src/lex/inlines/citations.rs
+++ b/crates/lex-core/src/lex/inlines/citations.rs
@@ -2,8 +2,14 @@
 //!
 //! Handles parsing of academic citations with the format `[@key1; @key2, pp. 45-46]`.
 //! Supports multiple citation keys and page locators.
+//!
+//! Separator handling honors the Lex structural escape convention: `\,` and `\;`
+//! inside a citation segment are literal characters, not key/locator boundaries.
+//! This lets citation keys or page labels contain literal commas and semicolons
+//! when needed.
 
 use crate::lex::ast::elements::inlines::{CitationData, CitationLocator, PageFormat, PageRange};
+use crate::lex::escape::{find_respecting_escape, split_respecting_escape};
 
 /// Parse citation data from the content inside `[@...]` brackets.
 pub(super) fn parse_citation_data(content: &str) -> Option<CitationData> {
@@ -21,11 +27,12 @@ pub(super) fn parse_citation_data(content: &str) -> Option<CitationData> {
 
 /// Split citation content into keys segment and optional locator segment.
 ///
-/// Finds the last comma that starts a page locator (e.g., ", pp. 45").
+/// Finds the last structural (unescaped) comma that starts a page locator
+/// (e.g., ", pp. 45"). `\,` is treated as a literal character, not a boundary.
 fn split_locator_segment(content: &str) -> (&str, Option<&str>) {
     let mut locator_index = None;
     let mut search_start = 0;
-    while let Some(pos) = content[search_start..].find(',') {
+    while let Some(pos) = find_respecting_escape(&content[search_start..], ',') {
         let idx = search_start + pos;
         let tail = content[idx + 1..].trim_start();
         if looks_like_locator_start(tail) {
@@ -67,17 +74,24 @@ fn looks_like_locator_start(text: &str) -> bool {
 
 /// Parse citation keys from the keys segment.
 ///
-/// Supports both comma and semicolon separators. Strips leading `@` from keys.
+/// Supports both comma and semicolon separators (escape-aware). Strips leading
+/// `@` from keys.
 fn parse_citation_keys(segment: &str) -> Option<Vec<String>> {
     let trimmed = segment.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    let delimiter = if trimmed.contains(';') { ';' } else { ',' };
+    // Choose delimiter by presence of a structural (unescaped) `;`.
+    let delimiter = if find_respecting_escape(trimmed, ';').is_some() {
+        ';'
+    } else {
+        ','
+    };
     let mut keys = Vec::new();
-    for chunk in trimmed.split(delimiter) {
-        let mut key = chunk.trim();
+    for chunk in split_respecting_escape(trimmed, delimiter) {
+        let chunk_str = chunk.as_ref();
+        let mut key = chunk_str.trim();
         if key.is_empty() {
             continue;
         }
@@ -135,10 +149,11 @@ fn parse_citation_locator(text: &str) -> Option<CitationLocator> {
 
 /// Parse page ranges from comma-separated page specifications.
 ///
-/// Supports single pages (45) and ranges (45-46).
+/// Supports single pages (45) and ranges (45-46). Separators are escape-aware;
+/// `\,` is a literal character.
 fn parse_page_ranges(text: &str) -> Vec<PageRange> {
     let mut ranges = Vec::new();
-    for part in text.split(',') {
+    for part in split_respecting_escape(text, ',') {
         let segment = part.trim();
         if segment.is_empty() {
             continue;
@@ -168,4 +183,62 @@ fn parse_page_ranges(text: &str) -> Vec<PageRange> {
         }
     }
     ranges
+}
+
+#[cfg(test)]
+mod escape_tests {
+    use super::*;
+
+    #[test]
+    fn escaped_semicolon_does_not_split_when_delimiter_is_semicolon() {
+        // `\;` inside a semicolon-delimited key list keeps the surrounding key unified,
+        // and the structural splitter strips the backslash (since `;` is its delimiter).
+        let data = parse_citation_data(r"@a; @b\; still-b; @c").expect("should parse");
+        assert_eq!(data.keys, vec!["a", "b; still-b", "c"]);
+    }
+
+    #[test]
+    fn escaped_comma_does_not_split_when_delimiter_is_comma() {
+        // Comma is the fallback delimiter when no structural `;` is present.
+        // `\,` inside a key stays unified; the backslash is stripped.
+        let data = parse_citation_data(r"@a, @b\,still-b, @c").expect("should parse");
+        assert_eq!(data.keys, vec!["a", "b,still-b", "c"]);
+    }
+
+    #[test]
+    fn unescaped_semicolon_still_splits_keys() {
+        let data = parse_citation_data("@a; @b; @c").expect("should parse");
+        assert_eq!(data.keys, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn escaped_comma_does_not_start_locator_detection() {
+        // `\,` should not be considered as a locator boundary even if followed by "pp."
+        let data = parse_citation_data(r"@doe\, pp. 42").expect("should parse");
+        // The whole thing is one key (no unescaped locator boundary, no `;`).
+        assert!(
+            data.locator.is_none(),
+            "escaped comma must not start a locator"
+        );
+    }
+
+    #[test]
+    fn unescaped_comma_still_starts_locator() {
+        // Sanity: plain comma before `pp.` still starts a locator.
+        let data = parse_citation_data("@doe, pp. 42").expect("should parse");
+        assert_eq!(data.keys, vec!["doe"]);
+        let loc = data.locator.expect("locator expected");
+        assert_eq!(loc.ranges.len(), 1);
+        assert_eq!(loc.ranges[0].start, 42);
+    }
+
+    #[test]
+    fn escaped_comma_in_page_range_skips_unparseable_segment() {
+        // Page-range segments split on `,`. `\,` is not a split point.
+        let ranges = parse_page_ranges(r"45\,abc, 50");
+        // First segment is "45,abc" (backslash stripped) which doesn't parse as number → skipped.
+        // Second segment is "50" which parses.
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, 50);
+    }
 }

--- a/crates/lex-core/tests/split_respecting_escape_proptest.proptest-regressions
+++ b/crates/lex-core/tests/split_respecting_escape_proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d16aec8a302dfd7692400adcf8accccb87bc5d62014c62a0f889d565b688b429 # shrinks to s = "`\\;\\,", sep = ","

--- a/crates/lex-core/tests/split_respecting_escape_proptest.rs
+++ b/crates/lex-core/tests/split_respecting_escape_proptest.rs
@@ -167,9 +167,10 @@ proptest! {
 /// segment back. Matches the no-literal split variant: every `sep` in the segment
 /// was originally escaped, so we re-escape all of them.
 ///
-/// Trailing backslash handling: if the segment ends with an odd number of `\`,
-/// the joining `\<sep>` we'd write next would get absorbed as escaping backslashes
-/// for the added `\`. To preserve round-trip, pad with an extra `\`.
+/// This helper only re-escapes separator characters; it does not apply any special
+/// handling for trailing backslashes. Segments that end with a backslash followed
+/// by a structural separator in the rejoined stream are a known round-trip edge
+/// case not covered by this helper.
 fn reescape_sep(seg: &str, sep: char) -> String {
     let mut out = String::with_capacity(seg.len());
     for ch in seg.chars() {

--- a/crates/lex-core/tests/split_respecting_escape_proptest.rs
+++ b/crates/lex-core/tests/split_respecting_escape_proptest.rs
@@ -1,0 +1,184 @@
+//! Property-based tests for escape-aware structural scanners.
+//!
+//! Invariants exercised:
+//! - Never panics on arbitrary input.
+//! - Segment count matches the number of structural separators + 1.
+//! - Re-escaping and re-joining segments round-trips to the original input
+//!   (modulo double-backslash normalization).
+//! - Literal regions (backticks) never contain a split boundary.
+//! - `is_structural_at` agrees with `find_respecting_escape` on the positions it reports.
+
+use std::borrow::Cow;
+
+use lex_core::lex::escape::{
+    find_respecting_escape, find_respecting_escape_and_literals, is_structural_at,
+    split_respecting_escape, split_respecting_escape_and_literals,
+};
+use proptest::prelude::*;
+
+/// Inputs that exercise escape-aware scanning: sep char, backslashes, literal delim,
+/// plain content, unicode.
+fn input_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        // Dense special-char mix
+        r"[a-z|\\`,;]{0,40}",
+        // Lots of backslashes
+        r"[a-z\\]{0,40}",
+        // Lots of pipes
+        r"[a-z|]{0,40}",
+        // Lots of backticks
+        r"[a-z`|\\]{0,40}",
+        // Generic printable ASCII
+        r"[ -~]{0,80}",
+        // Unicode + specials
+        r"[α-ω|\\`]{0,20}",
+    ]
+}
+
+/// Count how many positions in `s` would be reported as structural for `sep`.
+fn count_structural(s: &str, sep: char, literal_delim: Option<char>) -> usize {
+    let bytes = s.as_bytes();
+    let mut count = 0usize;
+    // Only meaningful for ASCII sep (most tests) — char-level version would need adaptation.
+    for (i, ch) in s.char_indices() {
+        if ch == sep {
+            let is_structural = match literal_delim {
+                Some(delim) => is_structural_at(bytes, i, Some(delim as u8)),
+                None => is_structural_at(bytes, i, None),
+            };
+            if is_structural {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Never panics on any input.
+    #[test]
+    fn split_never_panics(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let _ = split_respecting_escape(&s, sep_ch);
+    }
+
+    #[test]
+    fn split_with_literals_never_panics(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let _ = split_respecting_escape_and_literals(&s, sep_ch, '`');
+    }
+
+    #[test]
+    fn find_never_panics(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let _ = find_respecting_escape(&s, sep_ch);
+        let _ = find_respecting_escape_and_literals(&s, sep_ch, '`');
+    }
+
+    /// Segment count equals structural separator count + 1.
+    #[test]
+    fn split_segment_count_matches_structural_count(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let segments = split_respecting_escape(&s, sep_ch);
+        let structural = count_structural(&s, sep_ch, None);
+        prop_assert_eq!(segments.len(), structural + 1);
+    }
+
+    #[test]
+    fn split_with_literals_segment_count(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let segments = split_respecting_escape_and_literals(&s, sep_ch, '`');
+        let structural = count_structural(&s, sep_ch, Some('`'));
+        prop_assert_eq!(segments.len(), structural + 1);
+    }
+
+    /// Segments, when their escaped separators are re-escaped and rejoined with sep,
+    /// reproduce a string whose structural-separator positions match the original.
+    #[test]
+    fn split_rejoin_preserves_structural_positions(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let segments = split_respecting_escape(&s, sep_ch);
+        let rejoined = segments
+            .iter()
+            .map(|seg| reescape_sep(seg.as_ref(), sep_ch))
+            .collect::<Vec<_>>()
+            .join(&sep_ch.to_string());
+        // Re-splitting the rejoined string gives the same segments.
+        let resplit = split_respecting_escape(&rejoined, sep_ch);
+        let a: Vec<&str> = segments.iter().map(|c| c.as_ref()).collect();
+        let b: Vec<&str> = resplit.iter().map(|c| c.as_ref()).collect();
+        prop_assert_eq!(a, b);
+    }
+
+    /// `find_respecting_escape` reports the same first structural position as the splitter.
+    #[test]
+    fn find_matches_first_split(s in input_strategy(), sep in r"[|,;]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let found = find_respecting_escape(&s, sep_ch);
+        let segments = split_respecting_escape(&s, sep_ch);
+        if segments.len() == 1 {
+            prop_assert_eq!(found, None);
+        } else {
+            prop_assert!(found.is_some());
+            // The first segment's length (in the re-escaped form that came from the input)
+            // corresponds to the position of the first structural separator.
+            // We can verify by reconstructing: input[..found] must have zero structural seps.
+            let pos = found.unwrap();
+            let before = &s[..pos];
+            prop_assert_eq!(count_structural(before, sep_ch, None), 0);
+        }
+    }
+
+    /// Borrowed Cow when no escape stripping was needed.
+    #[test]
+    fn split_borrowed_when_no_escape_of_sep(s in r"[a-z|]{0,40}", sep in r"[|]") {
+        let sep_ch = sep.chars().next().unwrap();
+        let segments = split_respecting_escape(&s, sep_ch);
+        for seg in segments {
+            prop_assert!(matches!(seg, Cow::Borrowed(_)));
+        }
+    }
+
+    /// For inputs with only literal-region-protected separators, the split count
+    /// respects balanced backticks.
+    #[test]
+    fn literals_protect_separators(
+        content in r"[a-z,;]{0,20}",
+        prefix in r"[a-z|]{0,10}",
+        suffix in r"[a-z|]{0,10}"
+    ) {
+        let wrapped = format!("{prefix}`{content}`{suffix}");
+        let segments = split_respecting_escape_and_literals(&wrapped, '|', '`');
+        // Inside the backtick region, `|` must not cause a split. Count non-literal pipes.
+        let structural = count_structural(&wrapped, '|', Some('`'));
+        prop_assert_eq!(segments.len(), structural + 1);
+        // At least one segment contains the entire backtick region verbatim.
+        let reconstructed = segments.iter().map(|s| s.as_ref()).collect::<Vec<_>>().join("|");
+        let needle = format!("`{content}`");
+        prop_assert!(
+            reconstructed.contains(&needle) || content.is_empty() || content.contains('|')
+        );
+    }
+}
+
+/// Re-escape `sep` characters in a plain segment so that re-splitting gives the same
+/// segment back. Matches the no-literal split variant: every `sep` in the segment
+/// was originally escaped, so we re-escape all of them.
+///
+/// Trailing backslash handling: if the segment ends with an odd number of `\`,
+/// the joining `\<sep>` we'd write next would get absorbed as escaping backslashes
+/// for the added `\`. To preserve round-trip, pad with an extra `\`.
+fn reescape_sep(seg: &str, sep: char) -> String {
+    let mut out = String::with_capacity(seg.len());
+    for ch in seg.chars() {
+        if ch == sep {
+            out.push('\\');
+            out.push(ch);
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/crates/lex-core/tests/table_escape_integration.rs
+++ b/crates/lex-core/tests/table_escape_integration.rs
@@ -1,0 +1,99 @@
+//! End-to-end integration tests: tables with escaped pipes and backtick-protected
+//! pipes parse into the expected cells through the full parsing pipeline.
+
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::assert_ast;
+
+#[test]
+fn escaped_pipe_in_cell_preserves_content_as_literal() {
+    let src = "Table test:\n    | feature  | example |\n    | pipe alt | a\\|b    |\n:: table ::\n";
+    let doc = parse_document(src).expect("parse should succeed");
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .body_row_count(1)
+            .column_count(2)
+            .header_cells(0, &["feature", "example"])
+            .body_row(0, |row| {
+                row.cell_text(0, "pipe alt").cell_text(1, "a|b");
+            });
+    });
+}
+
+#[test]
+fn backtick_literal_region_protects_pipes_in_cell() {
+    let src = "Table test:\n    | code    | meaning          |\n    | `a|b`   | pipe inside code |\n    | `x|y|z` | three pipes      |\n:: table ::\n";
+    let doc = parse_document(src).expect("parse should succeed");
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .body_row_count(2)
+            .column_count(2)
+            .header_cells(0, &["code", "meaning"])
+            .body_row(0, |row| {
+                row.cell_text(0, "`a|b`").cell_text(1, "pipe inside code");
+            })
+            .body_row(1, |row| {
+                row.cell_text(0, "`x|y|z`").cell_text(1, "three pipes");
+            });
+    });
+}
+
+#[test]
+fn escaped_pipe_mixed_with_backtick_region() {
+    let src = "Mixed:\n    | plain | code  |\n    | a\\|b  | `c|d` |\n:: table ::\n";
+    let doc = parse_document(src).expect("parse should succeed");
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .body_row_count(1)
+            .column_count(2)
+            .body_row(0, |row| {
+                row.cell_text(0, "a|b").cell_text(1, "`c|d`");
+            });
+    });
+}
+
+#[test]
+fn double_backslash_before_pipe_still_splits() {
+    // `\\|` = literal backslash + structural pipe.
+    let src = "Double bs:\n    | a\\\\ | b |\n:: table ::\n";
+    let doc = parse_document(src).expect("parse should succeed");
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .column_count(2)
+            .header_row(0, |row| {
+                row.cell_text(0, "a\\\\").cell_text(1, "b");
+            });
+    });
+}
+
+#[test]
+fn multiple_escaped_pipes_in_one_cell() {
+    let src = "Many pipes:\n    | a\\|b\\|c\\|d | other |\n:: table ::\n";
+    let doc = parse_document(src).expect("parse should succeed");
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .column_count(2)
+            .header_row(0, |row| {
+                row.cell_text(0, "a|b|c|d").cell_text(1, "other");
+            });
+    });
+}
+
+#[test]
+fn backtick_in_cell_without_inner_pipe_unchanged() {
+    // Sanity check: backtick-delimited content without internal pipes still works.
+    let src = "Sanity:\n    | `code` | plain |\n:: table ::\n";
+    let doc = parse_document(src).expect("parse should succeed");
+    assert_ast(&doc).item(0, |item| {
+        item.assert_table()
+            .header_row_count(1)
+            .column_count(2)
+            .header_row(0, |row| {
+                row.cell_text(0, "`code`").cell_text(1, "plain");
+            });
+    });
+}


### PR DESCRIPTION
Fixes #451.

## Summary

- New generic split/find/is-structural utilities in `lex-core::escape` that honor `\<sep>` escapes and optional balanced literal regions (backticks).
- Table cell splitter (`table.rs`) now honors `\|` as a literal pipe and treats `` `...` `` as a literal region — so `` | `a|b` | c | `` is two cells, not three.
- Citation parsers (`citations.rs`) — three call sites — now use escape-aware variants: `\,` no longer starts a spurious locator, `\;` no longer splits a key.
- Spec updated with §3.4 "Structural Parsers" + meta-rule for future delimiters.

## New API (lex-core::escape)

```rust
split_respecting_escape(s, sep) -> Vec<Cow<str>>
split_respecting_escape_and_literals(s, sep, literal_delim) -> Vec<Cow<str>>
split_respecting_escape_with_ranges(s, sep, literal_delim) -> Vec<(Cow<str>, Range<usize>)>
find_respecting_escape(s, needle) -> Option<usize>
find_respecting_escape_and_literals(s, needle, literal_delim) -> Option<usize>
is_structural_at(bytes, pos, literal_delim) -> bool
```

`Cow::Borrowed` on the no-escape hot path — no allocation. `Cow::Owned` only when a backslash was stripped.

## Test coverage

- 31 unit tests + 9 proptests (500 cases each) for the new scanners — cover empty inputs, trailing backslashes, unbalanced literal delimiters, unicode separators, double-backslash semantics, Cow borrow/own behavior, and never-panic guarantees.
- 5 unit tests in `table.rs` for escaped pipes, multiple escapes, backtick-protected pipes, escapes inside backticks, double-backslash splitting.
- 6 end-to-end integration tests in `table_escape_integration.rs` exercising the full parser pipeline from source to AST.
- 6 unit tests in `citations.rs` for escape semantics across both delimiters, locator detection, and page ranges.

Full workspace test sweep (nextest): **1490 / 1490 passing**.

## Non-goals

- Does not unify inline-escape (§1) and quoted-param escape (§2). They have genuinely different rules; mixing them would create confusing interactions.
- Does not change the inline escape semantics — `unescape_inline` was already correct.

## Test plan

- [x] Unit tests for new utilities (`cargo test -p lex-core --lib lex::escape`)
- [x] Proptests (`cargo test -p lex-core --test split_respecting_escape_proptest`)
- [x] Table unit + integration tests (`cargo test -p lex-core table`)
- [x] Citation tests (`cargo test -p lex-core citation`)
- [x] Full workspace test sweep

## Commits

1. `fda4fb1f` — Add escape-aware structural scanners (#451)
2. `bf86573a` — Migrate table cell splitter to escape-aware scanner (#451)
3. `7845641d` — Migrate citation parsers to escape-aware scanners (#451)
4. `6e35e764` — Bump comms submodule: spec update

🤖 Generated with [Claude Code](https://claude.com/claude-code)