### PR TITLE
docs(changelog): seed Unreleased for v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Release pipeline consolidation: WASM/npm publishing is now part of
+  the canonical `arthur-debert/release@v1.2.0` rust-cli workflow
+  (opt-in via `wasm-package` input). Replaces the separate
+  `release-wasm.yml` workflow that re-installed Rust and recompiled the
+  workspace dep tree. One tag, one workflow run, one operator dashboard
+  view — `crates.io`, GH release tarballs (incl. `lex-wasm-wasm.tar.gz`
+  for direct-download consumers), Homebrew, and `npm` all ship from a
+  single pipeline. (#510)
+- `lex-lsp-core` is now part of the cargo publish list so its version
+  ships to crates.io in lockstep with the rest of the workspace.
+
 ## [0.10.3] - 2026-05-06
 
 


### PR DESCRIPTION
## Summary

`prepare-release` rejects empty `## [Unreleased]` sections. Seed the
entry that the upcoming v0.10.4 release will roll: pipeline
consolidation (#510) plus the lex-lsp-core publish-list addition since
v0.10.3.

This unblocks the v0.10.4-rc.1 release run that is verifying the new
WASM/npm slot end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)