### PR TITLE
fix(ci): correct crate publish order — lex-babel before lex-config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,11 @@ jobs:
     uses: arthur-debert/release/.github/workflows/rust-cli.yml@v1
     with:
       version: ${{ inputs.version }}
-      # 6 publishable crates in topological dep order. lex-wasm has
-      # publish = false and isn't in the list.
-      crates: lex-core,lex-config,lex-babel,lex-analysis,lexd-lsp,lexd
+      # Topological dep order. lex-config depends on lex-babel (not
+      # the other way around — CLAUDE.md was stale on this), so lex-babel
+      # must publish first. lex-wasm has publish = false and isn't in
+      # the list.
+      crates: lex-core,lex-babel,lex-config,lex-analysis,lexd-lsp,lexd
       # Brew formula subject. The other binary (lexd-lsp) is built and
       # signed alongside but ships as a tarball-only artifact (editor
       # extensions bundle it themselves).


### PR DESCRIPTION
## Summary

Empirical bug from v0.9.1 first attempt's publish-crates step:

```
→ publishing lex-config 0.9.1
error: failed to prepare local package for uploading
Caused by:
  failed to select a version for the requirement `lex-babel = "^0.9.1"`
  candidate versions found which didn't match: 0.9.0, ...
```

`lex-config` depends on `lex-babel`, not the other way around — CLAUDE.md's
documented order was stale. The empirical topological order is:

```
lex-core → lex-babel → lex-config → lex-analysis → lexd-lsp → lexd
```

## Recovery

`lex-core@0.9.1` was published in the partial run before publish-crates
errored. The v0.9.1 tag and the bumped Cargo.tomls are on main. Re-running
v0.9.1 after this PR merges will:

1. `prepare`: resume mode (tag exists, Cargo.toml matches) → skip bump
2. `publish-crates`: skip lex-core (already on crates.io via JSON-API check) → publish lex-babel, lex-config, lex-analysis, lexd-lsp, lexd
3. `build-binaries`: re-run with `--clobber`, harmless
4. `homebrew-formula`: re-render with new SHAs, push to tap

## Test plan

- [ ] CI green
- [ ] PR merges
- [ ] `gh workflow run release.yml -f version=0.9.1 --repo lex-fmt/lex`
- [ ] All 9 jobs green
- [ ] All 6 crates at 0.9.1 on crates.io
- [ ] Brew formula updated with correct lexd 0.9.1 URLs