### PR TITLE
ci(wasm): wasm32 build + wasm-pack CI job (PR 2 of 5 for #465)

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -41,6 +41,42 @@ jobs:
       - name: Test
         run: cargo nextest run --workspace --exclude lex-wasm
 
+  wasm:
+    name: WASM build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Rust (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm32
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build lex-wasm for wasm32-unknown-unknown
+        run: cargo build -p lex-wasm --target wasm32-unknown-unknown
+
+      - name: wasm-pack build (web target)
+        run: wasm-pack build crates/lex-wasm --target web --out-dir pkg
+
+      - name: Verify wasm-pack artifacts
+        run: |
+          test -f crates/lex-wasm/pkg/lex_wasm_bg.wasm
+          test -f crates/lex-wasm/pkg/lex_wasm.js
+          test -f crates/lex-wasm/pkg/lex_wasm.d.ts
+          test -f crates/lex-wasm/pkg/package.json
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 **/*.rs.bk
 *.pdb
 
+# wasm-pack output
+crates/lex-wasm/pkg/
+
 # Coverage files
 lcov.info
 coverage/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 
 [workspace.dependencies]
 lex-core = { version = "0.10.2", path = "crates/lex-core" }
-lex-babel = { version = "0.10.2", path = "crates/lex-babel", default-features = true }
+lex-babel = { version = "0.10.2", path = "crates/lex-babel", default-features = false }
 lex-config = { version = "0.10.2", path = "crates/lex-config" }
 lex-analysis = { version = "0.10.2", path = "crates/lex-analysis" }
 lex-lsp-core = { version = "0.10.2", path = "crates/lex-lsp-core" }

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 [dependencies]
 lex-core = { workspace = true }
 lex-analysis = { workspace = true }
-lex-babel = { workspace = true }
+lex-babel = { workspace = true, features = ["native-export"] }
 lex-config = { workspace = true }
 clapfig = { workspace = true }
 clap = { workspace = true }

--- a/crates/lex-wasm/Cargo.toml
+++ b/crates/lex-wasm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 lex-core = { workspace = true }
 lex-analysis = { workspace = true }
-lex-babel = { workspace = true, default-features = false }
+lex-babel = { workspace = true }
 lex-lsp-core = { workspace = true }
 lsp-types = { workspace = true }
 spellbook = "0.4"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
 channel = "1.88.0"
 components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

- New `WASM build` CI job in `test-rust.yml`: installs wasm32-unknown-unknown + wasm-pack, builds `lex-wasm` for wasm32, runs `wasm-pack build --target web`, and verifies the artifact set.
- Flipped `lex-babel` workspace dep to `default-features = false` and made `lex-cli` opt in to `native-export` explicitly. The previous default pulled `which` (incomplete `Sys` impl on wasm32) into every `lex-babel` consumer including `lex-wasm`. Native-export (PDF/PNG via Pandoc) is a CLI-only concern.

PR 2 of 5 for #465. Concretely closes risk #1: `spellbook` compiles cleanly on wasm32.

## Test plan
- [x] `cargo build -p lex-wasm --target wasm32-unknown-unknown` (local)
- [x] `wasm-pack build crates/lex-wasm --target web` produces `lex_wasm_bg.wasm` + JS/TS bindings (3.4 MB optimized wasm)
- [x] Native workspace tests still green (1647 / 1647)
- [x] `cargo run -p lexd -- --help` works (PDF/PNG paths still feature-gated correctly via the explicit opt-in)
- [ ] CI job passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)