### PR TITLE
Migrate footnote tests to footnotes.docs samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
 
   `convert` requires `--from` when reading from stdin (there is no filename to auto-detect the source format from).
 
+- `lex-core`: `Lexplore::footnotes(n)` loads footnote samples from `comms/specs/elements/footnotes.docs/`, mirroring the other per-element loaders.
+
+### Tests
+
+- Migrated all footnote-related tests off ad-hoc inline `.lex` strings: `lex-analysis` diagnostics and `collect_footnote_definitions`, `lexd-lsp` footnote reordering, and `lex-babel` HTML/IR table-footnote round-trips now load canonical samples from `footnotes.docs/` and `table.docs/` via `Lexplore`.
+- Migrated `lex-analysis` table diagnostic tests (inconsistent columns, colspan/rowspan interactions) to the existing `table.docs/` samples — no new fixtures needed.
+
 ## 0.8.0
 
 ### Breaking

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -169,15 +169,18 @@ fn compute_row_widths(rows: &[&TableRow]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lex_core::lex::parsing;
+    use lex_core::lex::testing::lexplore::Lexplore;
 
-    fn parse(source: &str) -> Document {
-        parsing::parse_document(source).expect("parse failed")
+    fn footnote_diags(doc: &Document) -> Vec<AnalysisDiagnostic> {
+        analyze(doc)
+            .into_iter()
+            .filter(|d| d.kind == DiagnosticKind::MissingFootnoteDefinition)
+            .collect()
     }
 
     #[test]
     fn detects_missing_footnote_definition() {
-        let doc = parse("Text with [1] reference.");
+        let doc = Lexplore::footnotes(1).parse().unwrap();
         let diags = analyze(&doc);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].kind, DiagnosticKind::MissingFootnoteDefinition);
@@ -185,129 +188,84 @@ mod tests {
 
     #[test]
     fn ignores_valid_footnote_with_notes_annotation() {
-        // :: notes :: annotated list provides the definitions
-        let doc = parse("Text [1].\n\n:: notes ::\n1. Note.\n2. Another.\n");
-        let diags = analyze(&doc);
-        let footnote_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::MissingFootnoteDefinition)
-            .collect();
-        assert!(footnote_diags.is_empty());
+        // :: notes :: annotated list at the document root provides the definitions
+        let doc = Lexplore::footnotes(2).parse().unwrap();
+        assert!(footnote_diags(&doc).is_empty());
     }
 
     #[test]
     fn ignores_valid_list_footnote_in_session() {
         // :: notes :: inside a session
-        let doc = parse("Text [1].\n\nNotes\n\n    :: notes ::\n\n    1. Note.\n    2. Another.\n");
-        let diags = analyze(&doc);
-        let footnote_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::MissingFootnoteDefinition)
-            .collect();
-        assert!(footnote_diags.is_empty());
+        let doc = Lexplore::footnotes(3).parse().unwrap();
+        assert!(footnote_diags(&doc).is_empty());
     }
 
     #[test]
     fn list_without_notes_annotation_is_not_footnotes() {
         // A "Notes" session without :: notes :: does NOT define footnotes
-        let doc = parse("Text [1].\n\nNotes\n\n    1. Note.\n    2. Another.\n");
-        let diags = analyze(&doc);
-        let footnote_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::MissingFootnoteDefinition)
-            .collect();
-        assert_eq!(footnote_diags.len(), 1);
+        let doc = Lexplore::footnotes(4).parse().unwrap();
+        assert_eq!(footnote_diags(&doc).len(), 1);
+    }
+
+    fn table_diags(doc: &Document) -> Vec<AnalysisDiagnostic> {
+        analyze(doc)
+            .into_iter()
+            .filter(|d| d.kind == DiagnosticKind::TableInconsistentColumns)
+            .collect()
     }
 
     #[test]
     fn detects_inconsistent_table_columns() {
-        let doc = parse("Data:\n    | A | B | C |\n    | 1 | 2 |\n:: table ::\n");
-        let diags = analyze(&doc);
-        let table_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::TableInconsistentColumns)
-            .collect();
-        assert_eq!(table_diags.len(), 1);
-        assert!(table_diags[0].message.contains("2 columns"));
-        assert!(table_diags[0].message.contains("expected 3"));
+        // table-13: 3-col header, 2-col row, 3-col row — middle row is short.
+        let doc = Lexplore::table(13).parse().unwrap();
+        let diags = table_diags(&doc);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("2 columns"));
+        assert!(diags[0].message.contains("expected 3"));
     }
 
     #[test]
     fn consistent_table_no_diagnostic() {
-        let doc = parse("Data:\n    | A | B |\n    | 1 | 2 |\n:: table ::\n");
-        let diags = analyze(&doc);
-        let table_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::TableInconsistentColumns)
-            .collect();
-        assert!(table_diags.is_empty());
+        // table-01: minimal 2-column table, all rows consistent.
+        let doc = Lexplore::table(1).parse().unwrap();
+        assert!(table_diags(&doc).is_empty());
     }
 
     #[test]
     fn table_with_rowspan_counts_carry_over() {
-        // Row 0: A | B | C           → 3 cells, widths all 1 → effective width 3
-        // Row 1: D | ^^ | E          → ^^ is absorbed into B (B gets rowspan=2),
-        //                              leaving row 1 with 2 cells [D, E]. But the
-        //                              column occupied by B's rowspan means row 1's
-        //                              effective width is still 3.
-        let doc = parse("Data:\n    | A | B  | C |\n    | D | ^^ | E |\n:: table ::\n");
-        let diags = analyze(&doc);
-        let table_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::TableInconsistentColumns)
-            .collect();
+        // table-17: rowspan via ^^ — effective widths remain consistent across rows.
+        let doc = Lexplore::table(17).parse().unwrap();
+        let diags = table_diags(&doc);
         assert!(
-            table_diags.is_empty(),
-            "rowspan carry-over should not trigger inconsistent-columns, got: {table_diags:?}"
+            diags.is_empty(),
+            "rowspan carry-over should not trigger inconsistent-columns, got: {diags:?}"
         );
     }
 
     #[test]
     fn table_with_colspan_and_rowspan_mixed() {
-        // Mirrors the "Conference Schedule" pattern from benchmark/080-gentle-introduction.lex:
-        //   | Time  | Room A          | Room B     |
-        //   | 9:00  | Opening Keynote | >>         |   (Opening Keynote colspan=2)
-        //   | 10:00 | Workshop        | Panel      |   (Workshop rowspan=2, via ^^ below)
-        //   | 11:00 | ^^              | Discussion |
-        let doc = parse(
-            "Data:\n    | Time  | Room A          | Room B     |\n    | 9:00  | Opening Keynote | >>         |\n    | 10:00 | Workshop        | Panel      |\n    | 11:00 | ^^              | Discussion |\n:: table ::\n",
-        );
-        let diags = analyze(&doc);
-        let table_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::TableInconsistentColumns)
-            .collect();
+        // table-18: combined >> colspan and ^^ rowspan; effective widths stay consistent.
+        let doc = Lexplore::table(18).parse().unwrap();
+        let diags = table_diags(&doc);
         assert!(
-            table_diags.is_empty(),
-            "mixed colspan/rowspan should not trigger inconsistent-columns, got: {table_diags:?}"
+            diags.is_empty(),
+            "mixed colspan/rowspan should not trigger inconsistent-columns, got: {diags:?}"
         );
     }
 
     #[test]
     fn table_with_colspan_counts_effective_width() {
-        // Row 1: A + >> = 2 effective columns (colspan=2)
-        // Row 2: B + C = 2 columns
-        // After merge resolution: row 1 has 1 cell (colspan=2), row 2 has 2 cells (colspan=1 each)
-        // Effective widths: 2 and 2 — consistent
-        let doc = parse("Data:\n    | A  | >> |\n    | B  | C  |\n:: table ::\n");
-        let diags = analyze(&doc);
-        let table_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::TableInconsistentColumns)
-            .collect();
-        assert!(table_diags.is_empty());
+        // table-04: colspan via >> contributes to effective width; all rows consistent.
+        let doc = Lexplore::table(4).parse().unwrap();
+        assert!(table_diags(&doc).is_empty());
     }
 
     #[test]
     fn footnote_ref_in_table_cell_is_checked() {
         // Table cell contains [1] but no footnote definition exists
-        let doc = parse("Data:\n    | Item  | Note |\n    | Alpha | [1]  |\n:: table ::\n");
-        let diags = analyze(&doc);
-        let footnote_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| d.kind == DiagnosticKind::MissingFootnoteDefinition)
-            .collect();
-        assert_eq!(footnote_diags.len(), 1);
-        assert!(footnote_diags[0].message.contains("[1]"));
+        let doc = Lexplore::footnotes(9).parse().unwrap();
+        let diags = footnote_diags(&doc);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("[1]"));
     }
 }

--- a/crates/lex-analysis/src/utils.rs
+++ b/crates/lex-analysis/src/utils.rs
@@ -777,17 +777,11 @@ fn collect_list_item_labels(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lex_core::lex::parsing;
-
-    fn parse(source: &str) -> Document {
-        parsing::parse_document(source).expect("parse failed")
-    }
+    use lex_core::lex::testing::lexplore::Lexplore;
 
     #[test]
     fn collects_footnotes_from_notes_annotated_list() {
-        let doc = parse(
-            "Text [1].\n\nNotes\n\n    :: notes ::\n\n    1. First note.\n    2. Second note.\n",
-        );
+        let doc = Lexplore::footnotes(3).parse().unwrap();
         let defs = collect_footnote_definitions(&doc);
         let labels: Vec<&str> = defs.iter().map(|(l, _)| l.as_str()).collect();
         assert_eq!(labels, vec!["1", "2"]);
@@ -796,14 +790,14 @@ mod tests {
     #[test]
     fn no_footnotes_without_notes_annotation() {
         // A plain list in a "Notes" session is NOT a footnote list without :: notes ::
-        let doc = parse("Content\n\nNotes\n\n    1. A note\n    2. Another.\n");
+        let doc = Lexplore::footnotes(4).parse().unwrap();
         let defs = collect_footnote_definitions(&doc);
         assert!(defs.is_empty());
     }
 
     #[test]
     fn collects_footnotes_at_document_root() {
-        let doc = parse("Text [1].\n\n:: notes ::\n\n1. Root-level note.\n2. Second.\n");
+        let doc = Lexplore::footnotes(2).parse().unwrap();
         let defs = collect_footnote_definitions(&doc);
         let labels: Vec<&str> = defs.iter().map(|(l, _)| l.as_str()).collect();
         assert_eq!(labels, vec!["1", "2"]);
@@ -812,9 +806,7 @@ mod tests {
     #[test]
     fn multiple_notes_lists_in_different_sessions() {
         // Each chapter has its own :: notes :: list with 2 items
-        let doc = parse(
-            "1. Chapter One\n\n    Text [1].\n\n    :: notes ::\n    1. Ch1 note A.\n    2. Ch1 note B.\n\n2. Chapter Two\n\n    Text [1].\n\n    :: notes ::\n    1. Ch2 note A.\n    2. Ch2 note B.\n",
-        );
+        let doc = Lexplore::footnotes(5).parse().unwrap();
         let defs = collect_footnote_definitions(&doc);
         assert_eq!(defs.len(), 4); // 2 items × 2 chapters
     }

--- a/crates/lex-babel/tests/html/table.rs
+++ b/crates/lex-babel/tests/html/table.rs
@@ -2,6 +2,7 @@ use lex_babel::format::Format;
 use lex_babel::formats::html::HtmlFormat;
 use lex_babel::formats::markdown::MarkdownFormat;
 use lex_babel::ir::nodes::*;
+use lex_core::lex::testing::lexplore::Lexplore;
 use lex_core::lex::transforms::standard::STRING_TO_AST;
 
 #[test]
@@ -76,9 +77,8 @@ fn test_table_html_rowspan() {
 
 #[test]
 fn test_table_html_footnotes() {
-    let lex_src =
-        "Notes:\n    | Item  | Cost [1] |\n    | Alpha | 100      |\n\n    1. All prices in USD.\n:: table ::\n";
-    let doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    // table-06: table with two footnotes; see comms/specs/elements/table.docs/
+    let doc = Lexplore::table(6).parse().unwrap();
 
     let html = HtmlFormat::default()
         .serialize(&doc)
@@ -88,7 +88,10 @@ fn test_table_html_footnotes() {
         html.contains("lex-table-footnotes"),
         "Should have footnotes section"
     );
-    assert!(html.contains("USD"), "Footnote content should be in output");
+    assert!(
+        html.contains("Precision measured at k=10"),
+        "First footnote content should be in output"
+    );
 }
 
 #[test]
@@ -153,9 +156,8 @@ fn test_table_ir_preserves_caption() {
 
 #[test]
 fn test_table_ir_preserves_footnotes() {
-    let lex_src =
-        "Notes:\n    | Item | Cost [1] |\n    | X    | 50       |\n\n    1. In EUR.\n:: table ::\n";
-    let doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    // table-06: table with two footnotes; see comms/specs/elements/table.docs/
+    let doc = Lexplore::table(6).parse().unwrap();
 
     let ir = lex_babel::to_ir(&doc);
 

--- a/crates/lex-core/src/lex/testing/lexplore/loader.rs
+++ b/crates/lex-core/src/lex/testing/lexplore/loader.rs
@@ -232,6 +232,7 @@ impl Lexplore {
         verbatim => Verbatim, "verbatim";
         table => Table, "table";
         document => Document, "document";
+        footnotes => Footnotes, "footnotes";
     }
 
     // ===== Convenience shortcuts for document collections =====

--- a/crates/lex-core/src/lex/testing/lexplore/specfile_finder.rs
+++ b/crates/lex-core/src/lex/testing/lexplore/specfile_finder.rs
@@ -43,6 +43,7 @@ pub enum ElementType {
     Verbatim,
     Table,
     Document,
+    Footnotes,
 }
 
 /// Document collection types for comprehensive testing
@@ -64,6 +65,7 @@ impl ElementType {
             ElementType::Verbatim => "verbatim",
             ElementType::Table => "table",
             ElementType::Document => "document",
+            ElementType::Footnotes => "footnotes",
         }
     }
 }

--- a/crates/lex-lsp/src/features/footnotes.rs
+++ b/crates/lex-lsp/src/features/footnotes.rs
@@ -224,42 +224,46 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lex_core::lex::parsing;
+    use lex_core::lex::testing::lexplore::Lexplore;
 
     #[test]
     fn reorders_references_and_definitions() {
-        // [2] → [1], [1] → [2]; list items renumbered accordingly
-        let source = "Ref [2] and [1].\n\n:: notes ::\n1. Note A\n2. Note B\n";
-        let doc = parsing::parse_document(source).unwrap();
-        let new_source = reorder_footnotes(&doc, source);
+        // footnotes-06: [2] then [1] at root; renumbering swaps both refs and list markers.
+        let loader = Lexplore::footnotes(6);
+        let source = loader.source();
+        let doc = loader.parse().unwrap();
+        let new_source = reorder_footnotes(&doc, &source);
 
-        let expected = "Ref [1] and [2].\n\n:: notes ::\n2. Note A\n1. Note B\n";
-        assert_eq!(new_source, expected);
+        // Refs swap: first [2]→[1], then [1]→[2].
+        assert!(new_source.contains("swapped: [1] before [2]"));
+        // List markers swap: the item originally at "1." now prints as "2." and vice versa.
+        assert!(new_source.contains("2. Note A"));
+        assert!(new_source.contains("1. Note B"));
     }
 
     #[test]
     fn keeps_correct_order_for_repeated_refs() {
-        // [10] first → 1, [5] second → 2
-        let source =
-            "Ref [10] then [10] then [5].\n\nNotes\n\n    :: notes ::\n\n    5. Content.\n    10. Other.\n";
-        let doc = parsing::parse_document(source).unwrap();
-        let new_source = reorder_footnotes(&doc, source);
+        // footnotes-07: refs [10] [10] [5]; definitions 5 and 10 inside a Notes session.
+        let loader = Lexplore::footnotes(7);
+        let source = loader.source();
+        let doc = loader.parse().unwrap();
+        let new_source = reorder_footnotes(&doc, &source);
 
-        // Reference 10 → 1, reference 5 → 2
-        // Definition "5." → "2.", definition "10." → "1."
-        assert!(new_source.contains("Ref [1] then [1] then [2]."));
+        // Reference 10 → 1 (seen first, twice), reference 5 → 2.
+        assert!(new_source.contains("References [1] then [1] then [2]"));
+        // Definition "5." → "2.", definition "10." → "1.".
         assert!(new_source.contains("    2. Content."));
         assert!(new_source.contains("    1. Other."));
     }
 
     #[test]
     fn reorders_list_items_in_notes_session() {
-        // [2] → [1], [1] → [2]; list items in :: notes :: list renumbered
-        let source =
-            "Ref [2] and [1].\n\nNotes\n\n    :: notes ::\n\n    1. Note A\n    2. Note B\n";
-        let doc = parsing::parse_document(source).unwrap();
-        let new_source = reorder_footnotes(&doc, source);
+        // footnotes-10: [2] before [1] inside a session-wrapped :: notes :: list.
+        let loader = Lexplore::footnotes(10);
+        let source = loader.source();
+        let doc = loader.parse().unwrap();
+        let new_source = reorder_footnotes(&doc, &source);
 
-        assert!(new_source.contains("Ref [1] and [2]."));
+        assert!(new_source.contains("References [1] and [2] appear"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Lexplore::footnotes(n)` and wires it to the new `comms/specs/elements/footnotes.docs/` sample set (companion PR: lex-fmt/comms#20).
- Every footnote-related test now loads its `.lex` input from a vetted sample file instead of embedding an ad-hoc multi-line string literal. Covers `lex-analysis` diagnostics + `collect_footnote_definitions`, `lexd-lsp` footnote reordering, and `lex-babel` HTML/IR round-trips.
- Bonus: `lex-analysis` table diagnostic tests (inconsistent-columns, colspan/rowspan interactions) also migrated off ad-hoc strings to existing `table.docs/` samples.

## Why

Footnotes had a freshly-minted spec but no `.docs/` directory — tests were hand-rolling `"Text [1].\n\n:: notes ::\n1. ..."` strings across four crates. That's exactly the trap the per-element sample policy exists to prevent: a language tweak means hunting hundreds of inline literals. Samples are vetted during spec review; tests load them by index.

## What's in `footnotes.docs/`

Ten per-form samples, one form each:

1. `01-reference-only` — bare `[1]` ref, no definitions (for unresolved-reference diagnostic)
2. `02-root-notes` — refs + `:: notes ::` at document root
3. `03-session-wrapper` — Notes session containing `:: notes ::`
4. `04-plain-notes-session` — Notes session with plain list (negative: not footnotes)
5. `05-per-section-scope` — two chapters, each with its own `:: notes ::`
6. `06-out-of-order-refs` — `[2]` before `[1]` (reordering test)
7. `07-non-sequential-numbers` — refs `[10] [10] [5]`, matching defs
8. `08-rich-definition-content` — note item with a continuation paragraph
9. `09-table-cell-ref-unresolved` — `[1]` inside a table cell, no notes list
10. `10-reorder-in-session` — `[2]` before `[1]` inside a session-wrapped notes list

## Test plan

- [x] `cargo test --workspace --exclude lex-wasm` — green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --exclude lex-wasm --all-targets -- -D warnings` — clean
- [x] Every sample parses cleanly via `lexd inspect ast-tag`
- [ ] Reviewer confirms no regression in diagnostic counts / messages after the migration

## Depends on

- lex-fmt/comms#20 (adds `footnotes.docs/`). Submodule bump is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)