### PR TITLE
fix(includes): attach include-not-found diagnostic to the offending site

### DIFF
--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -146,8 +146,11 @@ pub enum IncludeError {
     },
     /// A path resolved outside the configured [`ResolveConfig::root`].
     RootEscape { path: PathBuf, root: PathBuf },
-    /// The loader could not find or read the included file.
-    NotFound { path: PathBuf },
+    /// The loader could not find or read the included file. `include_site`
+    /// is the range of the offending `lex.include` annotation in its host
+    /// file, so editors can squiggle the line that asked for the missing
+    /// file rather than the document head.
+    NotFound { include_site: Range, path: PathBuf },
     /// The loader returned text that the parser rejected.
     ParseFailed { path: PathBuf, message: String },
     /// The included file's content is not legal in the include site's
@@ -199,7 +202,9 @@ impl std::fmt::Display for IncludeError {
                 path.display(),
                 root.display()
             ),
-            IncludeError::NotFound { path } => write!(f, "include not found: {}", path.display()),
+            IncludeError::NotFound { path, .. } => {
+                write!(f, "include not found: {}", path.display())
+            }
             IncludeError::ParseFailed { path, message } => {
                 write!(f, "failed to parse {}: {message}", path.display())
             }
@@ -229,14 +234,10 @@ impl std::fmt::Display for IncludeError {
 
 impl std::error::Error for IncludeError {}
 
-impl From<LoadError> for IncludeError {
-    fn from(err: LoadError) -> Self {
-        match err {
-            LoadError::NotFound { path } => IncludeError::NotFound { path },
-            LoadError::Io { path, message } => IncludeError::LoaderIo { path, message },
-        }
-    }
-}
+// No `From<LoadError>` impl: `IncludeError::NotFound` carries the include
+// site (the `lex.include` annotation's range), which a loader doesn't know
+// about. Callers map `LoadError` explicitly at the call site, where the
+// site is available.
 
 /// Which container the include site sits in. Determines the splice-time
 /// policy check (the only one today is "no Sessions in `GeneralContainer`").
@@ -480,7 +481,13 @@ fn resolve_one_include(
         });
     }
 
-    let target_source = state.loader.load(&target_path)?;
+    let target_source = state.loader.load(&target_path).map_err(|e| match e {
+        LoadError::NotFound { path } => IncludeError::NotFound {
+            include_site: annotation.location.clone(),
+            path,
+        },
+        LoadError::Io { path, message } => IncludeError::LoaderIo { path, message },
+    })?;
 
     let mut included =
         parse_no_attach(&target_source).map_err(|message| IncludeError::ParseFailed {

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -609,8 +609,19 @@ fn relative_path_resolves_from_host_directory() {
 fn missing_target_surfaces_not_found_with_canonical_path() {
     let result = fixture(":: lex.include src=\"missing.lex\" ::\n", &[]);
     let err = assert_err_kind!(result, IncludeError::NotFound { .. });
-    if let IncludeError::NotFound { path } = err {
+    if let IncludeError::NotFound {
+        path, include_site, ..
+    } = err
+    {
         assert_eq!(path, PathBuf::from("/repo/missing.lex"));
+        // Site spans the offending annotation in the host source — not the
+        // default head-range. The exact span is the parser's concern; here
+        // we just need to know we're not collapsing to (0,0).
+        assert_ne!(
+            include_site,
+            crate::lex::ast::Range::default(),
+            "include_site should locate the annotation, not be the default head-range",
+        );
     }
 }
 
@@ -1305,22 +1316,6 @@ fn memory_loader_missing_returns_not_found() {
         Err(LoadError::NotFound { path }) => assert_eq!(path, PathBuf::from("/missing.lex")),
         other => panic!("expected NotFound, got {other:?}"),
     }
-}
-
-#[test]
-fn load_error_converts_to_include_error_preserving_kind() {
-    let not_found: IncludeError = LoadError::NotFound {
-        path: PathBuf::from("/x"),
-    }
-    .into();
-    assert!(matches!(not_found, IncludeError::NotFound { .. }));
-
-    let io: IncludeError = LoadError::Io {
-        path: PathBuf::from("/y"),
-        message: "boom".into(),
-    }
-    .into();
-    assert!(matches!(io, IncludeError::LoaderIo { .. }));
 }
 
 #[test]

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1495,7 +1495,7 @@ fn absolutize_path(p: &Path) -> PathBuf {
 ///
 /// The diagnostic's range points at the offending `lex.include`
 /// annotation when the error carries one (Cycle, DepthExceeded,
-/// ContainerPolicy, MissingSrc); otherwise it falls back to the
+/// NotFound, ContainerPolicy, MissingSrc); otherwise it falls back to the
 /// document head (line 0, column 0) so the user at least sees something
 /// in the editor's diagnostics panel.
 fn include_error_to_diagnostic(err: &IncludeError) -> Diagnostic {
@@ -1509,7 +1509,11 @@ fn include_error_to_diagnostic(err: &IncludeError) -> Diagnostic {
             err.to_string(),
         ),
         IncludeError::RootEscape { .. } => (head_range(), "include-root-escape", err.to_string()),
-        IncludeError::NotFound { .. } => (head_range(), "include-not-found", err.to_string()),
+        IncludeError::NotFound { include_site, .. } => (
+            to_lsp_range(include_site),
+            "include-not-found",
+            err.to_string(),
+        ),
         IncludeError::ParseFailed { .. } => (head_range(), "include-parse-failed", err.to_string()),
         IncludeError::ContainerPolicy { include_site, .. } => (
             to_lsp_range(include_site),
@@ -2567,11 +2571,13 @@ mod tests {
 
     #[tokio::test]
     async fn includes_missing_target_emits_diagnostic_with_path() {
+        // The include sits on line 0, column 0 — flat fixture so the
+        // diagnostic should pin to that exact location, not the
+        // document head fallback (which would also be (0,0)–(0,0); the
+        // distinction the test cares about is "did the resolver wire
+        // annotation.location through to the diagnostic at all").
         let (_server, client, uri, _dir) = open_in_tempdir(
-            &[(
-                "main.lex",
-                "1. Host\n\n    :: lex.include src=\"missing.lex\" ::\n",
-            )],
+            &[("main.lex", ":: lex.include src=\"missing.lex\" ::\n")],
             "main.lex",
         )
         .await;
@@ -2584,6 +2590,25 @@ mod tests {
         assert!(
             diags.iter().any(|d| d.message.contains("missing.lex")),
             "diagnostic should name the missing file, got {diags:?}"
+        );
+        // The diagnostic must span more than a single point at (0,0).
+        // The default `head_range()` fallback was (0,0)–(0,0), a
+        // zero-width point — vscode renders nothing useful for that.
+        // After wiring annotation.location through, the range covers
+        // the annotation text.
+        let not_found = diags
+            .iter()
+            .find(|d| {
+                matches!(
+                    &d.code,
+                    Some(tower_lsp::lsp_types::NumberOrString::String(c)) if c == "include-not-found"
+                )
+            })
+            .expect("not-found diag");
+        let r = &not_found.range;
+        assert!(
+            r.end.line > r.start.line || r.end.character > r.start.character,
+            "include-not-found should span the annotation, not collapse to a point; got {r:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

`IncludeError::NotFound` now carries `include_site: Range`. The LSP threads it through into the diagnostic instead of falling back to `head_range()`.

## Why

A user opened `comms/specs/elements/lex.include.lex` (which has live `:: lex.include src="chapters/01.lex" ::` examples in the Examples section — those resolve as real annotations, not as text). The diagnostic surfaced as a zero-width point at line 1 col 1 — vscode renders nothing useful for that, so the user had no signal which annotation was at fault. After the fix, the squiggle lands on the offending annotation.

## Trade-offs

- **Drops `impl From<LoadError> for IncludeError`.** `NotFound` now needs `include_site`, which the `Loader` trait doesn't know about (and shouldn't). The single previous user of the impl (`resolve_one_include`) maps explicitly: `LoadError::NotFound` → `IncludeError::NotFound { include_site: annotation.location.clone(), path }`, `LoadError::Io` → `IncludeError::LoaderIo { ... }`. Removed the trait impl rather than keep a partial one. Tests cover both branches.
- **Other no-site variants left alone.** `RootEscape`, `LoaderIo`, and `ParseFailed` also fall back to `head_range()`. Same pattern would fix each (they all have `annotation.location` available at the call site), but kept out of this PR per requested scope.

## Test plan

- [x] `cargo nextest run --workspace` — 1635/1635 green locally
- [x] `lex-core::includes::tests::missing_target_surfaces_not_found_with_canonical_path` strengthened to assert `include_site` is not the default head-range
- [x] `lexd-lsp::server::tests::includes_missing_target_emits_diagnostic_with_path` strengthened to assert the diagnostic range spans more than a single point at (0,0)
- [ ] CI green