### PR TITLE
fix(ci): pass secrets explicitly to cross-org reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,16 @@ jobs:
       linux-musl-archs: 'x86_64'
       windows-archs: 'x86_64'
       submodules: true
-    secrets: inherit
+    # `secrets: inherit` doesn't propagate cross-org (lex-fmt → arthur-debert),
+    # so secrets must be passed explicitly. Note: lex-fmt/lex stores the
+    # crates.io token under `CARGO_REGISTRY_TOKEN`; the action's input is
+    # `CRATES_IO_KEY`, so we map across.
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+      CRATES_IO_KEY: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

`secrets: inherit` does not propagate across organizations — lex-fmt/lex calls `arthur-debert/release/.github/workflows/rust-cli.yml@v1`, so secrets need to be listed explicitly. Also maps `CARGO_REGISTRY_TOKEN` (lex-fmt's secret name) to `CRATES_IO_KEY` (the action's input name).

## Why

The first v0.9.1 attempt (run 25216608259) failed at the prepare job's `git push origin main`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

`main-branch-protection` ruleset has a bypass for RepositoryRole 5 (admin) — but that bypass requires the push to authenticate as an admin. With `secrets: inherit`, RELEASE_TOKEN didn't propagate to the cross-org reusable workflow, so the checkout fell back to GITHUB_TOKEN which can't bypass. Hence the PR-required violation.

## Other 5 consumers unaffected

dodot, padz, simple-gal, rustloc, burgertocow are all in `arthur-debert/*` — same owner as the action repo — so `inherit` works for them. lex is the only cross-org consumer.

## Test plan

- [ ] Lint passes
- [ ] PR merges to main
- [ ] `gh workflow run release.yml -f version=0.9.1 --repo lex-fmt/lex` triggers cleanly
- [ ] Prepare job's git push succeeds (RELEASE_TOKEN propagates and bypasses ruleset)
- [ ] Then the other lex-specific paths exercise (multi-binary signing, musl, windows, 6-crate publish)