### PR TITLE
fix(lex-core): scope DocumentLink ranges to the bracketed reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `lex-core::ast::links::find_all_links` now returns
+  `DocumentLink` ranges that cover only the `[bracketed]` reference,
+  not the containing paragraph or title line. Editors render LSP
+  `textDocument/documentLink` ranges as clickable underlined link
+  surfaces; the previous code used `paragraph.range()` (with a comment
+  acknowledging the limitation: "we don't have inline-level ranges
+  yet") for URL and File reference types, so any paragraph containing
+  a `[https://…]` or `[./path]` reference was rendered end-to-end as
+  one giant link in VSCode. A new internal `ReferenceLocator` walks
+  the inline tree with the same cursor / escape logic that
+  `lex-analysis::semantic_tokens::InlineWalker` uses, producing
+  precise byte and `Position` ranges for each URL/File reference.
+  Verbatim `src` parameters retain their verbatim-block range
+  (they aren't bracketed inline references). Existing extraction
+  tests only asserted `target` + `link_type`, never `range`; new
+  tests lock in the bracket-bounded invariant.
+
 ### Changed
 
 - Release pipeline consolidation: WASM/npm publishing is now part of

--- a/crates/lex-core/src/lex/ast/links.rs
+++ b/crates/lex-core/src/lex/ast/links.rs
@@ -28,9 +28,10 @@
 //! 3. **Verbatim src**: `:: image src=./image.png ::` - External resource references
 
 use super::elements::Verbatim;
-use super::range::Range;
+use super::range::{Position, Range};
+use super::text_content::TextContent;
 use super::{Document, Session};
-use crate::lex::inlines::{InlineNode, ReferenceType};
+use crate::lex::inlines::{InlineNode, ReferenceInline, ReferenceType};
 use std::fmt;
 
 /// Represents a document link with its location and type
@@ -123,66 +124,21 @@ impl Session {
 
         let mut links = Vec::new();
 
-        // Check for links in the session title
-        if let Some(inlines) = self.title.inlines() {
-            for inline in inlines {
-                if let InlineNode::Reference { data, .. } = inline {
-                    match &data.reference_type {
-                        ReferenceType::Url { target } => {
-                            // Use header location if available, otherwise session location
-                            let range = self.header_location().unwrap_or(&self.location).clone();
-                            let link = DocumentLink::new(range, target.clone(), LinkType::Url);
-                            links.push(link);
-                        }
-                        ReferenceType::File { target } => {
-                            let range = self.header_location().unwrap_or(&self.location).clone();
-                            let link = DocumentLink::new(range, target.clone(), LinkType::File);
-                            links.push(link);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
+        // Links in the session title — bracket-bounded ranges so editors only
+        // decorate the reference, not the whole title line.
+        collect_text_content_links(&self.title, &mut links);
 
-        // Use existing iter_all_references() API to find URL and File references
+        // Paragraphs (recursively into nested sessions).
         for paragraph in self.iter_paragraphs_recursive() {
             for line_item in &paragraph.lines {
                 if let ContentItem::TextLine(line) = line_item {
-                    // Use inlines() method which returns the parsed inlines without requiring mutable access
-                    if let Some(inlines) = line.content.inlines() {
-                        for inline in inlines {
-                            if let InlineNode::Reference { data, .. } = inline {
-                                match &data.reference_type {
-                                    ReferenceType::Url { target } => {
-                                        // Use paragraph's range since we don't have inline-level ranges yet
-                                        let link = DocumentLink::new(
-                                            paragraph.range().clone(),
-                                            target.clone(),
-                                            LinkType::Url,
-                                        );
-                                        links.push(link);
-                                    }
-                                    ReferenceType::File { target } => {
-                                        let link = DocumentLink::new(
-                                            paragraph.range().clone(),
-                                            target.clone(),
-                                            LinkType::File,
-                                        );
-                                        links.push(link);
-                                    }
-                                    _ => {
-                                        // Other reference types are not clickable links
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    collect_text_content_links(&line.content, &mut links);
                 }
             }
         }
 
-        // Iterate all verbatim blocks to find src parameters
+        // Verbatim `src` parameters — these aren't bracketed inline references,
+        // so the verbatim's range stays as-is.
         for (item, _depth) in self.iter_all_nodes_with_depth() {
             if let ContentItem::VerbatimBlock(verbatim) = item {
                 if let Some(src) = verbatim.src_parameter() {
@@ -223,29 +179,158 @@ impl Document {
     pub fn find_all_links(&self) -> Vec<DocumentLink> {
         let mut links = Vec::new();
         if let Some(title) = &self.title {
-            if let Some(inlines) = title.content.inlines() {
-                for inline in inlines {
-                    if let crate::lex::inlines::InlineNode::Reference { data, .. } = inline {
-                        let range = title.location.clone();
-                        match &data.reference_type {
-                            crate::lex::inlines::ReferenceType::Url { target } => {
-                                links.push(DocumentLink::new(range, target.clone(), LinkType::Url));
-                            }
-                            crate::lex::inlines::ReferenceType::File { target } => {
-                                links.push(DocumentLink::new(
-                                    range,
-                                    target.clone(),
-                                    LinkType::File,
-                                ));
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
+            collect_text_content_links(&title.content, &mut links);
         }
         links.extend(self.root.find_all_links());
         links
+    }
+}
+
+/// Walks `text`'s inline tree and pushes a [`DocumentLink`] for each URL and
+/// File reference, with a range covering exactly the `[bracketed]` reference.
+///
+/// LSP `textDocument/documentLink` ranges drive the clickable + visually
+/// underlined area in editors. Using the containing paragraph or title range
+/// would underline the whole element — which is exactly the bug this function
+/// is replacing.
+///
+/// The cursor logic mirrors `lex-analysis::semantic_tokens::InlineWalker`
+/// (which produces semantic-token ranges over the same raw text). The two
+/// implementations must stay in sync; consolidating them into a single
+/// inline-position walker in `lex-core` is a follow-up.
+fn collect_text_content_links(text: &TextContent, out: &mut Vec<DocumentLink>) {
+    let Some(base_range) = text.location.as_ref() else {
+        return;
+    };
+    let Some(nodes) = text.inlines() else {
+        return;
+    };
+    let raw = text.as_string();
+    if raw.is_empty() {
+        return;
+    }
+    let mut locator = ReferenceLocator {
+        raw,
+        base_range,
+        cursor: 0,
+    };
+    locator.walk_nodes(nodes, out);
+}
+
+/// Cursor-tracking walker that produces precise byte/position ranges for
+/// inline `Reference` nodes. Only emits links for URL and File reference
+/// types; other types intentionally fall through (footnote/citation/session/
+/// annotation/TK refs do not become document links).
+struct ReferenceLocator<'a> {
+    raw: &'a str,
+    base_range: &'a Range,
+    cursor: usize,
+}
+
+impl<'a> ReferenceLocator<'a> {
+    fn walk_nodes(&mut self, nodes: &'a [InlineNode], out: &mut Vec<DocumentLink>) {
+        for node in nodes {
+            self.walk_node(node, out);
+        }
+    }
+
+    fn walk_node(&mut self, node: &'a InlineNode, out: &mut Vec<DocumentLink>) {
+        match node {
+            InlineNode::Plain { text, .. } => self.advance_unescaped(text),
+            InlineNode::Strong { content, .. } => self.walk_container(content, '*', out),
+            InlineNode::Emphasis { content, .. } => self.walk_container(content, '_', out),
+            InlineNode::Code { text, .. } => self.skip_literal(text, '`'),
+            InlineNode::Math { text, .. } => self.skip_literal(text, '#'),
+            InlineNode::Reference { data, .. } => self.emit_reference(data, out),
+        }
+    }
+
+    fn walk_container(
+        &mut self,
+        content: &'a [InlineNode],
+        marker: char,
+        out: &mut Vec<DocumentLink>,
+    ) {
+        let m = marker.len_utf8();
+        self.cursor += m;
+        self.walk_nodes(content, out);
+        self.cursor += m;
+    }
+
+    fn skip_literal(&mut self, text: &str, marker: char) {
+        let m = marker.len_utf8();
+        self.cursor += m;
+        self.cursor += text.len();
+        self.cursor += m;
+    }
+
+    fn emit_reference(&mut self, data: &'a ReferenceInline, out: &mut Vec<DocumentLink>) {
+        let start = self.cursor;
+        // `[` + content + `]`. Reference content is literal — no escape rules
+        // apply, so the raw inline content length is the byte length.
+        self.cursor += 1 + data.raw.len() + 1;
+        let end = self.cursor;
+        let (target, link_type) = match &data.reference_type {
+            ReferenceType::Url { target } => (target.clone(), LinkType::Url),
+            ReferenceType::File { target } => (target.clone(), LinkType::File),
+            _ => return,
+        };
+        let range = self.make_range(start, end);
+        out.push(DocumentLink::new(range, target, link_type));
+    }
+
+    /// Mirrors the inline parser's escape rules so cursor advances through
+    /// raw bytes match each unescaped char emitted into a `Plain` node.
+    /// `\X` where `X` is non-alphanumeric → consumes 2 raw bytes (`\` + `X`)
+    /// for 1 unescaped char. Any other backslash stays literal.
+    fn advance_unescaped(&mut self, text: &str) {
+        for _expected in text.chars() {
+            if self.cursor >= self.raw.len() {
+                break;
+            }
+            let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
+            if raw_ch == '\\' {
+                if self.cursor + 1 >= self.raw.len() {
+                    self.cursor += 1;
+                } else {
+                    let next_ch = self.raw[self.cursor + 1..].chars().next();
+                    match next_ch {
+                        Some(nc) if !nc.is_alphanumeric() => {
+                            self.cursor += 1 + nc.len_utf8();
+                        }
+                        _ => {
+                            self.cursor += 1;
+                        }
+                    }
+                }
+            } else {
+                self.cursor += raw_ch.len_utf8();
+            }
+        }
+    }
+
+    fn make_range(&self, start: usize, end: usize) -> Range {
+        let start_pos = self.position_at(start);
+        let end_pos = self.position_at(end);
+        Range::new(
+            (self.base_range.span.start + start)..(self.base_range.span.start + end),
+            start_pos,
+            end_pos,
+        )
+    }
+
+    fn position_at(&self, offset: usize) -> Position {
+        let mut line = self.base_range.start.line;
+        let mut column = self.base_range.start.column;
+        for ch in self.raw[..offset].chars() {
+            if ch == '\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += ch.len_utf8();
+            }
+        }
+        Position::new(line, column)
     }
 }
 
@@ -367,5 +452,127 @@ mod tests {
         // Should find link in nested session
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].target, "https://example.com");
+    }
+
+    // -----------------------------------------------------------------------
+    // Range-precision tests
+    //
+    // The LSP `textDocument/documentLink` response uses each link's `range`
+    // to decide what is clickable and what gets the link decoration in the
+    // editor. Editors (notably VSCode) render the entire range as an
+    // underlined link. So the range must cover *only* the `[bracketed]`
+    // reference, not the surrounding paragraph or title line.
+    // -----------------------------------------------------------------------
+
+    use super::super::range::Position;
+
+    #[test]
+    fn test_url_link_range_is_bracket_bounded_in_paragraph() {
+        // Byte map of source line:
+        //   "Check out [https://example.com] for more info."
+        //    0123456789^                   ^
+        //              10                  30 (inclusive ']' position)
+        let source = "Check out [https://example.com] for more info.\n\n";
+        let doc = parse_document(source).unwrap();
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 1);
+        let link = &links[0];
+        assert_eq!(link.target, "https://example.com");
+
+        let captured = &source[link.range.span.clone()];
+        assert_eq!(
+            link.range.span,
+            10..31,
+            "DocumentLink range must cover only the [bracketed] reference, not the whole paragraph. \
+             Captured text: {captured:?}"
+        );
+        assert_eq!(link.range.start, Position::new(0, 10));
+        assert_eq!(link.range.end, Position::new(0, 31));
+    }
+
+    #[test]
+    fn test_file_link_range_is_bracket_bounded_in_paragraph() {
+        // Byte map of source line:
+        //   "See [./README.md] for details."
+        //    0123^         ^
+        //        4         16 (inclusive ']')
+        let source = "See [./README.md] for details.\n\n";
+        let doc = parse_document(source).unwrap();
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 1);
+        let link = &links[0];
+        assert_eq!(link.target, "./README.md");
+
+        let captured = &source[link.range.span.clone()];
+        assert_eq!(
+            link.range.span,
+            4..17,
+            "DocumentLink range must cover only the [bracketed] reference, not the whole paragraph. \
+             Captured text: {captured:?}"
+        );
+        assert_eq!(link.range.start, Position::new(0, 4));
+        assert_eq!(link.range.end, Position::new(0, 17));
+    }
+
+    #[test]
+    fn test_multiple_links_have_distinct_bracket_bounded_ranges() {
+        // Byte map:
+        //   "Visit [https://example.com] and check [./docs.md]."
+        //    0     6                    27          38       49
+        let source = "Visit [https://example.com] and check [./docs.md].\n\n";
+        let doc = parse_document(source).unwrap();
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 2);
+
+        let url = links
+            .iter()
+            .find(|l| l.link_type == LinkType::Url)
+            .expect("url link");
+        let file = links
+            .iter()
+            .find(|l| l.link_type == LinkType::File)
+            .expect("file link");
+
+        assert_eq!(
+            url.range.span,
+            6..27,
+            "URL link captured: {:?}",
+            &source[url.range.span.clone()]
+        );
+        assert_eq!(
+            file.range.span,
+            38..49,
+            "File link captured: {:?}",
+            &source[file.range.span.clone()]
+        );
+    }
+
+    #[test]
+    fn test_paragraph_with_only_other_text_around_url_does_not_include_them_in_range() {
+        // Reproduces the dodot architecture.lex case: a long paragraph that
+        // contains a single file reference. Before the fix, the link's range
+        // covered the whole paragraph so VSCode underlined every word.
+        let source = "\
+This document describes how dodot is organized. It is the conceptual view. \
+For concrete types, crate layout, and trait signatures, see [./types.lex].\n\n";
+        let doc = parse_document(source).unwrap();
+        let links = doc.find_all_links();
+
+        assert_eq!(links.len(), 1);
+        let link = &links[0];
+        assert_eq!(link.target, "./types.lex");
+
+        let bracket_start = source.find("[./types.lex]").expect("bracket present");
+        let bracket_end = bracket_start + "[./types.lex]".len();
+
+        let captured = &source[link.range.span.clone()];
+        assert_eq!(
+            link.range.span,
+            bracket_start..bracket_end,
+            "Link range must be bracket-bounded. Got captured text: {captured:?}"
+        );
     }
 }

--- a/crates/lex-core/src/lex/ast/links.rs
+++ b/crates/lex-core/src/lex/ast/links.rs
@@ -551,7 +551,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paragraph_with_only_other_text_around_url_does_not_include_them_in_range() {
+    fn test_long_paragraph_with_single_file_ref_does_not_include_surrounding_text_in_range() {
         // Reproduces the dodot architecture.lex case: a long paragraph that
         // contains a single file reference. Before the fix, the link's range
         // covered the whole paragraph so VSCode underlined every word.


### PR DESCRIPTION
## Summary

`Session::find_all_links` and `Document::find_all_links` produced `DocumentLink` ranges covering the entire containing paragraph or title line for URL and File reference types, because inline nodes do not carry source positions and the original implementation used `paragraph.range()` / `title.location` as a placeholder (with a comment acknowledging the limitation). Editors (notably VSCode) treat the LSP `textDocument/documentLink` range as the clickable + visually-underlined surface, so any paragraph containing `[https://...]` or `[./path]` was rendered end-to-end as one giant link.

This PR introduces an internal `ReferenceLocator` that walks the inline tree tracking byte offsets through the raw text, producing precise byte and `Position` ranges for each URL/File reference. The cursor and escape-handling logic mirrors `lex-analysis::semantic_tokens::InlineWalker`. Verbatim `src` parameters retain their verbatim-block range since they are not bracketed inline references.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only)
- [x] Project umbrella check passes locally — `cargo test --workspace --exclude lex-wasm` (1,656 tests pass), `cargo fmt -- --check`, `cargo clippy -- -D warnings`
- [x] Tests added or updated for behavior changes

## Notes for reviewers

- Existing tests in `links.rs` only asserted `target` + `link_type`, never `range` — that is how the bug went undetected. New tests in `mod tests` lock in the bracket-bounded invariant for URL refs in paragraphs, File refs in paragraphs, multiple refs on one line, and a dodot-style "long paragraph with single trailing file ref" case.
- The new `ReferenceLocator` cursor logic deliberately duplicates `lex-analysis::semantic_tokens::InlineWalker`. Consolidating into a shared `lex-core` walker is a planned follow-up; doing it in this PR would entangle the regression fix with a cross-module refactor.
- Two related issues uncovered while diagnosing this bug, intentionally left for separate follow-up PRs before the next release:
  - `Session::find_all_links` only checks its own title; nested-session titles never get scanned because `iter_paragraphs_recursive` yields paragraphs only.
  - The cursor-walker duplication mentioned above.
- No behavior change for footnote, citation, session, annotation, TK, or general references — those reference types intentionally do not become `DocumentLink`s and continue to fall through `_ => {}` (now in `ReferenceLocator::emit_reference`).