### PR TITLE
refactor(lex-core): consolidate inline-position walkers into shared visitor

### DIFF
--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -36,7 +36,7 @@
 //!         - Users get syntax highlighting that respects their theme
 //!         - Mapping logic is isolated to editor plugins; adding a new editor doesn't touch the LSP
 //!
-//! The file editors/vscode/themes/lex-light.json has the reocommended theming for Lex to be used in
+//! The file editors/vscode/themes/lex-light.json has the recommended theming for Lex to be used in
 //! tests and so forth.
 use lex_core::lex::ast::inline_positions::{walk_text_content_positions, InlinePositionVisitor};
 use lex_core::lex::ast::{

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -38,11 +38,12 @@
 //!
 //! The file editors/vscode/themes/lex-light.json has the reocommended theming for Lex to be used in
 //! tests and so forth.
+use lex_core::lex::ast::inline_positions::{walk_text_content_positions, InlinePositionVisitor};
 use lex_core::lex::ast::{
-    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Position, Range,
-    Session, Table, TextContent, Verbatim,
+    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Range, Session,
+    Table, TextContent, Verbatim,
 };
-use lex_core::lex::inlines::{InlineNode, ReferenceType};
+use lex_core::lex::inlines::{ReferenceInline, ReferenceType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LexSemanticTokenKind {
@@ -439,278 +440,123 @@ impl TokenCollector {
     }
 
     fn process_text_content(&mut self, text: &TextContent) {
-        let Some(base_range) = text.location.as_ref() else {
-            return;
-        };
-        let raw = text.as_string();
-        if raw.is_empty() {
-            return;
-        }
-        let nodes = text.inline_items();
-        let mut walker = InlineWalker {
-            raw,
-            base_range,
-            cursor: 0,
+        let mut emitter = InlineTokenEmitter {
             tokens: &mut self.tokens,
             in_annotation: self.in_annotation,
             in_definition: self.in_definition,
-            in_formatted: false,
+            in_formatted: 0,
         };
-        walker.walk_nodes(&nodes);
+        walk_text_content_positions(text, &mut emitter);
     }
 }
 
-/// Walks the InlineNode tree and raw text in parallel to produce positioned semantic tokens.
+/// Visitor that converts inline-tree positions into [`LexSemanticToken`]s.
 ///
-/// The inline parser consumes escape sequences and delimiters, so InlineNode text doesn't
-/// directly correspond to byte offsets in the raw source. This walker maintains a cursor
-/// into the raw text and advances it according to the same rules the inline parser uses,
-/// producing correctly positioned Range values for each token.
-struct InlineWalker<'a> {
-    raw: &'a str,
-    base_range: &'a Range,
-    cursor: usize,
+/// Bridges the shared inline-position walker (which only tracks structural
+/// ranges) with the editor-facing semantic-token taxonomy. Marker tokens
+/// (`InlineMarker_*_start`/`_end`) are emitted on every container/literal
+/// boundary; content tokens take the appropriate kind for the surrounding
+/// element, including reference-type discrimination
+/// (`ReferenceCitation`/`ReferenceFootnote`/`ReferenceAnnotation`/
+/// `Reference`). Plain text inside a Strong/Emphasis container is suppressed
+/// (`in_formatted > 0`) because the container's content span already covers
+/// it.
+struct InlineTokenEmitter<'a> {
     tokens: &'a mut Vec<LexSemanticToken>,
     in_annotation: bool,
     in_definition: bool,
-    /// True when inside a formatting container (Strong/Emphasis). Plain text inside
-    /// containers is covered by the container's content span, so context-dependent
-    /// tokens (AnnotationContent, DefinitionContent) are suppressed.
-    in_formatted: bool,
+    in_formatted: usize,
 }
 
-impl<'a> InlineWalker<'a> {
-    fn walk_nodes(&mut self, nodes: &[InlineNode]) {
-        for node in nodes {
-            self.walk_node(node);
+impl<'a> InlineTokenEmitter<'a> {
+    fn push(&mut self, range: &Range, kind: LexSemanticTokenKind) {
+        if range.span.start < range.span.end {
+            self.tokens.push(LexSemanticToken {
+                kind,
+                range: range.clone(),
+            });
         }
     }
+}
 
-    fn walk_node(&mut self, node: &InlineNode) {
-        match node {
-            InlineNode::Plain { text, .. } => self.walk_plain(text),
-            InlineNode::Strong { content, .. } => self.walk_container(
-                content,
-                '*',
-                LexSemanticTokenKind::InlineStrong,
-                LexSemanticTokenKind::InlineMarkerStrongStart,
-                LexSemanticTokenKind::InlineMarkerStrongEnd,
-            ),
-            InlineNode::Emphasis { content, .. } => self.walk_container(
-                content,
-                '_',
-                LexSemanticTokenKind::InlineEmphasis,
-                LexSemanticTokenKind::InlineMarkerEmphasisStart,
-                LexSemanticTokenKind::InlineMarkerEmphasisEnd,
-            ),
-            InlineNode::Code { text, .. } => self.walk_literal(
-                text,
-                '`',
-                LexSemanticTokenKind::InlineCode,
-                LexSemanticTokenKind::InlineMarkerCodeStart,
-                LexSemanticTokenKind::InlineMarkerCodeEnd,
-            ),
-            InlineNode::Math { text, .. } => self.walk_literal(
-                text,
-                '#',
-                LexSemanticTokenKind::InlineMath,
-                LexSemanticTokenKind::InlineMarkerMathStart,
-                LexSemanticTokenKind::InlineMarkerMathEnd,
-            ),
-            InlineNode::Reference { data, .. } => self.walk_reference(data),
+impl<'a> InlinePositionVisitor for InlineTokenEmitter<'a> {
+    fn visit_plain(&mut self, range: &Range, _text: &str) {
+        if self.in_formatted > 0 {
+            // Covered by the enclosing container's content span — see leave_strong/leave_emphasis.
+            return;
         }
+        let kind = if self.in_annotation {
+            LexSemanticTokenKind::AnnotationContent
+        } else if self.in_definition {
+            LexSemanticTokenKind::DefinitionContent
+        } else {
+            return;
+        };
+        self.push(range, kind);
     }
 
-    /// Walk a Plain text node, advancing cursor through escape sequences in raw text.
-    /// Emits AnnotationContent or DefinitionContent when inside those contexts.
-    fn walk_plain(&mut self, text: &str) {
-        let start = self.cursor;
-        self.advance_unescaped(text);
-        let end = self.cursor;
-
-        if start < end {
-            let kind = if self.in_formatted {
-                None // Covered by the container's content span
-            } else if self.in_annotation {
-                Some(LexSemanticTokenKind::AnnotationContent)
-            } else if self.in_definition {
-                Some(LexSemanticTokenKind::DefinitionContent)
-            } else {
-                None
-            };
-            if let Some(kind) = kind {
-                self.push(self.make_range(start, end), kind);
-            }
-        }
+    fn enter_strong(&mut self, open_marker: &Range) {
+        self.push(open_marker, LexSemanticTokenKind::InlineMarkerStrongStart);
+        self.in_formatted += 1;
     }
 
-    /// Walk a container node (Strong/Emphasis) which has an opening marker, children, and closing marker.
-    fn walk_container(
+    fn leave_strong(&mut self, content: &Range, close_marker: &Range) {
+        self.in_formatted -= 1;
+        self.push(content, LexSemanticTokenKind::InlineStrong);
+        self.push(close_marker, LexSemanticTokenKind::InlineMarkerStrongEnd);
+    }
+
+    fn enter_emphasis(&mut self, open_marker: &Range) {
+        self.push(open_marker, LexSemanticTokenKind::InlineMarkerEmphasisStart);
+        self.in_formatted += 1;
+    }
+
+    fn leave_emphasis(&mut self, content: &Range, close_marker: &Range) {
+        self.in_formatted -= 1;
+        self.push(content, LexSemanticTokenKind::InlineEmphasis);
+        self.push(close_marker, LexSemanticTokenKind::InlineMarkerEmphasisEnd);
+    }
+
+    fn visit_code(
         &mut self,
-        content: &[InlineNode],
-        marker: char,
-        content_kind: LexSemanticTokenKind,
-        start_marker_kind: LexSemanticTokenKind,
-        end_marker_kind: LexSemanticTokenKind,
+        open_marker: &Range,
+        content: &Range,
+        close_marker: &Range,
+        _text: &str,
     ) {
-        let marker_len = marker.len_utf8();
-
-        // Opening marker
-        let marker_start = self.cursor;
-        self.cursor += marker_len;
-        self.push(
-            self.make_range(marker_start, self.cursor),
-            start_marker_kind,
-        );
-
-        // Recurse into children — record span boundaries for the content token
-        let content_start = self.cursor;
-        let was_in_formatted = self.in_formatted;
-        self.in_formatted = true;
-        self.walk_nodes(content);
-        self.in_formatted = was_in_formatted;
-        let content_end = self.cursor;
-
-        // Emit a single content span covering all children
-        if content_start < content_end {
-            self.push(self.make_range(content_start, content_end), content_kind);
-        }
-
-        // Closing marker
-        let close_start = self.cursor;
-        self.cursor += marker_len;
-        self.push(self.make_range(close_start, self.cursor), end_marker_kind);
+        self.push(open_marker, LexSemanticTokenKind::InlineMarkerCodeStart);
+        self.push(content, LexSemanticTokenKind::InlineCode);
+        self.push(close_marker, LexSemanticTokenKind::InlineMarkerCodeEnd);
     }
 
-    /// Walk a literal node (Code/Math) — no escape processing inside.
-    fn walk_literal(
+    fn visit_math(
         &mut self,
-        text: &str,
-        marker: char,
-        content_kind: LexSemanticTokenKind,
-        start_marker_kind: LexSemanticTokenKind,
-        end_marker_kind: LexSemanticTokenKind,
+        open_marker: &Range,
+        content: &Range,
+        close_marker: &Range,
+        _text: &str,
     ) {
-        let marker_len = marker.len_utf8();
-
-        // Opening marker
-        let marker_start = self.cursor;
-        self.cursor += marker_len;
-        self.push(
-            self.make_range(marker_start, self.cursor),
-            start_marker_kind,
-        );
-
-        // Literal content (verbatim, no escape processing)
-        let content_start = self.cursor;
-        self.cursor += text.len();
-        if content_start < self.cursor {
-            self.push(self.make_range(content_start, self.cursor), content_kind);
-        }
-
-        // Closing marker
-        let close_start = self.cursor;
-        self.cursor += marker_len;
-        self.push(self.make_range(close_start, self.cursor), end_marker_kind);
+        self.push(open_marker, LexSemanticTokenKind::InlineMarkerMathStart);
+        self.push(content, LexSemanticTokenKind::InlineMath);
+        self.push(close_marker, LexSemanticTokenKind::InlineMarkerMathEnd);
     }
 
-    /// Walk a Reference node — literal content wrapped in `[` `]`.
-    fn walk_reference(&mut self, data: &lex_core::lex::inlines::ReferenceInline) {
+    fn visit_reference(
+        &mut self,
+        open_marker: &Range,
+        content: &Range,
+        close_marker: &Range,
+        data: &ReferenceInline,
+    ) {
+        self.push(open_marker, LexSemanticTokenKind::InlineMarkerRefStart);
         let ref_kind = match &data.reference_type {
             ReferenceType::Citation(_) => LexSemanticTokenKind::ReferenceCitation,
             ReferenceType::FootnoteNumber { .. } => LexSemanticTokenKind::ReferenceFootnote,
             ReferenceType::AnnotationReference { .. } => LexSemanticTokenKind::ReferenceAnnotation,
             _ => LexSemanticTokenKind::Reference,
         };
-
-        // Opening bracket
-        let open_start = self.cursor;
-        self.cursor += 1;
-        self.push(
-            self.make_range(open_start, self.cursor),
-            LexSemanticTokenKind::InlineMarkerRefStart,
-        );
-
-        // Reference content (literal — matches raw verbatim)
-        let content_start = self.cursor;
-        self.cursor += data.raw.len();
-        if content_start < self.cursor {
-            self.push(self.make_range(content_start, self.cursor), ref_kind);
-        }
-
-        // Closing bracket
-        let close_start = self.cursor;
-        self.cursor += 1;
-        self.push(
-            self.make_range(close_start, self.cursor),
-            LexSemanticTokenKind::InlineMarkerRefEnd,
-        );
-    }
-
-    /// Advance the raw-text cursor to match unescaped `text` from an InlineNode::Plain.
-    ///
-    /// The inline parser applies escape rules: `\*` → `*`, `\\` → `\`, but `\n` stays `\n`.
-    /// This function mirrors that logic to track how many raw bytes correspond to each
-    /// unescaped character.
-    fn advance_unescaped(&mut self, text: &str) {
-        for expected in text.chars() {
-            if self.cursor >= self.raw.len() {
-                break;
-            }
-            let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
-            if raw_ch == '\\' {
-                if self.cursor + 1 >= self.raw.len() {
-                    // Trailing backslash: treat as literal to mirror parser behavior and
-                    // avoid out-of-bounds slicing on `self.raw[self.cursor + 1..]`.
-                    self.cursor += 1;
-                } else {
-                    let next_ch = self.raw[self.cursor + 1..].chars().next();
-                    match next_ch {
-                        Some(nc) if !nc.is_alphanumeric() => {
-                            // Escaped: raw `\X` maps to unescaped `X`
-                            self.cursor += 1 + nc.len_utf8();
-                        }
-                        _ => {
-                            // Literal backslash: raw `\` stays as `\` in the node
-                            self.cursor += 1;
-                        }
-                    }
-                }
-            } else {
-                self.cursor += raw_ch.len_utf8();
-            }
-            let _ = expected; // cursor already advanced
-        }
-    }
-
-    fn make_range(&self, start: usize, end: usize) -> Range {
-        let start_pos = self.position_at(start);
-        let end_pos = self.position_at(end);
-        Range::new(
-            (self.base_range.span.start + start)..(self.base_range.span.start + end),
-            start_pos,
-            end_pos,
-        )
-    }
-
-    fn position_at(&self, offset: usize) -> Position {
-        let mut line = self.base_range.start.line;
-        let mut column = self.base_range.start.column;
-        for ch in self.raw[..offset].chars() {
-            if ch == '\n' {
-                line += 1;
-                column = 0;
-            } else {
-                column += ch.len_utf8();
-            }
-        }
-        Position::new(line, column)
-    }
-
-    fn push(&mut self, range: Range, kind: LexSemanticTokenKind) {
-        if range.span.start < range.span.end {
-            self.tokens.push(LexSemanticToken { kind, range });
-        }
+        self.push(content, ref_kind);
+        self.push(close_marker, LexSemanticTokenKind::InlineMarkerRefEnd);
     }
 }
 

--- a/crates/lex-core/src/lex/ast.rs
+++ b/crates/lex-core/src/lex/ast.rs
@@ -105,6 +105,7 @@
 pub mod diagnostics;
 pub mod elements;
 pub mod error;
+pub mod inline_positions;
 pub mod links;
 pub mod range;
 pub mod snapshot;

--- a/crates/lex-core/src/lex/ast/inline_positions.rs
+++ b/crates/lex-core/src/lex/ast/inline_positions.rs
@@ -11,7 +11,8 @@
 //!
 //! Two consumers in the workspace need the same cursor logic:
 //!
-//! - [`super::links::find_all_links`] — emits a `DocumentLink` per
+//! - [`super::Document::find_all_links`] /
+//!   [`super::Session::find_all_links`] — emit a `DocumentLink` per
 //!   URL/File reference, with a range covering exactly the `[bracketed]`
 //!   text.
 //! - `lex-analysis::semantic_tokens` — emits per-marker semantic tokens
@@ -93,10 +94,11 @@ pub trait InlinePositionVisitor {
 ///
 /// Returns immediately without invoking the visitor when `text.location` is
 /// `None` (no source range to anchor positions) or the raw text is empty.
-/// Inline nodes are obtained via [`TextContent::inline_items`], which parses
-/// fresh if [`crate::lex::transforms::stages::ParseInlines`] hasn't run yet
-/// — so this works on both pipeline-parsed documents and programmatically
-/// constructed ASTs (provided `location` is set).
+/// Inline nodes come from [`TextContent::inlines`] when already parsed
+/// (zero-allocation borrow — the common case after the standard
+/// `parse_document` pipeline ran [`crate::lex::transforms::stages::ParseInlines`]),
+/// falling back to [`TextContent::inline_items`] for programmatically
+/// constructed ASTs that haven't been parsed yet.
 ///
 /// Concretely the cursor advances through `text.as_string()` byte-for-byte,
 /// applying the inline parser's escape rules (`\X` where `X` is
@@ -111,13 +113,23 @@ pub fn walk_text_content_positions<V: InlinePositionVisitor>(text: &TextContent,
     if raw.is_empty() {
         return;
     }
-    let nodes = text.inline_items();
+    // Borrow when inlines were pre-parsed; only allocate when we have to
+    // parse fresh. The standard `parse_document` pipeline always pre-parses,
+    // so production traffic hits the borrow path.
+    let owned;
+    let nodes: &[InlineNode] = match text.inlines() {
+        Some(borrowed) => borrowed,
+        None => {
+            owned = text.inline_items();
+            &owned
+        }
+    };
     let mut walker = InlinePositionWalker {
         raw,
         base_range,
         cursor: 0,
     };
-    walker.walk_nodes(&nodes, visitor);
+    walker.walk_nodes(nodes, visitor);
 }
 
 struct InlinePositionWalker<'a> {

--- a/crates/lex-core/src/lex/ast/inline_positions.rs
+++ b/crates/lex-core/src/lex/ast/inline_positions.rs
@@ -1,0 +1,292 @@
+//! Inline-position visitor for [`TextContent`].
+//!
+//! Walks the inline tree of a parsed text run while tracking byte offsets
+//! through the raw source, and fires visitor callbacks at each leaf and
+//! container boundary. Each callback receives a precise [`Range`] (with both
+//! byte span and `line:column` positions) so consumers can emit LSP semantic
+//! tokens, document links, text objects, references for goto-def, etc.
+//! without re-implementing cursor and escape arithmetic.
+//!
+//! ## Why this exists
+//!
+//! Two consumers in the workspace need the same cursor logic:
+//!
+//! - [`super::links::find_all_links`] — emits a `DocumentLink` per
+//!   URL/File reference, with a range covering exactly the `[bracketed]`
+//!   text.
+//! - `lex-analysis::semantic_tokens` — emits per-marker semantic tokens
+//!   (`*` open, content span, `*` close, …) for every inline element type.
+//!
+//! Before consolidation, each consumer carried its own walker with its own
+//! copy of the escape-handling and marker-stepping logic. Any change to the
+//! inline parser (e.g., new escape rule) had to land in two places and was
+//! easy to miss. This module is the single source of truth.
+//!
+//! ## Inline-tree shape
+//!
+//! The inline parser produces nodes from these variants (see
+//! [`InlineNode`]):
+//!
+//! | Variant | Source shape | Notes |
+//! |---------|--------------|-------|
+//! | `Plain` | `text` | Subject to escape rules; raw bytes can be longer than the unescaped char count. |
+//! | `Strong` | `*content*` | `content` is recursive `[InlineNode]`; markers are single ASCII byte. |
+//! | `Emphasis` | `_content_` | Same as Strong with `_` marker. |
+//! | `Code` | `` `text` `` | `text` is literal — no escape processing inside. |
+//! | `Math` | `#text#` | Same as Code with `#` marker. |
+//! | `Reference` | `[content]` | `content` is literal; classified into `ReferenceType` already. |
+//!
+//! Containers (Strong/Emphasis) emit `enter_*` before recursing into
+//! children and `leave_*` after — the `content` range passed to `leave_*`
+//! covers the span between (but excluding) the markers. Literals
+//! (Code/Math/Reference) get a single combined call with separate
+//! `open_marker`, `content`, `close_marker` ranges so consumers can decorate
+//! markers and content independently.
+
+use super::range::{Position, Range};
+use super::text_content::TextContent;
+use crate::lex::inlines::{InlineNode, ReferenceInline};
+
+/// Visitor for inline-tree walks performed by
+/// [`walk_text_content_positions`]. Each method has a default no-op
+/// implementation — callers override only what they care about.
+///
+/// Containers (`Strong`, `Emphasis`) fire `enter_*` before child recursion
+/// and `leave_*` after, with the resolved content/close ranges passed at
+/// `leave_*` time. Visitors that need to suppress something while inside a
+/// container can track an `in_formatted` counter incremented on `enter_*`
+/// and decremented on `leave_*`; the walker guarantees balanced nesting.
+pub trait InlinePositionVisitor {
+    fn visit_plain(&mut self, _range: &Range, _text: &str) {}
+    fn enter_strong(&mut self, _open_marker: &Range) {}
+    fn leave_strong(&mut self, _content: &Range, _close_marker: &Range) {}
+    fn enter_emphasis(&mut self, _open_marker: &Range) {}
+    fn leave_emphasis(&mut self, _content: &Range, _close_marker: &Range) {}
+    fn visit_code(
+        &mut self,
+        _open_marker: &Range,
+        _content: &Range,
+        _close_marker: &Range,
+        _text: &str,
+    ) {
+    }
+    fn visit_math(
+        &mut self,
+        _open_marker: &Range,
+        _content: &Range,
+        _close_marker: &Range,
+        _text: &str,
+    ) {
+    }
+    fn visit_reference(
+        &mut self,
+        _open_marker: &Range,
+        _content: &Range,
+        _close_marker: &Range,
+        _data: &ReferenceInline,
+    ) {
+    }
+}
+
+/// Walk `text`'s parsed inline tree, firing visitor callbacks with precise
+/// source-position ranges.
+///
+/// Returns immediately without invoking the visitor when `text.location` is
+/// `None` (no source range to anchor positions) or the raw text is empty.
+/// Inline nodes are obtained via [`TextContent::inline_items`], which parses
+/// fresh if [`crate::lex::transforms::stages::ParseInlines`] hasn't run yet
+/// — so this works on both pipeline-parsed documents and programmatically
+/// constructed ASTs (provided `location` is set).
+///
+/// Concretely the cursor advances through `text.as_string()` byte-for-byte,
+/// applying the inline parser's escape rules (`\X` where `X` is
+/// non-alphanumeric → 2 raw bytes for 1 unescaped char, any other backslash
+/// stays literal). Marker characters (`*`, `_`, `` ` ``, `#`, `[`, `]`) are
+/// counted by their UTF-8 width.
+pub fn walk_text_content_positions<V: InlinePositionVisitor>(text: &TextContent, visitor: &mut V) {
+    let Some(base_range) = text.location.as_ref() else {
+        return;
+    };
+    let raw = text.as_string();
+    if raw.is_empty() {
+        return;
+    }
+    let nodes = text.inline_items();
+    let mut walker = InlinePositionWalker {
+        raw,
+        base_range,
+        cursor: 0,
+    };
+    walker.walk_nodes(&nodes, visitor);
+}
+
+struct InlinePositionWalker<'a> {
+    raw: &'a str,
+    base_range: &'a Range,
+    cursor: usize,
+}
+
+impl<'a> InlinePositionWalker<'a> {
+    fn walk_nodes<V: InlinePositionVisitor>(&mut self, nodes: &[InlineNode], v: &mut V) {
+        for node in nodes {
+            self.walk_node(node, v);
+        }
+    }
+
+    fn walk_node<V: InlinePositionVisitor>(&mut self, node: &InlineNode, v: &mut V) {
+        match node {
+            InlineNode::Plain { text, .. } => {
+                let start = self.cursor;
+                self.advance_unescaped(text);
+                let end = self.cursor;
+                if start < end {
+                    let range = self.make_range(start, end);
+                    v.visit_plain(&range, text);
+                }
+            }
+            InlineNode::Strong { content, .. } => self.walk_strong(content, v),
+            InlineNode::Emphasis { content, .. } => self.walk_emphasis(content, v),
+            InlineNode::Code { text, .. } => self.walk_literal(text, '`', v, EmitLiteral::Code),
+            InlineNode::Math { text, .. } => self.walk_literal(text, '#', v, EmitLiteral::Math),
+            InlineNode::Reference { data, .. } => self.walk_reference(data, v),
+        }
+    }
+
+    fn walk_strong<V: InlinePositionVisitor>(&mut self, children: &[InlineNode], v: &mut V) {
+        let m = '*'.len_utf8();
+        let open_start = self.cursor;
+        self.cursor += m;
+        let open = self.make_range(open_start, self.cursor);
+        v.enter_strong(&open);
+
+        let content_start = self.cursor;
+        self.walk_nodes(children, v);
+        let content_end = self.cursor;
+
+        let close_start = self.cursor;
+        self.cursor += m;
+        let close = self.make_range(close_start, self.cursor);
+        let content = self.make_range(content_start, content_end);
+        v.leave_strong(&content, &close);
+    }
+
+    fn walk_emphasis<V: InlinePositionVisitor>(&mut self, children: &[InlineNode], v: &mut V) {
+        let m = '_'.len_utf8();
+        let open_start = self.cursor;
+        self.cursor += m;
+        let open = self.make_range(open_start, self.cursor);
+        v.enter_emphasis(&open);
+
+        let content_start = self.cursor;
+        self.walk_nodes(children, v);
+        let content_end = self.cursor;
+
+        let close_start = self.cursor;
+        self.cursor += m;
+        let close = self.make_range(close_start, self.cursor);
+        let content = self.make_range(content_start, content_end);
+        v.leave_emphasis(&content, &close);
+    }
+
+    fn walk_literal<V: InlinePositionVisitor>(
+        &mut self,
+        text: &str,
+        marker: char,
+        v: &mut V,
+        kind: EmitLiteral,
+    ) {
+        let m = marker.len_utf8();
+        let open_start = self.cursor;
+        self.cursor += m;
+        let open = self.make_range(open_start, self.cursor);
+
+        let content_start = self.cursor;
+        self.cursor += text.len();
+        let content = self.make_range(content_start, self.cursor);
+
+        let close_start = self.cursor;
+        self.cursor += m;
+        let close = self.make_range(close_start, self.cursor);
+
+        match kind {
+            EmitLiteral::Code => v.visit_code(&open, &content, &close, text),
+            EmitLiteral::Math => v.visit_math(&open, &content, &close, text),
+        }
+    }
+
+    fn walk_reference<V: InlinePositionVisitor>(&mut self, data: &ReferenceInline, v: &mut V) {
+        let open_start = self.cursor;
+        self.cursor += 1;
+        let open = self.make_range(open_start, self.cursor);
+
+        let content_start = self.cursor;
+        self.cursor += data.raw.len();
+        let content = self.make_range(content_start, self.cursor);
+
+        let close_start = self.cursor;
+        self.cursor += 1;
+        let close = self.make_range(close_start, self.cursor);
+
+        v.visit_reference(&open, &content, &close, data);
+    }
+
+    /// Mirror the inline parser's escape handling so the cursor advances
+    /// through raw bytes by the same amount the parser consumed when
+    /// producing each unescaped char in the `Plain` node. `\X` with a
+    /// non-alphanumeric `X` is consumed as 2 raw bytes for 1 unescaped char;
+    /// any other backslash stays literal.
+    fn advance_unescaped(&mut self, text: &str) {
+        for _expected in text.chars() {
+            if self.cursor >= self.raw.len() {
+                break;
+            }
+            let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
+            if raw_ch == '\\' {
+                if self.cursor + 1 >= self.raw.len() {
+                    self.cursor += 1;
+                } else {
+                    let next_ch = self.raw[self.cursor + 1..].chars().next();
+                    match next_ch {
+                        Some(nc) if !nc.is_alphanumeric() => {
+                            self.cursor += 1 + nc.len_utf8();
+                        }
+                        _ => {
+                            self.cursor += 1;
+                        }
+                    }
+                }
+            } else {
+                self.cursor += raw_ch.len_utf8();
+            }
+        }
+    }
+
+    fn make_range(&self, start: usize, end: usize) -> Range {
+        let start_pos = self.position_at(start);
+        let end_pos = self.position_at(end);
+        Range::new(
+            (self.base_range.span.start + start)..(self.base_range.span.start + end),
+            start_pos,
+            end_pos,
+        )
+    }
+
+    fn position_at(&self, offset: usize) -> Position {
+        let mut line = self.base_range.start.line;
+        let mut column = self.base_range.start.column;
+        for ch in self.raw[..offset].chars() {
+            if ch == '\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += ch.len_utf8();
+            }
+        }
+        Position::new(line, column)
+    }
+}
+
+enum EmitLiteral {
+    Code,
+    Math,
+}

--- a/crates/lex-core/src/lex/ast/links.rs
+++ b/crates/lex-core/src/lex/ast/links.rs
@@ -28,10 +28,11 @@
 //! 3. **Verbatim src**: `:: image src=./image.png ::` - External resource references
 
 use super::elements::Verbatim;
-use super::range::{Position, Range};
+use super::inline_positions::{walk_text_content_positions, InlinePositionVisitor};
+use super::range::Range;
 use super::text_content::TextContent;
 use super::{Document, Session};
-use crate::lex::inlines::{InlineNode, ReferenceInline, ReferenceType};
+use crate::lex::inlines::{ReferenceInline, ReferenceType};
 use std::fmt;
 
 /// Represents a document link with its location and type
@@ -194,143 +195,42 @@ impl Document {
 /// would underline the whole element — which is exactly the bug this function
 /// is replacing.
 ///
-/// The cursor logic mirrors `lex-analysis::semantic_tokens::InlineWalker`
-/// (which produces semantic-token ranges over the same raw text). The two
-/// implementations must stay in sync; consolidating them into a single
-/// inline-position walker in `lex-core` is a follow-up.
+/// The cursor work is delegated to the shared
+/// [`crate::lex::ast::inline_positions::walk_text_content_positions`] visitor;
+/// this function only contributes the link-shaping logic in `LinkCollector`.
 fn collect_text_content_links(text: &TextContent, out: &mut Vec<DocumentLink>) {
-    let Some(base_range) = text.location.as_ref() else {
-        return;
-    };
-    let Some(nodes) = text.inlines() else {
-        return;
-    };
-    let raw = text.as_string();
-    if raw.is_empty() {
-        return;
-    }
-    let mut locator = ReferenceLocator {
-        raw,
-        base_range,
-        cursor: 0,
-    };
-    locator.walk_nodes(nodes, out);
+    let mut collector = LinkCollector { out };
+    walk_text_content_positions(text, &mut collector);
 }
 
-/// Cursor-tracking walker that produces precise byte/position ranges for
-/// inline `Reference` nodes. Only emits links for URL and File reference
-/// types; other types intentionally fall through (footnote/citation/session/
+/// Visitor that emits a [`DocumentLink`] per URL/File reference. All other
+/// inline node variants are intentionally ignored (footnote/citation/session/
 /// annotation/TK refs do not become document links).
-struct ReferenceLocator<'a> {
-    raw: &'a str,
-    base_range: &'a Range,
-    cursor: usize,
+struct LinkCollector<'a> {
+    out: &'a mut Vec<DocumentLink>,
 }
 
-impl<'a> ReferenceLocator<'a> {
-    fn walk_nodes(&mut self, nodes: &'a [InlineNode], out: &mut Vec<DocumentLink>) {
-        for node in nodes {
-            self.walk_node(node, out);
-        }
-    }
-
-    fn walk_node(&mut self, node: &'a InlineNode, out: &mut Vec<DocumentLink>) {
-        match node {
-            InlineNode::Plain { text, .. } => self.advance_unescaped(text),
-            InlineNode::Strong { content, .. } => self.walk_container(content, '*', out),
-            InlineNode::Emphasis { content, .. } => self.walk_container(content, '_', out),
-            InlineNode::Code { text, .. } => self.skip_literal(text, '`'),
-            InlineNode::Math { text, .. } => self.skip_literal(text, '#'),
-            InlineNode::Reference { data, .. } => self.emit_reference(data, out),
-        }
-    }
-
-    fn walk_container(
+impl<'a> InlinePositionVisitor for LinkCollector<'a> {
+    fn visit_reference(
         &mut self,
-        content: &'a [InlineNode],
-        marker: char,
-        out: &mut Vec<DocumentLink>,
+        open_marker: &Range,
+        _content: &Range,
+        close_marker: &Range,
+        data: &ReferenceInline,
     ) {
-        let m = marker.len_utf8();
-        self.cursor += m;
-        self.walk_nodes(content, out);
-        self.cursor += m;
-    }
-
-    fn skip_literal(&mut self, text: &str, marker: char) {
-        let m = marker.len_utf8();
-        self.cursor += m;
-        self.cursor += text.len();
-        self.cursor += m;
-    }
-
-    fn emit_reference(&mut self, data: &'a ReferenceInline, out: &mut Vec<DocumentLink>) {
-        let start = self.cursor;
-        // `[` + content + `]`. Reference content is literal — no escape rules
-        // apply, so the raw inline content length is the byte length.
-        self.cursor += 1 + data.raw.len() + 1;
-        let end = self.cursor;
         let (target, link_type) = match &data.reference_type {
             ReferenceType::Url { target } => (target.clone(), LinkType::Url),
             ReferenceType::File { target } => (target.clone(), LinkType::File),
             _ => return,
         };
-        let range = self.make_range(start, end);
-        out.push(DocumentLink::new(range, target, link_type));
-    }
-
-    /// Mirrors the inline parser's escape rules so cursor advances through
-    /// raw bytes match each unescaped char emitted into a `Plain` node.
-    /// `\X` where `X` is non-alphanumeric → consumes 2 raw bytes (`\` + `X`)
-    /// for 1 unescaped char. Any other backslash stays literal.
-    fn advance_unescaped(&mut self, text: &str) {
-        for _expected in text.chars() {
-            if self.cursor >= self.raw.len() {
-                break;
-            }
-            let raw_ch = self.raw[self.cursor..].chars().next().unwrap();
-            if raw_ch == '\\' {
-                if self.cursor + 1 >= self.raw.len() {
-                    self.cursor += 1;
-                } else {
-                    let next_ch = self.raw[self.cursor + 1..].chars().next();
-                    match next_ch {
-                        Some(nc) if !nc.is_alphanumeric() => {
-                            self.cursor += 1 + nc.len_utf8();
-                        }
-                        _ => {
-                            self.cursor += 1;
-                        }
-                    }
-                }
-            } else {
-                self.cursor += raw_ch.len_utf8();
-            }
-        }
-    }
-
-    fn make_range(&self, start: usize, end: usize) -> Range {
-        let start_pos = self.position_at(start);
-        let end_pos = self.position_at(end);
-        Range::new(
-            (self.base_range.span.start + start)..(self.base_range.span.start + end),
-            start_pos,
-            end_pos,
-        )
-    }
-
-    fn position_at(&self, offset: usize) -> Position {
-        let mut line = self.base_range.start.line;
-        let mut column = self.base_range.start.column;
-        for ch in self.raw[..offset].chars() {
-            if ch == '\n' {
-                line += 1;
-                column = 0;
-            } else {
-                column += ch.len_utf8();
-            }
-        }
-        Position::new(line, column)
+        // The link covers `[content]` inclusive of brackets — span from the
+        // open marker's start to the close marker's end.
+        let full = Range::new(
+            open_marker.span.start..close_marker.span.end,
+            open_marker.start,
+            close_marker.end,
+        );
+        self.out.push(DocumentLink::new(full, target, link_type));
     }
 }
 


### PR DESCRIPTION
## Summary

`lex-core::ast::links::ReferenceLocator` (introduced by #512) and `lex-analysis::semantic_tokens::InlineWalker` were each running their own copy of the same byte-cursor stepping plus the same `\X` escape-rule handling. Any change to the inline parser had to land in two places — and that exact synchronization gap is what produced the documentLink range bug fixed in #512 in the first place.

This PR extracts the shared cursor + escape-tracking machinery into a new `lex-core::ast::inline_positions` module exposing an `InlinePositionVisitor` trait + a `walk_text_content_positions` entry point. Both call sites become small visitor implementations:

- `links.rs::LinkCollector` — only overrides `visit_reference` to push `DocumentLink`s for URL/File refs.
- `semantic_tokens.rs::InlineTokenEmitter` — overrides every variant to push the corresponding `LexSemanticTokenKind`s; manages the `in_formatted` counter that suppresses plain-text tokens inside Strong/Emphasis containers.

Pure internal refactor: no API change for crate consumers, no behavior change for any path through `parse_document → analyze → LSP`. All 1,651 workspace tests pass unchanged.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore: pure internal refactor, no user-visible behavior change
- [x] Project umbrella check passes locally — `cargo test --workspace --exclude lex-wasm`, `cargo clippy --workspace --exclude lex-wasm --all-targets -- -D warnings`, `cargo fmt -- --check`
- [x] Tests added or updated for behavior changes — N/A (no behavior change; existing tests confirm parity)

## Notes for reviewers

- `walk_text_content_positions` uses `TextContent::inline_items()` (parses fresh if needed) rather than `inlines()` (requires pre-parsing). This matches the previous `semantic_tokens` behavior and is strictly more permissive than the old `links.rs` precondition. The standard `parse_document` pipeline always pre-parses inlines, so no production path observes a behavior change.
- The visitor uses an `in_formatted: usize` counter for nesting depth instead of the old `bool` save/restore pattern in `InlineWalker`. Equivalent end-state behavior; counter generalizes naturally to other visitors.
- This is the second of two follow-ups to #512. The first (#513 — extend `Session::find_all_links` to scan nested-session titles) is already up. The two PRs are intentionally independent of each other (each branches off main); minor merge conflicts in `links.rs` are possible but small.