### PR TITLE
fix(includes): reject platform-absolute include src up front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `lex-core::includes`: platform-absolute include `src` (Windows `C:\foo`, `\\server\share`, `\foo`) is now rejected up front in `resolve_path` with the new `IncludeError::AbsolutePath` variant instead of relying on `PathBuf::join`'s "absolute replaces base" semantics + the downstream root-escape check. The spec forbids absolute filesystem paths from entering the resolution pipeline; this holds the line at the input boundary and surfaces a clear "use relative or root-absolute" message instead of a misleading "escapes root" error. The root-absolute form (leading `/` against the includes root) is unchanged. Addresses item #4 from the security review. (#TBD)
+
 ### Added
 
-- `lex-core::includes`: resource limits to bound resolver work against adversarial input. `ResolveConfig::max_total_includes` (default 1000) caps the total number of `lex.include` annotations resolved across the entire document — `max_depth` alone bounds chain length but a doc with thousands of includes at depth 1 still blows past it. `FsLoader::with_max_file_size(bytes)` (default 10 MiB) caps per-include file size; oversize files are rejected before any bytes hit memory. Both are surfaced as their own `IncludeError` variants (`TotalIncludesExceeded`, `FileTooLarge`) with `include_site` for editor diagnostics. Configurable via new `[includes].max_total_includes` and `[includes].max_file_size` keys in `lex.toml`. Addresses item #3 from the security review. (#TBD)
+- `lex-core::includes`: resource limits to bound resolver work against adversarial input. `ResolveConfig::max_total_includes` (default 1000) caps the total number of `lex.include` annotations resolved across the entire document — `max_depth` alone bounds chain length but a doc with thousands of includes at depth 1 still blows past it. `FsLoader::with_max_file_size(bytes)` (default 10 MiB) caps per-include file size; oversize files are rejected before any bytes hit memory. Both are surfaced as their own `IncludeError` variants (`TotalIncludesExceeded`, `FileTooLarge`) with `include_site` for editor diagnostics. Configurable via new `[includes].max_total_includes` and `[includes].max_file_size` keys in `lex.toml`. Addresses item #3 from the security review. (#503)
 
 ### Security
 

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -219,6 +219,17 @@ pub enum IncludeError {
     },
     /// A path resolved outside the configured [`ResolveConfig::root`].
     RootEscape { path: PathBuf, root: PathBuf },
+    /// The include `src` was a platform-absolute filesystem path
+    /// (e.g. Windows `C:\foo`, `\\server\share`, `\foo`). The spec
+    /// forbids absolute filesystem paths from entering the
+    /// resolution pipeline; the *root-absolute* form (leading `/`
+    /// resolved against the includes root) is the only spec-allowed
+    /// way to write a path that doesn't start from the host's
+    /// directory. On Unix the only thing that's `Path::is_absolute()`
+    /// is a leading `/`, which is consumed by the root-absolute
+    /// branch first; this variant therefore only fires in practice
+    /// for Windows-shaped absolute paths.
+    AbsolutePath { path: PathBuf },
     /// The loader could not find or read the included file. `include_site`
     /// is the range of the offending `lex.include` annotation in its host
     /// file, so editors can squiggle the line that asked for the missing
@@ -286,6 +297,13 @@ impl std::fmt::Display for IncludeError {
                 "include path {} escapes resolution root {}",
                 path.display(),
                 root.display()
+            ),
+            IncludeError::AbsolutePath { path } => write!(
+                f,
+                "include src {} is a platform-absolute path; \
+                 the spec forbids absolute filesystem paths — use a relative path \
+                 (chapters/01.lex) or a root-absolute path (/shared/01.lex)",
+                path.display()
             ),
             IncludeError::NotFound { path, .. } => {
                 write!(f, "include not found: {}", path.display())
@@ -775,10 +793,27 @@ pub fn resolve_file_reference(
 
 fn resolve_path(src: &str, host_dir: &Path, root: &Path) -> Result<PathBuf, IncludeError> {
     let candidate = if let Some(rel) = src.strip_prefix('/') {
-        // Root-absolute: leading slash means "from the resolution root".
+        // Root-absolute (Lex spec convention): leading `/` means "from
+        // the resolution root", not "filesystem root".
         root.join(rel)
     } else {
-        // Relative: from the host file's directory.
+        // Anything else must be a relative path. Reject inputs the
+        // host platform would treat as absolute (Windows `C:\foo`,
+        // `\\server\share`, `\foo`) up front: the spec forbids
+        // platform-absolute paths from entering the resolution
+        // pipeline. Without this, `host_dir.join(src)` would silently
+        // discard `host_dir` because Rust's `PathBuf::join` replaces
+        // the base when the joined path is absolute. The downstream
+        // root-escape check would still catch the security side, but
+        // we'd surface a misleading "escapes root" error instead of
+        // "absolute paths not allowed", and we'd be relying on
+        // `PathBuf::join`'s override semantics for the security
+        // outcome rather than holding the line at the input boundary.
+        if Path::new(src).is_absolute() {
+            return Err(IncludeError::AbsolutePath {
+                path: PathBuf::from(src),
+            });
+        }
         host_dir.join(src)
     };
     let normalized = lexical_normalize(&candidate);

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -1709,3 +1709,62 @@ fn file_too_large_carries_include_site() {
         other => panic!("expected FileTooLarge, got {other:?}"),
     }
 }
+
+// ============================================================================
+// Absolute-path rejection (#4 from security review)
+// ============================================================================
+
+/// Root-absolute paths (leading `/` per spec convention) keep working
+/// after the `is_absolute()` rejection lands. Regression test: the
+/// rejection must sit *after* the strip_prefix branch.
+#[test]
+fn root_absolute_leading_slash_still_works() {
+    let mut loader = MemoryLoader::new();
+    loader.insert("/repo/leaf.lex", "Body.\n");
+    loader.insert("/repo/main.lex", ":: lex.include src=\"/leaf.lex\" ::\n");
+    let cfg = ResolveConfig::with_root(PathBuf::from("/repo"));
+    let _doc = resolve_from_source(
+        ":: lex.include src=\"/leaf.lex\" ::\n",
+        Some(PathBuf::from("/repo/main.lex")),
+        &cfg,
+        &loader,
+    )
+    .expect("root-absolute (leading /) include must still resolve");
+}
+
+/// Windows-shaped absolute paths (`C:\foo`) trip `Path::is_absolute()`
+/// only on Windows runners — on Unix `C:\` parses as a relative path
+/// with `C:` as a literal directory name. Test gated accordingly.
+#[cfg(windows)]
+#[test]
+fn windows_absolute_path_is_rejected_up_front() {
+    let cfg = ResolveConfig::with_root(PathBuf::from("C:\\repo"));
+    let loader = MemoryLoader::new();
+    let result = resolve_from_source(
+        ":: lex.include src=\"C:\\\\secret.txt\" ::\n",
+        Some(PathBuf::from("C:\\repo\\main.lex")),
+        &cfg,
+        &loader,
+    );
+    match result.expect_err("Windows-absolute src must be rejected") {
+        IncludeError::AbsolutePath { path } => {
+            assert_eq!(path, PathBuf::from("C:\\secret.txt"));
+        }
+        other => panic!("expected AbsolutePath, got {other:?}"),
+    }
+}
+
+/// Display message names the offending path and points the user at
+/// the two spec-allowed shapes.
+#[test]
+fn absolute_path_error_message_is_actionable() {
+    let err = IncludeError::AbsolutePath {
+        path: PathBuf::from("C:\\secret.txt"),
+    };
+    let s = err.to_string();
+    assert!(s.contains("C:\\secret.txt"), "names the offending path");
+    assert!(
+        s.contains("relative") && s.contains("root-absolute"),
+        "points the user at the two spec-allowed shapes; got: {s}"
+    );
+}

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1512,6 +1512,9 @@ fn include_error_to_diagnostic(err: &IncludeError) -> Diagnostic {
             err.to_string(),
         ),
         IncludeError::RootEscape { .. } => (head_range(), "include-root-escape", err.to_string()),
+        IncludeError::AbsolutePath { .. } => {
+            (head_range(), "include-absolute-path", err.to_string())
+        }
         IncludeError::NotFound { include_site, .. } => (
             to_lsp_range(include_site),
             "include-not-found",


### PR DESCRIPTION
## Summary

Addresses item #4 from the security review: \"Bypassing 'No Absolute Paths' Rule via Windows Drive Letters\".

\`resolve_path\` now rejects platform-absolute paths (\`C:\\foo\`, \`\\\\server\\share\`, \`\\foo\`) up front with the new \`IncludeError::AbsolutePath { path }\` variant.

## Why this matters

Reviewer correctly notes the existing root-escape check already catches these (so it's not a security exploit), but:

1. **Misleading error**: the user got \"escapes root\" when they actually gave an absolute path. \"Use relative or root-absolute\" is more actionable.
2. **Fragile reliance on \`PathBuf::join\` semantics**: \`host_dir.join(\"C:\\\\foo\")\` silently replaces \`host_dir\` with \`C:\\foo\` (Rust's behavior on absolute join). Security currently rides on that override → root-escape catching the result. Holding the line at the input boundary is more honest.
3. **Spec strictness**: the spec explicitly forbids \"absolute filesystem paths from entering the resolution pipeline\". Today, they enter and then get blocked downstream; this PR enforces what the spec says.

## Behavior

- Root-absolute (\`/leaf.lex\` resolved against includes root): **unchanged**, still works as before. The strip_prefix branch consumes that input before the new check.
- Relative (\`chapters/01.lex\`, \`./shared/header.lex\`): **unchanged**.
- Platform-absolute on Windows (\`C:\\foo\`): **rejected with \`IncludeError::AbsolutePath\`**.
- Platform-absolute on Unix: \`Path::is_absolute()\` only returns true for leading \`/\`, which the strip_prefix branch already handles. The new check is a no-op on Unix → no behavior change for Unix users.

## LSP

New diagnostic code: \`include-absolute-path\`. Falls back to document head (matches RootEscape's pattern; threading \`include_site\` through \`resolve_path\` would be more change than this fix warrants).

## Test plan

3 new tests:
- \`root_absolute_leading_slash_still_works\` — portable regression. Confirms the rejection sits *after* strip_prefix.
- \`windows_absolute_path_is_rejected_up_front\` — \`cfg(windows)\` end-to-end test that \`C:\\foo\` produces \`IncludeError::AbsolutePath\`.
- \`absolute_path_error_message_is_actionable\` — Display message names the offending path and points the user at the two spec-allowed shapes.

- [x] \`cargo nextest run --workspace\` — 1650/1650 green locally (60/60 on lex-core::includes; the cfg(windows) test skips on macOS)
- [ ] CI green

## Stack

Final fix from the security review trio (#502 symlink hardening, #503 resource limits, this one). Ready for a v0.10.2 release that bundles all three.