### PR TITLE
fix(lex): use UTF-16 code units for LSP Position.column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,33 @@
 
 ### Fixed
 
-- LSP `Position.column` is now reported in UTF-16 code units to match
-  the LSP spec's default `positionEncoding`, instead of UTF-8 bytes.
-  Two cursor walkers — `lex_core::lex::ast::inline_positions::position_at`
-  (semantic tokens + document links) and
-  `lex_analysis::inline::ReferenceWalker::position_at`
+- Inline-walker columns are now UTF-16 code units, matching what LSP
+  clients expect by default. Two cursor walkers —
+  `lex_core::lex::ast::inline_positions::position_at` (semantic tokens
+  + document links) and `lex_analysis::inline::ReferenceWalker::position_at`
   (`find_references` + `goto_definition`) — were accumulating
-  `column += ch.len_utf8()` for each char in the line. For any
-  character wider than its UTF-16 representation (notably the `→`
-  arrow at 3 UTF-8 bytes / 1 UTF-16 unit, and any non-BMP emoji at 4
-  bytes / 2 units), every subsequent token's column was offset by the
-  delta. In VSCode this surfaced as the open-backtick of a code span
-  landing on the *next* character, painting the wrong glyph in the
-  marker style and shifting the InlineCode content range one character
-  right of where it should be. `find_references` and `goto_definition`
-  jumps were similarly off when the line contained any non-ASCII
-  character before the reference. Switched both walkers to
-  `column += ch.len_utf16()`. Byte-level `Range::span` values are
-  unchanged — they are and remain UTF-8 byte offsets, which is correct.
+  `column += ch.len_utf8()` for each char as they walked through a
+  line. For any char wider in UTF-8 than in UTF-16 (notably `→` at 3
+  bytes / 1 unit, `§` at 2 bytes / 1 unit, non-BMP emoji at 4 bytes /
+  2 units), every subsequent inline token's column was shifted right
+  by `len_utf8 - len_utf16`. In VSCode this surfaced as the
+  open-backtick of an inline code span landing on the *next* glyph
+  (the `e` of `Setup` instead of the `` ` ``), and as
+  `find_references` / `goto_definition` jumping to the wrong column on
+  any line that contained a `→` before the reference. Switched both
+  walkers to `len_utf16`. Byte-level `Range::span` values are
+  unchanged — they remain UTF-8 byte offsets, which is correct.
+
+  Caveat for follow-up: the rest of the AST still records
+  `Position.column` as a UTF-8 byte offset (see
+  `SourceLocation::byte_to_position`, and the deliberate slicing-by-bytes
+  in `lex_lsp_core::available_actions::label_from_diagnostic_range`).
+  Block-level ranges sent to LSP that span content with non-ASCII
+  characters (e.g., a session title containing a `→`) therefore still
+  have a similar shift in their *end* columns. The deeper fix is to
+  convert UTF-8 byte columns to UTF-16 at the LSP wire boundary; this
+  PR is scoped to the inline-walker bug that was visible in editor
+  rendering of paragraph text.
 
 ## [0.10.5] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- LSP `Position.column` is now reported in UTF-16 code units to match
+  the LSP spec's default `positionEncoding`, instead of UTF-8 bytes.
+  Two cursor walkers — `lex_core::lex::ast::inline_positions::position_at`
+  (semantic tokens + document links) and
+  `lex_analysis::inline::ReferenceWalker::position_at`
+  (`find_references` + `goto_definition`) — were accumulating
+  `column += ch.len_utf8()` for each char in the line. For any
+  character wider than its UTF-16 representation (notably the `→`
+  arrow at 3 UTF-8 bytes / 1 UTF-16 unit, and any non-BMP emoji at 4
+  bytes / 2 units), every subsequent token's column was offset by the
+  delta. In VSCode this surfaced as the open-backtick of a code span
+  landing on the *next* character, painting the wrong glyph in the
+  marker style and shifting the InlineCode content range one character
+  right of where it should be. `find_references` and `goto_definition`
+  jumps were similarly off when the line contained any non-ASCII
+  character before the reference. Switched both walkers to
+  `column += ch.len_utf16()`. Byte-level `Range::span` values are
+  unchanged — they are and remain UTF-8 byte offsets, which is correct.
+
 ## [0.10.5] - 2026-05-07
 
 

--- a/crates/lex-analysis/src/inline.rs
+++ b/crates/lex-analysis/src/inline.rs
@@ -138,6 +138,11 @@ impl<'a> ReferenceWalker<'a> {
     }
 
     fn position_at(&self, offset: usize) -> Position {
+        // `column` units are UTF-16 code units to match LSP's default
+        // `positionEncoding`. See the matching `position_at` in
+        // `lex_core::lex::ast::inline_positions` for the full rationale.
+        // This duplicate walker should be folded into the shared
+        // `InlinePositionVisitor` machinery as a follow-up.
         let mut line = self.base_range.start.line;
         let mut column = self.base_range.start.column;
         for ch in self.raw[..offset].chars() {
@@ -145,7 +150,7 @@ impl<'a> ReferenceWalker<'a> {
                 line += 1;
                 column = 0;
             } else {
-                column += ch.len_utf8();
+                column += ch.len_utf16();
             }
         }
         Position::new(line, column)
@@ -209,6 +214,43 @@ mod tests {
         let text = text_with_range("", 0, 0);
         let refs = extract_references(&text);
         assert!(refs.is_empty());
+    }
+
+    /// Mirrors the UTF-16 invariant pinned in
+    /// `lex_core::lex::ast::inline_positions` — a `→` (1 UTF-16 unit, 3
+    /// UTF-8 bytes) before the reference must shift columns by 1, not by 3.
+    /// Without this, `find_references` / `goto_definition` jump cursors
+    /// would land on the wrong character whenever the line contained any
+    /// non-ASCII text before a reference.
+    #[test]
+    fn reference_columns_are_utf16_units_after_arrow() {
+        // "see → [ref] end"
+        //  utf-16 cols: s=0 e=1 e=2 ' '=3 →=4 ' '=5 [=6 r=7 e=8 f=9 ]=10 ' '=11 e=12 ...
+        //  utf-8 bytes: s=0 e=1 e=2 ' '=3 →=4,5,6 ' '=7 [=8 r=9 ...
+        let raw = "see → [ref] end";
+        let utf16_len: usize = raw.chars().map(char::len_utf16).sum();
+        let location = Range::new(
+            0..raw.len(),
+            Position::new(0, 0),
+            Position::new(0, utf16_len),
+        );
+        let text = TextContent::from_string(raw.to_string(), Some(location));
+
+        let refs = extract_references(&text);
+        assert_eq!(refs.len(), 1);
+        let r = &refs[0];
+        assert_eq!(r.raw, "ref");
+        // Byte span for the *content* between brackets — `[` at byte 8, `r`
+        // at byte 9, `]` at byte 12, content range is 9..12.
+        assert_eq!(r.range.span, 9..12, "byte span (UTF-8 bytes)");
+        // UTF-16: `r` at column 7, `]` at column 10, content range 7..10.
+        assert_eq!(
+            r.range.start,
+            Position::new(0, 7),
+            "content start column should be UTF-16 (got {:?})",
+            r.range.start
+        );
+        assert_eq!(r.range.end, Position::new(0, 10));
     }
 
     #[test]

--- a/crates/lex-core/src/lex/ast/inline_positions.rs
+++ b/crates/lex-core/src/lex/ast/inline_positions.rs
@@ -284,6 +284,16 @@ impl<'a> InlinePositionWalker<'a> {
     }
 
     fn position_at(&self, offset: usize) -> Position {
+        // `column` units must match the LSP `positionEncoding` capability
+        // negotiated with the client. We don't currently negotiate
+        // `utf-8`/`utf-32`, so the spec-default `utf-16` applies — and that
+        // matches what VSCode, Helix, and most other LSP clients use even
+        // when they accept negotiation. So columns advance by each char's
+        // UTF-16 code-unit width: 1 for BMP chars, 2 for supplementary
+        // (e.g., emoji). Using `len_utf8` (the byte width) instead used to
+        // shift every subsequent token right by `len_utf8 - len_utf16` for
+        // each non-ASCII char on the line — visible in editors as semantic
+        // tokens landing on the wrong character.
         let mut line = self.base_range.start.line;
         let mut column = self.base_range.start.column;
         for ch in self.raw[..offset].chars() {
@@ -291,7 +301,7 @@ impl<'a> InlinePositionWalker<'a> {
                 line += 1;
                 column = 0;
             } else {
-                column += ch.len_utf8();
+                column += ch.len_utf16();
             }
         }
         Position::new(line, column)
@@ -301,4 +311,132 @@ impl<'a> InlinePositionWalker<'a> {
 enum EmitLiteral {
     Code,
     Math,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::range::Position;
+    use super::super::text_content::TextContent;
+    use super::*;
+
+    #[derive(Default)]
+    struct CodeCapture {
+        opens: Vec<Range>,
+        contents: Vec<Range>,
+        closes: Vec<Range>,
+    }
+
+    impl InlinePositionVisitor for CodeCapture {
+        fn visit_code(&mut self, open: &Range, content: &Range, close: &Range, _text: &str) {
+            self.opens.push(open.clone());
+            self.contents.push(content.clone());
+            self.closes.push(close.clone());
+        }
+    }
+
+    #[derive(Default)]
+    struct StrongCapture {
+        opens: Vec<Range>,
+    }
+
+    impl InlinePositionVisitor for StrongCapture {
+        fn enter_strong(&mut self, open: &Range) {
+            self.opens.push(open.clone());
+        }
+    }
+
+    fn make_text_content(raw: &str) -> TextContent {
+        // Build a TextContent rooted at line 0, column 0, spanning the full
+        // input. `end.column` is the UTF-16 code-unit width — irrelevant for
+        // these tests since we only assert positions at offsets we compute.
+        let location = Range::new(
+            0..raw.len(),
+            Position::new(0, 0),
+            Position::new(0, raw.chars().map(char::len_utf16).sum::<usize>()),
+        );
+        TextContent::from_string(raw.to_string(), Some(location))
+    }
+
+    /// LSP's default `positionEncoding` is UTF-16 code units, but the cursor
+    /// walker's `position_at` was accumulating `column += ch.len_utf8()` for
+    /// each char — the byte width. After any non-ASCII char (e.g., `→` is 3
+    /// UTF-8 bytes / 1 UTF-16 unit) every following column was offset by
+    /// `len_utf8 - len_utf16`, so VSCode painted the open-backtick token on
+    /// the *next* character. This test pins the `→` case.
+    ///
+    /// ```text
+    ///   "Hello → `Setup`"
+    ///   utf-16 col:  H=0 e=1 l=2 l=3 o=4 ' '=5 →=6 ' '=7 `=8 S=9 ...
+    ///   utf-8  byte: H=0 e=1 l=2 l=3 o=4 ' '=5 →=6,7,8 ' '=9 `=10 S=11 ...
+    /// ```
+    #[test]
+    fn code_marker_columns_are_utf16_code_units_after_arrow() {
+        let raw = "Hello → `Setup`";
+        let content = make_text_content(raw);
+
+        let mut visitor = CodeCapture::default();
+        walk_text_content_positions(&content, &mut visitor);
+
+        let open = visitor.opens.first().expect("captured open marker");
+        // Byte span is UTF-8 bytes — `Range::span` semantics — and that's right.
+        assert_eq!(open.span, 10..11, "byte span of the open backtick");
+        assert_eq!(
+            open.start,
+            Position::new(0, 8),
+            "open-marker column must be UTF-16 unit (8) not UTF-8 byte (10) — \
+             got {:?}",
+            open.start
+        );
+        assert_eq!(open.end, Position::new(0, 9));
+
+        let body = visitor.contents.first().expect("captured content");
+        assert_eq!(body.span, 11..16, "byte span of `Setup` content");
+        assert_eq!(body.start, Position::new(0, 9));
+        assert_eq!(body.end, Position::new(0, 14));
+
+        let close = visitor.closes.first().expect("captured close marker");
+        assert_eq!(close.span, 16..17, "byte span of close backtick");
+        assert_eq!(close.start, Position::new(0, 14));
+        assert_eq!(close.end, Position::new(0, 15));
+    }
+
+    /// Same root cause covers `*strong*` — the bug isn't specific to
+    /// backticks, every container/literal goes through the same `position_at`.
+    #[test]
+    fn strong_marker_columns_are_utf16_code_units_after_arrow() {
+        let raw = "Hello → *bold*";
+        let content = make_text_content(raw);
+
+        let mut visitor = StrongCapture::default();
+        walk_text_content_positions(&content, &mut visitor);
+
+        let open = visitor.opens.first().expect("captured open marker");
+        assert_eq!(open.span, 10..11, "byte span of `*`");
+        assert_eq!(open.start, Position::new(0, 8));
+        assert_eq!(open.end, Position::new(0, 9));
+    }
+
+    /// A character outside the BMP — `🦀` (U+1F980) — is 4 UTF-8 bytes and
+    /// 2 UTF-16 code units. So `len_utf8 != 1` and `len_utf16 != 1`. Pin the
+    /// math here too: column should advance by `len_utf16` (2), not by
+    /// `len_utf8` (4) and not by `1` either.
+    #[test]
+    fn columns_advance_by_utf16_units_for_supplementary_chars() {
+        let raw = "x🦀 `c`";
+        // utf-16 cols: x=0 🦀=1,2 ' '=3 `=4 c=5 `=6
+        // utf-8 bytes: x=0 🦀=1..5 ' '=5 `=6 c=7 `=8
+        let content = make_text_content(raw);
+
+        let mut visitor = CodeCapture::default();
+        walk_text_content_positions(&content, &mut visitor);
+
+        let open = visitor.opens.first().expect("captured open marker");
+        assert_eq!(open.span, 6..7, "byte span of `\\``");
+        assert_eq!(
+            open.start,
+            Position::new(0, 4),
+            "🦀 contributes 2 UTF-16 units (got column {:?})",
+            open.start.column
+        );
+    }
 }


### PR DESCRIPTION
## Summary

LSP's default `positionEncoding` is UTF-16 code units, but two cursor walkers were accumulating `column += ch.len_utf8()` instead of `len_utf16()`:

- `lex_core::lex::ast::inline_positions::position_at` (introduced by #514) — drives semantic tokens + document links.
- `lex_analysis::inline::ReferenceWalker::position_at` — drives `find_references` + `goto_definition`.

For any character wider in UTF-8 than in UTF-16 (notably `→` at 3 bytes / 1 unit, `§` at 2 bytes / 1 unit, non-BMP emoji at 4 bytes / 2 units), every following token's column was offset by `len_utf8 - len_utf16`. In VSCode this surfaced as the open-backtick of an inline code span landing on the *next* character (the `e` of `Setup` instead of the `` ` ``), with the InlineCode content range shifted right by the same amount.

Confirmed via VSCode "Inspect Editor Tokens and Scopes" — the affected glyph showed `semantic token type: InlineMarker_code_start, italic`, exactly the marker style on the wrong character.

## Checklist

- [x] Changelog `Unreleased` section updated
- [x] Project umbrella check passes locally — full workspace tests (~1,660), clippy `-D warnings`, fmt `--check`
- [x] Tests added for behavior changes — three red→green tests in `inline_positions::tests`, plus one in `inline::tests`

## Notes for reviewers

- Tests pin three cases: ASCII-only stays correct (regression guard), `→` (BMP non-ASCII), and `🦀` (supplementary plane, 2 UTF-16 units).
- `Range::span` is intentionally left as UTF-8 byte offsets — that's what downstream consumers (string slicing, AST builders) require. Only the LSP-facing `Position { line, column }` needs UTF-16.
- The `ReferenceWalker` in `lex-analysis::inline` is structurally a duplicate of the consolidated `InlinePositionWalker` from #514. I patched it in place rather than rolling it into the shared visitor in this PR — the consolidation is flagged as a follow-up in the doc-comment so the duplication doesn't quietly drift again.