### PR TITLE
Resolve numbered footnote refs inside tables against table-local footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `lex-analysis`: the `missing-footnote` diagnostic no longer false-positives on numbered references inside a table cell when the resolving footnote list is the table's own positional list. The resolver now extends its in-scope footnote definitions with `table.footnotes` while walking a table's subject and cells, and restores the outer scope on exit. References outside a table still cannot reach table-local footnotes.
 - `lex-analysis`: the `table-inconsistent-columns` diagnostic no longer false-positives on rows whose column count is reduced by `^^` rowspan markers. Effective row width now accounts for cells carried over from previous rows via rowspan, not just colspans of the row's own cells.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- `lex-analysis`: the `missing-footnote` diagnostic no longer false-positives on numbered references inside a table cell when the resolving footnote list is the table's own positional list. The resolver now extends its in-scope footnote definitions with `table.footnotes` while walking a table's subject and cells, and restores the outer scope on exit. References outside a table still cannot reach table-local footnotes.
+- `lex-analysis`: the `missing-footnote` diagnostic no longer false-positives on numbered references inside a table cell when the resolving footnote list is the table's own positional list. The resolver now extends its in-scope footnote definitions with `table.footnotes` while walking a table's subject and cells, and restores the outer scope on exit. References outside a table still cannot reach table-local footnotes. The diagnostic message has been reworded from "no matching item in a `:: notes ::` list" to the scope-agnostic "no matching footnote definition in scope" to reflect that table-local definitions are also a valid resolution target.
 - `lex-analysis`: the `table-inconsistent-columns` diagnostic no longer false-positives on rows whose column count is reduced by `^^` rowspan markers. Effective row width now accounts for cells carried over from previous rows via rowspan, not just colspans of the row's own cells.
 
 ### Added

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -134,17 +134,27 @@ fn check_table(
     // Extend the in-scope definitions with the table's positional footnote
     // list. The table's own numbered items shadow nothing — they just add
     // table-local numbers that references inside this table may resolve to.
+    // Fast path: most tables have no footnotes, so reuse `outer_defs` rather
+    // than cloning it into a new `HashSet` for every such table.
     let table_defs = table_footnote_numbers(table);
-    let scope: HashSet<u32> = outer_defs.union(&table_defs).copied().collect();
+    if table_defs.is_empty() {
+        check_table_text(table, outer_defs, diagnostics);
+        return;
+    }
+    let mut scope = outer_defs.clone();
+    scope.extend(table_defs);
+    check_table_text(table, &scope, diagnostics);
+}
 
-    check_text(&table.subject, &scope, diagnostics);
+fn check_table_text(table: &Table, defs: &HashSet<u32>, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+    check_text(&table.subject, defs, diagnostics);
     for row in table.all_rows() {
         for cell in &row.cells {
-            check_text(&cell.content, &scope, diagnostics);
+            check_text(&cell.content, defs, diagnostics);
         }
     }
     for annotation in table.annotations() {
-        check_annotation(annotation, &scope, diagnostics);
+        check_annotation(annotation, defs, diagnostics);
     }
 }
 
@@ -176,7 +186,7 @@ fn check_text(text: &TextContent, defs: &HashSet<u32>, diagnostics: &mut Vec<Ana
                     range: reference.range,
                     kind: DiagnosticKind::MissingFootnoteDefinition,
                     message: format!(
-                        "Footnote [{number}] has no matching item in a :: notes :: list"
+                        "Footnote [{number}] has no matching footnote definition in scope"
                     ),
                 });
             }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -1,7 +1,9 @@
 use crate::inline::extract_references;
-use crate::utils::for_each_text_content;
-use lex_core::lex::ast::{ContentItem, Document, Range, Session, Table, TableRow};
+use lex_core::lex::ast::{
+    Annotation, ContentItem, Document, Range, Session, Table, TableRow, TextContent,
+};
 use lex_core::lex::inlines::ReferenceType;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiagnosticKind {
@@ -25,33 +27,159 @@ pub fn analyze(document: &Document) -> Vec<AnalysisDiagnostic> {
 }
 
 fn check_footnotes(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-    // 1. Collect all numbered footnote references
-    let mut numbered_refs = Vec::new();
-    for_each_text_content(document, &mut |text| {
-        for reference in extract_references(text) {
-            if let ReferenceType::FootnoteNumber { number } = reference.reference_type {
-                numbered_refs.push((number, reference.range));
+    // Numbered definitions reachable from outside any table: :: notes ::
+    // annotated lists at document or session scope.
+    let outer_defs: HashSet<u32> = crate::utils::collect_footnote_definitions(document)
+        .into_iter()
+        .filter_map(|(label, _)| label.parse::<u32>().ok())
+        .collect();
+
+    // References outside tables resolve to `outer_defs`; references inside a
+    // table resolve first to that table's own positional footnote list
+    // (`table.footnotes`) and then fall back to `outer_defs`.
+    if let Some(title) = &document.title {
+        check_text(&title.content, &outer_defs, diagnostics);
+    }
+    for annotation in document.annotations() {
+        check_annotation(annotation, &outer_defs, diagnostics);
+    }
+    check_session(&document.root, &outer_defs, diagnostics);
+}
+
+fn check_session(
+    session: &Session,
+    defs: &HashSet<u32>,
+    diagnostics: &mut Vec<AnalysisDiagnostic>,
+) {
+    check_text(&session.title, defs, diagnostics);
+    for annotation in session.annotations() {
+        check_annotation(annotation, defs, diagnostics);
+    }
+    for child in session.children.iter() {
+        check_content(child, defs, diagnostics);
+    }
+}
+
+fn check_content(
+    item: &ContentItem,
+    defs: &HashSet<u32>,
+    diagnostics: &mut Vec<AnalysisDiagnostic>,
+) {
+    match item {
+        ContentItem::Paragraph(p) => {
+            for line in &p.lines {
+                if let ContentItem::TextLine(tl) = line {
+                    check_text(&tl.content, defs, diagnostics);
+                }
+            }
+            for annotation in p.annotations() {
+                check_annotation(annotation, defs, diagnostics);
             }
         }
-    });
+        ContentItem::Session(s) => check_session(s, defs, diagnostics),
+        ContentItem::List(list) => {
+            for annotation in list.annotations() {
+                check_annotation(annotation, defs, diagnostics);
+            }
+            for entry in &list.items {
+                if let ContentItem::ListItem(li) = entry {
+                    for text in &li.text {
+                        check_text(text, defs, diagnostics);
+                    }
+                    for annotation in li.annotations() {
+                        check_annotation(annotation, defs, diagnostics);
+                    }
+                    for child in li.children.iter() {
+                        check_content(child, defs, diagnostics);
+                    }
+                }
+            }
+        }
+        ContentItem::Definition(def) => {
+            check_text(&def.subject, defs, diagnostics);
+            for annotation in def.annotations() {
+                check_annotation(annotation, defs, diagnostics);
+            }
+            for child in def.children.iter() {
+                check_content(child, defs, diagnostics);
+            }
+        }
+        ContentItem::Annotation(a) => check_annotation(a, defs, diagnostics),
+        ContentItem::VerbatimBlock(v) => {
+            check_text(&v.subject, defs, diagnostics);
+            for annotation in v.annotations() {
+                check_annotation(annotation, defs, diagnostics);
+            }
+        }
+        ContentItem::Table(table) => check_table(table, defs, diagnostics),
+        _ => {}
+    }
+}
 
-    // 2. Collect footnote definitions from :: notes ::-annotated lists
-    let definitions_list = crate::utils::collect_footnote_definitions(document);
-    let mut numeric_definitions = std::collections::HashSet::new();
-    for (label, _) in &definitions_list {
-        if let Ok(number) = label.parse::<u32>() {
-            numeric_definitions.insert(number);
+fn check_annotation(
+    annotation: &Annotation,
+    defs: &HashSet<u32>,
+    diagnostics: &mut Vec<AnalysisDiagnostic>,
+) {
+    for child in annotation.children.iter() {
+        check_content(child, defs, diagnostics);
+    }
+}
+
+fn check_table(
+    table: &Table,
+    outer_defs: &HashSet<u32>,
+    diagnostics: &mut Vec<AnalysisDiagnostic>,
+) {
+    // Extend the in-scope definitions with the table's positional footnote
+    // list. The table's own numbered items shadow nothing — they just add
+    // table-local numbers that references inside this table may resolve to.
+    let table_defs = table_footnote_numbers(table);
+    let scope: HashSet<u32> = outer_defs.union(&table_defs).copied().collect();
+
+    check_text(&table.subject, &scope, diagnostics);
+    for row in table.all_rows() {
+        for cell in &row.cells {
+            check_text(&cell.content, &scope, diagnostics);
         }
     }
+    for annotation in table.annotations() {
+        check_annotation(annotation, &scope, diagnostics);
+    }
+}
 
-    // 3. Check for missing definitions
-    for (number, range) in &numbered_refs {
-        if !numeric_definitions.contains(number) {
-            diagnostics.push(AnalysisDiagnostic {
-                range: range.clone(),
-                kind: DiagnosticKind::MissingFootnoteDefinition,
-                message: format!("Footnote [{number}] has no matching item in a :: notes :: list"),
-            });
+fn table_footnote_numbers(table: &Table) -> HashSet<u32> {
+    let Some(list) = &table.footnotes else {
+        return HashSet::new();
+    };
+    let mut numbers = HashSet::new();
+    for entry in &list.items {
+        if let ContentItem::ListItem(li) = entry {
+            let label = li
+                .marker()
+                .trim()
+                .trim_end_matches(['.', ')', ':'].as_ref())
+                .trim();
+            if let Ok(n) = label.parse::<u32>() {
+                numbers.insert(n);
+            }
+        }
+    }
+    numbers
+}
+
+fn check_text(text: &TextContent, defs: &HashSet<u32>, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+    for reference in extract_references(text) {
+        if let ReferenceType::FootnoteNumber { number } = reference.reference_type {
+            if !defs.contains(&number) {
+                diagnostics.push(AnalysisDiagnostic {
+                    range: reference.range,
+                    kind: DiagnosticKind::MissingFootnoteDefinition,
+                    message: format!(
+                        "Footnote [{number}] has no matching item in a :: notes :: list"
+                    ),
+                });
+            }
         }
     }
 }
@@ -262,10 +390,38 @@ mod tests {
 
     #[test]
     fn footnote_ref_in_table_cell_is_checked() {
-        // Table cell contains [1] but no footnote definition exists
+        // footnotes-09: table cell contains [1] but no footnote definition
+        // anywhere in scope — document, session, or table-local.
         let doc = Lexplore::footnotes(9).parse().unwrap();
         let diags = footnote_diags(&doc);
         assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("[1]"));
+    }
+
+    #[test]
+    fn table_scoped_footnotes_resolve_cell_refs() {
+        // footnotes-11: cell refs [1] and [2] resolve to the table's own
+        // positional footnote list (no :: notes :: annotation needed).
+        let doc = Lexplore::footnotes(11).parse().unwrap();
+        let diags = footnote_diags(&doc);
+        assert!(
+            diags.is_empty(),
+            "table-scoped cell refs should resolve to table.footnotes, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn table_scoped_footnotes_do_not_leak_out() {
+        // footnotes-12: a [1] ref in body text outside the table must NOT
+        // resolve to the table's own positional footnote list even when the
+        // numbers happen to match. The table's list is table-local.
+        let doc = Lexplore::footnotes(12).parse().unwrap();
+        let diags = footnote_diags(&doc);
+        assert_eq!(
+            diags.len(),
+            1,
+            "only the paragraph ref [1] should be unresolved, got: {diags:?}"
+        );
         assert!(diags[0].message.contains("[1]"));
     }
 }


### PR DESCRIPTION
## Summary

Fix a false-positive `missing-footnote` diagnostic on the canonical table-scoped footnote form. A numbered reference inside a table cell (or in the table's subject) now resolves first to the table's own positional footnote list (`table.footnotes`), and only then falls back to document/session `:: notes ::` lists. References outside any table are unchanged — they still cannot reach table-local footnotes.

### Before

```lex
Scores:
    | Model | Value [1] |
    | BM25  | 0.72      |
    | Dense | 0.85 [2]  |

    1. Measured at k=10
    2. Averaged across 5 runs

    :: table ::
```

Both `[1]` and `[2]` were flagged `Footnote [N] has no matching item in a :: notes :: list`, because the resolver only walked document/session annotations and never looked inside `table.footnotes`.

### After

Zero diagnostics. `table.footnotes` — which the parser already populates — is now added to the in-scope footnote set while the walker is inside that table.

## Implementation

Rewrote `check_footnotes` in `lex-analysis/src/diagnostics.rs` as a tree walker that threads a `HashSet<u32>` of in-scope definitions through the traversal:

- `outer_defs` — numeric labels collected from `:: notes ::` lists at document/session scope (unchanged behaviour for the pre-existing cases).
- On entering a `Table`, the walker unions the table's footnote numbers into the set for the table's subject, cells, and inner annotations. On exit the outer scope is naturally restored (the extension is scoped to the recursive call).
- References are checked in-place as the walker encounters each text node, using the currently-visible set.

The old `for_each_text_content` + flat collect approach had no way to express per-subtree scope, so it's gone; the new walker replaces it entirely for this diagnostic.

## Tests (`lex-analysis/diagnostics`)

All existing diagnostic tests still pass. Two new tests exercise the fix:

- `table_scoped_footnotes_resolve_cell_refs` — loads `footnotes-11-table-scoped.lex`; asserts zero missing-footnote diagnostics.
- `table_scoped_footnotes_do_not_leak_out` — loads `footnotes-12-table-scope-does-not-leak.lex`; asserts exactly one diagnostic, on the paragraph `[1]` outside the table, even though the table's footnote list happens to have a matching `1.` item.

## Depends on

- lex-fmt/comms#21 / #22 — added `footnotes.docs/footnotes-11-table-scoped.lex` and `footnotes-12-table-scope-does-not-leak.lex`. Both are on main; submodule bump included.

## Test plan

- [x] `cargo test --workspace --exclude lex-wasm` — green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --exclude lex-wasm --all-targets -- -D warnings` — clean
- [x] Pre-commit hook (`scripts/rust-pre-commit`) — passes (fmt + clippy + build + nextest)
- [ ] Reviewer sanity-checks that references in nested contexts (table-inside-list, table-inside-definition) still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)