### PR TITLE
fix(includes): address external code review findings

### DIFF
--- a/crates/lex-core/src/lex/ast/elements/document.rs
+++ b/crates/lex-core/src/lex/ast/elements/document.rs
@@ -326,11 +326,10 @@ impl Document {
     pub fn find_annotation_by_label_in_origin(
         &self,
         label: &str,
-        origin: &std::path::Path,
+        origin: Option<&std::path::Path>,
     ) -> Option<&Annotation> {
-        fn matches(ann: &Annotation, label: &str, origin: &std::path::Path) -> bool {
-            ann.data.label.value == label
-                && ann.location.origin().map(|p| p == origin).unwrap_or(false)
+        fn matches(ann: &Annotation, label: &str, origin: Option<&std::path::Path>) -> bool {
+            ann.data.label.value == label && ann.location.origin() == origin
         }
 
         // Document-level annotations first.
@@ -481,10 +480,10 @@ impl Default for Document {
 fn find_annotation_in_session_with_origin<'a>(
     s: &'a Session,
     label: &str,
-    origin: &std::path::Path,
+    origin: Option<&std::path::Path>,
 ) -> Option<&'a Annotation> {
-    fn matches(ann: &Annotation, label: &str, origin: &std::path::Path) -> bool {
-        ann.data.label.value == label && ann.location.origin().map(|p| p == origin).unwrap_or(false)
+    fn matches(ann: &Annotation, label: &str, origin: Option<&std::path::Path>) -> bool {
+        ann.data.label.value == label && ann.location.origin() == origin
     }
     for ann in &s.annotations {
         if matches(ann, label, origin) {
@@ -497,10 +496,10 @@ fn find_annotation_in_session_with_origin<'a>(
 fn find_annotation_in_items_with_origin<'a>(
     items: &'a [ContentItem],
     label: &str,
-    origin: &std::path::Path,
+    origin: Option<&std::path::Path>,
 ) -> Option<&'a Annotation> {
-    fn matches(ann: &Annotation, label: &str, origin: &std::path::Path) -> bool {
-        ann.data.label.value == label && ann.location.origin().map(|p| p == origin).unwrap_or(false)
+    fn matches(ann: &Annotation, label: &str, origin: Option<&std::path::Path>) -> bool {
+        ann.data.label.value == label && ann.location.origin() == origin
     }
     for item in items {
         // Attached annotations live on every node that has a public

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -570,7 +570,9 @@ fn prepare_splice_list(mut included: Document) -> Vec<ContentItem> {
 
     // Document title → Paragraph, prepended.
     // Equivalent to what a textual paste would parse (an unindented line
-    // becomes a paragraph in the host's context).
+    // becomes a paragraph in the host's context). Per the revised
+    // spec §5.2 this is "do nothing" semantics — converting matches what
+    // the parser would do if the included source were inlined and reparsed.
     if let Some(title) = included.title {
         let location = title.location.clone();
         let para = Paragraph::from_line(title.as_str().to_string()).at(location);
@@ -670,19 +672,30 @@ fn resolve_path(src: &str, host_dir: &Path, root: &Path) -> Result<PathBuf, Incl
 /// resolver only needs a stable identity for cycle detection and a uniform
 /// shape for the root-escape prefix check.
 ///
-/// Unresolvable `..` components (those that would pop past the start of the
-/// buffer) are *preserved* in the output. This matters when the buffer
-/// happens to be empty or holds only a relative prefix — silently dropping
-/// the `..` would let a path masquerade as inside the root and defeat the
-/// escape check. With absolute roots (the documented contract) `..`
-/// components only matter near the root itself, where preserving them
-/// makes the prefix check fail correctly.
+/// `..` is collapsed only when the *last* component in the buffer is a
+/// real directory name (`Component::Normal`). When the buffer is empty
+/// or its last component is itself `..` (or a root marker), the new `..`
+/// is *preserved* in the buffer.
+///
+/// This is what defeats `../../etc/passwd` from collapsing to
+/// `etc/passwd` and bypassing the root-escape check — `PathBuf::pop`
+/// would happily strip a `..` (since `Path::new("..").parent()` returns
+/// `Some("")`), silently losing the second `..` and producing a path
+/// that falsely starts with the root prefix. Each unmatched `..` in the
+/// preserved form keeps the normalized path outside any sane root, so
+/// the escape check fires correctly.
 fn lexical_normalize(p: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for c in p.components() {
         match c {
             std::path::Component::ParentDir => {
-                if !out.pop() {
+                let can_pop = matches!(
+                    out.components().next_back(),
+                    Some(std::path::Component::Normal(_))
+                );
+                if can_pop {
+                    out.pop();
+                } else {
                     out.push("..");
                 }
             }

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -628,6 +628,27 @@ fn root_escape_via_dotdot_is_rejected() {
 }
 
 #[test]
+fn root_escape_via_chained_dotdot_from_relative_root_is_rejected() {
+    // Regression for the lexical_normalize bug where the second `..`
+    // in `../../foo` was silently absorbed by `PathBuf::pop` (which
+    // returned true even when the buffer's last component was `..`,
+    // since `Path::new("..").parent()` is `Some("")`). The bug let a
+    // crafted include like `../../etc/passwd` collapse to a path that
+    // falsely satisfied the root-escape prefix check.
+    //
+    // After the fix, `..` is only collapsed when the last buffer
+    // component is `Normal`. We exercise the case via an include from
+    // a deep file with multiple `..`s — the result must escape and
+    // be rejected.
+    let result = fixture_at(
+        "/repo/a/b/c/host.lex",
+        ":: lex.include src=\"../../../../etc/passwd\" ::\n",
+        &[],
+    );
+    assert_err_kind!(result, IncludeError::RootEscape { .. });
+}
+
+#[test]
 fn include_inside_definition_with_sessions_is_policy_error() {
     // The Definition pattern is "subject:" + immediate indent + content.
     let result = fixture(
@@ -1098,11 +1119,11 @@ fn find_annotation_by_label_in_origin_filters_to_origin() {
 
     let main_one = tree
         .doc
-        .find_annotation_by_label_in_origin("1", main_origin)
+        .find_annotation_by_label_in_origin("1", Some(main_origin))
         .expect("main's :: 1 :: missing");
     let chapter_one = tree
         .doc
-        .find_annotation_by_label_in_origin("1", chapter_origin)
+        .find_annotation_by_label_in_origin("1", Some(chapter_origin))
         .expect("chapter's :: 1 :: missing");
 
     // The two annotations are physically different — confirms we're
@@ -1144,7 +1165,7 @@ fn find_annotation_by_label_in_origin_finds_attached_on_list_table_verbatim() {
     for label in ["my_list_note", "my_table_note", "my_verbatim_note"] {
         assert!(
             tree.doc
-                .find_annotation_by_label_in_origin(label, origin)
+                .find_annotation_by_label_in_origin(label, Some(origin))
                 .is_some(),
             "origin-aware lookup missed {label:?} attached to its container — \
              walker must check .annotations on List/Table/VerbatimBlock too"
@@ -1160,8 +1181,27 @@ fn find_annotation_by_label_in_origin_returns_none_when_no_match() {
     let chapter_origin = std::path::Path::new("/repo/chapter.lex");
     assert!(tree
         .doc
-        .find_annotation_by_label_in_origin("1", chapter_origin)
+        .find_annotation_by_label_in_origin("1", Some(chapter_origin))
         .is_none());
+}
+
+#[test]
+fn find_annotation_by_label_in_origin_handles_none_origin() {
+    // Querying with None matches annotations whose origin is also None
+    // — the case that was unreachable with the old `&Path`-only signature.
+    // We resolve a fixture WITHOUT a source_path so the entry document's
+    // annotations stay un-stamped, then assert we can still find them.
+    let mut loader = MemoryLoader::new();
+    loader.insert("/repo/main.lex", ":: 1 :: Top-level note.\n\nA para.\n");
+    let config = ResolveConfig::with_root(PathBuf::from(TEST_ROOT));
+    let doc = resolve_from_source(
+        ":: 1 :: Top-level note.\n\nA para.\n",
+        None, // no source_path → entry annotations have origin = None
+        &config,
+        &loader,
+    )
+    .unwrap();
+    assert!(doc.find_annotation_by_label_in_origin("1", None).is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

External code review against PRs #486–#491 (the includes feature foundation) raised four issues. After evaluation:

### Applied (net wins)

**1. Path normalization correctness bug.** `lexical_normalize` used `if !out.pop() { push(\"..\") }`. `PathBuf::pop()` returns true and strips a `..` component (since `Path::new(\"..\").parent()` is `Some(\"\")`), so a chain like `../../foo` silently collapsed to `foo` — defeating the root-escape prefix check for crafted relative includes.

Fix: only `pop()` when the buffer's last component is `Component::Normal`; otherwise push the literal `..`. Uses `next_back()` instead of `Iterator::last()` to keep clippy happy.

Added `root_escape_via_chained_dotdot_from_relative_root_is_rejected` regression test that exercises a 4-deep `..` chain from a deep entry file.

**2. `Document::find_annotation_by_label_in_origin` accepts `Option<&Path>`** (was `&Path`).

Lets callers query for annotations authored in *un-stamped* documents (entry from stdin, WASM in-memory inputs, etc.) — which the old signature couldn't express. Updated the recursive walker helpers to match. Existing call sites are now `Some(path)`. Added `find_annotation_by_label_in_origin_handles_none_origin` regression test.

### Skipped (would contradict our revised spec)

**Reviewer's \"AST shape\" issue** (splice into annotation children, not siblings). We intentionally revised §5.1 in lex-fmt/comms#25 to splice as siblings precisely because `GeneralContainer` rejects Sessions — splicing into the annotation's children slot would panic the moment an author included a chapter file. Splicing as siblings is the correct design; the reviewer was reading an older draft.

**Reviewer's \"discard title/annotations\" issue.** Our revised §5.2 says *convert and prepend* (`DocumentTitle` → `Paragraph`; doc-level annotations → regular annotations) to match the textual paste mental model that authors form intuitively. Discarding would lose information that authors expect to survive — the design call was made deliberately during the spec rewrite.

## Test plan

- [x] `cargo test -p lex-core --lib includes` — 47 pass (2 new regression tests + 45 existing)
- [x] `cargo build --workspace --exclude lex-wasm` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Context

Sandwiched between PR #492 (CLI integration) and the upcoming PR for LSP integration. Cleanly separable from feature-PR work since both fixes touch only the foundation modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)