### PR TITLE
chore(ci): group dependabot PRs and auto-merge patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,23 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns: ["*"]
+        exclude-patterns: ["comrak", "html5ever"]
+    ignore:
+      # Major API rewrite needed in lex-babel/serializer.rs. Re-enable after migration.
+      - dependency-name: comrak
+        versions: [">= 0.30"]
+      # markup5ever/html5ever Attribute types diverged + Serialize trait removed.
+      - dependency-name: html5ever
+        versions: [">= 0.36"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      gh-actions:
+        patterns: ["*"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        # Retry: `gh pr merge --auto` fails with "Pull request is in unstable
+        # status" if CI hasn't started yet on a freshly-opened PR.
+        run: |
+          for i in 1 2 3 4 5 6; do
+            if gh pr merge --auto --squash --delete-branch "$PR_URL"; then
+              exit 0
+            fi
+            sleep 30
+          done
+          exit 1
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reduce dependabot noise so humans only see PRs that need real attention.

## Changes

**Groups** (`.github/dependabot.yml`)
- `cargo`: all cargo deps in one weekly grouped PR (excluding comrak/html5ever which are separately ignored)
- `gh-actions`: all GitHub Actions bumps

**Ignores**
- `comrak >= 0.30` — needs serializer.rs rewrite (see #474)
- `html5ever >= 0.36` — Attribute types diverged + Serialize trait removed (see #475)

**Auto-merge** (`.github/workflows/dependabot-auto-merge.yml`)
- Patch and minor (and grouped patch/minor) auto-merge once CI passes
- Workflow restricted to `opened/reopened/ready_for_review` to avoid re-firing on every sync
- Majors still surface as PRs for human review

After this lands I'll close #474 and #475 — they're covered by the new ignore rules and won't be re-emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)