### PR TITLE
PR 1: scaffold lex-extension crate (trait + wire types + schema)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -154,9 +154,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -198,9 +198,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comrak"
@@ -337,7 +337,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -547,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -795,12 +795,13 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -808,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -821,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -835,15 +836,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -855,15 +856,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -899,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -925,12 +926,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -964,15 +965,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1045,6 +1046,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lex-extension"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lex-lsp-core"
 version = "0.10.6"
 dependencies = [
@@ -1113,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1125,9 +1134,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -1146,9 +1155,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1267,7 +1276,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1288,14 +1297,14 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1321,11 +1330,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1333,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1429,18 +1438,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1455,15 +1464,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
@@ -1484,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1569,7 +1578,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1588,9 +1597,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -1618,9 +1627,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1660,7 +1669,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1718,11 +1727,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1766,9 +1775,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1856,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1900,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -1912,9 +1921,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1945,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1955,7 +1964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28332bb44a9e7e7f1aa43ce4d97b6d1b27323a1fc160d4cfe0089245e1750845"
 dependencies = [
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2055,7 +2064,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2079,12 +2088,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2146,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2156,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2171,9 +2180,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2183,7 +2192,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2230,26 +2239,26 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2272,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -2290,16 +2299,16 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2310,9 +2319,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2417,7 +2426,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2523,11 +2532,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2536,14 +2545,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2554,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2564,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2574,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2587,18 +2596,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
  "async-trait",
  "cast",
@@ -2618,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2629,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
 
 [[package]]
 name = "wasm-encoder"
@@ -2661,7 +2670,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2694,7 +2703,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2702,15 +2711,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2722,71 +2722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,6 +2731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +2744,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2853,7 +2800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -2885,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xdg"
@@ -2916,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2927,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2939,18 +2886,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2959,18 +2906,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2980,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2991,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3002,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/lex-config",
     "crates/lex-cli",
     "crates/lex-analysis",
+    "crates/lex-extension",
     "crates/lex-lsp-core",
     "crates/lex-lsp",
     "crates/lex-wasm",
@@ -16,6 +17,7 @@ lex-core = { version = "0.10.6", path = "crates/lex-core" }
 lex-babel = { version = "0.10.6", path = "crates/lex-babel", default-features = false }
 lex-config = { version = "0.10.6", path = "crates/lex-config" }
 lex-analysis = { version = "0.10.6", path = "crates/lex-analysis" }
+lex-extension = { version = "0.1.0", path = "crates/lex-extension" }
 lex-lsp-core = { version = "0.10.6", path = "crates/lex-lsp-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/lex-extension/Cargo.toml
+++ b/crates/lex-extension/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lex-extension"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["lex contributors"]
+description = "Public surface for Lex extensions: handler trait, wire types, schema types"
+repository = "https://github.com/lex-fmt/lex"
+keywords = ["lex", "extension"]
+categories = ["text-processing"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/lex-extension/src/handler.rs
+++ b/crates/lex-extension/src/handler.rs
@@ -1,0 +1,189 @@
+//! The [`LexHandler`] trait — the protocol's source of truth.
+//!
+//! Native handlers (built-ins, in-process Rust embedders) `impl` this trait
+//! directly. Subprocess and WASM transports are delivered as generic adapters
+//! that `impl` the same trait by serialising calls to JSON-RPC or component
+//! imports respectively.
+//!
+//! Methods that produce non-trivial output return
+//! `Result<Option<T>, HandlerError>`. The `Result` distinguishes "I hit an
+//! error you should surface as a diagnostic" from "I succeeded but have
+//! nothing to contribute"; the inner `Option`/`Vec` covers the latter.
+//! [`LexHandler::on_label`] returns `()` because it is a notification.
+
+use crate::wire::{
+    CodeAction, Completion, Diagnostic, Format, Hover, LabelCtx, RenderOut, WireNode,
+};
+
+/// The hook-event interface a Lex extension implements.
+///
+/// Every method has a default implementation that returns the identity
+/// (`Ok(None)`, `Ok(Vec::new())`, `()`), so an extension only needs to
+/// override the methods it cares about. An empty `impl LexHandler for Foo {}`
+/// is a no-op handler that compiles and runs.
+pub trait LexHandler: Send + Sync {
+    /// Informational notification fired during the analyse phase. No response
+    /// is expected. Use this for handlers that maintain external state
+    /// (caches, indices, link graphs).
+    fn on_label(&self, _ctx: &LabelCtx) {}
+
+    /// Returns diagnostics for a labelled node. Fires during analyse, after
+    /// resolve.
+    fn on_validate(&self, _ctx: &LabelCtx) -> Result<Vec<Diagnostic>, HandlerError> {
+        Ok(Vec::new())
+    }
+
+    /// Returns an AST replacement subtree, which the host splices into the
+    /// parent in place of the labelled node. Fires during the resolve phase,
+    /// before analyse. `Ok(None)` leaves the original node in place.
+    fn on_resolve(&self, _ctx: &LabelCtx) -> Result<Option<WireNode>, HandlerError> {
+        Ok(None)
+    }
+
+    /// Returns the labelled node's representation in a target format. Fires
+    /// during `lexd convert` or library-driven rendering. `Ok(None)` falls
+    /// back to default rendering of the underlying node.
+    fn on_render(&self, _ctx: &LabelCtx, _fmt: Format) -> Result<Option<RenderOut>, HandlerError> {
+        Ok(None)
+    }
+
+    /// Returns hover content for a labelled node. Fires in response to
+    /// `textDocument/hover` LSP requests.
+    fn on_hover(&self, _ctx: &LabelCtx) -> Result<Option<Hover>, HandlerError> {
+        Ok(None)
+    }
+
+    /// Returns completion items for a position inside a labelled node's
+    /// params or body. Fires in response to `textDocument/completion`.
+    fn on_completion(&self, _ctx: &LabelCtx) -> Result<Vec<Completion>, HandlerError> {
+        Ok(Vec::new())
+    }
+
+    /// Returns code actions for a labelled node. Fires in response to
+    /// `textDocument/codeAction`.
+    fn on_code_action(&self, _ctx: &LabelCtx) -> Result<Vec<CodeAction>, HandlerError> {
+        Ok(Vec::new())
+    }
+}
+
+/// Errors a [`LexHandler`] method can surface.
+///
+/// A handler that hits an internal failure returns `Err(HandlerError::...)`;
+/// the host folds the error into a synthetic diagnostic at the labelled
+/// node's range and continues processing other labels. Subprocess transports
+/// map these variants onto JSON-RPC error responses with the standard
+/// reserved code ranges (`-32000..=-32099` for handler-defined; `-32601` for
+/// unsupported method/format).
+#[derive(Debug, Clone, PartialEq)]
+pub enum HandlerError {
+    /// Handler hit an internal error (panic, library failure, unexpected
+    /// state). Maps to JSON-RPC `-32603`.
+    Internal { message: String },
+    /// Handler does not support the requested operation — for example,
+    /// `on_render` was called with a format the handler does not produce.
+    /// Maps to JSON-RPC `-32601`.
+    Unsupported { detail: String },
+    /// Handler-defined error. `code` should fall in the
+    /// `-32000..=-32099` range reserved for handler use. Maps to
+    /// JSON-RPC `error` with the supplied code, message, and optional data.
+    Custom {
+        code: i32,
+        message: String,
+        data: Option<serde_json::Value>,
+    },
+}
+
+impl HandlerError {
+    /// Convenience constructor for the common case of an internal error.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    /// Convenience constructor for an unsupported operation.
+    pub fn unsupported(detail: impl Into<String>) -> Self {
+        Self::Unsupported {
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for HandlerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HandlerError::Internal { message } => {
+                write!(f, "handler internal error: {message}")
+            }
+            HandlerError::Unsupported { detail } => {
+                write!(f, "handler does not support: {detail}")
+            }
+            HandlerError::Custom { code, message, .. } => {
+                write!(f, "handler error {code}: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HandlerError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::{LabelCtx, NodeRef, Position, Range};
+
+    /// A no-op handler should compile with no method overrides — the
+    /// ergonomics check called out in PR 1's success criteria.
+    struct NoOp;
+    impl LexHandler for NoOp {}
+
+    fn ctx() -> LabelCtx {
+        LabelCtx {
+            label: "test.label".into(),
+            params: serde_json::json!({}),
+            body: crate::wire::AnnotationBody::None,
+            node: NodeRef {
+                kind: "annotation".into(),
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+            },
+        }
+    }
+
+    #[test]
+    fn noop_handler_returns_defaults() {
+        let h = NoOp;
+        let c = ctx();
+        h.on_label(&c);
+        assert!(h.on_validate(&c).unwrap().is_empty());
+        assert!(h.on_resolve(&c).unwrap().is_none());
+        assert!(h.on_render(&c, Format::Html).unwrap().is_none());
+        assert!(h.on_hover(&c).unwrap().is_none());
+        assert!(h.on_completion(&c).unwrap().is_empty());
+        assert!(h.on_code_action(&c).unwrap().is_empty());
+    }
+
+    #[test]
+    fn handler_error_display() {
+        assert_eq!(
+            HandlerError::internal("boom").to_string(),
+            "handler internal error: boom"
+        );
+        assert_eq!(
+            HandlerError::unsupported("png").to_string(),
+            "handler does not support: png"
+        );
+        assert_eq!(
+            HandlerError::Custom {
+                code: -32001,
+                message: "custom".into(),
+                data: None,
+            }
+            .to_string(),
+            "handler error -32001: custom"
+        );
+    }
+}

--- a/crates/lex-extension/src/lib.rs
+++ b/crates/lex-extension/src/lib.rs
@@ -17,14 +17,40 @@
 //!
 //! # Versioning
 //!
-//! [`WIRE_VERSION`] tracks the wire-format contract. The crate's major
-//! version mirrors it. A handler built against `lex-extension` 1.x speaks
-//! `wire_version: 1`. Non-breaking additions (new methods, new optional
-//! fields, new node kinds, new severity levels) are minor/patch bumps; any
-//! change to existing field shapes or method semantics is a major bump.
+//! There are two version axes, intentionally decoupled:
 //!
-//! See `comms/specs/proposals/lex-extension-wire.lex` for the normative wire
-//! format spec.
+//! - [`WIRE_VERSION`] identifies the JSON-RPC wire-format contract
+//!   exchanged at the `initialize` handshake. Handlers across any
+//!   transport (subprocess, native, future WASM) speaking the same
+//!   `WIRE_VERSION` interoperate. Once stable, breaking changes to the
+//!   wire format bump this integer.
+//! - The crate's *Cargo* version (`0.1.x` today) tracks the Rust API.
+//!
+//! The two axes line up at 1.0: this crate ticks to `1.0.0` when its Rust
+//! API stabilises, and at that point a handler built against
+//! `lex-extension = "1"` speaks `WIRE_VERSION = 1`. Until then the Rust
+//! API is per-Cargo unstable: any 0.x → 0.y bump may be source-incompatible.
+//!
+//! Where forward-compatibility is implementable today without API churn,
+//! it is:
+//!
+//! - String-shaped enums (severity, completion kind, code-action kind,
+//!   ref kind, hover format) deserialise unknown wire values as a
+//!   documented fallback (`Info`, `Value`, `Refactor`, `General`,
+//!   `Plaintext`). New variants in the wire protocol are non-breaking
+//!   *for handlers* — older handlers see the fallback.
+//! - Block AST kinds ([`WireNode`], [`WireInline`]) are *closed* within a
+//!   `WIRE_VERSION`. Adding a new kind is a wire-version bump, not a
+//!   silent extension. The `#[non_exhaustive]` attribute on those enums
+//!   keeps the Rust side additive across `lex-extension` major versions.
+//! - Public structs (`Diagnostic`, `Hover`, `Completion`, etc.) are *not*
+//!   `#[non_exhaustive]` today, by design — pre-1.0, struct-literal
+//!   construction is the right ergonomics for handler authors. Before
+//!   tagging 1.0 the public structs will gain `#[non_exhaustive]` plus
+//!   constructors, so post-1.0 field additions stay non-breaking.
+//!
+//! See `comms/specs/proposals/lex-extension-wire.lex` for the normative
+//! wire-format spec.
 
 pub mod handler;
 pub mod schema;

--- a/crates/lex-extension/src/lib.rs
+++ b/crates/lex-extension/src/lib.rs
@@ -1,0 +1,52 @@
+//! Public surface for Lex extensions.
+//!
+//! This crate is the stable contract that handler authors and Rust embedders
+//! depend on. It defines:
+//!
+//! - The [`LexHandler`] trait — the protocol's source of truth.
+//! - Wire types ([`LabelCtx`], [`WireNode`], [`WireInline`], diagnostics,
+//!   render output, hover, completions, code actions) — the cross-version
+//!   stable representation of Lex content and hook payloads.
+//! - Schema types ([`Schema`] and friends) — the read-only structs a YAML
+//!   loader produces.
+//! - The [`Format`] enum used by render hooks.
+//!
+//! The runtime registry, schema loader, transports (subprocess, WASM), trust
+//! gate, and sandboxing live in the internal `lex-extension-host` crate.
+//! Handler authors depend on `lex-extension` only.
+//!
+//! # Versioning
+//!
+//! [`WIRE_VERSION`] tracks the wire-format contract. The crate's major
+//! version mirrors it. A handler built against `lex-extension` 1.x speaks
+//! `wire_version: 1`. Non-breaking additions (new methods, new optional
+//! fields, new node kinds, new severity levels) are minor/patch bumps; any
+//! change to existing field shapes or method semantics is a major bump.
+//!
+//! See `comms/specs/proposals/lex-extension-wire.lex` for the normative wire
+//! format spec.
+
+pub mod handler;
+pub mod schema;
+pub mod wire;
+
+pub use handler::{HandlerError, LexHandler};
+pub use wire::{
+    AnnotationBody, CodeAction, CodeActionKind, Completion, CompletionKind, Diagnostic,
+    DiagnosticSeverity, Format, Hover, HoverFormat, LabelCtx, NodeRef, Position, Range, RefKind,
+    RelatedDiagnostic, RenderOut, TextEdit, WireFootnote, WireInline, WireListItem, WireNode,
+    WireRow, WireTableCell,
+};
+
+pub use schema::{
+    BodyKind, BodyPresence, BodyShape, Capabilities, EnumValue, HandlerSpec, HandlerTransport,
+    HookSet, ParamSpec, ParamType, RenderHook, Schema,
+};
+
+/// The wire-format protocol version exchanged in the `initialize` handshake.
+///
+/// A host that receives a higher `wire_version` than it understands negotiates
+/// down to the highest version both sides support. A host that receives a
+/// lower `wire_version` than this constant refuses the handler with a startup
+/// diagnostic.
+pub const WIRE_VERSION: u32 = 1;

--- a/crates/lex-extension/src/schema.rs
+++ b/crates/lex-extension/src/schema.rs
@@ -1,0 +1,296 @@
+//! Schema types — the read-only structs a YAML loader produces.
+//!
+//! The loader itself lives in `lex-extension-host` (PR 4); this module
+//! defines the types both the loader and consumers (registry, host, editors)
+//! share. The types are `serde`-derived so they can also be hand-built in
+//! Rust code without a YAML round-trip (useful for embedders).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One label's schema. Mirrors the YAML format documented in the *Extending
+/// Lex* proposal §13.2.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Schema {
+    /// Schema-format version. Currently `1`.
+    pub schema_version: u32,
+    /// Fully-qualified label, e.g. `"acme.commenting"`.
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Declared parameters, keyed by name.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub params: BTreeMap<String, ParamSpec>,
+    /// Permitted host node kinds.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attaches_to: Vec<String>,
+    /// Body shape when the label is used as an annotation.
+    #[serde(default)]
+    pub body: BodyShape,
+    /// Whether the label is also legal as a verbatim block closing.
+    #[serde(default)]
+    pub verbatim_label: bool,
+    /// Declared OS-level capabilities the handler needs. Honoured once
+    /// sandboxing is in place; see proposal §8.
+    #[serde(default)]
+    pub capabilities: Capabilities,
+    /// Hooks the label participates in.
+    #[serde(default)]
+    pub hooks: HookSet,
+    /// Optional handler delivery info. Schema-only labels (validation +
+    /// editor UX from the schema alone) omit this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handler: Option<HandlerSpec>,
+}
+
+/// One parameter declaration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParamSpec {
+    #[serde(rename = "type")]
+    pub ty: ParamType,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+    /// Allowed values when `ty == Enum`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub values: Vec<EnumValue>,
+}
+
+/// Allowed parameter types. Forward compatibility: schema loaders bail on
+/// unknown types (schema-format versioning is independent of `wire_version`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ParamType {
+    String,
+    Bool,
+    Int,
+    Float,
+    Enum,
+}
+
+/// One legal value of an enum-typed parameter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnumValue {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Body shape for annotation-form usage.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BodyShape {
+    #[serde(default = "BodyKind::default_kind")]
+    pub kind: BodyKind,
+    #[serde(default)]
+    pub presence: BodyPresence,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl Default for BodyShape {
+    fn default() -> Self {
+        Self {
+            kind: BodyKind::None,
+            presence: BodyPresence::Optional,
+            description: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BodyKind {
+    None,
+    Text,
+    Lex,
+}
+
+impl BodyKind {
+    fn default_kind() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BodyPresence {
+    Optional,
+    Required,
+}
+
+impl Default for BodyPresence {
+    fn default() -> Self {
+        Self::Optional
+    }
+}
+
+/// Declared capabilities. The subprocess transport will sandbox the handler
+/// to honour these once OS-level enforcement ships (see proposal §8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct Capabilities {
+    #[serde(default)]
+    pub fs: bool,
+    #[serde(default)]
+    pub net: bool,
+}
+
+impl Capabilities {
+    /// True when the handler declares neither fs nor network access.
+    pub fn is_pure(&self) -> bool {
+        !self.fs && !self.net
+    }
+}
+
+/// Hook participation. Each field defaults to "not implemented".
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct HookSet {
+    #[serde(default)]
+    pub label: bool,
+    #[serde(default)]
+    pub validate: bool,
+    #[serde(default)]
+    pub resolve: bool,
+    #[serde(default)]
+    pub hover: bool,
+    #[serde(default)]
+    pub completion: bool,
+    #[serde(default)]
+    pub code_action: bool,
+    /// Render hooks declare which target formats they produce. An empty
+    /// vector means the label does not participate in rendering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub render: Vec<RenderHook>,
+}
+
+/// One render-format the label can produce.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RenderHook(pub String);
+
+impl RenderHook {
+    pub fn new(format: impl Into<String>) -> Self {
+        Self(format.into())
+    }
+}
+
+/// Handler delivery info.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HandlerSpec {
+    pub transport: HandlerTransport,
+    /// Argv for the subprocess transport. Variables in the form `${NAME}`
+    /// are expanded at spawn time. Ignored for native and WASM transports.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub command: Vec<String>,
+    /// Per-request timeout. Defaults to 2000 ms in subprocess hosts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HandlerTransport {
+    Native,
+    Subprocess,
+    Wasm,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comment_schema() -> Schema {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "role".into(),
+            ParamSpec {
+                ty: ParamType::Enum,
+                required: true,
+                default: None,
+                description: None,
+                pattern: None,
+                values: vec![
+                    EnumValue {
+                        name: "author".into(),
+                        description: None,
+                    },
+                    EnumValue {
+                        name: "editor".into(),
+                        description: None,
+                    },
+                ],
+            },
+        );
+        Schema {
+            schema_version: 1,
+            label: "acme.commenting".into(),
+            description: Some("A comment thread.".into()),
+            params,
+            attaches_to: vec!["paragraph".into(), "session".into()],
+            body: BodyShape {
+                kind: BodyKind::Lex,
+                presence: BodyPresence::Required,
+                description: None,
+            },
+            verbatim_label: false,
+            capabilities: Capabilities {
+                fs: false,
+                net: false,
+            },
+            hooks: HookSet {
+                validate: true,
+                hover: true,
+                render: vec![RenderHook::new("html"), RenderHook::new("markdown")],
+                ..HookSet::default()
+            },
+            handler: Some(HandlerSpec {
+                transport: HandlerTransport::Subprocess,
+                command: vec!["acme-comment-handler".into()],
+                timeout_ms: Some(2000),
+            }),
+        }
+    }
+
+    #[test]
+    fn schema_round_trips_through_json() {
+        let s = comment_schema();
+        let serialised = serde_json::to_string(&s).unwrap();
+        let back: Schema = serde_json::from_str(&serialised).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn capabilities_is_pure_for_zero_fs_zero_net() {
+        assert!(Capabilities::default().is_pure());
+        assert!(!Capabilities {
+            fs: true,
+            net: false
+        }
+        .is_pure());
+        assert!(!Capabilities {
+            fs: false,
+            net: true
+        }
+        .is_pure());
+    }
+
+    #[test]
+    fn hookset_default_is_all_off() {
+        let hs = HookSet::default();
+        assert!(!hs.validate);
+        assert!(!hs.resolve);
+        assert!(hs.render.is_empty());
+    }
+
+    #[test]
+    fn body_shape_default_is_none_optional() {
+        let bs = BodyShape::default();
+        assert_eq!(bs.kind, BodyKind::None);
+        assert_eq!(bs.presence, BodyPresence::Optional);
+    }
+}

--- a/crates/lex-extension/src/schema.rs
+++ b/crates/lex-extension/src/schema.rs
@@ -62,10 +62,16 @@ pub struct ParamSpec {
     pub values: Vec<EnumValue>,
 }
 
-/// Allowed parameter types. Forward compatibility: schema loaders bail on
-/// unknown types (schema-format versioning is independent of `wire_version`).
+/// Allowed parameter types.
+///
+/// Forward compatibility: unlike the wire-format enums, schema loaders
+/// *reject* unknown types — schema-format versioning is independent of
+/// `wire_version` and a schema with an unknown `type` is malformed by
+/// definition. The `#[non_exhaustive]` attribute keeps adding new variants
+/// non-breaking on the Rust side.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ParamType {
     String,
     Bool,
@@ -105,6 +111,7 @@ impl Default for BodyShape {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BodyKind {
     None,
     Text,
@@ -119,6 +126,7 @@ impl BodyKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BodyPresence {
     Optional,
     Required,
@@ -194,6 +202,7 @@ pub struct HandlerSpec {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum HandlerTransport {
     Native,
     Subprocess,

--- a/crates/lex-extension/src/wire/ast.rs
+++ b/crates/lex-extension/src/wire/ast.rs
@@ -1,0 +1,236 @@
+//! Wire AST: the cross-version representation of Lex content.
+//!
+//! [`WireNode`] is a tagged enum (kind discriminator) covering all block
+//! kinds. Inline content uses [`WireInline`](crate::wire::WireInline).
+//!
+//! Forward compatibility: handlers must ignore unknown `kind` values
+//! gracefully (per wire spec §2.2). Adding new node kinds is a non-breaking
+//! change.
+
+use serde::{Deserialize, Serialize};
+
+use super::inline::WireInline;
+use super::range::Range;
+
+/// A block-level wire AST node. Wire form is a tagged object with `"kind"`
+/// selecting the variant, plus shared `range` and optional `origin` fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireNode {
+    Document {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        children: Vec<WireNode>,
+    },
+    Session {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        title: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        marker: Option<String>,
+        children: Vec<WireNode>,
+    },
+    Definition {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        subject: String,
+        children: Vec<WireNode>,
+    },
+    Paragraph {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        inlines: Vec<WireInline>,
+    },
+    List {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        marker_style: String,
+        items: Vec<WireListItem>,
+    },
+    Verbatim {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        label: String,
+        params: serde_json::Value,
+        body_text: String,
+    },
+    Table {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        caption: String,
+        header_rows: u32,
+        align: String,
+        rows: Vec<WireRow>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        footnotes: Vec<WireFootnote>,
+    },
+    Annotation {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        label: String,
+        params: serde_json::Value,
+        /// `null` for marker-form annotations, a string for opaque-text
+        /// bodies, an object `{ "kind": "block", "children": [...] }` for
+        /// parsed-Lex bodies. See [`AnnotationBody`](super::ctx::AnnotationBody)
+        /// for the corresponding [`LabelCtx`](super::ctx::LabelCtx) shape.
+        body: serde_json::Value,
+    },
+    Blank {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+    },
+}
+
+/// One item inside a [`WireNode::List`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WireListItem {
+    pub range: Range,
+    pub inlines: Vec<WireInline>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<WireNode>,
+}
+
+/// One row in a [`WireNode::Table`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WireRow {
+    pub cells: Vec<WireTableCell>,
+}
+
+/// One cell in a [`WireRow`]. `inlines` holds the cell's content; merge
+/// markers (`>>`, `^^`) are surfaced as `colspan` / `rowspan` for downstream
+/// renderers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WireTableCell {
+    pub inlines: Vec<WireInline>,
+    #[serde(default = "one")]
+    pub colspan: u32,
+    #[serde(default = "one")]
+    pub rowspan: u32,
+}
+
+fn one() -> u32 {
+    1
+}
+
+/// One footnote attached to a table.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WireFootnote {
+    pub marker: String,
+    pub inlines: Vec<WireInline>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::range::Position;
+
+    fn r(s_l: u32, s_c: u32, e_l: u32, e_c: u32) -> Range {
+        Range::new(Position::new(s_l, s_c), Position::new(e_l, e_c))
+    }
+
+    #[test]
+    fn paragraph_round_trips() {
+        let p = WireNode::Paragraph {
+            range: r(0, 0, 0, 5),
+            origin: None,
+            inlines: vec![WireInline::Text {
+                text: "hello".into(),
+            }],
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn paragraph_kind_in_serialized_form() {
+        let p = WireNode::Paragraph {
+            range: r(0, 0, 0, 5),
+            origin: None,
+            inlines: vec![],
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        assert!(s.contains(r#""kind":"paragraph""#));
+    }
+
+    #[test]
+    fn document_with_children() {
+        let d = WireNode::Document {
+            range: r(0, 0, 10, 0),
+            origin: Some("doc.lex".into()),
+            children: vec![WireNode::Paragraph {
+                range: r(0, 0, 0, 3),
+                origin: None,
+                inlines: vec![WireInline::Text { text: "x".into() }],
+            }],
+        };
+        let s = serde_json::to_string(&d).unwrap();
+        assert!(s.contains(r#""origin":"doc.lex""#));
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, d);
+    }
+
+    #[test]
+    fn annotation_with_lex_body() {
+        let a = WireNode::Annotation {
+            range: r(3, 0, 6, 0),
+            origin: None,
+            label: "acme.commenting".into(),
+            params: serde_json::json!({"role": "editor"}),
+            body: serde_json::json!({
+                "kind": "block",
+                "children": []
+            }),
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn verbatim_carries_label_and_body_text() {
+        let v = WireNode::Verbatim {
+            range: r(0, 0, 4, 0),
+            origin: None,
+            label: "rust".into(),
+            params: serde_json::json!({}),
+            body_text: "fn main() {}".into(),
+        };
+        let s = serde_json::to_string(&v).unwrap();
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn list_with_items() {
+        let l = WireNode::List {
+            range: r(0, 0, 2, 0),
+            origin: None,
+            marker_style: "dash".into(),
+            items: vec![
+                WireListItem {
+                    range: r(0, 0, 0, 5),
+                    inlines: vec![WireInline::Text { text: "a".into() }],
+                    children: vec![],
+                },
+                WireListItem {
+                    range: r(1, 0, 1, 5),
+                    inlines: vec![WireInline::Text { text: "b".into() }],
+                    children: vec![],
+                },
+            ],
+        };
+        let s = serde_json::to_string(&l).unwrap();
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, l);
+    }
+}

--- a/crates/lex-extension/src/wire/ast.rs
+++ b/crates/lex-extension/src/wire/ast.rs
@@ -3,9 +3,23 @@
 //! [`WireNode`] is a tagged enum (kind discriminator) covering all block
 //! kinds. Inline content uses [`WireInline`](crate::wire::WireInline).
 //!
-//! Forward compatibility: handlers must ignore unknown `kind` values
-//! gracefully (per wire spec §2.2). Adding new node kinds is a non-breaking
-//! change.
+//! # Forward compatibility
+//!
+//! Adding a new `kind` to the wire format is a *breaking* change: the
+//! `wire_version` integer bumps, and old hosts/handlers reject the
+//! mismatched protocol at the `initialize` handshake. Within a single
+//! `wire_version`, the set of node kinds is closed.
+//!
+//! This is deliberately stricter than the per-string-enum forward-compat
+//! policy used for [`DiagnosticSeverity`](crate::wire::DiagnosticSeverity)
+//! and similar (which fall back to a documented default on unknown
+//! values). Block AST is structural; treating an unknown `kind` as
+//! "ignore me" silently drops document content, which is worse than
+//! refusing the document with a clear protocol-version diagnostic.
+//!
+//! On the Rust side, [`WireNode`] is `#[non_exhaustive]` so that adding a
+//! new variant in a future major-version release of this crate is not a
+//! breaking source-level change for downstream `match` consumers.
 
 use serde::{Deserialize, Serialize};
 
@@ -14,8 +28,11 @@ use super::range::Range;
 
 /// A block-level wire AST node. Wire form is a tagged object with `"kind"`
 /// selecting the variant, plus shared `range` and optional `origin` fields.
+///
+/// See the module-level docs for the forward-compatibility contract.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum WireNode {
     Document {
         range: Range,

--- a/crates/lex-extension/src/wire/ctx.rs
+++ b/crates/lex-extension/src/wire/ctx.rs
@@ -1,0 +1,165 @@
+//! [`LabelCtx`] and supporting types — the payload every hook event carries.
+
+use serde::{Deserialize, Serialize};
+
+use super::ast::WireNode;
+use super::range::Range;
+
+/// The payload every hook receives. Describes a single label invocation:
+/// its parameters, body, and position in the source AST.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LabelCtx {
+    /// Fully-qualified label name, e.g. `"acme.commenting"`.
+    pub label: String,
+    /// Param values, validated against the schema before dispatch. Always an
+    /// object; defaults are filled in. (Stored as `serde_json::Value` rather
+    /// than a typed map to keep the wire format generic.)
+    pub params: serde_json::Value,
+    /// Body content. Shape depends on the schema's `body.kind`.
+    pub body: AnnotationBody,
+    /// The host AST node the label is attached to.
+    pub node: NodeRef,
+}
+
+/// Annotation body shape carried by [`LabelCtx::body`]. Wire form is
+/// untagged: `null`, a JSON string, or `{ "kind": "block", "children": [...] }`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnnotationBody {
+    /// `body.kind: none` — marker-form annotation, no body.
+    None,
+    /// `body.kind: text` — opaque body. Verbatim usage always lands here.
+    Text(String),
+    /// `body.kind: lex` — parsed body. Children are fully-formed wire AST
+    /// nodes the handler can walk directly.
+    Lex { children: Vec<WireNode> },
+}
+
+impl AnnotationBody {
+    /// Returns `true` for [`AnnotationBody::None`].
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+impl Serialize for AnnotationBody {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        match self {
+            Self::None => serializer.serialize_none(),
+            Self::Text(s) => serializer.serialize_str(s),
+            Self::Lex { children } => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("kind", "block")?;
+                map.serialize_entry("children", children)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AnnotationBody {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match value {
+            serde_json::Value::Null => Ok(Self::None),
+            serde_json::Value::String(s) => Ok(Self::Text(s)),
+            serde_json::Value::Object(map) => {
+                let kind = map.get("kind").and_then(|v| v.as_str());
+                if kind != Some("block") {
+                    return Err(serde::de::Error::custom(
+                        "annotation body object must have kind: \"block\"",
+                    ));
+                }
+                let children_value = map
+                    .get("children")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+                let children: Vec<WireNode> =
+                    serde_json::from_value(children_value).map_err(serde::de::Error::custom)?;
+                Ok(Self::Lex { children })
+            }
+            _ => Err(serde::de::Error::custom(
+                "annotation body must be null, a string, or an object",
+            )),
+        }
+    }
+}
+
+/// A reference to the AST node a label is attached to. Carries position
+/// metadata so handlers know where in the document the invocation sits;
+/// the body of the host node is *not* shipped (handlers receive only the
+/// label invocation's own body via [`LabelCtx::body`]).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeRef {
+    /// The host node's wire kind, e.g. `"annotation"`, `"verbatim"`.
+    pub kind: String,
+    pub range: Range,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::range::Position;
+
+    fn r(s_l: u32, s_c: u32, e_l: u32, e_c: u32) -> Range {
+        Range::new(Position::new(s_l, s_c), Position::new(e_l, e_c))
+    }
+
+    fn nref() -> NodeRef {
+        NodeRef {
+            kind: "annotation".into(),
+            range: r(0, 0, 0, 12),
+            origin: None,
+        }
+    }
+
+    #[test]
+    fn none_body_serialises_as_null() {
+        let c = LabelCtx {
+            label: "foo".into(),
+            params: serde_json::json!({}),
+            body: AnnotationBody::None,
+            node: nref(),
+        };
+        let s = serde_json::to_string(&c).unwrap();
+        assert!(s.contains(r#""body":null"#));
+        let back: LabelCtx = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn text_body_serialises_as_string() {
+        let c = LabelCtx {
+            label: "foo".into(),
+            params: serde_json::json!({}),
+            body: AnnotationBody::Text("raw".into()),
+            node: nref(),
+        };
+        let s = serde_json::to_string(&c).unwrap();
+        assert!(s.contains(r#""body":"raw""#));
+        let back: LabelCtx = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn lex_body_serialises_as_block() {
+        let c = LabelCtx {
+            label: "foo".into(),
+            params: serde_json::json!({"k": 1}),
+            body: AnnotationBody::Lex { children: vec![] },
+            node: nref(),
+        };
+        let s = serde_json::to_string(&c).unwrap();
+        assert!(s.contains(r#""body":{"kind":"block","children":[]}"#));
+        let back: LabelCtx = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, c);
+    }
+}

--- a/crates/lex-extension/src/wire/format.rs
+++ b/crates/lex-extension/src/wire/format.rs
@@ -1,0 +1,111 @@
+//! Target-format identifier used by the render hook.
+//!
+//! Built-in formats (`html`, `latex`, `markdown`, `pdf`) are exhaustively
+//! enumerated for ergonomic match arms. Namespace-defined formats slip
+//! through as [`Format::Custom`].
+
+use std::convert::Infallible;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// A render-target format. Wire form is the lowercase string name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Format {
+    Html,
+    Latex,
+    Markdown,
+    Pdf,
+    /// Any namespace-defined format string (e.g., `"plasma-spec-v4"`,
+    /// `"docx"`). Compared case-sensitively.
+    Custom(String),
+}
+
+impl Format {
+    /// Wire string for this format.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Format::Html => "html",
+            Format::Latex => "latex",
+            Format::Markdown => "markdown",
+            Format::Pdf => "pdf",
+            Format::Custom(s) => s.as_str(),
+        }
+    }
+}
+
+impl FromStr for Format {
+    type Err = Infallible;
+
+    /// Unknown strings become [`Format::Custom`]; parsing is infallible.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "html" => Format::Html,
+            "latex" => Format::Latex,
+            "markdown" => Format::Markdown,
+            "pdf" => Format::Pdf,
+            other => Format::Custom(other.to_string()),
+        })
+    }
+}
+
+impl std::fmt::Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for Format {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Format {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(s.parse().expect("Format::from_str is infallible"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_round_trips() {
+        let f = Format::Html;
+        let s = serde_json::to_string(&f).unwrap();
+        assert_eq!(s, r#""html""#);
+        let back: Format = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, f);
+    }
+
+    #[test]
+    fn unknown_becomes_custom() {
+        let s = r#""plasma-spec-v4""#;
+        let f: Format = serde_json::from_str(s).unwrap();
+        assert_eq!(f, Format::Custom("plasma-spec-v4".to_string()));
+        assert_eq!(serde_json::to_string(&f).unwrap(), s);
+    }
+
+    #[test]
+    fn from_str_via_trait() {
+        let f: Format = "html".parse().unwrap();
+        assert_eq!(f, Format::Html);
+        let f: Format = "docx".parse().unwrap();
+        assert_eq!(f, Format::Custom("docx".to_string()));
+    }
+
+    #[test]
+    fn display_uses_wire_string() {
+        assert_eq!(Format::Html.to_string(), "html");
+        assert_eq!(Format::Custom("docx".to_string()).to_string(), "docx");
+    }
+}

--- a/crates/lex-extension/src/wire/inline.rs
+++ b/crates/lex-extension/src/wire/inline.rs
@@ -1,0 +1,107 @@
+//! Inline-content wire types.
+//!
+//! Inlines appear inside paragraphs and list items. The serde derives produce
+//! the JSON shapes documented in wire spec §2.3.
+
+use serde::{Deserialize, Serialize};
+
+/// One inline element. Wire form is a tagged object with `"kind"` selecting
+/// the variant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireInline {
+    /// Plain text.
+    Text { text: String },
+    /// `*bold*` content.
+    Bold { children: Vec<WireInline> },
+    /// `_italic_` content.
+    Italic { children: Vec<WireInline> },
+    /// `` `code` `` content. Literal — no nested inlines.
+    Code { text: String },
+    /// `#math#` content. Literal — no nested inlines.
+    Math { text: String },
+    /// `[reference]` content. The kind sub-discriminator (`url`, `citation`,
+    /// `footnote`, …) selects the semantic meaning of `target`.
+    Reference {
+        ref_kind: RefKind,
+        target: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+}
+
+/// Sub-kind of an inline `reference`.
+///
+/// Forward compatibility: handlers must treat unknown values as
+/// [`RefKind::General`] (per the wire spec's "handlers must treat unknown
+/// `ref_kind` values as `general`" rule).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefKind {
+    Url,
+    Citation,
+    Footnote,
+    Session,
+    File,
+    Placeholder,
+    Unsure,
+    General,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_inline_round_trips() {
+        let i = WireInline::Text {
+            text: "hello".into(),
+        };
+        let s = serde_json::to_string(&i).unwrap();
+        assert_eq!(s, r#"{"kind":"text","text":"hello"}"#);
+        let back: WireInline = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, i);
+    }
+
+    #[test]
+    fn bold_with_nested_text() {
+        let i = WireInline::Bold {
+            children: vec![WireInline::Text {
+                text: "loud".into(),
+            }],
+        };
+        let s = serde_json::to_string(&i).unwrap();
+        assert_eq!(
+            s,
+            r#"{"kind":"bold","children":[{"kind":"text","text":"loud"}]}"#
+        );
+    }
+
+    #[test]
+    fn reference_url_round_trips() {
+        let i = WireInline::Reference {
+            ref_kind: RefKind::Url,
+            target: "https://example.com".into(),
+            label: None,
+        };
+        let s = serde_json::to_string(&i).unwrap();
+        assert_eq!(
+            s,
+            r#"{"kind":"reference","ref_kind":"url","target":"https://example.com"}"#
+        );
+        let back: WireInline = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, i);
+    }
+
+    #[test]
+    fn reference_with_label() {
+        let i = WireInline::Reference {
+            ref_kind: RefKind::Footnote,
+            target: "1".into(),
+            label: Some("note one".into()),
+        };
+        let s = serde_json::to_string(&i).unwrap();
+        let back: WireInline = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, i);
+    }
+}

--- a/crates/lex-extension/src/wire/inline.rs
+++ b/crates/lex-extension/src/wire/inline.rs
@@ -2,6 +2,12 @@
 //!
 //! Inlines appear inside paragraphs and list items. The serde derives produce
 //! the JSON shapes documented in wire spec §2.3.
+//!
+//! Forward compatibility: as with [`WireNode`](super::ast::WireNode), adding
+//! a new inline `kind` is a breaking wire-format change (bumps
+//! `wire_version`); within a `wire_version` the set is closed. The Rust
+//! enum is `#[non_exhaustive]` so a future major release can add a variant
+//! without breaking downstream `match` arms.
 
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +15,7 @@ use serde::{Deserialize, Serialize};
 /// the variant.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum WireInline {
     /// Plain text.
     Text { text: String },
@@ -32,11 +39,14 @@ pub enum WireInline {
 
 /// Sub-kind of an inline `reference`.
 ///
-/// Forward compatibility: handlers must treat unknown values as
-/// [`RefKind::General`] (per the wire spec's "handlers must treat unknown
-/// `ref_kind` values as `general`" rule).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Forward compatibility is implemented in the [`Deserialize`] impl: any
+/// string that doesn't match a known variant deserialises as
+/// [`RefKind::General`], matching the wire spec's "handlers must treat
+/// unknown `ref_kind` values as `general`" rule. The `#[non_exhaustive]`
+/// attribute makes adding new variants a non-breaking Rust change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum RefKind {
     Url,
     Citation,
@@ -46,6 +56,25 @@ pub enum RefKind {
     Placeholder,
     Unsure,
     General,
+}
+
+impl<'de> Deserialize<'de> for RefKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "url" => Self::Url,
+            "citation" => Self::Citation,
+            "footnote" => Self::Footnote,
+            "session" => Self::Session,
+            "file" => Self::File,
+            "placeholder" => Self::Placeholder,
+            "unsure" => Self::Unsure,
+            _ => Self::General,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -103,5 +132,11 @@ mod tests {
         let s = serde_json::to_string(&i).unwrap();
         let back: WireInline = serde_json::from_str(&s).unwrap();
         assert_eq!(back, i);
+    }
+
+    #[test]
+    fn unknown_ref_kind_falls_back_to_general() {
+        let kind: RefKind = serde_json::from_str(r#""acronym""#).unwrap();
+        assert_eq!(kind, RefKind::General);
     }
 }

--- a/crates/lex-extension/src/wire/mod.rs
+++ b/crates/lex-extension/src/wire/mod.rs
@@ -1,0 +1,24 @@
+//! Wire-format types: the cross-version stable representation of Lex content
+//! and hook payloads.
+//!
+//! These types are the public contract that JSON-RPC subprocess transports
+//! and (eventually) WASM transports both serialise to. Native handlers
+//! consume them directly. The serde derives on each type produce JSON shapes
+//! matching the wire spec under `comms/specs/proposals/lex-extension-wire.lex`.
+
+mod ast;
+mod ctx;
+mod format;
+mod inline;
+mod payload;
+mod range;
+
+pub use ast::{WireFootnote, WireListItem, WireNode, WireRow, WireTableCell};
+pub use ctx::{AnnotationBody, LabelCtx, NodeRef};
+pub use format::Format;
+pub use inline::{RefKind, WireInline};
+pub use payload::{
+    CodeAction, CodeActionKind, Completion, CompletionKind, Diagnostic, DiagnosticSeverity, Hover,
+    HoverFormat, RelatedDiagnostic, RenderOut, TextEdit,
+};
+pub use range::{Position, Range};

--- a/crates/lex-extension/src/wire/payload.rs
+++ b/crates/lex-extension/src/wire/payload.rs
@@ -28,15 +28,35 @@ pub struct RelatedDiagnostic {
     pub uri: Option<String>,
 }
 
-/// Diagnostic severity. Forward compatibility: handlers must treat unknown
-/// values as [`DiagnosticSeverity::Info`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Diagnostic severity.
+///
+/// Forward compatibility: unknown wire values deserialise as
+/// [`DiagnosticSeverity::Info`]. Adding new variants is non-breaking
+/// (`#[non_exhaustive]`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DiagnosticSeverity {
     Error,
     Warning,
     Info,
     Hint,
+}
+
+impl<'de> Deserialize<'de> for DiagnosticSeverity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "error" => Self::Error,
+            "warning" => Self::Warning,
+            "info" => Self::Info,
+            "hint" => Self::Hint,
+            _ => Self::Info,
+        })
+    }
 }
 
 /// The result of `on_render`. Either a target-format string snippet or a
@@ -59,11 +79,30 @@ pub struct Hover {
     pub range: Option<Range>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Hover content format.
+///
+/// Forward compatibility: unknown wire values deserialise as
+/// [`HoverFormat::Plaintext`]. Adding new variants is non-breaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum HoverFormat {
     Plaintext,
     Markdown,
+}
+
+impl<'de> Deserialize<'de> for HoverFormat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "plaintext" => Self::Plaintext,
+            "markdown" => Self::Markdown,
+            _ => Self::Plaintext,
+        })
+    }
 }
 
 /// One completion item returned by `on_completion`.
@@ -78,15 +117,34 @@ pub struct Completion {
     pub kind: CompletionKind,
 }
 
-/// Completion item kind. Forward compatibility: handlers must treat unknown
-/// values as [`CompletionKind::Value`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Completion item kind.
+///
+/// Forward compatibility: unknown wire values deserialise as
+/// [`CompletionKind::Value`]. Adding new variants is non-breaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum CompletionKind {
     Value,
     Param,
     Namespace,
     Snippet,
+}
+
+impl<'de> Deserialize<'de> for CompletionKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "value" => Self::Value,
+            "param" => Self::Param,
+            "namespace" => Self::Namespace,
+            "snippet" => Self::Snippet,
+            _ => Self::Value,
+        })
+    }
 }
 
 /// One code action returned by `on_code_action`.
@@ -98,14 +156,32 @@ pub struct CodeAction {
     pub edits: Vec<TextEdit>,
 }
 
-/// Code-action kind. Forward compatibility: handlers must treat unknown
-/// values as [`CodeActionKind::Refactor`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Code-action kind.
+///
+/// Forward compatibility: unknown wire values deserialise as
+/// [`CodeActionKind::Refactor`]. Adding new variants is non-breaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum CodeActionKind {
     Quickfix,
     Refactor,
     Source,
+}
+
+impl<'de> Deserialize<'de> for CodeActionKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "quickfix" => Self::Quickfix,
+            "refactor" => Self::Refactor,
+            "source" => Self::Source,
+            _ => Self::Refactor,
+        })
+    }
 }
 
 /// A textual edit applied as part of a code action.
@@ -206,5 +282,29 @@ mod tests {
         let s = serde_json::to_string(&a).unwrap();
         let back: CodeAction = serde_json::from_str(&s).unwrap();
         assert_eq!(back, a);
+    }
+
+    #[test]
+    fn unknown_severity_falls_back_to_info() {
+        let s: DiagnosticSeverity = serde_json::from_str(r#""trace""#).unwrap();
+        assert_eq!(s, DiagnosticSeverity::Info);
+    }
+
+    #[test]
+    fn unknown_completion_kind_falls_back_to_value() {
+        let k: CompletionKind = serde_json::from_str(r#""template""#).unwrap();
+        assert_eq!(k, CompletionKind::Value);
+    }
+
+    #[test]
+    fn unknown_code_action_kind_falls_back_to_refactor() {
+        let k: CodeActionKind = serde_json::from_str(r#""rename""#).unwrap();
+        assert_eq!(k, CodeActionKind::Refactor);
+    }
+
+    #[test]
+    fn unknown_hover_format_falls_back_to_plaintext() {
+        let f: HoverFormat = serde_json::from_str(r#""asciidoc""#).unwrap();
+        assert_eq!(f, HoverFormat::Plaintext);
     }
 }

--- a/crates/lex-extension/src/wire/payload.rs
+++ b/crates/lex-extension/src/wire/payload.rs
@@ -1,0 +1,210 @@
+//! Hook response payloads — diagnostics, render output, hover, completions,
+//! code actions.
+
+use serde::{Deserialize, Serialize};
+
+use super::ast::WireNode;
+use super::range::Range;
+
+/// A diagnostic returned by `on_validate`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    pub range: Range,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related: Vec<RelatedDiagnostic>,
+}
+
+/// A diagnostic linked to another location (e.g., the definition the
+/// diagnostic is about).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RelatedDiagnostic {
+    pub message: String,
+    pub range: Range,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+}
+
+/// Diagnostic severity. Forward compatibility: handlers must treat unknown
+/// values as [`DiagnosticSeverity::Info`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+/// The result of `on_render`. Either a target-format string snippet or a
+/// wire AST in a tree-shaped target's vocabulary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RenderOut {
+    /// String-shaped target (HTML, LaTeX, Markdown).
+    String { string: String },
+    /// Tree-shaped target (intermediate AST, namespace-defined format).
+    WireAst { ast: WireNode },
+}
+
+/// Hover content returned by `on_hover`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Hover {
+    pub contents: String,
+    pub format: HoverFormat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HoverFormat {
+    Plaintext,
+    Markdown,
+}
+
+/// One completion item returned by `on_completion`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Completion {
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc: Option<String>,
+    pub insert: String,
+    pub kind: CompletionKind,
+}
+
+/// Completion item kind. Forward compatibility: handlers must treat unknown
+/// values as [`CompletionKind::Value`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionKind {
+    Value,
+    Param,
+    Namespace,
+    Snippet,
+}
+
+/// One code action returned by `on_code_action`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeAction {
+    pub title: String,
+    pub kind: CodeActionKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edits: Vec<TextEdit>,
+}
+
+/// Code-action kind. Forward compatibility: handlers must treat unknown
+/// values as [`CodeActionKind::Refactor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeActionKind {
+    Quickfix,
+    Refactor,
+    Source,
+}
+
+/// A textual edit applied as part of a code action.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TextEdit {
+    pub range: Range,
+    pub new_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::range::Position;
+
+    fn r(s_l: u32, s_c: u32, e_l: u32, e_c: u32) -> Range {
+        Range::new(Position::new(s_l, s_c), Position::new(e_l, e_c))
+    }
+
+    #[test]
+    fn diagnostic_round_trips() {
+        let d = Diagnostic {
+            severity: DiagnosticSeverity::Error,
+            message: "oops".into(),
+            range: r(0, 0, 0, 5),
+            code: Some("E001".into()),
+            related: vec![],
+        };
+        let s = serde_json::to_string(&d).unwrap();
+        let back: Diagnostic = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, d);
+    }
+
+    #[test]
+    fn render_out_string_round_trips() {
+        let r0 = RenderOut::String {
+            string: "<p>hi</p>".into(),
+        };
+        let s = serde_json::to_string(&r0).unwrap();
+        assert!(s.contains(r#""kind":"string""#));
+        let back: RenderOut = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, r0);
+    }
+
+    #[test]
+    fn render_out_wire_ast_round_trips() {
+        let r0 = RenderOut::WireAst {
+            ast: WireNode::Paragraph {
+                range: r(0, 0, 0, 5),
+                origin: None,
+                inlines: vec![],
+            },
+        };
+        let s = serde_json::to_string(&r0).unwrap();
+        assert!(s.contains(r#""kind":"wire_ast""#));
+        let back: RenderOut = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, r0);
+    }
+
+    #[test]
+    fn hover_round_trips() {
+        let h = Hover {
+            contents: "**bold**".into(),
+            format: HoverFormat::Markdown,
+            range: Some(r(0, 0, 0, 5)),
+        };
+        let s = serde_json::to_string(&h).unwrap();
+        let back: Hover = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn completion_round_trips() {
+        let c = Completion {
+            label: "foo".into(),
+            detail: Some("Foo the bar".into()),
+            doc: None,
+            insert: "foo".into(),
+            kind: CompletionKind::Param,
+        };
+        let s = serde_json::to_string(&c).unwrap();
+        let back: Completion = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn code_action_round_trips() {
+        let a = CodeAction {
+            title: "Add missing footnote".into(),
+            kind: CodeActionKind::Quickfix,
+            edits: vec![TextEdit {
+                range: r(10, 0, 10, 0),
+                new_text: "[^1]: ...\n".into(),
+                uri: None,
+            }],
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        let back: CodeAction = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, a);
+    }
+}

--- a/crates/lex-extension/src/wire/range.rs
+++ b/crates/lex-extension/src/wire/range.rs
@@ -1,17 +1,30 @@
 //! Source-range types.
 //!
 //! The wire format encodes positions as `[line, column]` arrays — two-element
-//! tuples — to keep payload size small and match the LSP convention. Both
-//! values are 0-indexed; ranges are start-inclusive and end-exclusive.
+//! tuples — to keep payload size small. Both values are 0-indexed; ranges
+//! are start-inclusive and end-exclusive.
+//!
+//! # Column semantics
+//!
+//! `column` is a **0-indexed UTF-8 byte offset** within the line, matching
+//! lex-core's internal source representation (`byte_offset - line_start`).
+//! It is *not* an LSP-style UTF-16 code unit count and *not* a Unicode
+//! scalar count; multi-byte characters occupy more than one column. The
+//! `lex-lsp` server converts to UTF-16 code units at the LSP protocol
+//! boundary; that conversion is not the wire format's concern.
 
 use serde::{Deserialize, Serialize};
 
 /// A `(line, column)` position. Wire form: `[line, column]`.
+///
+/// `column` is a 0-indexed UTF-8 byte offset within the line — see the
+/// module-level docs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Position(pub u32, pub u32);
 
 impl Position {
-    /// Construct a position from a line and column.
+    /// Construct a position from a line and column (0-indexed UTF-8 byte
+    /// offset).
     pub fn new(line: u32, column: u32) -> Self {
         Self(line, column)
     }
@@ -21,7 +34,7 @@ impl Position {
         self.0
     }
 
-    /// 0-indexed column.
+    /// 0-indexed UTF-8 byte offset within the line.
     pub fn column(&self) -> u32 {
         self.1
     }

--- a/crates/lex-extension/src/wire/range.rs
+++ b/crates/lex-extension/src/wire/range.rs
@@ -1,0 +1,68 @@
+//! Source-range types.
+//!
+//! The wire format encodes positions as `[line, column]` arrays — two-element
+//! tuples — to keep payload size small and match the LSP convention. Both
+//! values are 0-indexed; ranges are start-inclusive and end-exclusive.
+
+use serde::{Deserialize, Serialize};
+
+/// A `(line, column)` position. Wire form: `[line, column]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Position(pub u32, pub u32);
+
+impl Position {
+    /// Construct a position from a line and column.
+    pub fn new(line: u32, column: u32) -> Self {
+        Self(line, column)
+    }
+
+    /// 0-indexed line.
+    pub fn line(&self) -> u32 {
+        self.0
+    }
+
+    /// 0-indexed column.
+    pub fn column(&self) -> u32 {
+        self.1
+    }
+}
+
+/// A half-open source range. `start` inclusive, `end` exclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+impl Range {
+    pub fn new(start: Position, end: Position) -> Self {
+        Self { start, end }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_serialises_as_array() {
+        let p = Position::new(12, 4);
+        let s = serde_json::to_string(&p).unwrap();
+        assert_eq!(s, "[12,4]");
+    }
+
+    #[test]
+    fn position_deserialises_from_array() {
+        let p: Position = serde_json::from_str("[12,4]").unwrap();
+        assert_eq!(p, Position::new(12, 4));
+    }
+
+    #[test]
+    fn range_round_trips() {
+        let r = Range::new(Position::new(1, 2), Position::new(3, 4));
+        let s = serde_json::to_string(&r).unwrap();
+        assert_eq!(s, r#"{"start":[1,2],"end":[3,4]}"#);
+        let back: Range = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, r);
+    }
+}


### PR DESCRIPTION
Closes #517 (part of #516 — extension system implementation plan).

## Summary

First PR in the 12-PR extension-system rollout (α phase). Lands the public-surface ``lex-extension`` crate that handler authors and Rust embedders depend on. Pure types — no runtime, no transport, no registry. Those land in subsequent PRs.

- ``LexHandler`` trait with default no-op impls. Non-trivial methods return ``Result<Option<T>, HandlerError>`` per the corrections from lex-fmt/comms#27.
- ``HandlerError`` with Internal / Unsupported / Custom variants matching the JSON-RPC reserved-code ranges.
- Wire types: ``Position`` (``[line, col]`` array), ``Range``, ``WireNode`` (tagged enum over all block kinds), ``WireInline``, ``RefKind``, ``LabelCtx``, ``NodeRef``, ``AnnotationBody`` (custom serde for the ``null | string | {kind:"block", children:[...]}`` shape).
- Hook payloads: ``Diagnostic``, ``RenderOut``, ``Hover``, ``Completion``, ``CodeAction``, ``TextEdit`` and their kind enums.
- Schema types: ``Schema``, ``ParamSpec``, ``BodyShape``, ``Capabilities``, ``HookSet``, ``HandlerSpec`` etc. Loader lives in ``lex-extension-host`` (PR 4).
- ``Format`` enum with ``FromStr`` and string-shaped serde.
- ``WIRE_VERSION = 1`` constant.

## Scope adjustment vs the original #517 spec

The AST codec (``WireAst::from_lex_core`` / ``try_into_lex_core``) is moved to PR 3. Putting it in ``lex-extension`` would have required a dep on ``lex-core``, which becomes circular once PR 3 introduces ``lex-core``'s registry-driven resolve pass. Putting the conversion next to the AST it converts (``lex-core``) avoids the cycle entirely. The wire *types* still live here; only the converter relocates. ``lex-extension`` stays free of internal-crate deps, which is the right shape for a public-surface crate anyway.

## Test plan

- [x] Workspace builds clean (``cargo build --workspace --exclude lex-wasm``)
- [x] 32 new unit tests in ``lex-extension``: serde round-trips for every wire type, no-op handler ergonomics check, ``HandlerError`` Display, ``AnnotationBody`` shape compliance
- [x] ``cargo clippy -p lex-extension --all-targets -- -D warnings`` clean
- [x] ``cargo fmt -p lex-extension`` clean
- [x] Full pre-commit (``scripts/rust-pre-commit``): 1695 workspace tests pass
- [ ] Follow-up commits on this PR: serde golden samples matching wire-spec example payloads (validate-request, render-request, resolve-request); ``trybuild`` harness for the empty-impl ergonomics check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)