### PR TITLE
chore(ci): drop cargo freshness from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,17 @@
+# Dependabot config — see arthur-debert/release/README.md "Dependabot policy"
+#
+# Application-dependency freshness (cargo) is deliberately not enabled.
+# Major-version sweeps are evaluated as development work, not pushed by a bot.
+# Security exposure for cargo deps is covered by Dependabot security updates,
+# which are enabled per-repo via the GitHub API (not this file).
+#
+# Only github-actions freshness is enabled — old action versions silently
+# break when GitHub deprecates a runtime, so a low-volume freshness stream
+# here is worth the cost.
 version: 2
 updates:
-  - package-ecosystem: cargo
-    directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      cargo:
-        patterns: ["*"]
-        exclude-patterns: ["comrak", "html5ever"]
-    ignore:
-      # Major API rewrite needed in lex-babel/serializer.rs. Re-enable after migration.
-      - dependency-name: comrak
-        versions: [">= 0.30"]
-      # markup5ever/html5ever Attribute types diverged + Serialize trait removed.
-      - dependency-name: html5ever
-        versions: [">= 0.36"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    groups:
-      gh-actions:
-        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Drops `package-ecosystem: cargo` from dependabot.yml; keeps `github-actions` only.
- Aligns with portfolio dependabot policy in arthur-debert/release.

## Why
App-dep freshness mode generates dozens of low-value PRs/day. Major-version sweeps are evaluation work, not bot churn. Cargo security exposure is covered by Dependabot security updates (enabled portfolio-wide via API alongside this PR).

## chore/docs-only
Yes — config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)