### PR TITLE
chore: bump comms submodule to v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   - New `lex_core::lex::includes::FsLoader` is the production loader (filesystem-backed). Only `FsLoader` references `std::fs` — the rest of `lex-core` stays sandbox-clean.
   - Editor packages (`vscode`, `nvim`, `lexed`) pick up nothing yet — LSP integration lands in PR 8.
 
+### Changed
+
+- Bumped `comms` submodule to v0.16.0, which adds the canonical `specs/elements/lex.include.lex` element doc, the `specs/elements/lex.include.docs/` fixture set, and formally reserves the `lex.*` annotation label namespace in `specs/general.lex` §3.1. Also archives the includes proposal to `specs/proposals/done/includes.lex` per the new "frozen-when-implemented" convention.
+
 ## [0.9.2] - 2026-05-02
 
 

--- a/crates/lex-core/tests/integration/spec_documents.rs
+++ b/crates/lex-core/tests/integration/spec_documents.rs
@@ -91,6 +91,16 @@ fn spec_inlines() {
 }
 
 #[test]
+fn spec_lex_include() {
+    let doc = Lexplore::from_path(workspace_path("comms/specs/elements/lex.include.lex"))
+        .parse()
+        .unwrap();
+    assert_ast(&doc).item_count(11).item(0, |item| {
+        item.assert_session().label("Introduction");
+    });
+}
+
+#[test]
 fn spec_label() {
     let doc = Lexplore::from_path(workspace_path("comms/specs/elements/label.lex"))
         .parse()
@@ -231,6 +241,7 @@ fn all_element_spec_files_covered() {
         "footnotes.lex",
         "inlines.lex",
         "label.lex",
+        "lex.include.lex",
         "list.lex",
         "paragraph.lex",
         "parameter.lex",


### PR DESCRIPTION
## Summary

- Bumps `comms` submodule from `d320594` (v0.15.0) to `5fc5810` (v0.16.0).
- Adds the `spec_lex_include` integration test (caught by the spec-coverage discovery test once the new `lex.include.lex` element file landed in comms).
- Adds a CHANGELOG `### Changed` entry under `[Unreleased]` summarising the comms bump.

Comms v0.16.0 ships the canonical `lex.include` element doc, the `lex.include.docs/` fixture set, and formally reserves the `lex.*` annotation label namespace. This is release-prep for the next user-visible lex release covering the includes feature (PRs 7-10 of the 10-PR plan, all already merged into main).

## Test plan

- [x] `cargo nextest run -p lex-core --test integration spec_documents::` — all 19 spec tests green
- [x] Full pre-commit hook (fmt + clippy + build + 1636 tests) green locally
- [ ] CI green