### PR TITLE
feat(includes): resource limits — max_total_includes + max_file_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `lex-core::includes`: resource limits to bound resolver work against adversarial input. `ResolveConfig::max_total_includes` (default 1000) caps the total number of `lex.include` annotations resolved across the entire document — `max_depth` alone bounds chain length but a doc with thousands of includes at depth 1 still blows past it. `FsLoader::with_max_file_size(bytes)` (default 10 MiB) caps per-include file size; oversize files are rejected before any bytes hit memory. Both are surfaced as their own `IncludeError` variants (`TotalIncludesExceeded`, `FileTooLarge`) with `include_site` for editor diagnostics. Configurable via new `[includes].max_total_includes` and `[includes].max_file_size` keys in `lex.toml`. Addresses item #3 from the security review. (#TBD)
+
 ### Security
 
 - `lex-core`: `FsLoader` now defends against arbitrary-file-read via symlink path traversal. Previously the resolver's lexical `..`-normalization correctly blocked textual root escapes, but a symlink inside the repository pointing outside the resolution root (e.g., `repo/sneaky -> /etc`) bypassed the check — `lexical_normalize` doesn't touch the filesystem, so it can't see through symlinks. `FsLoader` now stores its allowed root and, on every load, calls `fs::canonicalize` on both the requested path and the root, then verifies the canonical target sits under the canonical root. Symlinks pointing outside root are rejected as `IncludeError::RootEscape` before any read happens. Editors and CI that process untrusted Lex repositories should pick up this fix immediately. Surfaces a new `LoadError::OutsideRoot` variant; `Loader` trait now returns `LoadedFile { source, canonical_path }` instead of bare `String` so the resolver can use the loader's authoritative identity for cycle detection. (#502)

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -578,6 +578,12 @@ struct IncludeOptions {
     /// Maximum include depth, taken from `[includes].max_depth`
     /// (default 8).
     max_depth: usize,
+    /// Maximum total include count, taken from
+    /// `[includes].max_total_includes` (default 1000).
+    max_total_includes: usize,
+    /// Maximum size of any single included file in bytes, taken from
+    /// `[includes].max_file_size` (default 10 MiB).
+    max_file_size: u64,
 }
 
 impl IncludeOptions {
@@ -590,6 +596,8 @@ impl IncludeOptions {
                 .map(PathBuf::from)
                 .or_else(|| config.includes.root.as_ref().map(PathBuf::from)),
             max_depth: config.includes.max_depth,
+            max_total_includes: config.includes.max_total_includes,
+            max_file_size: config.includes.max_file_size,
         }
     }
 
@@ -599,6 +607,8 @@ impl IncludeOptions {
             enabled: false,
             root_override: None,
             max_depth: 8,
+            max_total_includes: 1000,
+            max_file_size: 10 * 1024 * 1024,
         }
     }
 
@@ -743,8 +753,9 @@ fn expand_includes_to_source(source: &str, entry_path: &str, inc: &IncludeOption
     let resolve_config = ResolveConfig {
         root: root.clone(),
         max_depth: inc.max_depth,
+        max_total_includes: inc.max_total_includes,
     };
-    let loader = FsLoader::new(root);
+    let loader = FsLoader::new(root).with_max_file_size(inc.max_file_size);
     let doc =
         resolve_from_source(source, Some(entry), &resolve_config, &loader).unwrap_or_else(|e| {
             eprintln!("Include resolution error: {e}");
@@ -796,8 +807,9 @@ fn handle_convert_command(
         let resolve_config = ResolveConfig {
             root: root.clone(),
             max_depth: inc.max_depth,
+            max_total_includes: inc.max_total_includes,
         };
-        let loader = FsLoader::new(root);
+        let loader = FsLoader::new(root).with_max_file_size(inc.max_file_size);
         resolve_from_source(&source, Some(entry), &resolve_config, &loader).unwrap_or_else(|e| {
             eprintln!("Include resolution error: {e}");
             std::process::exit(1);

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -198,6 +198,18 @@ pub struct IncludesConfig {
     /// not a silent truncation.
     #[config(default = 8)]
     pub max_depth: usize,
+    /// Maximum total include count across the document (DoS bound).
+    /// Default 1000. Caps fan-out — `max_depth` alone bounds chain
+    /// length but a doc with thousands of includes at depth 1 still
+    /// blows past it.
+    #[config(default = 1000)]
+    pub max_total_includes: usize,
+    /// Maximum size of any single included file in bytes (DoS bound).
+    /// Default 10 MiB (10485760). Files larger than this are rejected
+    /// before any bytes hit memory. Used by `FsLoader`; the in-memory
+    /// `MemoryLoader` doesn't enforce a size limit.
+    #[config(default = 10485760)]
+    pub max_file_size: u64,
 }
 
 #[cfg(test)]

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -70,6 +70,15 @@ pub struct ResolveConfig {
     /// Maximum include depth. Default 8 (see [`ResolveConfig::DEFAULT_MAX_DEPTH`]).
     /// Hitting the limit is an error, not a silent truncation.
     pub max_depth: usize,
+    /// Maximum total number of `lex.include` annotations resolved across
+    /// the whole tree (depth × breadth). Default 1000
+    /// (see [`ResolveConfig::DEFAULT_MAX_TOTAL_INCLUDES`]).
+    ///
+    /// Caps fan-out: `max_depth` alone bounds chain length but not
+    /// breadth. A document with 100 thousand top-level includes at depth
+    /// 1 sits inside `max_depth` but can still OOM the resolver / LSP /
+    /// CI. Hitting this limit is an error, not a silent truncation.
+    pub max_total_includes: usize,
 }
 
 impl ResolveConfig {
@@ -78,11 +87,18 @@ impl ResolveConfig {
     /// keep the resolver's worst-case work predictable.
     pub const DEFAULT_MAX_DEPTH: usize = 8;
 
-    /// Construct a config with the given root and default depth.
+    /// Default maximum total include count (DoS bound). Generous enough
+    /// for a book-length document with thousands of small fragments,
+    /// tight enough to contain adversarial fan-out within a few seconds
+    /// of resolver work.
+    pub const DEFAULT_MAX_TOTAL_INCLUDES: usize = 1000;
+
+    /// Construct a config with the given root and default limits.
     pub fn with_root(root: PathBuf) -> Self {
         Self {
             root,
             max_depth: Self::DEFAULT_MAX_DEPTH,
+            max_total_includes: Self::DEFAULT_MAX_TOTAL_INCLUDES,
         }
     }
 }
@@ -128,6 +144,14 @@ pub enum LoadError {
     /// check post-canonicalization to catch symlinks that escape the
     /// boundary lexically-correct paths can't reach.
     OutsideRoot { path: PathBuf, root: PathBuf },
+    /// The resource exists but its size exceeds the loader's configured
+    /// limit. `size` and `limit` are in bytes. The resolver maps this to
+    /// [`IncludeError::FileTooLarge`] with the offending annotation's site.
+    TooLarge {
+        path: PathBuf,
+        size: u64,
+        limit: u64,
+    },
     /// Underlying I/O error (or virtual-filesystem equivalent).
     Io { path: PathBuf, message: String },
 }
@@ -141,6 +165,11 @@ impl std::fmt::Display for LoadError {
                 "include path {} resolves outside loader root {}",
                 path.display(),
                 root.display()
+            ),
+            LoadError::TooLarge { path, size, limit } => write!(
+                f,
+                "include file {} is {size} bytes, exceeds limit of {limit} bytes",
+                path.display()
             ),
             LoadError::Io { path, message } => {
                 write!(f, "io error reading {}: {message}", path.display())
@@ -172,6 +201,21 @@ pub enum IncludeError {
         include_site: Range,
         limit: usize,
         chain: Vec<PathBuf>,
+    },
+    /// The total number of includes resolved across the document
+    /// exceeded [`ResolveConfig::max_total_includes`]. Bounds adversarial
+    /// fan-out (which `max_depth` alone does not). `include_site` is the
+    /// `lex.include` annotation that pushed the count past the limit.
+    TotalIncludesExceeded { include_site: Range, limit: usize },
+    /// The included file's size exceeded the loader's configured limit.
+    /// Surfaced by loaders that read from a real filesystem (FsLoader)
+    /// to bound memory allocation per include. `include_site` is the
+    /// offending annotation; `size` and `limit` are in bytes.
+    FileTooLarge {
+        include_site: Range,
+        path: PathBuf,
+        size: u64,
+        limit: u64,
     },
     /// A path resolved outside the configured [`ResolveConfig::root`].
     RootEscape { path: PathBuf, root: PathBuf },
@@ -223,6 +267,18 @@ impl std::fmt::Display for IncludeError {
                     f,
                     "include depth exceeded limit of {limit} (chain: {})",
                     chain_display.join(" -> ")
+                )
+            }
+            IncludeError::TotalIncludesExceeded { limit, .. } => {
+                write!(f, "total include count exceeded limit of {limit}")
+            }
+            IncludeError::FileTooLarge {
+                path, size, limit, ..
+            } => {
+                write!(
+                    f,
+                    "included file {} is {size} bytes, exceeds limit of {limit} bytes",
+                    path.display()
                 )
             }
             IncludeError::RootEscape { path, root } => write!(
@@ -360,6 +416,7 @@ pub fn resolve_from_source(
         loader,
         chain: &mut chain,
         depth: 0,
+        total_resolved: 0,
     };
 
     splice_in_session_container(doc.root.children.as_mut_vec(), &host_dir, &mut state)?;
@@ -401,6 +458,11 @@ struct ResolverState<'a> {
     /// Number of include hops from the entry point. Each recursion into a
     /// loaded file increments by 1. Hitting `config.max_depth` is an error.
     depth: usize,
+    /// Total includes resolved across the entire walk (depth × breadth).
+    /// Incremented on every successful load. Hitting
+    /// `config.max_total_includes` aborts with `TotalIncludesExceeded` —
+    /// caps adversarial fan-out that `max_depth` alone wouldn't catch.
+    total_resolved: usize,
 }
 
 fn splice_in_session_container(
@@ -501,6 +563,16 @@ fn resolve_one_include(
         });
     }
 
+    // Total-count check before loading. Caps fan-out — a doc with
+    // 100k top-level includes would blow past max_total_includes long
+    // before max_depth would catch anything.
+    if state.total_resolved >= state.config.max_total_includes {
+        return Err(IncludeError::TotalIncludesExceeded {
+            include_site: annotation.location.clone(),
+            limit: state.config.max_total_includes,
+        });
+    }
+
     // Load via the injected loader. The loader returns the source plus
     // a *canonical* identity for the resource — for FsLoader that's
     // post-`fs::canonicalize` (symlinks resolved, case-folded on
@@ -517,8 +589,15 @@ fn resolve_one_include(
             path,
         },
         LoadError::OutsideRoot { path, root } => IncludeError::RootEscape { path, root },
+        LoadError::TooLarge { path, size, limit } => IncludeError::FileTooLarge {
+            include_site: annotation.location.clone(),
+            path,
+            size,
+            limit,
+        },
         LoadError::Io { path, message } => IncludeError::LoaderIo { path, message },
     })?;
+    state.total_resolved += 1;
 
     // Cycle check uses the canonical path so symlink/case-fold cycles
     // are caught even though `target_path` (which we used for the load
@@ -896,15 +975,36 @@ pub struct FsLoader {
     /// as a `LoadError::OutsideRoot` instead of silently disabling the
     /// security check.
     canonical_root: PathBuf,
+    /// Per-file size cap (bytes). Loads of larger files surface as
+    /// `LoadError::TooLarge` before any bytes are read into memory.
+    /// Default [`FsLoader::DEFAULT_MAX_FILE_SIZE`].
+    max_file_size: u64,
 }
 
 impl FsLoader {
-    /// Construct a loader rooted at `root`. The loader stores `root`'s
-    /// fs-canonical form (with symlinks resolved); subsequent loads
-    /// validate that the requested path's canonical form lives under it.
+    /// Default per-file size cap: 10 MiB. Generous for realistic Lex
+    /// source documents (text only) and tight enough to bound memory
+    /// allocation per include against an adversarial 1 GB file.
+    pub const DEFAULT_MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
+
+    /// Construct a loader rooted at `root` with default size limits.
+    /// The loader stores `root`'s fs-canonical form (with symlinks
+    /// resolved); subsequent loads validate that the requested path's
+    /// canonical form lives under it.
     pub fn new(root: PathBuf) -> Self {
         let canonical_root = std::fs::canonicalize(&root).unwrap_or(root);
-        Self { canonical_root }
+        Self {
+            canonical_root,
+            max_file_size: Self::DEFAULT_MAX_FILE_SIZE,
+        }
+    }
+
+    /// Override the default per-file size cap (bytes). Use to widen the
+    /// limit for projects with genuinely large source files, or tighten
+    /// it for stricter sandboxes (e.g., LSPs serving untrusted content).
+    pub fn with_max_file_size(mut self, max_file_size: u64) -> Self {
+        self.max_file_size = max_file_size;
+        self
     }
 }
 
@@ -948,9 +1048,20 @@ impl Loader for FsLoader {
             });
         }
 
-        // 4. Read. By this point we know the path is a regular file under
-        //    the canonical root; anything that fails here is a real I/O
-        //    error worth surfacing.
+        // 4. Size cap. Bounds memory allocation per include against an
+        //    adversarial 1 GB file before any bytes hit the heap.
+        let size = meta.len();
+        if size > self.max_file_size {
+            return Err(LoadError::TooLarge {
+                path: canonical_path,
+                size,
+                limit: self.max_file_size,
+            });
+        }
+
+        // 5. Read. By this point we know the path is a regular file under
+        //    the canonical root and within the size cap; anything that
+        //    fails here is a real I/O error worth surfacing.
         let source = std::fs::read_to_string(&canonical_path).map_err(|e| LoadError::Io {
             path: canonical_path.clone(),
             message: e.to_string(),

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -965,6 +965,7 @@ fn depth_limit_triggers_at_configured_threshold() {
     let config = ResolveConfig {
         root: PathBuf::from(TEST_ROOT),
         max_depth: 3,
+        max_total_includes: ResolveConfig::DEFAULT_MAX_TOTAL_INCLUDES,
     };
     let result = resolve_from_source(
         ":: lex.include src=\"a.lex\" ::\n",
@@ -992,6 +993,7 @@ fn depth_limit_at_exact_max_is_allowed() {
     let config = ResolveConfig {
         root: PathBuf::from(TEST_ROOT),
         max_depth: 2,
+        max_total_includes: ResolveConfig::DEFAULT_MAX_TOTAL_INCLUDES,
     };
     let doc = resolve_from_source(
         ":: lex.include src=\"a.lex\" ::\n",
@@ -1566,5 +1568,144 @@ fn cycle_detection_uses_canonical_path_from_loader() {
              cycle detection isn't using canonical_path from the loader"
         ),
         other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Resource-limit tests (max_total_includes + max_file_size, post-PR2)
+// ============================================================================
+
+/// `max_total_includes` caps fan-out: a doc with many top-level
+/// includes at depth 1 (well within `max_depth`) still trips the
+/// total-count limit and aborts cleanly with `TotalIncludesExceeded`.
+#[test]
+fn total_includes_limit_caps_breadth() {
+    let mut loader = MemoryLoader::new();
+    loader.insert("/repo/leaf.lex", "Body.\n");
+    // Host with 5 sibling includes, all pointing at the same leaf.
+    let host = "1. Host\n\n    :: lex.include src=\"leaf.lex\" ::\n\n    :: lex.include src=\"leaf.lex\" ::\n\n    :: lex.include src=\"leaf.lex\" ::\n\n    :: lex.include src=\"leaf.lex\" ::\n\n    :: lex.include src=\"leaf.lex\" ::\n";
+    loader.insert("/repo/main.lex", host);
+    let config = ResolveConfig {
+        root: PathBuf::from(TEST_ROOT),
+        max_depth: ResolveConfig::DEFAULT_MAX_DEPTH,
+        max_total_includes: 3,
+    };
+    let result = resolve_from_source(
+        host,
+        Some(PathBuf::from(DEFAULT_MAIN_PATH)),
+        &config,
+        &loader,
+    );
+    match result.expect_err("breadth past total limit must error") {
+        IncludeError::TotalIncludesExceeded { limit, .. } => {
+            assert_eq!(limit, 3, "error reports the configured limit");
+        }
+        other => panic!("expected TotalIncludesExceeded, got {other:?}"),
+    }
+}
+
+/// Total-include count is on a successful-load basis. A failed load
+/// (NotFound, etc.) should not consume budget — otherwise the user
+/// gets a confusing TotalIncludesExceeded for a doc with mostly-broken
+/// links.
+#[test]
+fn total_includes_limit_only_counts_successful_loads() {
+    let mut loader = MemoryLoader::new();
+    loader.insert("/repo/leaf.lex", "Body.\n");
+    // 1 broken + 2 working = 2 successful loads, well under limit of 5.
+    let host = "1. Host\n\n    :: lex.include src=\"missing.lex\" ::\n";
+    loader.insert("/repo/main.lex", host);
+    let config = ResolveConfig {
+        root: PathBuf::from(TEST_ROOT),
+        max_depth: 8,
+        max_total_includes: 5,
+    };
+    let result = resolve_from_source(
+        host,
+        Some(PathBuf::from(DEFAULT_MAIN_PATH)),
+        &config,
+        &loader,
+    );
+    // Should fail with NotFound, not TotalIncludesExceeded.
+    match result.expect_err("missing include must surface NotFound") {
+        IncludeError::NotFound { .. } => {}
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+/// FsLoader's `max_file_size` rejects oversize files before reading.
+/// We construct a file just above the limit so the test stays small
+/// (default test budget = 1 KiB; real file = 2 KiB).
+#[test]
+fn fsloader_rejects_file_exceeding_max_size() {
+    let (_dir, root) = canonical_tempdir();
+    let target = root.join("oversize.lex");
+    let body = "x".repeat(2 * 1024); // 2 KiB
+    std::fs::write(&target, &body).unwrap();
+
+    let loader = FsLoader::new(root.clone()).with_max_file_size(1024);
+    match loader
+        .load(&target)
+        .expect_err("file over limit must be rejected")
+    {
+        LoadError::TooLarge { size, limit, .. } => {
+            assert_eq!(size, 2048, "reports actual size");
+            assert_eq!(limit, 1024, "reports configured limit");
+        }
+        other => panic!("expected TooLarge, got {other:?}"),
+    }
+}
+
+/// FsLoader at the default size limit accepts a small file. Pure
+/// regression check that the size machinery doesn't break the
+/// happy path.
+#[test]
+fn fsloader_accepts_small_file_under_default_limit() {
+    let (_dir, root) = canonical_tempdir();
+    let target = root.join("small.lex");
+    std::fs::write(&target, "Body.\n").unwrap();
+    let loader = FsLoader::new(root.clone());
+    let loaded = loader.load(&target).expect("small file loads");
+    assert_eq!(loaded.source, "Body.\n");
+}
+
+/// `LoadError::TooLarge` from the loader maps to
+/// `IncludeError::FileTooLarge` with the offending annotation site.
+#[test]
+fn file_too_large_carries_include_site() {
+    // Custom loader that always reports TooLarge for the requested
+    // file. Avoids needing a real on-disk oversize file in this test.
+    struct AlwaysTooLargeLoader;
+    impl Loader for AlwaysTooLargeLoader {
+        fn load(&self, path: &std::path::Path) -> Result<LoadedFile, LoadError> {
+            Err(LoadError::TooLarge {
+                path: path.to_path_buf(),
+                size: 100,
+                limit: 50,
+            })
+        }
+    }
+    let cfg = ResolveConfig::with_root(PathBuf::from("/repo"));
+    let entry = ":: lex.include src=\"big.lex\" ::\n";
+    let result = resolve_from_source(
+        entry,
+        Some(PathBuf::from("/repo/main.lex")),
+        &cfg,
+        &AlwaysTooLargeLoader,
+    );
+    match result.expect_err("too-large include must error") {
+        IncludeError::FileTooLarge {
+            include_site,
+            path,
+            size,
+            limit,
+        } => {
+            assert_eq!(size, 100);
+            assert_eq!(limit, 50);
+            assert_eq!(path, PathBuf::from("/repo/big.lex"));
+            // Site must locate the annotation, not be the default.
+            assert_ne!(include_site, crate::lex::ast::Range::default());
+        }
+        other => panic!("expected FileTooLarge, got {other:?}"),
     }
 }

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -360,13 +360,16 @@ where
         let cfg = self.config.read().await;
         let inc_root = inc_root_for(&path, &cfg);
         let max_depth = cfg.includes.max_depth;
+        let max_total_includes = cfg.includes.max_total_includes;
+        let max_file_size = cfg.includes.max_file_size;
         drop(cfg);
 
         let resolve_config = ResolveConfig {
             root: inc_root.clone(),
             max_depth,
+            max_total_includes,
         };
-        let loader = FsLoader::new(inc_root);
+        let loader = FsLoader::new(inc_root).with_max_file_size(max_file_size);
 
         match resolve_from_source(text, Some(path), &resolve_config, &loader) {
             Ok(_doc) => {
@@ -1494,9 +1497,10 @@ fn absolutize_path(p: &Path) -> PathBuf {
 ///
 /// The diagnostic's range points at the offending `lex.include`
 /// annotation when the error carries one (Cycle, DepthExceeded,
-/// NotFound, ContainerPolicy, MissingSrc); otherwise it falls back to the
-/// document head (line 0, column 0) so the user at least sees something
-/// in the editor's diagnostics panel.
+/// NotFound, ContainerPolicy, MissingSrc, TotalIncludesExceeded,
+/// FileTooLarge); otherwise it falls back to the document head
+/// (line 0, column 0) so the user at least sees something in the
+/// editor's diagnostics panel.
 fn include_error_to_diagnostic(err: &IncludeError) -> Diagnostic {
     let (range, code, message) = match err {
         IncludeError::Cycle { include_site, .. } => {
@@ -1523,6 +1527,16 @@ fn include_error_to_diagnostic(err: &IncludeError) -> Diagnostic {
         IncludeError::MissingSrc { include_site } => (
             to_lsp_range(include_site),
             "include-missing-src",
+            err.to_string(),
+        ),
+        IncludeError::TotalIncludesExceeded { include_site, .. } => (
+            to_lsp_range(include_site),
+            "include-total-exceeded",
+            err.to_string(),
+        ),
+        IncludeError::FileTooLarge { include_site, .. } => (
+            to_lsp_range(include_site),
+            "include-file-too-large",
             err.to_string(),
         ),
     };


### PR DESCRIPTION
## Summary

Addresses item #3 from the security review: bounds resolver work against adversarial input.

\`max_depth\` (already present, default 8) caps chain length but a doc with thousands of includes at depth 1 still blows past available memory. Likewise, an attacker could point an include at a 1 GB file and the resolver would happily allocate. These two new knobs close the gap.

## Limits

| Knob | Default | Where |
|---|---|---|
| \`max_total_includes\` | 1000 | \`ResolveConfig\` (resolver-tracked). Counts successful loads across the whole walk; the include that pushes the count past the limit aborts with \`TotalIncludesExceeded\`. |
| \`max_file_size\` | 10 MiB | \`FsLoader\` (loader-enforced). Checked via \`meta.len()\` after the regular-file check, before any bytes hit memory. Surfaces as \`LoadError::TooLarge\` → \`IncludeError::FileTooLarge\`. |

Both configurable via new \`[includes].max_total_includes\` and \`[includes].max_file_size\` keys in \`lex.toml\`.

## Defaults rationale

- **1000 total includes**: a book-length doc with thousands of small fragments stays inside; adversarial fan-out (10k siblings at depth 1) is contained within a few seconds of resolver work.
- **10 MiB per file**: realistic Lex source documents are text, tens of KB at most. 10 MiB is enormous (probably 20k+ pages) and tight enough to bound per-include memory against an adversarial 1 GB file.

Both can be widened or tightened per project. Tests cover both edges.

## New error variants + LSP codes

- \`IncludeError::TotalIncludesExceeded { include_site, limit }\` → \`include-total-exceeded\`
- \`IncludeError::FileTooLarge { include_site, path, size, limit }\` → \`include-file-too-large\`

Both carry \`include_site\` so the squiggle lands on the offending annotation.

## Notable behavior detail

Failed loads (NotFound, etc.) don't consume the total-includes budget — otherwise a doc with mostly-broken links would surface as \`TotalIncludesExceeded\` rather than the actual underlying problem. Verified by \`total_includes_limit_only_counts_successful_loads\`.

## Test plan

5 new tests in \`crates/lex-core/src/lex/includes/tests.rs\`:
- breadth-fan-out trips total limit (5 sibling includes vs limit=3)
- failed loads don't consume total budget
- FsLoader rejects 2 KiB file against 1 KiB limit
- FsLoader at default limit accepts a small file
- LoadError::TooLarge from a custom loader correctly maps to IncludeError::FileTooLarge with the annotation site

- [x] \`cargo nextest run --workspace\` — 1647/1647 green locally
- [ ] CI green

## Stack

Builds on #502 (security hardening). Will be followed by a small PR for item #4 (reject absolute include src up front).