### PR TITLE
PR 3b — wire AST codec (forward + reverse)

### DIFF
--- a/crates/lex-core/src/lex/wire/error.rs
+++ b/crates/lex-core/src/lex/wire/error.rs
@@ -1,0 +1,40 @@
+//! Error types for the wire codec's reverse direction.
+
+/// Errors the reverse codec can surface when converting a `WireNode` back
+/// to a lex-core [`crate::lex::ast::ContentItem`].
+///
+/// Forward conversion (`to_wire_*`) is total — every lex-core AST shape
+/// has a defined mapping to a wire form. Reverse conversion is fallible
+/// because the wire input may be malformed or carry an unknown variant.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FromWireError {
+    /// The wire node carried an unknown structural placeholder (an
+    /// `Unknown` variant added in a future wire version, or a kind the
+    /// host's `WIRE_VERSION` does not recognise).
+    UnsupportedKind { kind: String },
+    /// A required field was missing or had the wrong shape — for
+    /// example, a `WireNode::Annotation` whose `params` was not a
+    /// JSON object.
+    MalformedField { field: &'static str, detail: String },
+    /// A nested `serde_json::from_value` conversion failed when
+    /// destructuring an opaque field (e.g., `params` blob).
+    DeserialisationFailed(String),
+}
+
+impl std::fmt::Display for FromWireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FromWireError::UnsupportedKind { kind } => {
+                write!(f, "wire AST: unsupported kind `{kind}`")
+            }
+            FromWireError::MalformedField { field, detail } => {
+                write!(f, "wire AST: malformed field `{field}`: {detail}")
+            }
+            FromWireError::DeserialisationFailed(msg) => {
+                write!(f, "wire AST: deserialisation failed: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FromWireError {}

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -1,0 +1,202 @@
+//! Reverse codec: `lex_extension::WireNode` → lex-core internal AST.
+//!
+//! Fallible — wire input may be malformed (handler returned an unknown
+//! kind, missing required field, etc.). Recognised variants produce
+//! lex-core [`ContentItem`]s; unrecognised or partially-supported
+//! shapes return [`FromWireError::UnsupportedKind`].
+//!
+//! Coverage matches `to_wire.rs`: this commit handles `Document`,
+//! `Paragraph`, `Annotation`, and `Blank`. Follow-up commits on the
+//! same PR extend to the remaining shapes.
+
+use crate::lex::ast::elements::annotation::Annotation as CoreAnnotation;
+use crate::lex::ast::elements::blank_line_group::BlankLineGroup;
+use crate::lex::ast::elements::content_item::ContentItem;
+use crate::lex::ast::elements::data::Data;
+use crate::lex::ast::elements::label::Label;
+use crate::lex::ast::elements::paragraph::{Paragraph, TextLine};
+use crate::lex::ast::elements::parameter::Parameter;
+use lex_extension::wire::WireNode;
+use serde_json::Value;
+
+use super::error::FromWireError;
+use super::inline::text_content_from_wire;
+use super::range::range_from_wire;
+
+/// Convert a `WireNode::Document` into a list of lex-core
+/// `ContentItem`s — one per child. The `WireNode::Document` wrapper
+/// itself is unwrapped; callers wrap the resulting children in a host
+/// container as needed.
+///
+/// Non-document roots are accepted: if `node` is not a `Document` (for
+/// example a single `WireNode::Paragraph`), the result is a single-
+/// element vector containing the converted item.
+pub fn from_wire_node(node: &WireNode) -> Result<Vec<ContentItem>, FromWireError> {
+    match node {
+        WireNode::Document { children, .. } => from_wire_subtree(children),
+        single => Ok(vec![convert_one(single)?]),
+    }
+}
+
+/// Convert a slice of wire nodes into a vector of `ContentItem`s.
+pub fn from_wire_subtree(nodes: &[WireNode]) -> Result<Vec<ContentItem>, FromWireError> {
+    nodes.iter().map(convert_one).collect()
+}
+
+fn convert_one(node: &WireNode) -> Result<ContentItem, FromWireError> {
+    match node {
+        WireNode::Paragraph { range, inlines, .. } => {
+            Ok(ContentItem::Paragraph(paragraph_from_wire(range, inlines)))
+        }
+        WireNode::Blank { range, .. } => {
+            let mut blg = BlankLineGroup::new(1, Vec::new());
+            blg.location = range_from_wire(range);
+            Ok(ContentItem::BlankLineGroup(blg))
+        }
+        WireNode::Annotation {
+            range,
+            label,
+            params,
+            body,
+            ..
+        } => Ok(ContentItem::Annotation(annotation_from_wire(
+            range, label, params, body,
+        )?)),
+        WireNode::Verbatim { label, .. } if label.starts_with("lex.internal.unsupported.") => {
+            // Forward codec emitted this for an as-yet-unwired variant;
+            // surface the gap rather than silently dropping content.
+            Err(FromWireError::UnsupportedKind {
+                kind: label
+                    .strip_prefix("lex.internal.unsupported.")
+                    .unwrap_or(label.as_str())
+                    .to_string(),
+            })
+        }
+        // Variants not yet wired in the reverse direction.
+        WireNode::Document { .. }
+        | WireNode::Session { .. }
+        | WireNode::Definition { .. }
+        | WireNode::List { .. }
+        | WireNode::Verbatim { .. }
+        | WireNode::Table { .. } => Err(FromWireError::UnsupportedKind {
+            kind: kind_name(node).into(),
+        }),
+        // WireNode is `#[non_exhaustive]` — future kinds surface here.
+        _ => Err(FromWireError::UnsupportedKind {
+            kind: "unknown".into(),
+        }),
+    }
+}
+
+fn paragraph_from_wire(
+    range: &lex_extension::wire::Range,
+    inlines: &[lex_extension::wire::WireInline],
+) -> Paragraph {
+    let location = range_from_wire(range);
+    let text = text_content_from_wire(inlines);
+    let line = TextLine::new(text);
+    let mut p = Paragraph::new(vec![ContentItem::TextLine(line)]);
+    p.location = location;
+    p
+}
+
+fn annotation_from_wire(
+    range: &lex_extension::wire::Range,
+    label: &str,
+    params: &Value,
+    body: &Value,
+) -> Result<CoreAnnotation, FromWireError> {
+    let parameters = parameters_from_json(params)?;
+    let label = Label::new(label.to_string());
+    let data = Data::new(label, parameters);
+
+    let children = annotation_body_from_json(body)?;
+    let mut a = CoreAnnotation::from_data(data, Vec::new());
+    a.location = range_from_wire(range);
+    // Re-attach children via the container's typed setter.
+    if !children.is_empty() {
+        // GeneralContainer stores ContentItems; ContentElement is the
+        // typed projection used by from_data. Splicing through the
+        // raw container preserves whatever shapes the wire delivered.
+        for child in children {
+            a.children.as_mut_vec().push(child);
+        }
+    }
+    Ok(a)
+}
+
+fn parameters_from_json(params: &Value) -> Result<Vec<Parameter>, FromWireError> {
+    let obj = params
+        .as_object()
+        .ok_or_else(|| FromWireError::MalformedField {
+            field: "params",
+            detail: "expected JSON object".into(),
+        })?;
+    let mut out = Vec::with_capacity(obj.len());
+    for (k, v) in obj {
+        let value_str = match v {
+            Value::String(s) => s.clone(),
+            Value::Bool(b) => b.to_string(),
+            Value::Number(n) => n.to_string(),
+            Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        out.push(Parameter {
+            key: k.clone(),
+            value: value_str,
+            location: crate::lex::ast::range::Range::new(
+                0..0,
+                crate::lex::ast::range::Position::new(0, 0),
+                crate::lex::ast::range::Position::new(0, 0),
+            ),
+        });
+    }
+    Ok(out)
+}
+
+fn annotation_body_from_json(body: &Value) -> Result<Vec<ContentItem>, FromWireError> {
+    match body {
+        Value::Null => Ok(Vec::new()),
+        Value::String(_) => {
+            // Opaque-text body; reverse codec doesn't carry a body
+            // type for opaque strings on annotations, so drop. (The
+            // typical "annotation with text body" case is round-
+            // tripped via the children-of-paragraphs path anyway.)
+            Ok(Vec::new())
+        }
+        Value::Object(obj) => {
+            let kind = obj.get("kind").and_then(|v| v.as_str());
+            if kind != Some("block") {
+                return Err(FromWireError::MalformedField {
+                    field: "body.kind",
+                    detail: format!("expected \"block\", got {kind:?}"),
+                });
+            }
+            let children: Vec<WireNode> = match obj.get("children") {
+                Some(arr) => serde_json::from_value(arr.clone())
+                    .map_err(|e| FromWireError::DeserialisationFailed(e.to_string()))?,
+                None => Vec::new(),
+            };
+            from_wire_subtree(&children)
+        }
+        _ => Err(FromWireError::MalformedField {
+            field: "body",
+            detail: "expected null, string, or object".into(),
+        }),
+    }
+}
+
+fn kind_name(node: &WireNode) -> &'static str {
+    match node {
+        WireNode::Document { .. } => "document",
+        WireNode::Session { .. } => "session",
+        WireNode::Definition { .. } => "definition",
+        WireNode::Paragraph { .. } => "paragraph",
+        WireNode::List { .. } => "list",
+        WireNode::Verbatim { .. } => "verbatim",
+        WireNode::Table { .. } => "table",
+        WireNode::Annotation { .. } => "annotation",
+        WireNode::Blank { .. } => "blank",
+        _ => "unknown",
+    }
+}

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -49,7 +49,15 @@ fn convert_one(node: &WireNode) -> Result<ContentItem, FromWireError> {
             Ok(ContentItem::Paragraph(paragraph_from_wire(range, inlines)))
         }
         WireNode::Blank { range, .. } => {
-            let mut blg = BlankLineGroup::new(1, Vec::new());
+            // Reconstruct the blank-line count from the range when
+            // possible: an N-line blank group spans N lines, so
+            // `end.line - start.line` (clamped to >= 1) recovers the
+            // count. Wire ranges that came from lex-core preserve
+            // line boundaries; ranges with collapsed start/end fall
+            // back to count = 1.
+            let span_lines = range.end.line().saturating_sub(range.start.line());
+            let count = (span_lines as usize).max(1);
+            let mut blg = BlankLineGroup::new(count, Vec::new());
             blg.location = range_from_wire(range);
             Ok(ContentItem::BlankLineGroup(blg))
         }
@@ -93,9 +101,34 @@ fn paragraph_from_wire(
     inlines: &[lex_extension::wire::WireInline],
 ) -> Paragraph {
     let location = range_from_wire(range);
-    let text = text_content_from_wire(inlines);
-    let line = TextLine::new(text);
-    let mut p = Paragraph::new(vec![ContentItem::TextLine(line)]);
+    // Round-trip the wire inlines back into a single source string,
+    // then split on `\n` to reconstruct multiple TextLines. The
+    // forward codec inserts an explicit `\n` Text inline between
+    // each TextLine, so an N-line paragraph round-trips back to N
+    // TextLines.
+    let combined = text_content_from_wire(inlines);
+    let raw = combined.as_string();
+    let line_strings: Vec<&str> = if raw.is_empty() {
+        Vec::new()
+    } else {
+        raw.split('\n').collect()
+    };
+    let lines: Vec<ContentItem> = line_strings
+        .into_iter()
+        .map(|line_str| {
+            ContentItem::TextLine(TextLine::new(crate::lex::ast::TextContent::from_string(
+                line_str.to_string(),
+                None,
+            )))
+        })
+        .collect();
+    let mut p = if lines.is_empty() {
+        Paragraph::new(vec![ContentItem::TextLine(TextLine::new(
+            crate::lex::ast::TextContent::empty(),
+        ))])
+    } else {
+        Paragraph::new(lines)
+    };
     p.location = location;
     p
 }
@@ -157,12 +190,17 @@ fn parameters_from_json(params: &Value) -> Result<Vec<Parameter>, FromWireError>
 fn annotation_body_from_json(body: &Value) -> Result<Vec<ContentItem>, FromWireError> {
     match body {
         Value::Null => Ok(Vec::new()),
-        Value::String(_) => {
-            // Opaque-text body; reverse codec doesn't carry a body
-            // type for opaque strings on annotations, so drop. (The
-            // typical "annotation with text body" case is round-
-            // tripped via the children-of-paragraphs path anyway.)
-            Ok(Vec::new())
+        Value::String(text) => {
+            // Single-line / opaque-text annotation body. lex-core
+            // represents this as a single Paragraph child (matching
+            // `extract_annotation_single_content` in the parser). We
+            // mirror that here so content isn't silently dropped.
+            let line = TextLine::new(crate::lex::ast::TextContent::from_string(
+                text.clone(),
+                None,
+            ));
+            let para = Paragraph::new(vec![ContentItem::TextLine(line)]);
+            Ok(vec![ContentItem::Paragraph(para)])
         }
         Value::Object(obj) => {
             let kind = obj.get("kind").and_then(|v| v.as_str());

--- a/crates/lex-core/src/lex/wire/inline.rs
+++ b/crates/lex-core/src/lex/wire/inline.rs
@@ -1,0 +1,121 @@
+//! Inline-content conversion between lex-core's `TextContent` /
+//! `InlineNode` and `lex_extension::WireInline`.
+//!
+//! The current strategy is pragmatic and Phase-1-aware: most lex-core
+//! `TextContent` is stored as a raw string (`TextRepresentation::Text`)
+//! pending the inline-parser migration. We convert that as a single
+//! [`WireInline::Text`] carrying the raw source. When parsed inlines are
+//! present (`TextRepresentation::Inlines`), we walk the tree and produce
+//! matching `WireInline` variants, dropping inline-attached annotations
+//! (Phase 2 fidelity is a future codec improvement).
+//!
+//! The reverse direction always produces a `TextContent::from_string`
+//! whose body is the concatenation of the wire inlines re-serialised to
+//! `.lex` source form (`*x*` for bold, `_y_` for italic, `` `code` ``,
+//! `#math#`, `[ref]`). That string parses identically when fed back to
+//! the inline parser.
+
+use crate::lex::ast::elements::inlines::{InlineContent, InlineNode, ReferenceInline};
+use crate::lex::ast::TextContent;
+use lex_extension::wire::{RefKind, WireInline};
+
+/// Forward: `TextContent` → list of `WireInline`s.
+///
+/// Total: every TextContent shape produces at least one wire inline.
+pub(crate) fn text_content_to_wire(tc: &TextContent) -> Vec<WireInline> {
+    // For Phase 1 representations (Text(String)), emit a single Text
+    // inline with the raw source. The parser will re-interpret formatting
+    // markers when this round-trips back through from_wire.
+    let raw = tc.as_string().to_string();
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    vec![WireInline::Text { text: raw }]
+}
+
+/// Forward: walk a parsed inline tree (`Vec<InlineNode>`) into wire
+/// inlines. Used when (future) callers have access to a parsed tree
+/// directly, rather than via `TextContent`.
+#[allow(dead_code)]
+pub(crate) fn inline_nodes_to_wire(nodes: &InlineContent) -> Vec<WireInline> {
+    nodes.iter().map(inline_node_to_wire).collect()
+}
+
+fn inline_node_to_wire(node: &InlineNode) -> WireInline {
+    match node {
+        InlineNode::Plain { text, .. } => WireInline::Text { text: text.clone() },
+        InlineNode::Strong { content, .. } => WireInline::Bold {
+            children: inline_nodes_to_wire(content),
+        },
+        InlineNode::Emphasis { content, .. } => WireInline::Italic {
+            children: inline_nodes_to_wire(content),
+        },
+        InlineNode::Code { text, .. } => WireInline::Code { text: text.clone() },
+        InlineNode::Math { text, .. } => WireInline::Math { text: text.clone() },
+        InlineNode::Reference { data, .. } => reference_to_wire(data),
+        // No catch-all needed — InlineNode is exhaustive in lex-core.
+    }
+}
+
+fn reference_to_wire(data: &ReferenceInline) -> WireInline {
+    // Emit a generic reference; the discriminator best-effort maps to
+    // the documented RefKind values. Detail-level fidelity beyond the
+    // raw target string is a future improvement.
+    WireInline::Reference {
+        ref_kind: RefKind::General,
+        target: data.raw.clone(),
+        label: None,
+    }
+}
+
+/// Reverse: wire inlines → a single `TextContent` carrying the
+/// re-serialised source form.
+pub(crate) fn text_content_from_wire(inlines: &[WireInline]) -> TextContent {
+    let mut buf = String::new();
+    for inline in inlines {
+        write_inline_source(inline, &mut buf);
+    }
+    TextContent::from_string(buf, None)
+}
+
+fn write_inline_source(inline: &WireInline, buf: &mut String) {
+    match inline {
+        WireInline::Text { text } => buf.push_str(text),
+        WireInline::Bold { children } => {
+            buf.push('*');
+            for c in children {
+                write_inline_source(c, buf);
+            }
+            buf.push('*');
+        }
+        WireInline::Italic { children } => {
+            buf.push('_');
+            for c in children {
+                write_inline_source(c, buf);
+            }
+            buf.push('_');
+        }
+        WireInline::Code { text } => {
+            buf.push('`');
+            buf.push_str(text);
+            buf.push('`');
+        }
+        WireInline::Math { text } => {
+            buf.push('#');
+            buf.push_str(text);
+            buf.push('#');
+        }
+        WireInline::Reference { target, label, .. } => {
+            buf.push('[');
+            // Emit `[label]` form when a label is present; otherwise
+            // bare `[target]`. Re-parsing reconstructs the appropriate
+            // ReferenceInline variant.
+            buf.push_str(label.as_deref().unwrap_or(target));
+            buf.push(']');
+        }
+        // WireInline is `#[non_exhaustive]` — guard against future
+        // variants by emitting an empty span. Round-trip will be lossy
+        // for any new inline kind, but this avoids panicking.
+        _ => {}
+    }
+}

--- a/crates/lex-core/src/lex/wire/inline.rs
+++ b/crates/lex-core/src/lex/wire/inline.rs
@@ -1,19 +1,26 @@
 //! Inline-content conversion between lex-core's `TextContent` /
 //! `InlineNode` and `lex_extension::WireInline`.
 //!
-//! The current strategy is pragmatic and Phase-1-aware: most lex-core
-//! `TextContent` is stored as a raw string (`TextRepresentation::Text`)
-//! pending the inline-parser migration. We convert that as a single
-//! [`WireInline::Text`] carrying the raw source. When parsed inlines are
-//! present (`TextRepresentation::Inlines`), we walk the tree and produce
-//! matching `WireInline` variants, dropping inline-attached annotations
-//! (Phase 2 fidelity is a future codec improvement).
+//! Forward path:
 //!
-//! The reverse direction always produces a `TextContent::from_string`
-//! whose body is the concatenation of the wire inlines re-serialised to
+//! - When `TextContent` has parsed inlines available
+//!   ([`TextContent::inline_nodes`]), the codec walks the inline tree
+//!   and produces matching `WireInline` variants
+//!   (`Plain → Text`, `Strong → Bold`, `Emphasis → Italic`, `Code →
+//!   Code`, `Math → Math`, `Reference → Reference`). Inline-attached
+//!   annotations are dropped (Phase 2 fidelity is a future codec
+//!   improvement).
+//! - Otherwise (the raw-string Phase-1 representation) the codec
+//!   emits a single [`WireInline::Text`] carrying the raw source. The
+//!   parser re-interprets formatting markers when this round-trips
+//!   back through `from_wire`.
+//! - Empty text yields an empty `Vec` (no inline element is emitted).
+//!
+//! Reverse path always produces a `TextContent::from_string` whose
+//! body is the concatenation of the wire inlines re-serialised to
 //! `.lex` source form (`*x*` for bold, `_y_` for italic, `` `code` ``,
-//! `#math#`, `[ref]`). That string parses identically when fed back to
-//! the inline parser.
+//! `#math#`, `[ref]`). That string parses identically when fed back
+//! to the inline parser.
 
 use crate::lex::ast::elements::inlines::{InlineContent, InlineNode, ReferenceInline};
 use crate::lex::ast::TextContent;
@@ -21,22 +28,24 @@ use lex_extension::wire::{RefKind, WireInline};
 
 /// Forward: `TextContent` → list of `WireInline`s.
 ///
-/// Total: every TextContent shape produces at least one wire inline.
+/// Returns an empty vector for empty text. Walks parsed inline nodes
+/// when they're available; otherwise emits a single `Text` inline
+/// carrying the raw source string.
 pub(crate) fn text_content_to_wire(tc: &TextContent) -> Vec<WireInline> {
-    // For Phase 1 representations (Text(String)), emit a single Text
-    // inline with the raw source. The parser will re-interpret formatting
-    // markers when this round-trips back through from_wire.
-    let raw = tc.as_string().to_string();
+    if let Some(nodes) = tc.inline_nodes() {
+        return nodes.iter().map(inline_node_to_wire).collect();
+    }
+    let raw = tc.as_string();
     if raw.is_empty() {
         return Vec::new();
     }
-    vec![WireInline::Text { text: raw }]
+    vec![WireInline::Text {
+        text: raw.to_string(),
+    }]
 }
 
 /// Forward: walk a parsed inline tree (`Vec<InlineNode>`) into wire
-/// inlines. Used when (future) callers have access to a parsed tree
-/// directly, rather than via `TextContent`.
-#[allow(dead_code)]
+/// inlines.
 pub(crate) fn inline_nodes_to_wire(nodes: &InlineContent) -> Vec<WireInline> {
     nodes.iter().map(inline_node_to_wire).collect()
 }

--- a/crates/lex-core/src/lex/wire/mod.rs
+++ b/crates/lex-core/src/lex/wire/mod.rs
@@ -15,21 +15,32 @@
 //!
 //! # Lossy in places, by design
 //!
-//! The forward codec preserves *structural* fidelity but drops some
-//! representation-only details:
+//! The forward codec preserves *block structure* but drops several
+//! representation-only details that the wire format does not have
+//! slots for:
 //!
 //! - `Range::span` (byte offsets) — the wire format encodes only
 //!   `(line, column)`. Reverse codec reconstructs `span = 0..0` since
 //!   spliced content's byte offsets are advisory.
-//! - Inline-attached annotations on inline nodes — wire `WireInline`
-//!   doesn't carry annotation slots. (Block-level annotations on
-//!   paragraphs/sessions/etc. are preserved.)
-//! - `TextContent` always normalises to a single `WireInline::Text`
-//!   carrying the raw source string when the internal representation
-//!   is `Text(s)` (Phase 1 of the inline-parsing migration). When the
-//!   internal representation is parsed inlines (Phase 2), the codec
-//!   walks the inline tree and produces matching `WireInline` variants;
-//!   reverse codec round-trips through a stringified form that the
+//! - **Inline-attached annotations** on inline nodes — wire
+//!   `WireInline` doesn't carry annotation slots.
+//! - **Block-level annotations** on `Paragraph`, `Session`, `List`,
+//!   `Table`, etc. — none of the wire `WireNode` variants carry an
+//!   `annotations` field, so attached annotations are dropped in the
+//!   forward direction. (Standalone `ContentItem::Annotation` nodes
+//!   *are* round-tripped fully via `WireNode::Annotation`.)
+//! - **Document-level metadata** — `Document.title` and
+//!   `Document.annotations` are dropped: the forward codec returns a
+//!   `WireNode::Document` whose `children` are the root session's
+//!   children, and only those.
+//! - **Marker structure** on sessions and lists — the wire format
+//!   stringifies the marker (`"1.1."`, `"(a)"`); the parser
+//!   reconstructs the typed marker on the next parse.
+//! - **`TextContent`** uses the parsed-inline path
+//!   ([`TextContent::inline_nodes`]) when available (Phase 2),
+//!   producing matching `WireInline` variants; otherwise emits the
+//!   raw source as a single `WireInline::Text`. Reverse codec
+//!   re-serialises through a `.lex` source-form string that the
 //!   parser re-interprets identically.
 //!
 //! For the consumer that matters today (`LexIncludeHandler` in PR 3c),

--- a/crates/lex-core/src/lex/wire/mod.rs
+++ b/crates/lex-core/src/lex/wire/mod.rs
@@ -5,25 +5,51 @@
 //! crate. The codec is what lets the registry-driven resolve pass round-trip
 //! handler-returned wire ASTs back into typed lex-core nodes for splicing.
 //!
-//! # Status: skeleton only
+//! # Direction
 //!
-//! This module is the placeholder landed in PR 3a (lex-fmt/lex#519); the
-//! actual codec implementation lands in PR 3b (lex-fmt/lex#531). PR 3c
-//! ([lex-fmt/lex#532](https://github.com/lex-fmt/lex/issues/532)) is the
-//! first consumer (`LexIncludeHandler`); PR 3d
-//! ([lex-fmt/lex#533](https://github.com/lex-fmt/lex/issues/533)) wires
-//! the codec into the resolve pass.
+//! - [`to_wire_node`] — forward: total over the AST shapes a parsed lex
+//!   document can produce. Output is a [`lex_extension::WireNode`] tree.
+//! - [`from_wire_node`] — reverse: fallible. Recognised `WireNode`
+//!   variants become lex-core [`crate::lex::ast::ContentItem`]s; unknown
+//!   shapes return [`FromWireError::UnsupportedKind`].
 //!
-//! # Design overview (forward reference for PR 3b)
+//! # Lossy in places, by design
 //!
-//! - **Forward** (`Document → WireNode`): a total walk over lex-core's AST
-//!   that produces a `WireNode::Document` rooted at the document's root
-//!   session. Per-variant conversion for sessions, definitions, paragraphs,
-//!   annotations, blank groups, lists, tables, and verbatim blocks.
-//! - **Reverse** (`WireNode → Vec<ContentItem>`): fallible — wire input may
-//!   be malformed. The reverse direction is what the registry-driven
-//!   resolve pass uses to splice handler output back into the host AST.
-//! - **Versioning**: this codec speaks `lex_extension::WIRE_VERSION = 1`.
-//!   The codec lives next to the AST it converts so internal AST changes
-//!   that affect the wire format are caught at compile time here, not
-//!   downstream in handler crates.
+//! The forward codec preserves *structural* fidelity but drops some
+//! representation-only details:
+//!
+//! - `Range::span` (byte offsets) — the wire format encodes only
+//!   `(line, column)`. Reverse codec reconstructs `span = 0..0` since
+//!   spliced content's byte offsets are advisory.
+//! - Inline-attached annotations on inline nodes — wire `WireInline`
+//!   doesn't carry annotation slots. (Block-level annotations on
+//!   paragraphs/sessions/etc. are preserved.)
+//! - `TextContent` always normalises to a single `WireInline::Text`
+//!   carrying the raw source string when the internal representation
+//!   is `Text(s)` (Phase 1 of the inline-parsing migration). When the
+//!   internal representation is parsed inlines (Phase 2), the codec
+//!   walks the inline tree and produces matching `WireInline` variants;
+//!   reverse codec round-trips through a stringified form that the
+//!   parser re-interprets identically.
+//!
+//! For the consumer that matters today (`LexIncludeHandler` in PR 3c),
+//! these losses are invisible: the spliced content renders to the same
+//! `.lex` source as the original.
+//!
+//! # Versioning
+//!
+//! This codec speaks `lex_extension::WIRE_VERSION = 1`. Wire-format
+//! changes that bump that constant require codec updates here.
+
+mod error;
+pub mod from_wire;
+mod inline;
+mod range;
+pub mod to_wire;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::FromWireError;
+pub use from_wire::{from_wire_node, from_wire_subtree};
+pub use to_wire::{to_wire_document, to_wire_node};

--- a/crates/lex-core/src/lex/wire/range.rs
+++ b/crates/lex-core/src/lex/wire/range.rs
@@ -9,7 +9,21 @@ use crate::lex::ast::range::{Position as CorePosition, Range as CoreRange};
 use lex_extension::wire::{Position as WirePosition, Range as WireRange};
 
 pub(crate) fn position_to_wire(p: &CorePosition) -> WirePosition {
-    WirePosition::new(p.line as u32, p.column as u32)
+    // Wire format pins line/column to u32. lex-core stores them as
+    // usize because they index bytes within typical 64-bit address
+    // space; values that exceed u32::MAX would mean a single document
+    // containing >4 billion lines, which doesn't happen in practice.
+    // Saturate-and-debug-assert so a future regression surfaces in
+    // dev rather than producing a wrapped value silently.
+    let line = u32::try_from(p.line).unwrap_or_else(|_| {
+        debug_assert!(false, "position line {} exceeds u32::MAX", p.line);
+        u32::MAX
+    });
+    let column = u32::try_from(p.column).unwrap_or_else(|_| {
+        debug_assert!(false, "position column {} exceeds u32::MAX", p.column);
+        u32::MAX
+    });
+    WirePosition::new(line, column)
 }
 
 pub(crate) fn position_from_wire(p: &WirePosition) -> CorePosition {

--- a/crates/lex-core/src/lex/wire/range.rs
+++ b/crates/lex-core/src/lex/wire/range.rs
@@ -1,0 +1,64 @@
+//! `Range` / `Position` conversion between lex-core and `lex_extension`.
+//!
+//! Forward path: drops `span` (byte offsets) and `origin_path`
+//! (`origin_path` is lifted to the wire node's `origin` field by the
+//! caller). Reverse path reconstructs `span = 0..0` since byte offsets
+//! are advisory in spliced content.
+
+use crate::lex::ast::range::{Position as CorePosition, Range as CoreRange};
+use lex_extension::wire::{Position as WirePosition, Range as WireRange};
+
+pub(crate) fn position_to_wire(p: &CorePosition) -> WirePosition {
+    WirePosition::new(p.line as u32, p.column as u32)
+}
+
+pub(crate) fn position_from_wire(p: &WirePosition) -> CorePosition {
+    CorePosition::new(p.line() as usize, p.column() as usize)
+}
+
+pub(crate) fn range_to_wire(r: &CoreRange) -> WireRange {
+    WireRange::new(position_to_wire(&r.start), position_to_wire(&r.end))
+}
+
+pub(crate) fn range_from_wire(r: &WireRange) -> CoreRange {
+    CoreRange::new(
+        0..0,
+        position_from_wire(&r.start),
+        position_from_wire(&r.end),
+    )
+}
+
+/// Lift a lex-core `Range`'s `origin_path` to the wire `origin` string.
+#[allow(dead_code)] // consumed by to_wire.rs starting in the next module
+pub(crate) fn origin_string(r: &CoreRange) -> Option<String> {
+    r.origin_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_round_trip() {
+        let core = CorePosition::new(12, 34);
+        let wire = position_to_wire(&core);
+        assert_eq!(wire, WirePosition::new(12, 34));
+        let back = position_from_wire(&wire);
+        assert_eq!(back.line, 12);
+        assert_eq!(back.column, 34);
+    }
+
+    #[test]
+    fn range_round_trip() {
+        let core = CoreRange::new(10..20, CorePosition::new(1, 2), CorePosition::new(1, 12));
+        let wire = range_to_wire(&core);
+        let back = range_from_wire(&wire);
+        // span is dropped, but line/col are preserved
+        assert_eq!(back.start.line, 1);
+        assert_eq!(back.start.column, 2);
+        assert_eq!(back.end.line, 1);
+        assert_eq!(back.end.column, 12);
+    }
+}

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -150,3 +150,109 @@ fn from_wire_subtree_handles_empty() {
     let items = from_wire_subtree(&[]).expect("ok");
     assert!(items.is_empty());
 }
+
+#[test]
+fn multi_line_paragraph_round_trips() {
+    // A paragraph with two TextLines should preserve both lines
+    // through the wire round-trip — without explicit `\n` separators
+    // in the forward codec, "Hello" + "World" would become
+    // "HelloWorld".
+    let p = Paragraph::new(vec![
+        ContentItem::TextLine(TextLine::new(TextContent::from_string(
+            "Hello".into(),
+            None,
+        ))),
+        ContentItem::TextLine(TextLine::new(TextContent::from_string(
+            "World".into(),
+            None,
+        ))),
+    ]);
+    let item = ContentItem::Paragraph(p);
+    let wire = to_wire_node(&item);
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Paragraph(p) => {
+            assert_eq!(p.lines.len(), 2, "expected two TextLines after round-trip");
+            let texts: Vec<&str> = p
+                .lines
+                .iter()
+                .filter_map(|li| match li {
+                    ContentItem::TextLine(line) => Some(line.content.as_string()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(texts, vec!["Hello", "World"]);
+        }
+        other => panic!("expected Paragraph, got {other:?}"),
+    }
+}
+
+#[test]
+fn string_body_annotation_becomes_paragraph_child() {
+    // A wire annotation with a string body (the single-line form,
+    // e.g. `:: note :: hello`) should round-trip into an Annotation
+    // whose children contain a single Paragraph carrying the text.
+    let wire = lex_extension::wire::WireNode::Annotation {
+        range: lex_extension::wire::Range::new(
+            lex_extension::wire::Position::new(0, 0),
+            lex_extension::wire::Position::new(0, 18),
+        ),
+        origin: None,
+        label: "note".into(),
+        params: serde_json::json!({}),
+        body: serde_json::Value::String("hello".into()),
+    };
+    let back = from_wire_node(&wire).expect("ok");
+    match &back[0] {
+        ContentItem::Annotation(a) => {
+            let children: Vec<&ContentItem> = a.children.iter().collect();
+            assert_eq!(children.len(), 1, "string body should produce one child");
+            match children[0] {
+                ContentItem::Paragraph(p) => {
+                    let line = match &p.lines[0] {
+                        ContentItem::TextLine(line) => line,
+                        _ => panic!("expected TextLine"),
+                    };
+                    assert_eq!(line.content.as_string(), "hello");
+                }
+                other => panic!("expected Paragraph child, got {other:?}"),
+            }
+        }
+        other => panic!("expected Annotation, got {other:?}"),
+    }
+}
+
+#[test]
+fn blank_count_from_range_span() {
+    // A wire blank node whose range spans 3 lines should reverse
+    // into a BlankLineGroup with count=3, not the prior fixed
+    // count=1.
+    let wire = lex_extension::wire::WireNode::Blank {
+        range: lex_extension::wire::Range::new(
+            lex_extension::wire::Position::new(5, 0),
+            lex_extension::wire::Position::new(8, 0),
+        ),
+        origin: None,
+    };
+    let back = from_wire_node(&wire).expect("ok");
+    match &back[0] {
+        ContentItem::BlankLineGroup(blg) => assert_eq!(blg.count, 3),
+        other => panic!("expected BlankLineGroup, got {other:?}"),
+    }
+}
+
+#[test]
+fn blank_count_clamps_to_one_for_collapsed_range() {
+    let wire = lex_extension::wire::WireNode::Blank {
+        range: lex_extension::wire::Range::new(
+            lex_extension::wire::Position::new(0, 0),
+            lex_extension::wire::Position::new(0, 0),
+        ),
+        origin: None,
+    };
+    let back = from_wire_node(&wire).expect("ok");
+    match &back[0] {
+        ContentItem::BlankLineGroup(blg) => assert_eq!(blg.count, 1),
+        _ => panic!("expected BlankLineGroup"),
+    }
+}

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -1,0 +1,152 @@
+//! Round-trip tests for the wire codec.
+//!
+//! Strategy: for each shape currently covered, build a synthetic
+//! lex-core AST node, run through `to_wire_node`, JSON-serialise +
+//! deserialise (proves the wire form actually round-trips through the
+//! protocol envelope), then convert back via `from_wire_node`. The
+//! recovered AST should be structurally equivalent to the input.
+//!
+//! Corpus-driven round-trip across every `.lex` fixture lands in a
+//! follow-up commit on the same PR once Session/Definition/List/Table/
+//! Verbatim coverage is complete in `to_wire.rs` / `from_wire.rs`.
+
+use super::from_wire::{from_wire_node, from_wire_subtree};
+use super::to_wire::to_wire_node;
+use crate::lex::ast::elements::annotation::Annotation;
+use crate::lex::ast::elements::blank_line_group::BlankLineGroup;
+use crate::lex::ast::elements::content_item::ContentItem;
+use crate::lex::ast::elements::label::Label;
+use crate::lex::ast::elements::paragraph::{Paragraph, TextLine};
+use crate::lex::ast::range::{Position, Range};
+use crate::lex::ast::TextContent;
+use lex_extension::wire::WireNode;
+
+fn r(s: usize, e: usize) -> Range {
+    Range::new(0..0, Position::new(s, 0), Position::new(e, 0))
+}
+
+fn json_round_trip(node: &WireNode) -> WireNode {
+    let s = serde_json::to_string(node).expect("wire node serialises");
+    serde_json::from_str(&s).expect("wire node deserialises")
+}
+
+#[test]
+fn paragraph_round_trips() {
+    let p = Paragraph::new(vec![ContentItem::TextLine(TextLine::new(
+        TextContent::from_string("hello world".into(), None),
+    ))]);
+    let item = ContentItem::Paragraph(p);
+    let wire = to_wire_node(&item);
+    let wire_after = json_round_trip(&wire);
+    let back = from_wire_node(&wire_after).expect("from_wire ok");
+    assert_eq!(back.len(), 1);
+    match &back[0] {
+        ContentItem::Paragraph(p) => {
+            // The single text line should carry the original raw string.
+            assert_eq!(p.lines.len(), 1);
+            if let ContentItem::TextLine(line) = &p.lines[0] {
+                assert_eq!(line.content.as_string(), "hello world");
+            } else {
+                panic!("expected TextLine inside Paragraph");
+            }
+        }
+        other => panic!("expected Paragraph, got {other:?}"),
+    }
+}
+
+#[test]
+fn blank_round_trips() {
+    let mut blg = BlankLineGroup::new(1, Vec::new());
+    blg.location = r(0, 1);
+    let item = ContentItem::BlankLineGroup(blg);
+    let wire = to_wire_node(&item);
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    assert!(matches!(back[0], ContentItem::BlankLineGroup(_)));
+}
+
+#[test]
+fn marker_annotation_round_trips() {
+    let a = Annotation::marker(Label::new("note".into()));
+    let item = ContentItem::Annotation(a);
+    let wire = to_wire_node(&item);
+    // Marker annotation has no body — wire carries `body: null`.
+    if let WireNode::Annotation { body, .. } = &wire {
+        assert!(body.is_null(), "marker annotation must serialise body=null");
+    } else {
+        panic!("expected Annotation");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Annotation(a) => {
+            assert_eq!(a.data.label.value, "note");
+            assert_eq!(a.data.parameters.len(), 0);
+            assert_eq!(a.children.iter().count(), 0);
+        }
+        other => panic!("expected Annotation, got {other:?}"),
+    }
+}
+
+#[test]
+fn parameterised_annotation_round_trips() {
+    use crate::lex::ast::elements::parameter::Parameter;
+    let mut a = Annotation::marker(Label::new("acme.task".into()));
+    a.data.parameters.push(Parameter {
+        key: "id".into(),
+        value: "ACME-1234".into(),
+        location: r(0, 0),
+    });
+    a.data.parameters.push(Parameter {
+        key: "priority".into(),
+        value: "high".into(),
+        location: r(0, 0),
+    });
+    let item = ContentItem::Annotation(a);
+    let wire = to_wire_node(&item);
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Annotation(a) => {
+            assert_eq!(a.data.label.value, "acme.task");
+            // Parameter ordering may not be preserved (JSON object key
+            // ordering is implementation-defined); compare as a sorted
+            // key/value set instead.
+            let mut got: Vec<(String, String)> = a
+                .data
+                .parameters
+                .iter()
+                .map(|p| (p.key.clone(), p.value.clone()))
+                .collect();
+            got.sort();
+            assert_eq!(
+                got,
+                vec![
+                    ("id".to_string(), "ACME-1234".to_string()),
+                    ("priority".to_string(), "high".to_string()),
+                ]
+            );
+        }
+        other => panic!("expected Annotation, got {other:?}"),
+    }
+}
+
+#[test]
+fn unsupported_variant_surfaces_as_error() {
+    use super::error::FromWireError;
+    use crate::lex::ast::elements::session::Session;
+    // Session is intentionally not yet wired through the codec; the
+    // forward direction emits a placeholder, the reverse surfaces it
+    // as UnsupportedKind.
+    let s = Session::with_title("title".into());
+    let item = ContentItem::Session(s);
+    let wire = to_wire_node(&item);
+    let result = from_wire_node(&json_round_trip(&wire));
+    assert!(matches!(
+        result,
+        Err(FromWireError::UnsupportedKind { ref kind }) if kind == "session"
+    ));
+}
+
+#[test]
+fn from_wire_subtree_handles_empty() {
+    let items = from_wire_subtree(&[]).expect("ok");
+    assert!(items.is_empty());
+}

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -65,13 +65,19 @@ pub fn to_wire_node(item: &ContentItem) -> WireNode {
 }
 
 fn paragraph_to_wire(p: &Paragraph) -> WireNode {
-    // Concatenate every TextLine's text content into a single inline
-    // sequence. Round-trip through the reverse codec rebuilds a single
-    // TextLine; the parser re-interprets line breaks identically.
+    // Walk each TextLine, separating lines with explicit newline
+    // inlines so the reverse codec can reconstruct the original
+    // multi-line shape. Without the separator, "Hello" + "World"
+    // would round-trip as "HelloWorld".
     let mut inlines = Vec::new();
+    let mut first_line = true;
     for line_item in &p.lines {
         if let ContentItem::TextLine(line) = line_item {
+            if !first_line {
+                inlines.push(lex_extension::wire::WireInline::Text { text: "\n".into() });
+            }
             inlines.extend(text_content_to_wire(&line.content));
+            first_line = false;
         }
     }
     WireNode::Paragraph {

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -1,0 +1,173 @@
+//! Forward codec: lex-core internal AST → `lex_extension::WireNode`.
+//!
+//! Total over the AST shapes a parsed lex document can produce. Build-up
+//! is incremental: this commit covers the simpler block shapes
+//! (`Document`, `Paragraph`, `Annotation`, `BlankLineGroup`); follow-up
+//! commits on the same PR extend coverage to `Session`, `Definition`,
+//! `List`, `Table`, and `Verbatim`. Variants not yet wired return
+//! [`unsupported_node`] which produces a structural placeholder rather
+//! than panicking; the placeholder round-trips through the reverse
+//! codec to surface the gap as a [`crate::lex::wire::FromWireError`].
+
+use crate::lex::ast::elements::annotation::Annotation;
+use crate::lex::ast::elements::blank_line_group::BlankLineGroup;
+use crate::lex::ast::elements::content_item::ContentItem;
+use crate::lex::ast::elements::paragraph::Paragraph;
+use crate::lex::ast::Document;
+use lex_extension::wire::WireNode;
+use serde_json::{Map, Value};
+
+use super::inline::text_content_to_wire;
+use super::range::{origin_string, range_to_wire};
+
+/// Convert a lex-core `Document` to a `WireNode::Document`.
+///
+/// The document's root session's children become the wire document's
+/// children. Document-level title and document-level annotations are
+/// **dropped** in this codec (lex.include's splice path discards both
+/// for similar reasons — only the body content is interesting).
+pub fn to_wire_document(doc: &Document) -> WireNode {
+    let children = doc
+        .root
+        .children
+        .iter()
+        .map(to_wire_node)
+        .collect::<Vec<_>>();
+    WireNode::Document {
+        range: range_to_wire(&doc.root.location),
+        origin: origin_string(&doc.root.location),
+        children,
+    }
+}
+
+/// Convert a single `ContentItem` to a `WireNode`.
+///
+/// Variants not yet implemented produce an `Unknown`-shaped placeholder
+/// (see [`unsupported_node`]); the reverse codec surfaces these as
+/// [`super::FromWireError::UnsupportedKind`] so the gap is visible to
+/// callers.
+pub fn to_wire_node(item: &ContentItem) -> WireNode {
+    match item {
+        ContentItem::Paragraph(p) => paragraph_to_wire(p),
+        ContentItem::BlankLineGroup(blg) => blank_to_wire(blg),
+        ContentItem::Annotation(a) => annotation_to_wire(a),
+
+        // Coverage built up in follow-up commits.
+        ContentItem::Session(_)
+        | ContentItem::Definition(_)
+        | ContentItem::List(_)
+        | ContentItem::ListItem(_)
+        | ContentItem::TextLine(_)
+        | ContentItem::VerbatimBlock(_)
+        | ContentItem::Table(_)
+        | ContentItem::VerbatimLine(_) => unsupported_node(item),
+    }
+}
+
+fn paragraph_to_wire(p: &Paragraph) -> WireNode {
+    // Concatenate every TextLine's text content into a single inline
+    // sequence. Round-trip through the reverse codec rebuilds a single
+    // TextLine; the parser re-interprets line breaks identically.
+    let mut inlines = Vec::new();
+    for line_item in &p.lines {
+        if let ContentItem::TextLine(line) = line_item {
+            inlines.extend(text_content_to_wire(&line.content));
+        }
+    }
+    WireNode::Paragraph {
+        range: range_to_wire(&p.location),
+        origin: origin_string(&p.location),
+        inlines,
+    }
+}
+
+fn blank_to_wire(blg: &BlankLineGroup) -> WireNode {
+    WireNode::Blank {
+        range: range_to_wire(&blg.location),
+        origin: origin_string(&blg.location),
+    }
+}
+
+fn annotation_to_wire(a: &Annotation) -> WireNode {
+    let label = a.data.label.value.clone();
+    let params = parameters_to_json(&a.data.parameters);
+    let body = annotation_body_to_json(a);
+    WireNode::Annotation {
+        range: range_to_wire(&a.location),
+        origin: origin_string(&a.location),
+        label,
+        params,
+        body,
+    }
+}
+
+fn parameters_to_json(params: &[crate::lex::ast::elements::parameter::Parameter]) -> Value {
+    let mut obj = Map::with_capacity(params.len());
+    for p in params {
+        obj.insert(p.key.clone(), Value::String(p.value.clone()));
+    }
+    Value::Object(obj)
+}
+
+fn annotation_body_to_json(a: &Annotation) -> Value {
+    let children = a.children.iter().collect::<Vec<_>>();
+    if children.is_empty() {
+        return Value::Null;
+    }
+    let wire_children: Vec<Value> = children
+        .iter()
+        .map(|c| serde_json::to_value(to_wire_node(c)).expect("wire node serialises"))
+        .collect();
+    let mut obj = Map::with_capacity(2);
+    obj.insert("kind".into(), Value::String("block".into()));
+    obj.insert("children".into(), Value::Array(wire_children));
+    Value::Object(obj)
+}
+
+/// Placeholder for ContentItem variants not yet wired through the
+/// codec. Emits a `Verbatim` carrying the lex-core node-type name and
+/// no body — the reverse codec (which checks for `lex.internal`-prefix
+/// labels) surfaces this as `FromWireError::UnsupportedKind`.
+///
+/// This keeps the forward codec total without panicking, so partial
+/// coverage doesn't break callers that incidentally encounter an
+/// unsupported shape during testing.
+fn unsupported_node(item: &ContentItem) -> WireNode {
+    let location = match item {
+        ContentItem::Session(s) => &s.location,
+        ContentItem::Definition(d) => &d.location,
+        ContentItem::List(l) => &l.location,
+        ContentItem::ListItem(li) => &li.location,
+        ContentItem::TextLine(tl) => &tl.location,
+        ContentItem::VerbatimBlock(v) => &v.location,
+        ContentItem::Table(t) => &t.location,
+        ContentItem::VerbatimLine(vl) => &vl.location,
+        // The other arms are wired through the direct path; reaching
+        // this branch via them would be a programmer error.
+        _ => unreachable!("unsupported_node only used for unwired variants"),
+    };
+    let kind_name = item_node_type(item);
+    WireNode::Verbatim {
+        range: range_to_wire(location),
+        origin: origin_string(location),
+        label: format!("lex.internal.unsupported.{kind_name}"),
+        params: Value::Object(Map::new()),
+        body_text: String::new(),
+    }
+}
+
+fn item_node_type(item: &ContentItem) -> &'static str {
+    match item {
+        ContentItem::Paragraph(_) => "paragraph",
+        ContentItem::Session(_) => "session",
+        ContentItem::List(_) => "list",
+        ContentItem::ListItem(_) => "list_item",
+        ContentItem::TextLine(_) => "text_line",
+        ContentItem::Definition(_) => "definition",
+        ContentItem::Annotation(_) => "annotation",
+        ContentItem::VerbatimBlock(_) => "verbatim_block",
+        ContentItem::Table(_) => "table",
+        ContentItem::VerbatimLine(_) => "verbatim_line",
+        ContentItem::BlankLineGroup(_) => "blank",
+    }
+}


### PR DESCRIPTION
Closes #531. Part of #516 (the master extension-system implementation plan).

## Summary

Second of four sub-PRs splitting the original PR 3 work along clean seams (deps wire-up; codec; handler; resolve-pass flip). This PR implements the wire AST codec — the bidirectional bridge between lex-core's typed AST and ``lex_extension::WireNode``.

**No call-site change.** The codec is callable but nothing yet calls it. PR 3c (``LexIncludeHandler``) is its first consumer; PR 3d wires it into the resolve pass.

## Status: phase 1

This first commit covers the simpler block shapes: ``Document``, ``Paragraph``, ``BlankLineGroup``, and ``Annotation`` (with parameters and parsed bodies). Follow-up commits on this branch extend coverage to ``Session``, ``Definition``, ``List``, ``Table``, and ``Verbatim`` before the corpus-driven round-trip test (against every ``.lex`` fixture) lands.

Variants not yet wired emit a placeholder Verbatim with a reserved ``lex.internal.unsupported.<kind>`` label that the reverse direction surfaces as ``FromWireError::UnsupportedKind`` — the gap is visible to callers rather than silently dropped.

## What lands in this commit

- ``crates/lex-core/src/lex/wire/range.rs`` — Position/Range conversion. Forward drops byte_offset and origin_path (origin_path is lifted to the wire node's ``origin`` field).
- ``crates/lex-core/src/lex/wire/inline.rs`` — ``TextContent`` ↔ ``Vec<WireInline>``. Phase-1 aware: most TextContent today is raw String, so forward emits a single ``WireInline::Text`` carrying the source. Phase-2-ready for parsed inline trees.
- ``crates/lex-core/src/lex/wire/to_wire.rs`` — forward codec.
- ``crates/lex-core/src/lex/wire/from_wire.rs`` — reverse codec; fallible.
- ``crates/lex-core/src/lex/wire/error.rs`` — ``FromWireError``.
- ``crates/lex-core/src/lex/wire/tests.rs`` — 6 round-trip tests.

## Test plan

- [x] 8 new unit tests in ``lex-core::lex::wire::*`` covering Position/Range round-trips, paragraph, blank, marker annotation, parameterised annotation, unsupported-variant error path, and empty-subtree handling.
- [x] ``cargo build --workspace`` clean.
- [x] ``cargo clippy -p lex-core --all-targets -- -D warnings`` clean.
- [x] ``cargo fmt -p lex-core`` clean.
- [x] Pre-commit: 1719 workspace tests pass.

## Coming on this branch (subsequent commits)

- Forward + reverse coverage for ``Session``, ``Definition``, ``List``, ``Table``, ``Verbatim``.
- Inline-attached annotations (Phase 2 fidelity).
- Corpus-driven round-trip test that runs ``parse → to_wire → JSON round-trip → from_wire → format`` against every fixture in ``comms/specs/`` and asserts ``format(input) == format(output)``.

I'll undraft once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)