### PR TITLE
fix(security): defend FsLoader against symlink path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 ## [Unreleased]
 
-## [0.10.1] - 2026-05-05
+### Security
 
+- `lex-core`: `FsLoader` now defends against arbitrary-file-read via symlink path traversal. Previously the resolver's lexical `..`-normalization correctly blocked textual root escapes, but a symlink inside the repository pointing outside the resolution root (e.g., `repo/sneaky -> /etc`) bypassed the check — `lexical_normalize` doesn't touch the filesystem, so it can't see through symlinks. `FsLoader` now stores its allowed root and, on every load, calls `fs::canonicalize` on both the requested path and the root, then verifies the canonical target sits under the canonical root. Symlinks pointing outside root are rejected as `IncludeError::RootEscape` before any read happens. Editors and CI that process untrusted Lex repositories should pick up this fix immediately. Surfaces a new `LoadError::OutsideRoot` variant; `Loader` trait now returns `LoadedFile { source, canonical_path }` instead of bare `String` so the resolver can use the loader's authoritative identity for cycle detection. (#502)
+
+### Changed
+
+- `lex-core::includes`: `Loader::load` now returns `LoadedFile { source, canonical_path }` instead of `String`. Implementations decide what `canonical_path` means — `FsLoader` returns the post-`fs::canonicalize` path (symlinks resolved, case-folded on case-insensitive FS); `MemoryLoader` returns the lookup key unchanged. The resolver uses `canonical_path` for cycle detection and origin stamping, so symlink loops and case-folded re-includes are now caught as `IncludeError::Cycle` rather than slipping through to `IncludeError::DepthExceeded`.
+- `lex-core::includes`: `FsLoader::new` now takes the resolution root: `FsLoader::new(root: PathBuf)`. `Default` impl removed (a loader without a root would be unsafe).
+- `lex-core::includes`: `FsLoader` now rejects non-regular files (FIFOs, sockets, devices, directories) before reading. Previously a malicious symlink to `/dev/zero` could block or OOM the reader once the symlink check landed; this is the second layer of defense.
+
+## [0.10.1] - 2026-05-05
 
 ### Fixed
 
 - `lex-lsp`: `include-not-found` diagnostic now points at the offending `:: lex.include src=… ::` annotation instead of falling back to the document head. Without this fix, vscode rendered the diagnostic as a zero-length point at line 1 col 1, giving no signal which include in a multi-include doc was broken. `IncludeError::NotFound` now carries `include_site: Range`; the resolver wires `annotation.location` through. The other no-site error variants (`RootEscape`, `LoaderIo`, `ParseFailed`) still fall back to head_range for now — same fix pattern applies but kept out of scope here. (#500)
+
 ## [0.10.0] - 2026-05-04
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "trybuild",
 ]
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -741,10 +741,10 @@ fn expand_includes_to_source(source: &str, entry_path: &str, inc: &IncludeOption
     let entry = absolutize_path(&PathBuf::from(entry_path));
     let root = inc.resolved_root(&entry);
     let resolve_config = ResolveConfig {
-        root,
+        root: root.clone(),
         max_depth: inc.max_depth,
     };
-    let loader = FsLoader::new();
+    let loader = FsLoader::new(root);
     let doc =
         resolve_from_source(source, Some(entry), &resolve_config, &loader).unwrap_or_else(|e| {
             eprintln!("Include resolution error: {e}");
@@ -794,10 +794,10 @@ fn handle_convert_command(
         let entry = absolutize_path(&PathBuf::from(input.expect("input is Some by guard")));
         let root = inc.resolved_root(&entry);
         let resolve_config = ResolveConfig {
-            root,
+            root: root.clone(),
             max_depth: inc.max_depth,
         };
-        let loader = FsLoader::new();
+        let loader = FsLoader::new(root);
         resolve_from_source(&source, Some(entry), &resolve_config, &loader).unwrap_or_else(|e| {
             eprintln!("Include resolution error: {e}");
             std::process::exit(1);

--- a/crates/lex-core/Cargo.toml
+++ b/crates/lex-core/Cargo.toml
@@ -31,3 +31,4 @@ polymath-rs = "0.1.2"
 proptest = { workspace = true }
 insta = { workspace = true }
 trybuild = "1.0"
+tempfile = { workspace = true }

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -94,10 +94,27 @@ impl ResolveConfig {
 /// `std::fs` directly through this trait; that keeps the resolver pure and
 /// usable in WASM, sandboxes, and unit tests.
 pub trait Loader {
-    /// Load the source text for `path`. The path is the canonical absolute
-    /// path the resolver decided on after applying the rules in §4 of the
-    /// proposal.
-    fn load(&self, path: &Path) -> Result<String, LoadError>;
+    /// Load the source text for `path` and return both the contents and a
+    /// canonical identity for the loaded resource. The path is what the
+    /// resolver decided on after applying the rules in §4 of the proposal.
+    ///
+    /// `LoadedFile::canonical_path` is the loader's authoritative identity
+    /// for the resource. For [`FsLoader`] this is the filesystem-canonical
+    /// path (symlinks resolved, case-folded if the underlying FS is
+    /// case-insensitive); for [`MemoryLoader`] it's the lookup key (since
+    /// memory loaders have no symlinks). The resolver uses this for cycle
+    /// detection and for stamping `Range.origin_path` on the loaded tree.
+    fn load(&self, path: &Path) -> Result<LoadedFile, LoadError>;
+}
+
+/// Result of a successful [`Loader::load`].
+#[derive(Debug, Clone)]
+pub struct LoadedFile {
+    /// The file's source text.
+    pub source: String,
+    /// The loader's authoritative identity for the resource. See
+    /// [`Loader::load`] for how loaders decide this.
+    pub canonical_path: PathBuf,
 }
 
 /// Errors a [`Loader`] can produce.
@@ -105,6 +122,12 @@ pub trait Loader {
 pub enum LoadError {
     /// The loader could not find a resource at the given path.
     NotFound { path: PathBuf },
+    /// The resource exists but resolves outside the loader's allowed
+    /// boundary. The lexical resolver normalizes `..` in the requested
+    /// path, but loaders that touch a real filesystem must do a second
+    /// check post-canonicalization to catch symlinks that escape the
+    /// boundary lexically-correct paths can't reach.
+    OutsideRoot { path: PathBuf, root: PathBuf },
     /// Underlying I/O error (or virtual-filesystem equivalent).
     Io { path: PathBuf, message: String },
 }
@@ -113,6 +136,12 @@ impl std::fmt::Display for LoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LoadError::NotFound { path } => write!(f, "include not found: {}", path.display()),
+            LoadError::OutsideRoot { path, root } => write!(
+                f,
+                "include path {} resolves outside loader root {}",
+                path.display(),
+                root.display()
+            ),
             LoadError::Io { path, message } => {
                 write!(f, "io error reading {}: {message}", path.display())
             }
@@ -461,18 +490,9 @@ fn resolve_one_include(
 
     let target_path = resolve_path(&src, host_dir, &state.config.root)?;
 
-    // Cycle check before load — keep loader free of duplicate work.
-    if state.chain.iter().any(|p| p == &target_path) {
-        return Err(IncludeError::Cycle {
-            include_site: annotation.location.clone(),
-            path: target_path,
-            chain: state.chain.clone(),
-        });
-    }
-
-    // Depth check before recursing into the loaded file. A site that sits
-    // exactly at `max_depth` is fine; a site that would push us *past* it
-    // is the failure case.
+    // Depth check before any FS access. A site sitting exactly at
+    // `max_depth` is fine; one that would push us *past* it is the
+    // failure case.
     if state.depth >= state.config.max_depth {
         return Err(IncludeError::DepthExceeded {
             include_site: annotation.location.clone(),
@@ -481,33 +501,55 @@ fn resolve_one_include(
         });
     }
 
-    let target_source = state.loader.load(&target_path).map_err(|e| match e {
+    // Load via the injected loader. The loader returns the source plus
+    // a *canonical* identity for the resource — for FsLoader that's
+    // post-`fs::canonicalize` (symlinks resolved, case-folded on
+    // case-insensitive FS); for MemoryLoader it's the lookup key. We
+    // use the canonical path for cycle detection so a symlink loop or
+    // a case-folded re-include is caught here rather than slipping
+    // through to `max_depth`.
+    let LoadedFile {
+        source: target_source,
+        canonical_path,
+    } = state.loader.load(&target_path).map_err(|e| match e {
         LoadError::NotFound { path } => IncludeError::NotFound {
             include_site: annotation.location.clone(),
             path,
         },
+        LoadError::OutsideRoot { path, root } => IncludeError::RootEscape { path, root },
         LoadError::Io { path, message } => IncludeError::LoaderIo { path, message },
     })?;
 
+    // Cycle check uses the canonical path so symlink/case-fold cycles
+    // are caught even though `target_path` (which we used for the load
+    // request) was just lexically resolved.
+    if state.chain.iter().any(|p| p == &canonical_path) {
+        return Err(IncludeError::Cycle {
+            include_site: annotation.location.clone(),
+            path: canonical_path,
+            chain: state.chain.clone(),
+        });
+    }
+
     let mut included =
         parse_no_attach(&target_source).map_err(|message| IncludeError::ParseFailed {
-            path: target_path.clone(),
+            path: canonical_path.clone(),
             message,
         })?;
 
-    let target_origin = Arc::new(target_path.clone());
+    let target_origin = Arc::new(canonical_path.clone());
     stamp_doc(&mut included, &target_origin);
 
     // Recursively resolve includes inside the loaded file. The host_dir
-    // for that walk is the loaded file's own parent; the chain gains
-    // this path and depth bumps by 1 — both are popped/restored on the
-    // way back so siblings see the same state we got.
-    let included_dir = target_path
+    // for that walk is the loaded file's own canonical parent; the
+    // chain gains the canonical path and depth bumps by 1 — both are
+    // popped/restored on the way back so siblings see the same state.
+    let included_dir = canonical_path
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| state.config.root.clone());
 
-    state.chain.push(target_path.clone());
+    state.chain.push(canonical_path.clone());
     let saved_depth = state.depth;
     state.depth = saved_depth + 1;
     let recurse_result =
@@ -521,7 +563,7 @@ fn resolve_one_include(
         &splice_items,
         parent_kind,
         &annotation.location,
-        &target_path,
+        &canonical_path,
     )?;
 
     Ok(splice_items)
@@ -833,27 +875,45 @@ fn parse_no_attach(source: &str) -> Result<Document, String> {
 /// behind the [`Loader`] trait so the rest of the crate stays sandbox- and
 /// WASM-friendly.
 ///
-/// `FsLoader` is stateless; construct one at the start of a resolution and
-/// share it for the duration. Errors map cleanly:
-/// - `std::io::ErrorKind::NotFound` → [`LoadError::NotFound`]
-/// - any other I/O error → [`LoadError::Io`]
-pub struct FsLoader;
-
-impl FsLoader {
-    pub fn new() -> Self {
-        Self
-    }
+/// `FsLoader` is constructed with the resolution root and rechecks every
+/// load against it post-`fs::canonicalize`, so a symlink pointing outside
+/// the root is rejected even though the lexical-only check in
+/// [`resolve_path`] cannot see it. Also rejects non-regular files (devices,
+/// FIFOs, directories) before reading, so the loader can't be tricked into
+/// blocking on `/dev/zero` or allocating against an open device.
+///
+/// Errors map:
+/// - canonicalization fails (file missing, permission denied at a parent,
+///   broken symlink, …) → [`LoadError::NotFound`]
+/// - canonical path doesn't sit under canonical root → [`LoadError::OutsideRoot`]
+/// - target is not a regular file → [`LoadError::Io`] with a clear message
+/// - any other I/O error during read → [`LoadError::Io`]
+pub struct FsLoader {
+    /// Filesystem-canonical resolution root. Constructed once at
+    /// `FsLoader::new`; if canonicalization fails (e.g., the configured
+    /// root doesn't exist on disk), we fall back to the input verbatim
+    /// and the bounds check will simply never pass — visible to the user
+    /// as a `LoadError::OutsideRoot` instead of silently disabling the
+    /// security check.
+    canonical_root: PathBuf,
 }
 
-impl Default for FsLoader {
-    fn default() -> Self {
-        Self::new()
+impl FsLoader {
+    /// Construct a loader rooted at `root`. The loader stores `root`'s
+    /// fs-canonical form (with symlinks resolved); subsequent loads
+    /// validate that the requested path's canonical form lives under it.
+    pub fn new(root: PathBuf) -> Self {
+        let canonical_root = std::fs::canonicalize(&root).unwrap_or(root);
+        Self { canonical_root }
     }
 }
 
 impl Loader for FsLoader {
-    fn load(&self, path: &Path) -> Result<String, LoadError> {
-        std::fs::read_to_string(path).map_err(|e| match e.kind() {
+    fn load(&self, path: &Path) -> Result<LoadedFile, LoadError> {
+        // 1. Canonicalize. Resolves symlinks and `..` segments against the
+        //    real filesystem. NotFound / broken-symlink / permission errors
+        //    all surface here.
+        let canonical_path = std::fs::canonicalize(path).map_err(|e| match e.kind() {
             std::io::ErrorKind::NotFound => LoadError::NotFound {
                 path: path.to_path_buf(),
             },
@@ -861,6 +921,44 @@ impl Loader for FsLoader {
                 path: path.to_path_buf(),
                 message: e.to_string(),
             },
+        })?;
+
+        // 2. Bounds check against the *canonical* root. This is the
+        //    actual security gate against symlink traversal — the lexical
+        //    check in resolve_path can't see through symlinks.
+        if !canonical_path.starts_with(&self.canonical_root) {
+            return Err(LoadError::OutsideRoot {
+                path: canonical_path,
+                root: self.canonical_root.clone(),
+            });
+        }
+
+        // 3. Reject non-regular files. Without this, an attacker (with
+        //    write access to the repo) could symlink an include target to
+        //    `/dev/zero` or a FIFO and block / OOM the reader. The
+        //    is_file() metadata call is a cheap sanity check.
+        let meta = std::fs::metadata(&canonical_path).map_err(|e| LoadError::Io {
+            path: canonical_path.clone(),
+            message: e.to_string(),
+        })?;
+        if !meta.is_file() {
+            return Err(LoadError::Io {
+                path: canonical_path,
+                message: "include target is not a regular file".to_string(),
+            });
+        }
+
+        // 4. Read. By this point we know the path is a regular file under
+        //    the canonical root; anything that fails here is a real I/O
+        //    error worth surfacing.
+        let source = std::fs::read_to_string(&canonical_path).map_err(|e| LoadError::Io {
+            path: canonical_path.clone(),
+            message: e.to_string(),
+        })?;
+
+        Ok(LoadedFile {
+            source,
+            canonical_path,
         })
     }
 }
@@ -915,13 +1013,22 @@ impl Default for MemoryLoader {
 
 #[cfg(any(test, feature = "test-support"))]
 impl Loader for MemoryLoader {
-    fn load(&self, path: &Path) -> Result<String, LoadError> {
-        self.files
+    fn load(&self, path: &Path) -> Result<LoadedFile, LoadError> {
+        // Memory loaders have no symlinks; the lookup key *is* the
+        // canonical identity. Cycle detection in the resolver compares
+        // `LoadedFile::canonical_path` values; for tests this matches the
+        // lexically-normalized paths the resolver already produces.
+        let source = self
+            .files
             .get(path)
             .cloned()
             .ok_or_else(|| LoadError::NotFound {
                 path: path.to_path_buf(),
-            })
+            })?;
+        Ok(LoadedFile {
+            source,
+            canonical_path: path.to_path_buf(),
+        })
     }
 }
 

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -1304,8 +1304,12 @@ fn memory_loader_returns_inserted_files() {
         (PathBuf::from("/b.lex"), "Bbb\n"),
     ]);
     use std::path::Path;
-    assert_eq!(loader.load(Path::new("/a.lex")).unwrap(), "Aaa\n");
-    assert_eq!(loader.load(Path::new("/b.lex")).unwrap(), "Bbb\n");
+    let a = loader.load(Path::new("/a.lex")).unwrap();
+    assert_eq!(a.source, "Aaa\n");
+    assert_eq!(a.canonical_path, PathBuf::from("/a.lex"));
+    let b = loader.load(Path::new("/b.lex")).unwrap();
+    assert_eq!(b.source, "Bbb\n");
+    assert_eq!(b.canonical_path, PathBuf::from("/b.lex"));
 }
 
 #[test]
@@ -1357,4 +1361,210 @@ fn errors_format_with_relevant_paths() {
     assert!(s.contains("/chapter.lex"));
     assert!(s.contains("Sessions"));
     assert!(s.contains("does not allow Sessions"));
+}
+
+// ============================================================================
+// FsLoader security tests (post v0.10.1 hardening)
+//
+// These exercise the real filesystem via tempdirs. The FsLoader's job is to
+// be the security gate: lexical_normalize handles textual `..` traversal,
+// but only the loader can defend against symlinks (which require touching
+// the real FS to detect) and special device files (which require metadata).
+// ============================================================================
+
+use tempfile::TempDir;
+
+/// Build a tempdir whose canonical path matches what FsLoader will use.
+/// On macOS `TempDir` returns paths under `/var/folders/...` but the real
+/// path is `/private/var/folders/...`; canonicalizing once at construction
+/// keeps every assertion in this module working in canonical-path space.
+fn canonical_tempdir() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let canonical = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+    (dir, canonical)
+}
+
+#[test]
+fn fsloader_reads_regular_file_under_root() {
+    let (_dir, root) = canonical_tempdir();
+    let target = root.join("legit.lex");
+    std::fs::write(&target, "Body\n").unwrap();
+
+    let loader = FsLoader::new(root.clone());
+    let loaded = loader.load(&target).expect("legit file under root loads");
+    assert_eq!(loaded.source, "Body\n");
+    assert_eq!(loaded.canonical_path, target);
+}
+
+#[test]
+fn fsloader_missing_file_returns_not_found() {
+    let (_dir, root) = canonical_tempdir();
+    let loader = FsLoader::new(root.clone());
+    let target = root.join("does-not-exist.lex");
+    let err = loader.load(&target).expect_err("missing file should error");
+    assert!(matches!(err, LoadError::NotFound { .. }));
+}
+
+#[test]
+fn fsloader_directory_target_is_rejected() {
+    let (_dir, root) = canonical_tempdir();
+    let sub = root.join("not-a-file");
+    std::fs::create_dir(&sub).unwrap();
+
+    let loader = FsLoader::new(root.clone());
+    let err = loader.load(&sub).expect_err("directory should not load");
+    match err {
+        LoadError::Io { message, .. } => assert!(
+            message.contains("regular file"),
+            "directory should be rejected as non-regular file, got: {message}"
+        ),
+        other => panic!("expected Io with not-a-regular-file message, got {other:?}"),
+    }
+}
+
+/// Symlink pointing OUTSIDE the resolution root must be rejected even
+/// though the lexical path looks innocent. This is the central
+/// security test for the v0.10.2 hardening — without canonicalize +
+/// post-canonical bounds check, an attacker who can write a symlink
+/// inside the repo can read arbitrary files via `lex.include`.
+#[cfg(unix)]
+#[test]
+fn fsloader_rejects_symlink_pointing_outside_root() {
+    let (_root_dir, root) = canonical_tempdir();
+    let (_outside_dir, outside) = canonical_tempdir();
+    let secret = outside.join("secret.lex");
+    std::fs::write(&secret, "STOLEN\n").unwrap();
+
+    // root/sneaky.lex -> outside/secret.lex
+    let link = root.join("sneaky.lex");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+    let loader = FsLoader::new(root.clone());
+    let err = loader
+        .load(&link)
+        .expect_err("symlink to file outside root must be rejected");
+    match err {
+        LoadError::OutsideRoot { path, root: r } => {
+            assert_eq!(
+                path, secret,
+                "error reports the canonical out-of-root target"
+            );
+            assert_eq!(r, root, "error reports the canonical root");
+        }
+        other => panic!("expected OutsideRoot, got {other:?}"),
+    }
+}
+
+/// A symlink that resolves *inside* the root is fine — the loader
+/// should accept it without complaint and report the canonical path.
+#[cfg(unix)]
+#[test]
+fn fsloader_accepts_symlink_within_root() {
+    let (_dir, root) = canonical_tempdir();
+    let real = root.join("real.lex");
+    std::fs::write(&real, "Body\n").unwrap();
+    let link = root.join("link.lex");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let loader = FsLoader::new(root.clone());
+    let loaded = loader
+        .load(&link)
+        .expect("symlink within root should resolve");
+    assert_eq!(loaded.source, "Body\n");
+    // The canonical path is the real file, not the symlink — important
+    // for cycle detection (symlinks to the same target match).
+    assert_eq!(loaded.canonical_path, real);
+}
+
+/// Special device files (FIFOs, character devices, sockets) must be
+/// rejected before reading, otherwise `read_to_string` on `/dev/zero`
+/// would block / OOM. We construct a FIFO since it's cheap and works
+/// on every Unix without admin privileges.
+#[cfg(unix)]
+#[test]
+fn fsloader_rejects_fifo_special_file() {
+    use std::ffi::CString;
+
+    let (_dir, root) = canonical_tempdir();
+    let fifo = root.join("named-pipe.lex");
+    let cpath = CString::new(fifo.as_os_str().to_str().unwrap()).unwrap();
+    // mkfifo with 0o644
+    let rc = unsafe { libc_mkfifo(cpath.as_ptr(), 0o644) };
+    assert_eq!(rc, 0, "mkfifo failed");
+
+    let loader = FsLoader::new(root.clone());
+    let err = loader.load(&fifo).expect_err("FIFO must be rejected");
+    match err {
+        LoadError::Io { message, .. } => assert!(
+            message.contains("regular file"),
+            "FIFO should be rejected as non-regular file, got: {message}"
+        ),
+        other => panic!("expected Io non-regular-file, got {other:?}"),
+    }
+}
+
+// We don't pull `libc` in as a dep just for one mkfifo. Bind the symbol
+// directly — it's stable on every Unix.
+#[cfg(unix)]
+extern "C" {
+    #[link_name = "mkfifo"]
+    fn libc_mkfifo(path: *const std::os::raw::c_char, mode: u32) -> std::os::raw::c_int;
+}
+
+/// Cycle detection now uses `LoadedFile::canonical_path` from the loader.
+/// We prove the wiring with a MemoryLoader that reports a fixed canonical
+/// path regardless of which lexical key was requested — if the resolver
+/// is using the canonical identity for cycle checks, the second include
+/// of the "same" canonical resource (under different lexical names) will
+/// be caught as a cycle, not as DepthExceeded.
+#[test]
+fn cycle_detection_uses_canonical_path_from_loader() {
+    // Two files that are LEXICALLY distinct (`/repo/A.lex` vs
+    // `/repo/a.lex`) but the loader pretends they have the same
+    // canonical path (simulating a case-insensitive FS).
+    struct CaseFoldLoader;
+    impl Loader for CaseFoldLoader {
+        fn load(&self, path: &std::path::Path) -> Result<LoadedFile, LoadError> {
+            // Lowercase the file name to produce a stable canonical
+            // identity regardless of which case was requested.
+            let canonical = lowercase_name(path);
+            let source = match canonical.to_str().unwrap() {
+                "/repo/a.lex" => ":: lex.include src=\"A.lex\" ::\n".to_string(),
+                _ => {
+                    return Err(LoadError::NotFound {
+                        path: path.to_path_buf(),
+                    })
+                }
+            };
+            Ok(LoadedFile {
+                source,
+                canonical_path: canonical,
+            })
+        }
+    }
+    fn lowercase_name(p: &std::path::Path) -> std::path::PathBuf {
+        let parent = p.parent().unwrap_or_else(|| std::path::Path::new(""));
+        let name = p.file_name().unwrap().to_str().unwrap().to_lowercase();
+        parent.join(name)
+    }
+
+    let cfg = ResolveConfig::with_root(PathBuf::from("/repo"));
+    let entry = "1. Top\n\n    :: lex.include src=\"A.lex\" ::\n";
+    let result = resolve_from_source(
+        entry,
+        Some(PathBuf::from("/repo/main.lex")),
+        &cfg,
+        &CaseFoldLoader,
+    );
+
+    // Without canonical-path cycle detection this would be DepthExceeded;
+    // with the v0.10.2 fix it's caught as a Cycle on the second visit.
+    match result.expect_err("case-folded self-include must error") {
+        IncludeError::Cycle { .. } => {}
+        IncludeError::DepthExceeded { .. } => panic!(
+            "case-folded re-include should be caught as Cycle, not DepthExceeded — \
+             cycle detection isn't using canonical_path from the loader"
+        ),
+        other => panic!("unexpected error variant: {other:?}"),
+    }
 }

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -363,10 +363,10 @@ where
         drop(cfg);
 
         let resolve_config = ResolveConfig {
-            root: inc_root,
+            root: inc_root.clone(),
             max_depth,
         };
-        let loader = FsLoader::new();
+        let loader = FsLoader::new(inc_root);
 
         match resolve_from_source(text, Some(path), &resolve_config, &loader) {
             Ok(_doc) => {
@@ -463,10 +463,9 @@ where
         )
         .ok()?;
 
-        let loader = FsLoader::new();
-        let target_source =
-            lex_core::lex::includes::Loader::load(&loader, target.as_path()).ok()?;
-        let preview = include_preview_markdown(&src, &target, &target_source);
+        let loader = FsLoader::new(inc_root.clone());
+        let loaded = lex_core::lex::includes::Loader::load(&loader, target.as_path()).ok()?;
+        let preview = include_preview_markdown(&src, &target, &loaded.source);
 
         Some(Hover {
             contents: HoverContents::Markup(MarkupContent {


### PR DESCRIPTION
## Summary

Addresses items #1, #2, and #5 from the recent security review of the includes implementation.

The lexical normalization in `resolve_path` correctly blocks textual `..` traversal but cannot see through symlinks (it doesn't touch the filesystem, by design — that keeps lex-core sandbox-clean). An attacker with write access to a Lex repo could place a symlink pointing outside the resolution root (e.g., \`repo/sneaky -> /etc\`) and use it as an include target. The lexical check passes; \`FsLoader\` then read the file via OS path resolution, following the symlink and returning arbitrary on-disk content.

**Threat model**: contributor PRs into a CI pipeline that runs \`lex convert\` / \`lex inspect\`; the rendered/converted output (HTML, PR comments, build artifacts, log files) becomes the exfiltration channel. Severity high in CI contexts; lower for local-only use.

## Hardening

1. **\`FsLoader\` stores its allowed root** and canonicalizes once at construction: \`FsLoader::new(root: PathBuf)\`.
2. **Post-canonicalize bounds check** on every load: \`fs::canonicalize\` the requested path, verify it sits under the canonical root. Symlinks pointing outside root surface as the new \`LoadError::OutsideRoot\` → \`IncludeError::RootEscape\`. Symlinks pointing *inside* root continue to work and report the canonical target.
3. **Reject non-regular files** (FIFO, socket, device, directory) before reading. Without this, a malicious symlink to \`/dev/zero\` could block / OOM the reader the moment the symlink check landed; defense in depth (item #2 from the review).
4. **\`Loader::load\` returns \`LoadedFile { source, canonical_path }\`** instead of bare \`String\`. The resolver uses \`canonical_path\` for cycle detection and origin stamping, so symlink loops and case-folded re-includes (on case-insensitive FS) are now caught as \`IncludeError::Cycle\` rather than slipping through to \`IncludeError::DepthExceeded\` (item #5).

## Behavior changes worth noting

- Anyone with a legit cross-root symlink (\`vendor/foo.lex -> /elsewhere/shared/foo.lex\` outside their includes root) must either move the file in-root or widen \`[includes].root\`. Honors the security promise; CHANGELOG documents.
- \`FsLoader::default()\` removed — a loader without a configured root would have no security boundary.
- \`Loader::load\` return type changed (breaking for any third-party impls; in-tree we updated \`MemoryLoader\` and the 4 \`FsLoader::new\` call sites in lex-cli and lex-lsp).

## Test plan

7 new tests in \`crates/lex-core/src/lex/includes/tests.rs\`:
- regular file under root loads cleanly
- missing file → NotFound
- directory target → Io with \"not a regular file\"
- **symlink pointing outside root → OutsideRoot** (the central security test)
- symlink pointing inside root works, reports canonical target
- FIFO target → Io with \"not a regular file\"
- canonical-path cycle detection: case-folding loader proves the chain uses \`canonical_path\` from the loader, not the lexical request path

\`tempfile\` added as a dev-dependency for the FS tests.

- [x] \`cargo nextest run --workspace\` — 1642/1642 green locally
- [ ] CI green