### PR TITLE
feat(includes): Annotation include accessors + lex.* namespace (PR 2 of 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- `lex-core`: `Range.origin_path: Option<Arc<PathBuf>>` field with `with_origin` builder and `origin()` accessor. Currently always `None` — pure additive scaffolding for the upcoming includes feature (PR 1 of 10). The field is `#[serde(skip)]` so existing AST JSON output is byte-identical. See `comms/specs/proposals/includes.lex` for the full design.
+- `lex-core`: `Range.origin_path: Option<Arc<PathBuf>>` field with `with_origin` builder and `origin()` accessor. Currently always `None` — pure additive scaffolding for the upcoming includes feature (PR 1 of 10). The field is `#[serde(skip)]` so existing AST JSON output is byte-identical. `Range` is now `#[non_exhaustive]`; equality and hashing ignore `origin_path` (positional only). See `comms/specs/proposals/includes.lex` for the full design.
+- `lex-core`: `Annotation::is_include()` and `Annotation::include_src()` accessors plus `RESERVED_NAMESPACE_PREFIX` (`"lex."`) and `INCLUDE_LABEL` (`"lex.include"`) constants. The `lex.*` annotation label namespace is now reserved for core-defined semantics; the accessors hide the string-match on the reserved label and serve as a migration boundary if includes are later modeled as a distinct AST node type. Pure additive scaffolding for the includes feature (PR 2 of 10).
 
 ## [0.9.2] - 2026-05-02
 

--- a/crates/lex-core/src/lex/ast/elements/annotation.rs
+++ b/crates/lex-core/src/lex/ast/elements/annotation.rs
@@ -60,6 +60,17 @@ use super::typed_content::ContentElement;
 use std::fmt;
 
 /// An annotation represents some metadata about an AST element.
+///
+/// # Reserved label namespace
+///
+/// Labels starting with `lex.` (the `lex.*` namespace, [`Annotation::RESERVED_NAMESPACE_PREFIX`])
+/// are reserved for core-defined semantics. Third-party tooling must not author labels in
+/// this namespace; the core may add new `lex.*` labels without a coordinating versioning
+/// concern. Non-reserved labels remain freely available for extensions
+/// (`mycompany.include`, `docs.embed`, etc.).
+///
+/// The current set of reserved labels:
+/// - [`Annotation::INCLUDE_LABEL`] (`"lex.include"`) — see `comms/specs/proposals/includes.lex`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Annotation {
     pub data: Data,
@@ -68,6 +79,21 @@ pub struct Annotation {
 }
 
 impl Annotation {
+    /// Reserved label prefix for core-defined annotation semantics.
+    ///
+    /// Any annotation whose label starts with this prefix is owned by the Lex
+    /// core and may carry behavior in the resolver / analysis layers. External
+    /// authors should pick a different namespace.
+    pub const RESERVED_NAMESPACE_PREFIX: &'static str = "lex.";
+
+    /// Reserved label for the include directive.
+    ///
+    /// An annotation with this label and a `src=` parameter is interpreted by
+    /// `lex_core::includes` as a request to splice another Lex file's content
+    /// into the parent container at the annotation's position. See
+    /// `comms/specs/proposals/includes.lex` for the full design.
+    pub const INCLUDE_LABEL: &'static str = "lex.include";
+
     fn default_location() -> Range {
         Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
     }
@@ -103,6 +129,38 @@ impl Annotation {
     /// Bounding range covering only the annotation's children.
     pub fn body_location(&self) -> Option<Range> {
         Range::bounding_box(self.children.iter().map(|item| item.range()))
+    }
+
+    /// Whether this annotation's label is in the reserved `lex.*` namespace.
+    pub fn is_reserved(&self) -> bool {
+        self.data
+            .label
+            .value
+            .starts_with(Self::RESERVED_NAMESPACE_PREFIX)
+    }
+
+    /// Whether this annotation is the include directive (label `lex.include`).
+    ///
+    /// Hides the string-match on the reserved label so callers don't sprinkle
+    /// `annotation.label == "lex.include"` throughout the codebase. Also serves
+    /// as the migration boundary if a future version models includes as a
+    /// distinct AST node type.
+    pub fn is_include(&self) -> bool {
+        self.data.label.value == Self::INCLUDE_LABEL
+    }
+
+    /// The `src=` parameter value, if present.
+    ///
+    /// Useful on its own for any annotation that uses a `src` parameter
+    /// (verbatim-via-annotation, future `lex.*` directives, etc.). For
+    /// the include-specific case, callers typically pair this with
+    /// [`Annotation::is_include`].
+    pub fn include_src(&self) -> Option<&str> {
+        self.data
+            .parameters
+            .iter()
+            .find(|p| p.key == "src")
+            .map(|p| p.value.as_str())
     }
 }
 
@@ -190,5 +248,58 @@ mod tests {
 
         assert_eq!(annotation.header_location().span, header_range.span);
         assert_eq!(annotation.body_location().unwrap().span, child_range.span);
+    }
+
+    fn ann(label: &str, params: Vec<(&str, &str)>) -> Annotation {
+        let parameters = params
+            .into_iter()
+            .map(|(k, v)| Parameter::new(k.to_string(), v.to_string()))
+            .collect();
+        Annotation::with_parameters(Label::new(label.to_string()), parameters)
+    }
+
+    #[test]
+    fn test_is_reserved() {
+        assert!(ann("lex.include", vec![]).is_reserved());
+        assert!(ann("lex.foo.bar", vec![]).is_reserved());
+        // Boundary: a label that starts with "lex" but not "lex." is NOT reserved.
+        assert!(!ann("lexicon", vec![]).is_reserved());
+        assert!(!ann("review", vec![]).is_reserved());
+        assert!(!ann("mycompany.include", vec![]).is_reserved());
+    }
+
+    #[test]
+    fn test_is_include() {
+        assert!(ann("lex.include", vec![("src", "x.lex")]).is_include());
+        // Other lex.* labels are reserved but not includes.
+        assert!(!ann("lex.something_else", vec![]).is_include());
+        // Same trailing label without the lex. prefix is not an include.
+        assert!(!ann("include", vec![("src", "x.lex")]).is_include());
+    }
+
+    #[test]
+    fn test_include_src() {
+        let with_src = ann("lex.include", vec![("src", "chapters/01.lex")]);
+        assert_eq!(with_src.include_src(), Some("chapters/01.lex"));
+
+        // The accessor is independent of the label — works for any annotation
+        // that happens to carry a `src` parameter (verbatim-via-annotation, etc.)
+        let other_with_src = ann("image", vec![("src", "diagram.png")]);
+        assert_eq!(other_with_src.include_src(), Some("diagram.png"));
+
+        // No src parameter → None.
+        assert_eq!(ann("lex.include", vec![]).include_src(), None);
+        assert_eq!(
+            ann("lex.include", vec![("title", "Chapter 1")]).include_src(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_constants_match_documented_values() {
+        assert_eq!(Annotation::RESERVED_NAMESPACE_PREFIX, "lex.");
+        assert_eq!(Annotation::INCLUDE_LABEL, "lex.include");
+        // Sanity: the include label is itself reserved.
+        assert!(Annotation::INCLUDE_LABEL.starts_with(Annotation::RESERVED_NAMESPACE_PREFIX));
     }
 }


### PR DESCRIPTION
## Summary

Second foundation PR of the includes feature. Pure additive ergonomics — no behavior change.

- `Annotation::RESERVED_NAMESPACE_PREFIX` (`\"lex.\"`) and `Annotation::INCLUDE_LABEL` (`\"lex.include\"`) constants centralize the reserved-namespace string literals.
- `Annotation::is_reserved()` — whether the label sits in the `lex.*` namespace.
- `Annotation::is_include()` — whether this is the include directive.
- `Annotation::include_src()` — the `src=` parameter value, if any. Independent of label so it works for any annotation that carries `src` (verbatim-via-annotation, future `lex.*` directives).
- Doc comment on `Annotation` formally reserves the `lex.*` label namespace for core-defined semantics.

These hide the string-match on the reserved label so callers don't sprinkle `annotation.label == \"lex.include\"` throughout the codebase, and serve as the migration boundary if a future version chooses to model includes as a distinct AST node type.

## Context

Part of the includes feature design landed in lex-fmt/comms#25 (proposal merged). Builds on lex-fmt/lex#486 (Range.origin_path). This is PR 2 of 10 (release model B). See `comms/specs/proposals/includes.lex` for the full design.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` clean
- [x] `cargo test -p lex-core --lib annotation` — 62 pass (4 new + 58 existing)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] New tests cover: `is_reserved` boundary cases (\"lexicon\" is NOT reserved), `is_include` requires the full label not just suffix, `include_src` works on any annotation with a src param, constants match documented values

🤖 Generated with [Claude Code](https://claude.com/claude-code)