### PR TITLE
feat(wasm): publish @lex-fmt/lex-wasm to npm (PR 3 of 5 for #465)

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -1,0 +1,66 @@
+name: Release WASM (npm)
+
+# Publishes @lex-fmt/lex-wasm to npm whenever a workspace release tag
+# (vX.Y.Z) is pushed by the canonical Rust release pipeline.
+#
+# The Rust release workflow at `.github/workflows/release.yml` calls
+# `arthur-debert/release/.../rust-cli.yml@v1`, which bumps Cargo.toml
+# versions across the workspace (lex-wasm included), commits, and pushes
+# `vX.Y.Z` using a PAT (RELEASE_TOKEN). PAT-pushed tags trigger downstream
+# workflows, so this job fires automatically without an explicit hand-off.
+#
+# wasm-pack reads the version from `crates/lex-wasm/Cargo.toml`, so the
+# npm package version stays in lockstep with the Rust crates.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    name: Publish @lex-fmt/lex-wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Rust (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm32-release
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build wasm package
+        run: wasm-pack build crates/lex-wasm --target bundler --scope lex-fmt --out-dir pkg
+
+      - name: Confirm tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(jq -r .version crates/lex-wasm/pkg/package.json)
+          if [ "$tag" != "$pkg" ]; then
+            echo "Tag ($tag) does not match package version ($pkg)" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        working-directory: crates/lex-wasm/pkg
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -67,15 +67,20 @@ jobs:
       - name: Build lex-wasm for wasm32-unknown-unknown
         run: cargo build -p lex-wasm --target wasm32-unknown-unknown
 
-      - name: wasm-pack build (web target)
-        run: wasm-pack build crates/lex-wasm --target web --out-dir pkg
+      - name: wasm-pack build (bundler target, scoped)
+        run: wasm-pack build crates/lex-wasm --target bundler --scope lex-fmt --out-dir pkg
 
       - name: Verify wasm-pack artifacts
         run: |
           test -f crates/lex-wasm/pkg/lex_wasm_bg.wasm
           test -f crates/lex-wasm/pkg/lex_wasm.js
+          test -f crates/lex-wasm/pkg/lex_wasm_bg.js
           test -f crates/lex-wasm/pkg/lex_wasm.d.ts
           test -f crates/lex-wasm/pkg/package.json
+          test -f crates/lex-wasm/pkg/README.md
+          test -f crates/lex-wasm/pkg/LICENSE
+          # Sanity-check the published name
+          grep -q '"name": "@lex-fmt/lex-wasm"' crates/lex-wasm/pkg/package.json
 
   docs:
     name: Documentation

--- a/crates/lex-wasm/LICENSE
+++ b/crates/lex-wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lex Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/lex-wasm/README.md
+++ b/crates/lex-wasm/README.md
@@ -1,0 +1,45 @@
+# @lex-fmt/lex-wasm
+
+WebAssembly bindings for the [Lex](https://github.com/lex-fmt/lex) language —
+parser, semantic analysis, formatting, and HTML export running entirely in the
+browser. No server round-trip, no native dependency.
+
+These bindings expose the same sync feature surface as `lexd-lsp` (the stdio
+LSP server), routed through the shared `lex-lsp-core` crate. Editors that
+already speak the Language Server Protocol can drive the WASM module via a
+WebWorker transport instead of stdio.
+
+## Install
+
+```sh
+npm install @lex-fmt/lex-wasm
+```
+
+## Usage
+
+```js
+import init, { LexDocument } from "@lex-fmt/lex-wasm";
+
+await init();
+const doc = LexDocument.new("Section:\n\n    - item one\n");
+console.log(doc.format());
+```
+
+The module ships as ESM with TypeScript declarations. Use the `web` target if
+you load it directly in the browser without a bundler; this package is built
+with `--target bundler`, intended for Vite, webpack, esbuild, etc.
+
+## Features
+
+- Parsing and AST inspection (`LexDocument.new`, `toHtml`)
+- LSP-equivalent providers: semantic tokens, document symbols, hover,
+  goto-definition, references, folding, completion, diagnostics
+- Spellcheck against an embedded en_US dictionary (`EmbeddedSpellchecker`)
+- Document formatting (`format`)
+
+See the [main repository](https://github.com/lex-fmt/lex) for the Lex language
+reference and editor integrations (VS Code, Neovim, Lexed).
+
+## License
+
+MIT — see [LICENSE](https://github.com/lex-fmt/lex/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- New `Release WASM (npm)` workflow triggered on `vX.Y.Z` tag push (the same tag the Rust release pipeline produces). Builds with `wasm-pack --target bundler --scope lex-fmt`, asserts the tarball version matches the tag, and `npm publish --access public`.
- CI smoke build (`test-rust.yml`) switched to the same `--target bundler --scope lex-fmt` we publish, with extra artifact assertions (`README.md`, `LICENSE`, scoped name in `package.json`).
- Added `crates/lex-wasm/README.md` and `crates/lex-wasm/LICENSE` so wasm-pack includes them in the published tarball.

PR 3 of 5 for #465.

## Operator note

The workflow needs **`NPM_TOKEN`** in repo secrets (npm automation token with publish access to the `@lex-fmt` scope) before the next release will publish. Until then the workflow will run on tag push and fail on the publish step — which is acceptable as long as the operator knows.

## Test plan

- [x] `wasm-pack build crates/lex-wasm --target bundler --scope lex-fmt` produces `@lex-fmt/lex-wasm@0.10.2` locally
- [x] `npm pack --dry-run` from `pkg/` shows the expected tarball: 7 files, 1.3 MB packed (3.6 MB unpacked), proper README/LICENSE included, no LICENSE warning
- [x] CI WASM build green on this branch (artifact assertions all pass)
- [ ] First post-merge release tag publishes to npmjs.org
- [ ] `npm install @lex-fmt/lex-wasm` from a downstream consumer works

🤖 Generated with [Claude Code](https://claude.com/claude-code)