### PR TITLE
PR 3c — LexIncludeHandler (built-in handler, no call-site change)

### DIFF
--- a/crates/lex-core/src/lex/builtins/include.rs
+++ b/crates/lex-core/src/lex/builtins/include.rs
@@ -123,8 +123,44 @@ impl LexHandler for LexIncludeHandler {
         let origin = Arc::new(canonical_path);
         stamp_doc(&mut included, &origin);
 
+        // Splice-equivalent normalisation: convert the included
+        // document's title and document-level annotations into leading
+        // children of the root session, mirroring the legacy
+        // `prepare_splice_list` semantics so PR 3d's call-site flip
+        // produces an identical observable splice.
+        promote_title_and_doc_annotations(&mut included);
+
         let wire = to_wire_document(&included);
         Ok(Some(wire))
+    }
+}
+
+/// Mutate `doc` in place so that its title (if any) and document-level
+/// annotations are prepended to the root session's children — the same
+/// transformation `lex/includes.rs::prepare_splice_list` does, but
+/// applied to a still-typed `Document` so the wire codec can walk it
+/// uniformly.
+///
+/// Order matches the legacy splice list: title first, then
+/// `doc.annotations` in source order, then the original root children.
+fn promote_title_and_doc_annotations(doc: &mut crate::lex::ast::Document) {
+    use crate::lex::ast::elements::content_item::ContentItem;
+    use crate::lex::ast::elements::paragraph::Paragraph;
+
+    let mut prefix: Vec<ContentItem> = Vec::new();
+    if let Some(title) = doc.title.take() {
+        let location = title.location.clone();
+        let para = Paragraph::from_line(title.as_str().to_string()).at(location);
+        prefix.push(ContentItem::Paragraph(para));
+    }
+    for ann in doc.annotations.drain(..) {
+        prefix.push(ContentItem::Annotation(ann));
+    }
+    if !prefix.is_empty() {
+        let original = std::mem::take(doc.root.children.as_mut_vec());
+        let mut combined = prefix;
+        combined.extend(original);
+        *doc.root.children.as_mut_vec() = combined;
     }
 }
 
@@ -421,31 +457,122 @@ mod tests {
 
     #[test]
     fn parse_failure_maps_to_internal_error() {
-        // Construct a fixture that fails `parse_no_attach`. The
-        // parser is permissive, so we use a verbatim block whose
-        // closing marker is missing — that surfaces as a parse
-        // error in `parse_without_annotation_attachment`.
-        let mut loader = MemoryLoader::new();
-        // A subject + indented content with no closing `:: label ::`
-        // line is the canonical "unterminated verbatim" shape.
-        loader.insert(
-            PathBuf::from("/root/broken.lex"),
-            "Subject:\n    line one\n    line two\n",
-        );
-        let handler = handler_with_loader(loader, PathBuf::from("/root"));
-        let ctx = make_ctx("broken.lex", Some("/root/host.lex"));
-        // Whether this fixture trips a parse error depends on the
-        // current parser; the test only fails the handler if a
-        // parse error is surfaced. If the parser successfully parses
-        // the fixture, we still get Ok(Some(_)) and the assertion
-        // below short-circuits.
-        let result = handler.on_resolve(&ctx);
-        if let Err(err) = result {
+        // Deterministic test of the parse-failure → HandlerError mapping.
+        // The lex parser is permissive (most malformed inputs parse to
+        // *something*), so rather than depending on parser behaviour we
+        // test the mapping via a `MockParseFail` loader whose `load`
+        // returns source the wrapping `parse_no_attach` is documented
+        // to reject. To stay robust against future parser changes
+        // we *also* directly invoke `parse_no_attach` and verify it
+        // either errors (in which case the handler must produce
+        // `Internal`) or succeeds (in which case we exercise the
+        // mapping function via a synthetic call).
+        let probe = "Subject:\n    line one\n    line two\n";
+        let probe_parses_cleanly = parse_no_attach(probe).is_ok();
+
+        if !probe_parses_cleanly {
+            let mut loader = MemoryLoader::new();
+            loader.insert(PathBuf::from("/root/broken.lex"), probe);
+            let handler = handler_with_loader(loader, PathBuf::from("/root"));
+            let ctx = make_ctx("broken.lex", Some("/root/host.lex"));
+            let err = handler.on_resolve(&ctx).expect_err("must error");
             assert!(
                 matches!(err, HandlerError::Internal { .. }),
                 "parse failures must map to HandlerError::Internal, got {err:?}"
             );
+            return;
         }
+
+        // Parser accepted the probe; exercise the mapping function
+        // directly so the test still covers the error path.
+        let synthesised = HandlerError::internal(format!(
+            "parse of `{}` failed: {}",
+            std::path::Path::new("/root/broken.lex").display(),
+            "synthetic parse failure"
+        ));
+        assert!(
+            matches!(synthesised, HandlerError::Internal { .. }),
+            "synthesised parse-failure must be HandlerError::Internal"
+        );
+        assert!(
+            synthesised.to_string().contains("/root/broken.lex"),
+            "internal error message must include the offending path"
+        );
+        assert!(
+            synthesised.to_string().contains("synthetic parse failure"),
+            "internal error message must include the underlying parser message"
+        );
+    }
+
+    #[test]
+    fn included_document_title_and_annotations_are_promoted_to_leading_children() {
+        // Locks the `prepare_splice_list`-equivalent semantics: a
+        // titled and document-annotated include must produce wire
+        // children whose leading entries are the title (as a
+        // Paragraph) and each document-level annotation. This is the
+        // observable contract PR 3d's call-site flip relies on to
+        // avoid a behaviour change in the existing integration suite.
+        use crate::lex::ast::elements::content_item::ContentItem;
+        use crate::lex::wire::from_wire_node;
+
+        let mut loader = MemoryLoader::new();
+        // Source with a document title, a document-level annotation,
+        // and one body paragraph.
+        loader.insert(
+            PathBuf::from("/root/titled.lex"),
+            ":: meta author=alice ::\n\
+             Document Title\n\
+             \n\
+             Body paragraph.\n",
+        );
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        let ctx = make_ctx("titled.lex", Some("/root/host.lex"));
+        let wire = handler
+            .on_resolve(&ctx)
+            .expect("on_resolve ok")
+            .expect("Some(WireNode)");
+
+        let items = from_wire_node(&wire).expect("from_wire ok");
+        // Find the indices of the first paragraph and the first
+        // annotation in the recovered list.
+        let first_paragraph = items
+            .iter()
+            .position(|i| matches!(i, ContentItem::Paragraph(_)));
+        let first_annotation = items
+            .iter()
+            .position(|i| matches!(i, ContentItem::Annotation(_)));
+        assert!(
+            first_paragraph.is_some(),
+            "title-as-paragraph must survive into the wire payload"
+        );
+        assert!(
+            first_annotation.is_some(),
+            "document-level annotation must survive into the wire payload"
+        );
+        // Verify the title appears as paragraph text. Either the
+        // title-Paragraph or the original body Paragraph satisfies
+        // this — what matters is that *some* recovered paragraph
+        // carries the title's text.
+        let title_present = items.iter().any(|i| match i {
+            ContentItem::Paragraph(p) => p.lines.iter().any(|li| match li {
+                ContentItem::TextLine(line) => line.content.as_string() == "Document Title",
+                _ => false,
+            }),
+            _ => false,
+        });
+        assert!(
+            title_present,
+            "Document.title must round-trip as a leading Paragraph"
+        );
+        // And the meta annotation must come through with its label.
+        let meta_present = items.iter().any(|i| match i {
+            ContentItem::Annotation(a) => a.data.label.value == "meta",
+            _ => false,
+        });
+        assert!(
+            meta_present,
+            "document-level :: meta :: annotation must round-trip"
+        );
     }
 
     #[test]

--- a/crates/lex-core/src/lex/builtins/include.rs
+++ b/crates/lex-core/src/lex/builtins/include.rs
@@ -56,10 +56,17 @@ pub const CODE_ABSOLUTE_PATH: i32 = -32004;
 /// Error code: underlying I/O error during load.
 pub const CODE_IO: i32 = -32005;
 
+/// Function-pointer type for the parse step. Tests can substitute a
+/// stub via [`LexIncludeHandler::with_parse_fn`] to deterministically
+/// exercise the parse-error mapping without depending on which inputs
+/// the (permissive) lex parser happens to reject.
+pub(crate) type ParseFn = fn(&str) -> Result<crate::lex::ast::Document, String>;
+
 /// Built-in handler for the `lex.include` label.
 pub struct LexIncludeHandler {
     loader: Arc<dyn Loader + Send + Sync>,
     config: ResolveConfig,
+    parse_fn: ParseFn,
 }
 
 impl LexIncludeHandler {
@@ -74,7 +81,28 @@ impl LexIncludeHandler {
     /// so that future hooks (validate, render) can read its limits
     /// without an additional indirection.
     pub fn new(loader: Arc<dyn Loader + Send + Sync>, config: ResolveConfig) -> Self {
-        Self { loader, config }
+        Self {
+            loader,
+            config,
+            parse_fn: parse_no_attach,
+        }
+    }
+
+    /// Construct a handler with a custom parse function. Used by
+    /// tests to deterministically exercise the parse-error path; the
+    /// production constructor [`Self::new`] uses
+    /// [`parse_no_attach`].
+    #[cfg(test)]
+    pub(crate) fn with_parse_fn(
+        loader: Arc<dyn Loader + Send + Sync>,
+        config: ResolveConfig,
+        parse_fn: ParseFn,
+    ) -> Self {
+        Self {
+            loader,
+            config,
+            parse_fn,
+        }
     }
 
     /// Read-only access to the resolution root the handler was built
@@ -109,8 +137,11 @@ impl LexHandler for LexIncludeHandler {
 
         // Parse without annotation attachment — annotations stay
         // visible as standalone children, matching what
-        // `resolve_from_source` does in the inline path.
-        let mut included = parse_no_attach(&source).map_err(|message| {
+        // `resolve_from_source` does in the inline path. The parse
+        // function is injectable so tests can deterministically
+        // exercise the parse-error mapping; production uses
+        // `parse_no_attach`.
+        let mut included = (self.parse_fn)(&source).map_err(|message| {
             HandlerError::internal(format!(
                 "parse of `{}` failed: {message}",
                 canonical_path.display()
@@ -457,50 +488,40 @@ mod tests {
 
     #[test]
     fn parse_failure_maps_to_internal_error() {
-        // Deterministic test of the parse-failure → HandlerError mapping.
-        // The lex parser is permissive (most malformed inputs parse to
-        // *something*), so rather than depending on parser behaviour we
-        // test the mapping via a `MockParseFail` loader whose `load`
-        // returns source the wrapping `parse_no_attach` is documented
-        // to reject. To stay robust against future parser changes
-        // we *also* directly invoke `parse_no_attach` and verify it
-        // either errors (in which case the handler must produce
-        // `Internal`) or succeeds (in which case we exercise the
-        // mapping function via a synthetic call).
-        let probe = "Subject:\n    line one\n    line two\n";
-        let probe_parses_cleanly = parse_no_attach(probe).is_ok();
-
-        if !probe_parses_cleanly {
-            let mut loader = MemoryLoader::new();
-            loader.insert(PathBuf::from("/root/broken.lex"), probe);
-            let handler = handler_with_loader(loader, PathBuf::from("/root"));
-            let ctx = make_ctx("broken.lex", Some("/root/host.lex"));
-            let err = handler.on_resolve(&ctx).expect_err("must error");
-            assert!(
-                matches!(err, HandlerError::Internal { .. }),
-                "parse failures must map to HandlerError::Internal, got {err:?}"
-            );
-            return;
+        // Deterministic test of the parse-failure → HandlerError
+        // mapping. The lex parser is permissive — most malformed
+        // inputs parse to *something* — so finding a fixture that
+        // reliably trips `parse_no_attach` is brittle. Instead we
+        // inject a stub parser that always returns `Err` (via
+        // `LexIncludeHandler::with_parse_fn`) and assert the handler
+        // maps that error onto `HandlerError::Internal` with the
+        // offending path and underlying parser message both present
+        // in the diagnostic.
+        fn always_fails(_source: &str) -> Result<crate::lex::ast::Document, String> {
+            Err("synthetic parser failure".into())
         }
 
-        // Parser accepted the probe; exercise the mapping function
-        // directly so the test still covers the error path.
-        let synthesised = HandlerError::internal(format!(
-            "parse of `{}` failed: {}",
-            std::path::Path::new("/root/broken.lex").display(),
-            "synthetic parse failure"
-        ));
+        let mut loader = MemoryLoader::new();
+        loader.insert(PathBuf::from("/root/broken.lex"), "anything\n");
+        let handler = LexIncludeHandler::with_parse_fn(
+            Arc::new(loader),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+            always_fails,
+        );
+        let ctx = make_ctx("broken.lex", Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
         assert!(
-            matches!(synthesised, HandlerError::Internal { .. }),
-            "synthesised parse-failure must be HandlerError::Internal"
+            matches!(err, HandlerError::Internal { .. }),
+            "parse failures must map to HandlerError::Internal, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("/root/broken.lex"),
+            "internal error message must include the offending path: {message}"
         );
         assert!(
-            synthesised.to_string().contains("/root/broken.lex"),
-            "internal error message must include the offending path"
-        );
-        assert!(
-            synthesised.to_string().contains("synthetic parse failure"),
-            "internal error message must include the underlying parser message"
+            message.contains("synthetic parser failure"),
+            "internal error message must include the underlying parser message: {message}"
         );
     }
 

--- a/crates/lex-core/src/lex/builtins/include.rs
+++ b/crates/lex-core/src/lex/builtins/include.rs
@@ -1,0 +1,479 @@
+//! `LexIncludeHandler` — the first built-in [`LexHandler`].
+//!
+//! Wraps the existing [`Loader`] + [`parse_no_attach`] + [`stamp_doc`]
+//! pipeline so that `lex.include` runs through the registry-driven
+//! dispatch fabric the rest of the extension system uses. The
+//! observable behaviour matches the legacy inline path in
+//! [`crate::lex::includes::resolve_from_source`]: same parameter
+//! syntax, same path-resolution rules, same `FsLoader` security
+//! defenses (path traversal, symlink loop, size limit, root escape,
+//! absolute-path rejection).
+//!
+//! # Lifecycle
+//!
+//! In α (this PR — lex-fmt/lex#532), the handler is registrable but
+//! the resolve pass keeps using the inline path. PR 3d
+//! (lex-fmt/lex#533) flips the call site so this handler runs in
+//! production. That gives us a clean separation between *handler is
+//! correct* (proven here) and *resolve pass dispatches via the
+//! registry* (proven there).
+//!
+//! # Error mapping
+//!
+//! Loader errors map onto `HandlerError::Custom` with codes in the
+//! handler-defined `-32000..=-32099` range reserved by the wire spec
+//! §5. `Loader::load` failures and path-resolution failures all
+//! become diagnostics at the labelled node's range when surfaced
+//! through `Registry::dispatch_resolve`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use lex_extension::{
+    handler::{HandlerError, LexHandler},
+    wire::{LabelCtx, WireNode},
+};
+
+use crate::lex::includes::{
+    parse_no_attach, resolve_file_reference, stamp_doc, IncludeError, LoadError, LoadedFile,
+    Loader, ResolveConfig,
+};
+use crate::lex::wire::to_wire_document;
+
+/// Error code: `lex.include` annotation was missing the required `src`
+/// parameter. Matches the wire spec's handler-defined range.
+pub const CODE_MISSING_SRC: i32 = -32000;
+/// Error code: `Loader::load` returned `NotFound`.
+pub const CODE_NOT_FOUND: i32 = -32001;
+/// Error code: include path canonicalised outside the loader's root,
+/// or the resolver rejected it pre-load as a root escape.
+pub const CODE_OUTSIDE_ROOT: i32 = -32002;
+/// Error code: include target exceeded the loader's size cap.
+pub const CODE_TOO_LARGE: i32 = -32003;
+/// Error code: include path was a platform-absolute path
+/// (`C:\foo`, `/abs` on Unix), which the resolver rejects pre-load.
+pub const CODE_ABSOLUTE_PATH: i32 = -32004;
+/// Error code: underlying I/O error during load.
+pub const CODE_IO: i32 = -32005;
+
+/// Built-in handler for the `lex.include` label.
+pub struct LexIncludeHandler {
+    loader: Arc<dyn Loader + Send + Sync>,
+    config: ResolveConfig,
+}
+
+impl LexIncludeHandler {
+    /// Construct a handler from a loader (typically [`crate::lex::includes::FsLoader`]
+    /// in production, [`crate::lex::includes::MemoryLoader`] in tests)
+    /// and a resolve config bundling the resolution `root` plus depth /
+    /// total-include caps.
+    ///
+    /// Depth and total-include limits are not enforced by the handler
+    /// itself; they belong to the resolve-pass walker that wraps
+    /// dispatches across the document. The handler stores the config
+    /// so that future hooks (validate, render) can read its limits
+    /// without an additional indirection.
+    pub fn new(loader: Arc<dyn Loader + Send + Sync>, config: ResolveConfig) -> Self {
+        Self { loader, config }
+    }
+
+    /// Read-only access to the resolution root the handler was built
+    /// with. Useful for tests and for the resolve pass that wires
+    /// this handler into a registry.
+    pub fn root(&self) -> &Path {
+        &self.config.root
+    }
+}
+
+impl LexHandler for LexIncludeHandler {
+    fn on_resolve(&self, ctx: &LabelCtx) -> Result<Option<WireNode>, HandlerError> {
+        let src = extract_src(ctx)?;
+
+        // Path resolution against the host file's directory. When the
+        // host file's origin is unknown, resolution falls back to the
+        // configured root (per `resolve_file_reference`).
+        let host_origin = ctx.node.origin.as_deref().map(Path::new);
+        let target_path = resolve_file_reference(&src, host_origin, &self.config.root)
+            .map_err(|e| include_error_to_handler(&e))?;
+
+        // Load through the injected loader. Same security gate as the
+        // inline path: FsLoader canonicalises and bounds-checks against
+        // its canonical root post-symlink resolution.
+        let LoadedFile {
+            source,
+            canonical_path,
+        } = self
+            .loader
+            .load(&target_path)
+            .map_err(|e| load_error_to_handler(&e))?;
+
+        // Parse without annotation attachment — annotations stay
+        // visible as standalone children, matching what
+        // `resolve_from_source` does in the inline path.
+        let mut included = parse_no_attach(&source).map_err(|message| {
+            HandlerError::internal(format!(
+                "parse of `{}` failed: {message}",
+                canonical_path.display()
+            ))
+        })?;
+
+        // Stamp every node's `Range.origin_path` with the loaded file's
+        // canonical path so downstream tooling (file-reference
+        // resolution, scoped footnote lookup) sees the right origin.
+        let origin = Arc::new(canonical_path);
+        stamp_doc(&mut included, &origin);
+
+        let wire = to_wire_document(&included);
+        Ok(Some(wire))
+    }
+}
+
+fn extract_src(ctx: &LabelCtx) -> Result<String, HandlerError> {
+    ctx.params
+        .get("src")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| HandlerError::Custom {
+            code: CODE_MISSING_SRC,
+            message: format!(
+                "lex.include is missing required `src` parameter; got params: {}",
+                ctx.params
+            ),
+            data: None,
+        })
+}
+
+fn load_error_to_handler(err: &LoadError) -> HandlerError {
+    match err {
+        LoadError::NotFound { path } => HandlerError::Custom {
+            code: CODE_NOT_FOUND,
+            message: format!("include not found: {}", path.display()),
+            data: Some(serde_json::json!({ "path": path.display().to_string() })),
+        },
+        LoadError::OutsideRoot { path, root } => HandlerError::Custom {
+            code: CODE_OUTSIDE_ROOT,
+            message: format!(
+                "include path {} resolves outside loader root {}",
+                path.display(),
+                root.display()
+            ),
+            data: Some(serde_json::json!({
+                "path": path.display().to_string(),
+                "root": root.display().to_string(),
+            })),
+        },
+        LoadError::TooLarge { path, size, limit } => HandlerError::Custom {
+            code: CODE_TOO_LARGE,
+            message: format!(
+                "include file {} is {size} bytes, exceeds limit of {limit} bytes",
+                path.display()
+            ),
+            data: Some(serde_json::json!({
+                "path": path.display().to_string(),
+                "size": size,
+                "limit": limit,
+            })),
+        },
+        LoadError::Io { path, message } => HandlerError::Custom {
+            code: CODE_IO,
+            message: format!("io error reading {}: {message}", path.display()),
+            data: Some(serde_json::json!({ "path": path.display().to_string() })),
+        },
+    }
+}
+
+fn include_error_to_handler(err: &IncludeError) -> HandlerError {
+    match err {
+        IncludeError::AbsolutePath { path } => HandlerError::Custom {
+            code: CODE_ABSOLUTE_PATH,
+            message: format!(
+                "lex.include `src` rejected: {} is a platform-absolute path",
+                path.display()
+            ),
+            data: Some(serde_json::json!({ "path": path.display().to_string() })),
+        },
+        IncludeError::RootEscape { path, root } => HandlerError::Custom {
+            code: CODE_OUTSIDE_ROOT,
+            message: format!(
+                "include path {} resolves outside resolution root {}",
+                path.display(),
+                root.display()
+            ),
+            data: Some(serde_json::json!({
+                "path": path.display().to_string(),
+                "root": root.display().to_string(),
+            })),
+        },
+        // `resolve_file_reference` only ever returns `AbsolutePath` or
+        // `RootEscape` — the other `IncludeError` variants come from
+        // the resolve-pass walker, not from path resolution. Treat
+        // them as internal here so a future change in the resolver
+        // doesn't silently produce a misleading custom code.
+        other => HandlerError::internal(format!("path resolution failed: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::includes::{LoadError, LoadedFile, MemoryLoader};
+    use lex_extension::wire::{AnnotationBody, NodeRef, Position, Range};
+    use std::path::PathBuf;
+
+    fn make_ctx(src: &str, host_origin: Option<&str>) -> LabelCtx {
+        LabelCtx {
+            label: "lex.include".into(),
+            params: serde_json::json!({ "src": src }),
+            body: AnnotationBody::None,
+            node: NodeRef {
+                kind: "annotation".into(),
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: host_origin.map(|s| s.to_string()),
+            },
+        }
+    }
+
+    fn handler_with_loader(loader: MemoryLoader, root: PathBuf) -> LexIncludeHandler {
+        LexIncludeHandler::new(Arc::new(loader), ResolveConfig::with_root(root))
+    }
+
+    #[test]
+    fn happy_path_returns_wire_document() {
+        let mut loader = MemoryLoader::new();
+        loader.insert(
+            PathBuf::from("/root/included.lex"),
+            "Hello from included.\n",
+        );
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+
+        let ctx = make_ctx("included.lex", Some("/root/host.lex"));
+        let result = handler.on_resolve(&ctx).expect("on_resolve ok");
+        let wire = result.expect("returned Some(WireNode)");
+
+        // Top-level result is a WireNode::Document.
+        let WireNode::Document {
+            children, origin, ..
+        } = wire
+        else {
+            panic!("expected WireNode::Document, got something else");
+        };
+        // Origin should reflect the *included* file (canonical_path),
+        // because stamp_doc walks the loaded tree and the wire codec
+        // lifts origin_path from the root session's range.
+        assert_eq!(origin.as_deref(), Some("/root/included.lex"));
+        // The single paragraph from the included source must survive
+        // the round trip.
+        assert!(
+            !children.is_empty(),
+            "included document children must reach the wire payload"
+        );
+    }
+
+    #[test]
+    fn missing_src_returns_custom_error() {
+        let loader = MemoryLoader::new();
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        let mut ctx = make_ctx("ignored", None);
+        ctx.params = serde_json::json!({});
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        match err {
+            HandlerError::Custom { code, .. } => {
+                assert_eq!(code, CODE_MISSING_SRC);
+            }
+            other => panic!("expected Custom code, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_maps_to_code_minus_32001() {
+        let loader = MemoryLoader::new();
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        let ctx = make_ctx("missing.lex", Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        match err {
+            HandlerError::Custom { code, .. } => assert_eq!(code, CODE_NOT_FOUND),
+            other => panic!("expected NotFound→Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outside_root_via_resolver_maps_to_code_minus_32002() {
+        let loader = MemoryLoader::new();
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        // ../../../etc/passwd would normalise outside `/root`, so the
+        // resolver returns `RootEscape` before any load attempt.
+        let ctx = make_ctx("../../../etc/passwd", Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        match err {
+            HandlerError::Custom { code, .. } => assert_eq!(code, CODE_OUTSIDE_ROOT),
+            other => panic!("expected RootEscape→Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absolute_path_maps_to_code_minus_32004() {
+        let loader = MemoryLoader::new();
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        // Platform-absolute path on Unix; the resolver rejects up front
+        // before any load. (`/x` would normalise as `root-absolute` per
+        // Lex spec; we use a Windows-style path so the platform-
+        // absolute check fires regardless of OS.)
+        #[cfg(windows)]
+        let absolute = "C:\\Windows\\System32\\drivers\\etc\\hosts";
+        #[cfg(not(windows))]
+        let absolute = "//absolute/elsewhere"; // double-slash → host on UNC; treated as absolute
+        let ctx = make_ctx(absolute, Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        // On platforms where `Path::is_absolute(absolute)` returns true
+        // we expect AbsolutePath (-32004); otherwise we expect
+        // OutsideRoot (-32002). Both are valid security outcomes.
+        match err {
+            HandlerError::Custom { code, .. } => {
+                assert!(
+                    code == CODE_ABSOLUTE_PATH || code == CODE_OUTSIDE_ROOT,
+                    "expected -32002 or -32004, got {code}"
+                );
+            }
+            other => panic!("expected Custom code, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loader_outside_root_maps_to_code_minus_32002() {
+        // A loader that itself returns OutsideRoot (e.g., FsLoader
+        // catching a symlink escape post-canonicalisation). Simulate
+        // this with a custom mock loader.
+        struct MockEscape;
+        impl Loader for MockEscape {
+            fn load(&self, path: &std::path::Path) -> Result<LoadedFile, LoadError> {
+                Err(LoadError::OutsideRoot {
+                    path: path.to_path_buf(),
+                    root: PathBuf::from("/root"),
+                })
+            }
+        }
+        let handler = LexIncludeHandler::new(
+            Arc::new(MockEscape),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        );
+        let ctx = make_ctx("inner.lex", Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        match err {
+            HandlerError::Custom { code, .. } => assert_eq!(code, CODE_OUTSIDE_ROOT),
+            other => panic!("expected OutsideRoot→Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn too_large_maps_to_code_minus_32003() {
+        struct MockTooLarge;
+        impl Loader for MockTooLarge {
+            fn load(&self, path: &std::path::Path) -> Result<LoadedFile, LoadError> {
+                Err(LoadError::TooLarge {
+                    path: path.to_path_buf(),
+                    size: 1_000_000,
+                    limit: 100,
+                })
+            }
+        }
+        let handler = LexIncludeHandler::new(
+            Arc::new(MockTooLarge),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        );
+        let ctx = make_ctx("big.lex", Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        match err {
+            HandlerError::Custom { code, data, .. } => {
+                assert_eq!(code, CODE_TOO_LARGE);
+                let data = data.expect("data attached");
+                assert_eq!(data["size"], 1_000_000);
+                assert_eq!(data["limit"], 100);
+            }
+            other => panic!("expected TooLarge→Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn io_error_maps_to_code_minus_32005() {
+        struct MockIo;
+        impl Loader for MockIo {
+            fn load(&self, path: &std::path::Path) -> Result<LoadedFile, LoadError> {
+                Err(LoadError::Io {
+                    path: path.to_path_buf(),
+                    message: "permission denied".into(),
+                })
+            }
+        }
+        let handler = LexIncludeHandler::new(
+            Arc::new(MockIo),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        );
+        let ctx = make_ctx("locked.lex", Some("/root/host.lex"));
+        let err = handler.on_resolve(&ctx).expect_err("must error");
+        match err {
+            HandlerError::Custom { code, .. } => assert_eq!(code, CODE_IO),
+            other => panic!("expected Io→Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_failure_maps_to_internal_error() {
+        // Construct a fixture that fails `parse_no_attach`. The
+        // parser is permissive, so we use a verbatim block whose
+        // closing marker is missing — that surfaces as a parse
+        // error in `parse_without_annotation_attachment`.
+        let mut loader = MemoryLoader::new();
+        // A subject + indented content with no closing `:: label ::`
+        // line is the canonical "unterminated verbatim" shape.
+        loader.insert(
+            PathBuf::from("/root/broken.lex"),
+            "Subject:\n    line one\n    line two\n",
+        );
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        let ctx = make_ctx("broken.lex", Some("/root/host.lex"));
+        // Whether this fixture trips a parse error depends on the
+        // current parser; the test only fails the handler if a
+        // parse error is surfaced. If the parser successfully parses
+        // the fixture, we still get Ok(Some(_)) and the assertion
+        // below short-circuits.
+        let result = handler.on_resolve(&ctx);
+        if let Err(err) = result {
+            assert!(
+                matches!(err, HandlerError::Internal { .. }),
+                "parse failures must map to HandlerError::Internal, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn round_trip_via_from_wire_recovers_typed_ast() {
+        use crate::lex::ast::elements::content_item::ContentItem;
+        use crate::lex::wire::from_wire_node;
+
+        let mut loader = MemoryLoader::new();
+        loader.insert(PathBuf::from("/root/snippet.lex"), "First paragraph.\n");
+        let handler = handler_with_loader(loader, PathBuf::from("/root"));
+        let ctx = make_ctx("snippet.lex", Some("/root/host.lex"));
+        let wire = handler
+            .on_resolve(&ctx)
+            .expect("on_resolve ok")
+            .expect("Some(WireNode)");
+
+        // The wire payload must round-trip through from_wire_node
+        // back into typed lex-core ContentItems — that's the
+        // contract PR 3d will rely on when splicing.
+        let items = from_wire_node(&wire).expect("from_wire ok");
+        assert!(
+            !items.is_empty(),
+            "from_wire on the included document must recover at least one item"
+        );
+        // The first paragraph must come through.
+        let saw_paragraph = items
+            .iter()
+            .any(|item| matches!(item, ContentItem::Paragraph(_)));
+        assert!(saw_paragraph, "included paragraph must survive round-trip");
+    }
+}

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -3,16 +3,236 @@
 //! Built-ins flow through the same `lex_extension::LexHandler` trait and
 //! `lex_extension_host::Registry` dispatch fabric as third-party namespaces.
 //! Their only privilege is being compiled-in: at host startup, the CLI
-//! and LSP call this module's `register_into(&Registry, ...)` helper to
-//! attach the bundled `lex.*` schemas and handlers.
+//! and LSP call this module's [`register_into`] helper to attach the
+//! bundled `lex.*` schemas and handlers.
 //!
-//! # Status: skeleton only
+//! # What ships today
 //!
-//! This module is the placeholder landed in PR 3a (lex-fmt/lex#519). The
-//! first concrete built-in, `LexIncludeHandler`, lands in PR 3c
-//! (lex-fmt/lex#532) once the wire codec from PR 3b
-//! (lex-fmt/lex#531) exists. The resolve pass wires through this
-//! module's `register_into` helper in PR 3d (lex-fmt/lex#533).
+//! | Label         | Handler              | Status                            |
+//! |---------------|----------------------|-----------------------------------|
+//! | `lex.include` | [`LexIncludeHandler`] | Registrable; resolve pass still   |
+//! |               |                      | runs through the legacy inline    |
+//! |               |                      | path until PR 3d (#533).          |
 //!
-//! Future built-ins (`lex.toc`, …) follow the same shape: one impl per
-//! label, registered through this module's helper at host startup.
+//! Future built-ins (`lex.toc`, …) follow the same shape: one handler
+//! impl per label, registered through [`register_into`].
+
+use std::sync::Arc;
+
+use lex_extension::schema::{
+    BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+};
+use lex_extension_host::registry::{Registry, RegistryError};
+
+use crate::lex::includes::{Loader, ResolveConfig};
+
+pub mod include;
+
+pub use include::LexIncludeHandler;
+
+/// The reserved namespace owned by the lex core. Its prefix is
+/// `lex.` (with the trailing dot), so registered labels look like
+/// `lex.include`, `lex.toc`, etc.
+pub const NAMESPACE: &str = "lex";
+
+/// Register every built-in `lex.*` schema and handler into `registry`.
+///
+/// The current set is `{ lex.include }`; future built-ins land here as
+/// they're added. The single registration call covers the whole
+/// namespace because [`Registry::register_namespace`] wants every
+/// label for a namespace handed in atomically.
+///
+/// `loader` and `config` flow into [`LexIncludeHandler`] verbatim: the
+/// handler holds them by `Arc` so the registry can be cheaply cloned
+/// and shared across threads. `config.root` should already be
+/// canonicalised by the caller — see
+/// [`ResolveConfig::with_root`](crate::lex::includes::ResolveConfig::with_root).
+pub fn register_into(
+    registry: &Registry,
+    loader: Arc<dyn Loader + Send + Sync>,
+    config: ResolveConfig,
+) -> Result<(), RegistryError> {
+    let schemas = vec![lex_include_schema()];
+    let handler = Box::new(LexIncludeHandler::new(loader, config));
+    registry.register_namespace(NAMESPACE, schemas, handler)
+}
+
+/// Schema for the `lex.include` label. Inlined here because v1 has
+/// exactly one built-in label; once the YAML schema loader lands in
+/// PR 4 (#520), built-ins will share the same load path as third
+/// parties (a baked-in `lex.yaml` shipped with the crate).
+pub fn lex_include_schema() -> Schema {
+    let mut params = std::collections::BTreeMap::new();
+    params.insert(
+        "src".into(),
+        ParamSpec {
+            ty: ParamType::String,
+            required: true,
+            default: None,
+            description: Some(
+                "Path to the file to splice in. Resolves relative to the host file's directory; \
+                 leading `/` resolves under the resolution root."
+                    .into(),
+            ),
+            pattern: None,
+            values: Vec::new(),
+        },
+    );
+    Schema {
+        schema_version: 1,
+        label: "lex.include".into(),
+        description: Some(
+            "Splice the referenced Lex file's content into the parent container at this \
+             annotation's position."
+                .into(),
+        ),
+        params,
+        attaches_to: vec!["annotation".into()],
+        body: BodyShape {
+            kind: BodyKind::None,
+            presence: BodyPresence::Optional,
+            description: None,
+        },
+        verbatim_label: false,
+        // Built-ins read from the filesystem; once the trust matrix
+        // gates third-party fs access in δ (PR 12), built-ins remain
+        // trusted by linkage.
+        capabilities: Capabilities {
+            fs: true,
+            net: false,
+        },
+        hooks: HookSet {
+            resolve: true,
+            ..HookSet::default()
+        },
+        // Native built-ins skip the handler-spec field — the registry
+        // dispatches in-process via `Box<dyn LexHandler>`.
+        handler: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::includes::MemoryLoader;
+    use lex_extension::wire::{AnnotationBody, LabelCtx, NodeRef, Position, Range};
+    use std::path::PathBuf;
+
+    fn make_ctx(src: &str, host_origin: Option<&str>) -> LabelCtx {
+        LabelCtx {
+            label: "lex.include".into(),
+            params: serde_json::json!({ "src": src }),
+            body: AnnotationBody::None,
+            node: NodeRef {
+                kind: "annotation".into(),
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: host_origin.map(|s| s.to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn register_into_attaches_namespace_and_schema() {
+        let mut loader = MemoryLoader::new();
+        loader.insert(PathBuf::from("/root/inner.lex"), "Hello.\n");
+        let registry = Registry::new();
+        register_into(
+            &registry,
+            Arc::new(loader),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        )
+        .expect("registration ok");
+
+        assert_eq!(registry.namespace_count(), 1);
+        assert!(registry.is_namespace_healthy(NAMESPACE));
+        let schema = registry
+            .schema_for("lex.include")
+            .expect("schema indexed under fully-qualified label");
+        assert_eq!(schema.label, "lex.include");
+        assert!(schema.hooks.resolve, "resolve hook must be declared");
+        assert!(
+            schema.params.contains_key("src"),
+            "src parameter must be declared"
+        );
+    }
+
+    #[test]
+    fn dispatch_resolve_round_trip_via_registry() {
+        // End-to-end through the registry: register handler, dispatch
+        // a resolve via dispatch_resolve, get back Some(WireNode).
+        let mut loader = MemoryLoader::new();
+        loader.insert(PathBuf::from("/root/inner.lex"), "Spliced paragraph.\n");
+        let registry = Registry::new();
+        register_into(
+            &registry,
+            Arc::new(loader),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        )
+        .expect("registration ok");
+
+        let ctx = make_ctx("inner.lex", Some("/root/host.lex"));
+        let wire = registry
+            .dispatch_resolve(&ctx)
+            .expect("dispatch_resolve ok")
+            .expect("returned Some");
+        match wire {
+            lex_extension::wire::WireNode::Document { children, .. } => {
+                assert!(
+                    !children.is_empty(),
+                    "registry-routed resolve must surface the included content"
+                );
+            }
+            other => panic!("expected WireNode::Document, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_resolve_load_error_surfaces_diagnostic() {
+        let loader = MemoryLoader::new();
+        let registry = Registry::new();
+        register_into(
+            &registry,
+            Arc::new(loader),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        )
+        .expect("registration ok");
+
+        let ctx = make_ctx("missing.lex", Some("/root/host.lex"));
+        let err = registry
+            .dispatch_resolve(&ctx)
+            .expect_err("registry must surface the load error");
+        // The diagnostic uses `handler.custom` for our `Custom`-coded
+        // errors — see Registry::dispatch's error mapping.
+        assert_eq!(err.code.as_deref(), Some("handler.custom"));
+        assert!(
+            err.message.contains("not found"),
+            "diagnostic must mention the load failure"
+        );
+    }
+
+    #[test]
+    fn duplicate_register_into_call_is_rejected() {
+        let registry = Registry::new();
+        register_into(
+            &registry,
+            Arc::new(MemoryLoader::new()),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        )
+        .expect("first registration ok");
+        let second = register_into(
+            &registry,
+            Arc::new(MemoryLoader::new()),
+            ResolveConfig::with_root(PathBuf::from("/root")),
+        );
+        assert!(
+            matches!(
+                second,
+                Err(RegistryError::NamespaceAlreadyRegistered { .. })
+            ),
+            "second register_into must error: {second:?}"
+        );
+    }
+}

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -878,7 +878,7 @@ fn lexical_normalize(p: &Path) -> PathBuf {
 // fields here; finer-grained inline ranges land in PR 6 when file-ref
 // resolution starts consulting them.
 
-fn stamp_doc(doc: &mut Document, origin: &Arc<PathBuf>) {
+pub(crate) fn stamp_doc(doc: &mut Document, origin: &Arc<PathBuf>) {
     if let Some(title) = doc.title.as_mut() {
         title.location.origin_path = Some(Arc::clone(origin));
     }
@@ -973,7 +973,7 @@ fn stamp_item(item: &mut ContentItem, origin: &Arc<PathBuf>) {
 
 /// Parse `source` into a Document but skip the annotation-attachment stage,
 /// so include annotations are findable in container children lists.
-fn parse_no_attach(source: &str) -> Result<Document, String> {
+pub(crate) fn parse_no_attach(source: &str) -> Result<Document, String> {
     crate::lex::testing::parse_without_annotation_attachment(source)
 }
 

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -129,8 +129,12 @@ fn convert_one(node: &WireNode) -> Result<ContentItem, FromWireError> {
             label,
             params,
             body_text,
+            subject,
+            mode,
             ..
-        } => Ok(verbatim_from_wire(range, label, params, body_text)?),
+        } => Ok(verbatim_from_wire(
+            range, label, params, body_text, subject, mode,
+        )?),
         // WireNode is `#[non_exhaustive]` — future kinds surface here.
         _ => Err(FromWireError::UnsupportedKind {
             kind: kind_name(node).into(),
@@ -276,7 +280,10 @@ fn synthetic_marker_text(marker_style: &str, index: usize) -> String {
     match marker_style {
         "dash" => "-".into(),
         "numerical" => format!("{}.", index + 1),
-        "alphabetical" => format!("{}.", char::from(b'a' + (index as u8 % 26))),
+        // Compute the modulo on `usize` first so lists with more than
+        // 256 items don't wrap before the cast — `index as u8` would
+        // truncate at index=256, mis-numbering everything past.
+        "alphabetical" => format!("{}.", char::from(b'a' + ((index % 26) as u8))),
         "roman" => format!("{}.", roman_numeral(index + 1)),
         _ => "-".into(),
     }
@@ -385,6 +392,8 @@ fn verbatim_from_wire(
     label: &str,
     params: &Value,
     body_text: &str,
+    subject: &str,
+    mode: &str,
 ) -> Result<ContentItem, FromWireError> {
     if label == "lex.internal.unsupported.unknown" {
         return Err(FromWireError::UnsupportedKind {
@@ -422,15 +431,26 @@ fn verbatim_from_wire(
             })
             .collect()
     };
-    let subject = TextContent::empty();
-    let mut v = Verbatim::new(
-        subject,
-        typed_lines,
-        closing_data,
-        VerbatimBlockMode::Inflow,
-    );
+    let subject_tc = if subject.is_empty() {
+        TextContent::empty()
+    } else {
+        TextContent::from_string(subject.to_string(), None)
+    };
+    let block_mode = parse_verbatim_mode(mode);
+    let mut v = Verbatim::new(subject_tc, typed_lines, closing_data, block_mode);
     v.location = range_from_wire(range);
     Ok(ContentItem::VerbatimBlock(Box::new(v)))
+}
+
+/// Map the wire `mode` string back to a [`VerbatimBlockMode`].
+/// Unknown values fall back to `Inflow` — the documented default
+/// matching the parser's behaviour for ambiguous mode classification.
+fn parse_verbatim_mode(mode: &str) -> VerbatimBlockMode {
+    match mode {
+        "fullwidth" => VerbatimBlockMode::Fullwidth,
+        // "inflow" or anything unrecognised
+        _ => VerbatimBlockMode::Inflow,
+    }
 }
 
 fn parameters_from_json(params: &Value) -> Result<Vec<Parameter>, FromWireError> {

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -2,21 +2,32 @@
 //!
 //! Fallible — wire input may be malformed (handler returned an unknown
 //! kind, missing required field, etc.). Recognised variants produce
-//! lex-core [`ContentItem`]s; unrecognised or partially-supported
-//! shapes return [`FromWireError::UnsupportedKind`].
+//! lex-core [`ContentItem`]s; unrecognised shapes return
+//! [`FromWireError::UnsupportedKind`].
 //!
-//! Coverage matches `to_wire.rs`: this commit handles `Document`,
-//! `Paragraph`, `Annotation`, and `Blank`. Follow-up commits on the
-//! same PR extend to the remaining shapes.
+//! The reverse path mirrors [`super::to_wire`]: every `WireNode` variant
+//! emitted by the forward codec has a defined inverse, so a forward+
+//! reverse round trip on a parser-produced AST yields a structurally
+//! equivalent tree (modulo the documented losses listed in the module-
+//! level docs).
 
 use crate::lex::ast::elements::annotation::Annotation as CoreAnnotation;
 use crate::lex::ast::elements::blank_line_group::BlankLineGroup;
 use crate::lex::ast::elements::content_item::ContentItem;
 use crate::lex::ast::elements::data::Data;
+use crate::lex::ast::elements::definition::Definition;
 use crate::lex::ast::elements::label::Label;
+use crate::lex::ast::elements::list::{List, ListItem};
 use crate::lex::ast::elements::paragraph::{Paragraph, TextLine};
 use crate::lex::ast::elements::parameter::Parameter;
-use lex_extension::wire::WireNode;
+use crate::lex::ast::elements::sequence_marker::SequenceMarker;
+use crate::lex::ast::elements::session::Session;
+use crate::lex::ast::elements::table::{Table, TableCell, TableCellAlignment, TableRow};
+use crate::lex::ast::elements::typed_content::{ContentElement, SessionContent, VerbatimContent};
+use crate::lex::ast::elements::verbatim::{Verbatim, VerbatimBlockMode};
+use crate::lex::ast::elements::verbatim_line::VerbatimLine;
+use crate::lex::ast::TextContent;
+use lex_extension::wire::{WireFootnote, WireListItem, WireNode, WireRow, WireTableCell};
 use serde_json::Value;
 
 use super::error::FromWireError;
@@ -70,28 +81,59 @@ fn convert_one(node: &WireNode) -> Result<ContentItem, FromWireError> {
         } => Ok(ContentItem::Annotation(annotation_from_wire(
             range, label, params, body,
         )?)),
-        WireNode::Verbatim { label, .. } if label.starts_with("lex.internal.unsupported.") => {
-            // Forward codec emitted this for an as-yet-unwired variant;
-            // surface the gap rather than silently dropping content.
-            Err(FromWireError::UnsupportedKind {
-                kind: label
-                    .strip_prefix("lex.internal.unsupported.")
-                    .unwrap_or(label.as_str())
-                    .to_string(),
-            })
-        }
-        // Variants not yet wired in the reverse direction.
-        WireNode::Document { .. }
-        | WireNode::Session { .. }
-        | WireNode::Definition { .. }
-        | WireNode::List { .. }
-        | WireNode::Verbatim { .. }
-        | WireNode::Table { .. } => Err(FromWireError::UnsupportedKind {
-            kind: kind_name(node).into(),
-        }),
+        WireNode::Session {
+            range,
+            title,
+            marker,
+            children,
+            ..
+        } => Ok(ContentItem::Session(session_from_wire(
+            range, title, marker, children,
+        )?)),
+        WireNode::Definition {
+            range,
+            subject,
+            children,
+            ..
+        } => Ok(ContentItem::Definition(definition_from_wire(
+            range, subject, children,
+        )?)),
+        WireNode::List {
+            range,
+            marker_style,
+            items,
+            ..
+        } => Ok(ContentItem::List(list_from_wire(
+            range,
+            marker_style,
+            items,
+        )?)),
+        WireNode::Table {
+            range,
+            caption,
+            header_rows,
+            align,
+            rows,
+            footnotes,
+            ..
+        } => Ok(ContentItem::Table(Box::new(table_from_wire(
+            range,
+            caption,
+            *header_rows,
+            align,
+            rows,
+            footnotes,
+        )?))),
+        WireNode::Verbatim {
+            range,
+            label,
+            params,
+            body_text,
+            ..
+        } => Ok(verbatim_from_wire(range, label, params, body_text)?),
         // WireNode is `#[non_exhaustive]` — future kinds surface here.
         _ => Err(FromWireError::UnsupportedKind {
-            kind: "unknown".into(),
+            kind: kind_name(node).into(),
         }),
     }
 }
@@ -116,7 +158,7 @@ fn paragraph_from_wire(
     let lines: Vec<ContentItem> = line_strings
         .into_iter()
         .map(|line_str| {
-            ContentItem::TextLine(TextLine::new(crate::lex::ast::TextContent::from_string(
+            ContentItem::TextLine(TextLine::new(TextContent::from_string(
                 line_str.to_string(),
                 None,
             )))
@@ -124,7 +166,7 @@ fn paragraph_from_wire(
         .collect();
     let mut p = if lines.is_empty() {
         Paragraph::new(vec![ContentItem::TextLine(TextLine::new(
-            crate::lex::ast::TextContent::empty(),
+            TextContent::empty(),
         ))])
     } else {
         Paragraph::new(lines)
@@ -146,16 +188,249 @@ fn annotation_from_wire(
     let children = annotation_body_from_json(body)?;
     let mut a = CoreAnnotation::from_data(data, Vec::new());
     a.location = range_from_wire(range);
-    // Re-attach children via the container's typed setter.
     if !children.is_empty() {
-        // GeneralContainer stores ContentItems; ContentElement is the
-        // typed projection used by from_data. Splicing through the
-        // raw container preserves whatever shapes the wire delivered.
         for child in children {
             a.children.as_mut_vec().push(child);
         }
     }
     Ok(a)
+}
+
+fn session_from_wire(
+    range: &lex_extension::wire::Range,
+    title: &str,
+    marker: &Option<String>,
+    children: &[WireNode],
+) -> Result<Session, FromWireError> {
+    let title_tc = TextContent::from_string(title.to_string(), None);
+    let typed_children = wire_children_to_session_content(children)?;
+    let mut s = Session::new(title_tc, typed_children);
+    s.location = range_from_wire(range);
+    s.marker = marker
+        .as_deref()
+        .and_then(|m| SequenceMarker::parse(m, None));
+    Ok(s)
+}
+
+fn definition_from_wire(
+    range: &lex_extension::wire::Range,
+    subject: &str,
+    children: &[WireNode],
+) -> Result<Definition, FromWireError> {
+    let subject_tc = TextContent::from_string(subject.to_string(), None);
+    let typed_children = wire_children_to_content_elements(children)?;
+    let mut d = Definition::new(subject_tc, typed_children);
+    d.location = range_from_wire(range);
+    Ok(d)
+}
+
+fn list_from_wire(
+    range: &lex_extension::wire::Range,
+    marker_style: &str,
+    items: &[WireListItem],
+) -> Result<List, FromWireError> {
+    let marker = synthetic_marker_for_style(marker_style);
+    let list_items = items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| list_item_from_wire(item, marker_style, index))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut l = List::new(list_items);
+    l.location = range_from_wire(range);
+    l.marker = marker;
+    Ok(l)
+}
+
+fn list_item_from_wire(
+    item: &WireListItem,
+    marker_style: &str,
+    index: usize,
+) -> Result<ListItem, FromWireError> {
+    let combined = text_content_from_wire(&item.inlines);
+    let raw = combined.as_string();
+    let text_lines: Vec<TextContent> = if raw.is_empty() {
+        vec![TextContent::empty()]
+    } else {
+        raw.split('\n')
+            .map(|s| TextContent::from_string(s.to_string(), None))
+            .collect()
+    };
+    let marker_text = synthetic_marker_text(marker_style, index);
+    let typed_children = wire_children_to_content_elements(&item.children)?;
+    let mut li = ListItem::with_text_content(
+        TextContent::from_string(marker_text, None),
+        text_lines
+            .first()
+            .cloned()
+            .unwrap_or_else(TextContent::empty),
+        typed_children,
+    );
+    if text_lines.len() > 1 {
+        li.text = text_lines;
+    }
+    li.location = range_from_wire(&item.range);
+    Ok(li)
+}
+
+fn synthetic_marker_text(marker_style: &str, index: usize) -> String {
+    match marker_style {
+        "dash" => "-".into(),
+        "numerical" => format!("{}.", index + 1),
+        "alphabetical" => format!("{}.", char::from(b'a' + (index as u8 % 26))),
+        "roman" => format!("{}.", roman_numeral(index + 1)),
+        _ => "-".into(),
+    }
+}
+
+fn synthetic_marker_for_style(marker_style: &str) -> Option<SequenceMarker> {
+    let probe = synthetic_marker_text(marker_style, 0);
+    SequenceMarker::parse(&probe, None)
+}
+
+fn roman_numeral(mut n: usize) -> String {
+    const TABLE: &[(usize, &str)] = &[
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ];
+    let mut out = String::new();
+    for (value, sym) in TABLE {
+        while n >= *value {
+            out.push_str(sym);
+            n -= *value;
+        }
+    }
+    if out.is_empty() {
+        "I".into()
+    } else {
+        out
+    }
+}
+
+fn table_from_wire(
+    range: &lex_extension::wire::Range,
+    caption: &str,
+    header_rows: u32,
+    align: &str,
+    rows: &[WireRow],
+    footnotes: &[WireFootnote],
+) -> Result<Table, FromWireError> {
+    let alignment = match align {
+        "left" => TableCellAlignment::Left,
+        "center" => TableCellAlignment::Center,
+        "right" => TableCellAlignment::Right,
+        _ => TableCellAlignment::None,
+    };
+    let header_count = header_rows as usize;
+    let mut header_vec = Vec::with_capacity(header_count.min(rows.len()));
+    let mut body_vec = Vec::with_capacity(rows.len().saturating_sub(header_count));
+    for (i, row) in rows.iter().enumerate() {
+        let is_header = i < header_count;
+        let cells = row
+            .cells
+            .iter()
+            .map(|c| table_cell_from_wire(c, alignment, is_header))
+            .collect();
+        let table_row = TableRow::new(cells);
+        if is_header {
+            header_vec.push(table_row);
+        } else {
+            body_vec.push(table_row);
+        }
+    }
+    let subject = TextContent::from_string(caption.to_string(), None);
+    let mut t = Table::new(subject, header_vec, body_vec, VerbatimBlockMode::Inflow);
+    t.location = range_from_wire(range);
+    if !footnotes.is_empty() {
+        let footnote_items: Vec<ListItem> = footnotes
+            .iter()
+            .map(|f| {
+                let combined = text_content_from_wire(&f.inlines);
+                ListItem::with_text_content(
+                    TextContent::from_string(f.marker.clone(), None),
+                    combined,
+                    Vec::new(),
+                )
+            })
+            .collect();
+        t.footnotes = Some(Box::new(List::new(footnote_items)));
+    }
+    Ok(t)
+}
+
+fn table_cell_from_wire(
+    cell: &WireTableCell,
+    align: TableCellAlignment,
+    header: bool,
+) -> TableCell {
+    let content = text_content_from_wire(&cell.inlines);
+    TableCell::new(content)
+        .with_span(cell.colspan as usize, cell.rowspan as usize)
+        .with_align(align)
+        .with_header(header)
+}
+
+fn verbatim_from_wire(
+    range: &lex_extension::wire::Range,
+    label: &str,
+    params: &Value,
+    body_text: &str,
+) -> Result<ContentItem, FromWireError> {
+    if label == "lex.internal.unsupported.unknown" {
+        return Err(FromWireError::UnsupportedKind {
+            kind: "unknown".into(),
+        });
+    }
+    if let Some(stripped) = label.strip_prefix("lex.internal.unsupported.") {
+        // Forward codec emitted this for an as-yet-unwired variant;
+        // surface the gap rather than silently dropping content.
+        return Err(FromWireError::UnsupportedKind {
+            kind: stripped.to_string(),
+        });
+    }
+
+    if label.is_empty() {
+        // Standalone VerbatimLine round-trip — see
+        // `verbatim_line_standalone_to_wire` in the forward codec.
+        let mut vl =
+            VerbatimLine::from_text_content(TextContent::from_string(body_text.to_string(), None));
+        vl.location = range_from_wire(range);
+        return Ok(ContentItem::VerbatimLine(vl));
+    }
+
+    let parameters = parameters_from_json(params)?;
+    let closing_data = Data::new(Label::new(label.to_string()), parameters);
+    let typed_lines: Vec<VerbatimContent> = if body_text.is_empty() {
+        Vec::new()
+    } else {
+        body_text
+            .split('\n')
+            .map(|line| {
+                VerbatimContent::VerbatimLine(VerbatimLine::from_text_content(
+                    TextContent::from_string(line.to_string(), None),
+                ))
+            })
+            .collect()
+    };
+    let subject = TextContent::empty();
+    let mut v = Verbatim::new(
+        subject,
+        typed_lines,
+        closing_data,
+        VerbatimBlockMode::Inflow,
+    );
+    v.location = range_from_wire(range);
+    Ok(ContentItem::VerbatimBlock(Box::new(v)))
 }
 
 fn parameters_from_json(params: &Value) -> Result<Vec<Parameter>, FromWireError> {
@@ -195,10 +470,7 @@ fn annotation_body_from_json(body: &Value) -> Result<Vec<ContentItem>, FromWireE
             // represents this as a single Paragraph child (matching
             // `extract_annotation_single_content` in the parser). We
             // mirror that here so content isn't silently dropped.
-            let line = TextLine::new(crate::lex::ast::TextContent::from_string(
-                text.clone(),
-                None,
-            ));
+            let line = TextLine::new(TextContent::from_string(text.clone(), None));
             let para = Paragraph::new(vec![ContentItem::TextLine(line)]);
             Ok(vec![ContentItem::Paragraph(para)])
         }
@@ -222,6 +494,28 @@ fn annotation_body_from_json(body: &Value) -> Result<Vec<ContentItem>, FromWireE
             detail: "expected null, string, or object".into(),
         }),
     }
+}
+
+fn wire_children_to_session_content(
+    children: &[WireNode],
+) -> Result<Vec<SessionContent>, FromWireError> {
+    let items = from_wire_subtree(children)?;
+    Ok(items.into_iter().map(SessionContent::from).collect())
+}
+
+fn wire_children_to_content_elements(
+    children: &[WireNode],
+) -> Result<Vec<ContentElement>, FromWireError> {
+    let items = from_wire_subtree(children)?;
+    items
+        .into_iter()
+        .map(|item| {
+            ContentElement::try_from(item).map_err(|e| FromWireError::MalformedField {
+                field: "children",
+                detail: e.to_string(),
+            })
+        })
+        .collect()
 }
 
 fn kind_name(node: &WireNode) -> &'static str {

--- a/crates/lex-core/src/lex/wire/mod.rs
+++ b/crates/lex-core/src/lex/wire/mod.rs
@@ -28,11 +28,16 @@
 //!   `Table`, etc. — none of the wire `WireNode` variants carry an
 //!   `annotations` field, so attached annotations are dropped in the
 //!   forward direction. (Standalone `ContentItem::Annotation` nodes
-//!   *are* round-tripped fully via `WireNode::Annotation`.)
+//!   *are* round-tripped fully via `WireNode::Annotation`.) The
+//!   `LexIncludeHandler` mitigates this for include splicing by
+//!   promoting `Document.annotations` to leading root children
+//!   *before* the codec runs, matching the legacy
+//!   `prepare_splice_list` behaviour.
 //! - **Document-level metadata** — `Document.title` and
-//!   `Document.annotations` are dropped: the forward codec returns a
-//!   `WireNode::Document` whose `children` are the root session's
-//!   children, and only those.
+//!   `Document.annotations` are dropped by the codec itself. The
+//!   `LexIncludeHandler` re-applies the legacy `prepare_splice_list`
+//!   transformation in front of the codec so these surface as
+//!   leading children of the wire `Document`.
 //! - **Marker structure** on sessions and lists — the wire format
 //!   stringifies the marker (`"1.1."`, `"(a)"`); the parser
 //!   reconstructs the typed marker on the next parse.
@@ -47,8 +52,9 @@
 //!   codec consumer.
 //! - **Table per-cell alignment** — wire tables carry one alignment
 //!   string for the whole table; lex-core tracks alignment per cell.
-//!   Forward picks the first non-`None` cell alignment; reverse
-//!   applies that alignment to every cell.
+//!   Forward picks the first non-`None` *body* cell's alignment
+//!   (header-row alignment is skipped because it is often a styling
+//!   artefact); reverse applies that alignment to every cell.
 //! - **Tables with block-content cells** — `WireTableCell` only
 //!   carries inline content; lex-core's `TableCell.children` (block
 //!   content inside a cell, e.g. nested lists) has no slot in the
@@ -65,9 +71,19 @@
 //!   through a `.lex` source-form string that the parser
 //!   re-interprets identically.
 //!
-//! For the consumer that matters today (`LexIncludeHandler`), these
-//! losses are invisible: the spliced content renders to the same
-//! `.lex` source as the original.
+//! Verbatim `subject` and `mode` (`Inflow` / `Fullwidth`) **are**
+//! preserved end-to-end: `WireNode::Verbatim` carries dedicated
+//! `subject` and `mode` fields that the forward codec populates and
+//! the reverse codec applies during reconstruction.
+//!
+//! For the consumer that matters today (`LexIncludeHandler`), the
+//! remaining losses do not change observable include output: the
+//! handler's `prepare_splice_list`-equivalent normalisation covers
+//! the document-level losses, table-with-block-cells surfaces as a
+//! visible `UnsupportedKind` rather than silent drop, and the
+//! representation-only losses (spans, marker structure, per-cell
+//! alignment) re-derive identically when the spliced content is
+//! re-formatted to `.lex` source.
 //!
 //! # Versioning
 //!

--- a/crates/lex-core/src/lex/wire/mod.rs
+++ b/crates/lex-core/src/lex/wire/mod.rs
@@ -49,6 +49,15 @@
 //!   string for the whole table; lex-core tracks alignment per cell.
 //!   Forward picks the first non-`None` cell alignment; reverse
 //!   applies that alignment to every cell.
+//! - **Tables with block-content cells** — `WireTableCell` only
+//!   carries inline content; lex-core's `TableCell.children` (block
+//!   content inside a cell, e.g. nested lists) has no slot in the
+//!   wire form. Rather than silently drop that content, the forward
+//!   codec emits a `lex.internal.unsupported.table_block_cells`
+//!   placeholder; the reverse codec rejects it with
+//!   `FromWireError::UnsupportedKind`. Future codec work that
+//!   introduces an escape-hatch encoding for these tables (e.g.,
+//!   `body_text` carrying the raw source) can lift this restriction.
 //! - **`TextContent`** uses the parsed-inline path
 //!   ([`TextContent::inline_nodes`]) when available, producing
 //!   matching `WireInline` variants; otherwise emits the raw source

--- a/crates/lex-core/src/lex/wire/mod.rs
+++ b/crates/lex-core/src/lex/wire/mod.rs
@@ -36,15 +36,28 @@
 //! - **Marker structure** on sessions and lists — the wire format
 //!   stringifies the marker (`"1.1."`, `"(a)"`); the parser
 //!   reconstructs the typed marker on the next parse.
+//! - **List-item per-item markers** — list-item markers are derived
+//!   from the parent list's `marker_style` plus item index in the
+//!   reverse direction; the original raw marker text on each item is
+//!   not preserved.
+//! - **Verbatim multi-group bodies** — a multi-group verbatim block
+//!   collapses to its first group in the forward direction; the
+//!   additional groups are dropped. `lex.include` never returns
+//!   multi-group verbatims, so this loss is invisible to the current
+//!   codec consumer.
+//! - **Table per-cell alignment** — wire tables carry one alignment
+//!   string for the whole table; lex-core tracks alignment per cell.
+//!   Forward picks the first non-`None` cell alignment; reverse
+//!   applies that alignment to every cell.
 //! - **`TextContent`** uses the parsed-inline path
-//!   ([`TextContent::inline_nodes`]) when available (Phase 2),
-//!   producing matching `WireInline` variants; otherwise emits the
-//!   raw source as a single `WireInline::Text`. Reverse codec
-//!   re-serialises through a `.lex` source-form string that the
-//!   parser re-interprets identically.
+//!   ([`TextContent::inline_nodes`]) when available, producing
+//!   matching `WireInline` variants; otherwise emits the raw source
+//!   as a single `WireInline::Text`. Reverse codec re-serialises
+//!   through a `.lex` source-form string that the parser
+//!   re-interprets identically.
 //!
-//! For the consumer that matters today (`LexIncludeHandler` in PR 3c),
-//! these losses are invisible: the spliced content renders to the same
+//! For the consumer that matters today (`LexIncludeHandler`), these
+//! losses are invisible: the spliced content renders to the same
 //! `.lex` source as the original.
 //!
 //! # Versioning

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -510,6 +510,55 @@ fn standalone_verbatim_line_round_trips_via_empty_label() {
 }
 
 #[test]
+fn table_with_block_content_cells_surfaces_as_unsupported_kind() {
+    // Tables with block-level cell children have no representation
+    // in the wire format (`WireTableCell` only carries inlines), so
+    // the forward codec must emit an unsupported-kind placeholder
+    // rather than silently lose the cell children. The reverse codec
+    // surfaces the placeholder as `FromWireError::UnsupportedKind`.
+    use super::error::FromWireError;
+    use crate::lex::ast::elements::list::{List, ListItem};
+    use crate::lex::ast::elements::table::{Table, TableCell, TableRow};
+    use crate::lex::ast::elements::typed_content::ContentElement;
+    use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+
+    // Build a table with one body cell whose children contain a
+    // nested list.
+    let nested_list = List::new(vec![
+        ListItem::new("-".into(), "alpha".into()),
+        ListItem::new("-".into(), "beta".into()),
+    ]);
+    let block_cell = TableCell::new(TextContent::from_string("see list".into(), None))
+        .with_children(vec![ContentElement::List(nested_list)]);
+    let plain_cell = TableCell::new(TextContent::from_string("inline".into(), None));
+    let row = TableRow::new(vec![block_cell, plain_cell]);
+    let t = Table::new(
+        TextContent::from_string("Caption".into(), None),
+        Vec::new(),
+        vec![row],
+        VerbatimBlockMode::Inflow,
+    );
+
+    let item = ContentItem::Table(Box::new(t));
+    let wire = to_wire_node(&item);
+    // Forward emits the placeholder, not a Table.
+    if let WireNode::Verbatim { ref label, .. } = wire {
+        assert_eq!(label, "lex.internal.unsupported.table_block_cells");
+    } else {
+        panic!("expected unsupported-kind placeholder, got {wire:?}");
+    }
+    // Reverse rejects the placeholder.
+    let result = from_wire_node(&json_round_trip(&wire));
+    assert!(
+        matches!(
+            result,
+            Err(FromWireError::UnsupportedKind { ref kind }) if kind == "table_block_cells"
+        ),
+        "expected UnsupportedKind, got {result:?}"
+    );
+}
+
+#[test]
 fn table_round_trips_caption_and_rows() {
     use crate::lex::ast::elements::table::{Table, TableCell, TableRow};
     use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
@@ -608,6 +657,9 @@ fn document_with_session_paragraph_blank_round_trips() {
 /// representation-only details (see module docs); the bar here is
 /// that real-world include payloads survive a full round trip without
 /// content drops.
+///
+/// Fails loudly if a listed fixture is missing — silent skipping
+/// would let the test pass while exercising zero coverage.
 #[test]
 fn corpus_round_trips_without_unsupported_kinds() {
     use super::to_wire::to_wire_document;
@@ -616,18 +668,19 @@ fn corpus_round_trips_without_unsupported_kinds() {
 
     let fixtures = [
         "comms/specs/elements/paragraph.docs/paragraph-01-flat-oneline.lex",
-        "comms/specs/elements/list.docs/list-01-flat-plain.lex",
-        "comms/specs/elements/session.docs/session-01-flat.lex",
-        "comms/specs/elements/definition.docs/definition-01-flat.lex",
+        "comms/specs/elements/list.docs/list-01-flat-simple-dash.lex",
+        "comms/specs/elements/session.docs/session-01-flat-simple.lex",
+        "comms/specs/elements/definition.docs/definition-01-flat-simple.lex",
     ];
 
+    let mut exercised = 0usize;
     for fixture in fixtures {
         let path = workspace_path(fixture);
-        if !path.exists() {
-            // Skip fixtures whose paths we can't locate (corpus
-            // versions drift); the test still asserts on the others.
-            continue;
-        }
+        assert!(
+            path.exists(),
+            "corpus fixture missing: {fixture} (resolved to {})",
+            path.display()
+        );
         let doc = DocumentLoader::from_path(&path)
             .unwrap_or_else(|e| panic!("could not load {fixture}: {e}"))
             .parse()
@@ -643,5 +696,11 @@ fn corpus_round_trips_without_unsupported_kinds() {
             !back.is_empty() || children.is_empty(),
             "round-trip dropped content for {fixture}"
         );
+        exercised += 1;
     }
+    assert_eq!(
+        exercised,
+        fixtures.len(),
+        "corpus test must exercise every listed fixture"
+    );
 }

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -147,6 +147,8 @@ fn unsupported_kind_in_internal_namespace_surfaces_as_error() {
         label: "lex.internal.unsupported.session".into(),
         params: serde_json::json!({}),
         body_text: String::new(),
+        subject: String::new(),
+        mode: "inflow".into(),
     };
     let result = from_wire_node(&wire);
     assert!(matches!(
@@ -462,11 +464,15 @@ fn verbatim_round_trips_label_and_body() {
     if let WireNode::Verbatim {
         ref label,
         ref body_text,
+        ref subject,
+        ref mode,
         ..
     } = wire
     {
         assert_eq!(label, "rust");
         assert_eq!(body_text, "fn main() {\n    println!(\"hi\");\n}");
+        assert_eq!(subject, "Code:");
+        assert_eq!(mode, "inflow");
     } else {
         panic!("expected WireNode::Verbatim");
     }
@@ -474,6 +480,16 @@ fn verbatim_round_trips_label_and_body() {
     match &back[0] {
         ContentItem::VerbatimBlock(v) => {
             assert_eq!(v.closing_data.label.value, "rust");
+            assert_eq!(
+                v.subject.as_string(),
+                "Code:",
+                "subject must round-trip verbatim"
+            );
+            assert_eq!(
+                v.mode,
+                VerbatimBlockMode::Inflow,
+                "mode must round-trip verbatim"
+            );
             let lines: Vec<String> = v
                 .children
                 .iter()
@@ -490,6 +506,34 @@ fn verbatim_round_trips_label_and_body() {
                     "}".to_string(),
                 ]
             );
+        }
+        other => panic!("expected VerbatimBlock, got {other:?}"),
+    }
+}
+
+#[test]
+fn verbatim_fullwidth_mode_round_trips() {
+    use crate::lex::ast::elements::data::Data;
+    use crate::lex::ast::elements::label::Label;
+    use crate::lex::ast::elements::verbatim::{Verbatim, VerbatimBlockMode};
+    let v = Verbatim::new(
+        TextContent::from_string("Wide:".into(), None),
+        Vec::new(),
+        Data::new(Label::new("text".into()), Vec::new()),
+        VerbatimBlockMode::Fullwidth,
+    );
+    let item = ContentItem::VerbatimBlock(Box::new(v));
+    let wire = to_wire_node(&item);
+    if let WireNode::Verbatim { ref mode, .. } = wire {
+        assert_eq!(mode, "fullwidth");
+    } else {
+        panic!("expected WireNode::Verbatim");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::VerbatimBlock(v) => {
+            assert_eq!(v.mode, VerbatimBlockMode::Fullwidth);
+            assert_eq!(v.subject.as_string(), "Wide:");
         }
         other => panic!("expected VerbatimBlock, got {other:?}"),
     }

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -129,16 +129,26 @@ fn parameterised_annotation_round_trips() {
 }
 
 #[test]
-fn unsupported_variant_surfaces_as_error() {
+fn unsupported_kind_in_internal_namespace_surfaces_as_error() {
+    // The reverse codec must reject a `Verbatim` whose label uses the
+    // reserved `lex.internal.unsupported.*` prefix — that prefix is
+    // how the forward codec used to flag uncovered variants. Now that
+    // every variant is wired, the prefix should never show up in
+    // codec output, but the reverse-side guard remains so a malformed
+    // wire input still surfaces an error instead of silently
+    // round-tripping into an empty Verbatim.
     use super::error::FromWireError;
-    use crate::lex::ast::elements::session::Session;
-    // Session is intentionally not yet wired through the codec; the
-    // forward direction emits a placeholder, the reverse surfaces it
-    // as UnsupportedKind.
-    let s = Session::with_title("title".into());
-    let item = ContentItem::Session(s);
-    let wire = to_wire_node(&item);
-    let result = from_wire_node(&json_round_trip(&wire));
+    let wire = lex_extension::wire::WireNode::Verbatim {
+        range: lex_extension::wire::Range::new(
+            lex_extension::wire::Position::new(0, 0),
+            lex_extension::wire::Position::new(0, 0),
+        ),
+        origin: None,
+        label: "lex.internal.unsupported.session".into(),
+        params: serde_json::json!({}),
+        body_text: String::new(),
+    };
+    let result = from_wire_node(&wire);
     assert!(matches!(
         result,
         Err(FromWireError::UnsupportedKind { ref kind }) if kind == "session"
@@ -254,5 +264,384 @@ fn blank_count_clamps_to_one_for_collapsed_range() {
     match &back[0] {
         ContentItem::BlankLineGroup(blg) => assert_eq!(blg.count, 1),
         _ => panic!("expected BlankLineGroup"),
+    }
+}
+
+// ============================================================================
+// Per-variant round-trip tests for the variants newly wired in PR 3c.
+// ============================================================================
+
+#[test]
+fn session_round_trips() {
+    use crate::lex::ast::elements::session::Session;
+    let mut s = Session::with_title("Intro".into());
+    s.children
+        .as_mut_vec()
+        .push(ContentItem::Paragraph(Paragraph::from_line(
+            "First paragraph".into(),
+        )));
+    let item = ContentItem::Session(s);
+    let wire = to_wire_node(&item);
+    if let WireNode::Session { ref title, .. } = wire {
+        assert_eq!(title, "Intro");
+    } else {
+        panic!("expected WireNode::Session, got {wire:?}");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Session(s) => {
+            assert_eq!(s.title.as_string(), "Intro");
+            // The single paragraph child should have round-tripped.
+            let mut found_para = false;
+            for child in s.children.iter() {
+                if let ContentItem::Paragraph(p) = child {
+                    if let Some(ContentItem::TextLine(line)) = p.lines.first() {
+                        if line.content.as_string() == "First paragraph" {
+                            found_para = true;
+                        }
+                    }
+                }
+            }
+            assert!(found_para, "session paragraph child must round-trip");
+        }
+        other => panic!("expected Session, got {other:?}"),
+    }
+}
+
+#[test]
+fn session_marker_round_trips_as_string() {
+    use crate::lex::ast::elements::sequence_marker::SequenceMarker;
+    use crate::lex::ast::elements::session::Session;
+    let mut s = Session::with_title("Chapter Two".into());
+    s.marker = SequenceMarker::parse("2.", None);
+    let item = ContentItem::Session(s);
+    let wire = to_wire_node(&item);
+    if let WireNode::Session { ref marker, .. } = wire {
+        assert_eq!(marker.as_deref(), Some("2."));
+    } else {
+        panic!("expected WireNode::Session");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Session(s) => {
+            let m = s.marker.as_ref().expect("marker reconstructed");
+            assert_eq!(m.as_str(), "2.");
+        }
+        other => panic!("expected Session, got {other:?}"),
+    }
+}
+
+#[test]
+fn definition_round_trips() {
+    use crate::lex::ast::elements::definition::Definition;
+    let mut d = Definition::with_subject("Cache".into());
+    d.children
+        .as_mut_vec()
+        .push(ContentItem::Paragraph(Paragraph::from_line(
+            "Temporary storage.".into(),
+        )));
+    let item = ContentItem::Definition(d);
+    let wire = to_wire_node(&item);
+    if let WireNode::Definition { ref subject, .. } = wire {
+        assert_eq!(subject, "Cache");
+    } else {
+        panic!("expected WireNode::Definition");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Definition(d) => {
+            assert_eq!(d.subject.as_string(), "Cache");
+            assert!(!d.children.is_empty(), "child paragraph must survive");
+        }
+        other => panic!("expected Definition, got {other:?}"),
+    }
+}
+
+#[test]
+fn list_round_trips() {
+    use crate::lex::ast::elements::list::{List, ListItem};
+    use crate::lex::ast::elements::sequence_marker::SequenceMarker;
+    let mut list = List::new(vec![
+        ListItem::new("-".into(), "Bread".into()),
+        ListItem::new("-".into(), "Milk".into()),
+    ]);
+    list.marker = SequenceMarker::parse("-", None);
+    let item = ContentItem::List(list);
+    let wire = to_wire_node(&item);
+    if let WireNode::List {
+        ref marker_style,
+        ref items,
+        ..
+    } = wire
+    {
+        assert_eq!(marker_style, "dash");
+        assert_eq!(items.len(), 2);
+    } else {
+        panic!("expected WireNode::List");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::List(l) => {
+            assert_eq!(l.items.len(), 2);
+            // Second item's text must round-trip.
+            let texts: Vec<String> = l
+                .items
+                .iter()
+                .filter_map(|item| match item {
+                    ContentItem::ListItem(li) => {
+                        li.text.first().map(|tc| tc.as_string().to_string())
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(texts, vec!["Bread".to_string(), "Milk".to_string()]);
+        }
+        other => panic!("expected List, got {other:?}"),
+    }
+}
+
+#[test]
+fn nested_list_children_round_trip() {
+    use crate::lex::ast::elements::list::{List, ListItem};
+    use crate::lex::ast::elements::typed_content::ContentElement;
+    let nested_list = List::new(vec![
+        ListItem::new("-".into(), "child a".into()),
+        ListItem::new("-".into(), "child b".into()),
+    ]);
+    let parent_with_children = ListItem::with_content(
+        "-".into(),
+        "parent".into(),
+        vec![ContentElement::List(nested_list)],
+    );
+    let other = ListItem::new("-".into(), "sibling".into());
+    let list = List::new(vec![parent_with_children, other]);
+    let item = ContentItem::List(list);
+    let wire = to_wire_node(&item);
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::List(l) => {
+            // First item carries a nested list as a child.
+            let parent = match l.items.iter().next() {
+                Some(ContentItem::ListItem(li)) => li,
+                _ => panic!("expected ListItem"),
+            };
+            let nested = parent.children.iter().find_map(|c| match c {
+                ContentItem::List(inner) => Some(inner),
+                _ => None,
+            });
+            assert!(
+                nested.is_some(),
+                "nested list inside list-item must round-trip"
+            );
+            assert_eq!(nested.unwrap().items.len(), 2);
+        }
+        other => panic!("expected List, got {other:?}"),
+    }
+}
+
+#[test]
+fn verbatim_round_trips_label_and_body() {
+    use crate::lex::ast::elements::data::Data;
+    use crate::lex::ast::elements::label::Label;
+    use crate::lex::ast::elements::typed_content::VerbatimContent;
+    use crate::lex::ast::elements::verbatim::{Verbatim, VerbatimBlockMode};
+    use crate::lex::ast::elements::verbatim_line::VerbatimLine;
+    let body_lines = vec![
+        VerbatimContent::VerbatimLine(VerbatimLine::new("fn main() {".into())),
+        VerbatimContent::VerbatimLine(VerbatimLine::new("    println!(\"hi\");".into())),
+        VerbatimContent::VerbatimLine(VerbatimLine::new("}".into())),
+    ];
+    let v = Verbatim::new(
+        TextContent::from_string("Code:".into(), None),
+        body_lines,
+        Data::new(Label::new("rust".into()), Vec::new()),
+        VerbatimBlockMode::Inflow,
+    );
+    let item = ContentItem::VerbatimBlock(Box::new(v));
+    let wire = to_wire_node(&item);
+    if let WireNode::Verbatim {
+        ref label,
+        ref body_text,
+        ..
+    } = wire
+    {
+        assert_eq!(label, "rust");
+        assert_eq!(body_text, "fn main() {\n    println!(\"hi\");\n}");
+    } else {
+        panic!("expected WireNode::Verbatim");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::VerbatimBlock(v) => {
+            assert_eq!(v.closing_data.label.value, "rust");
+            let lines: Vec<String> = v
+                .children
+                .iter()
+                .filter_map(|item| match item {
+                    ContentItem::VerbatimLine(vl) => Some(vl.content.as_string().to_string()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                lines,
+                vec![
+                    "fn main() {".to_string(),
+                    "    println!(\"hi\");".to_string(),
+                    "}".to_string(),
+                ]
+            );
+        }
+        other => panic!("expected VerbatimBlock, got {other:?}"),
+    }
+}
+
+#[test]
+fn standalone_verbatim_line_round_trips_via_empty_label() {
+    use crate::lex::ast::elements::verbatim_line::VerbatimLine;
+    let item = ContentItem::VerbatimLine(VerbatimLine::new("loose verbatim line".into()));
+    let wire = to_wire_node(&item);
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::VerbatimLine(vl) => {
+            assert_eq!(vl.content.as_string(), "loose verbatim line");
+        }
+        other => panic!("expected VerbatimLine, got {other:?}"),
+    }
+}
+
+#[test]
+fn table_round_trips_caption_and_rows() {
+    use crate::lex::ast::elements::table::{Table, TableCell, TableRow};
+    use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+    let header = TableRow::new(vec![
+        TableCell::new(TextContent::from_string("Name".into(), None)).with_header(true),
+        TableCell::new(TextContent::from_string("Score".into(), None)).with_header(true),
+    ]);
+    let body = vec![
+        TableRow::new(vec![
+            TableCell::new(TextContent::from_string("Alice".into(), None)),
+            TableCell::new(TextContent::from_string("42".into(), None)),
+        ]),
+        TableRow::new(vec![
+            TableCell::new(TextContent::from_string("Bob".into(), None)),
+            TableCell::new(TextContent::from_string("17".into(), None)),
+        ]),
+    ];
+    let t = Table::new(
+        TextContent::from_string("Scoreboard".into(), None),
+        vec![header],
+        body,
+        VerbatimBlockMode::Inflow,
+    );
+    let item = ContentItem::Table(Box::new(t));
+    let wire = to_wire_node(&item);
+    if let WireNode::Table {
+        ref caption,
+        header_rows,
+        ref rows,
+        ..
+    } = wire
+    {
+        assert_eq!(caption, "Scoreboard");
+        assert_eq!(header_rows, 1);
+        assert_eq!(rows.len(), 3);
+    } else {
+        panic!("expected WireNode::Table");
+    }
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Table(t) => {
+            assert_eq!(t.subject.as_string(), "Scoreboard");
+            assert_eq!(t.header_rows.len(), 1);
+            assert_eq!(t.body_rows.len(), 2);
+            let alice = &t.body_rows[0].cells[0];
+            assert_eq!(alice.text(), "Alice");
+        }
+        other => panic!("expected Table, got {other:?}"),
+    }
+}
+
+#[test]
+fn document_with_session_paragraph_blank_round_trips() {
+    use crate::lex::ast::elements::session::Session;
+    let mut s = Session::with_title("Intro".into());
+    s.children
+        .as_mut_vec()
+        .push(ContentItem::Paragraph(Paragraph::from_line("Hello".into())));
+    s.children
+        .as_mut_vec()
+        .push(ContentItem::BlankLineGroup(BlankLineGroup::new(
+            1,
+            Vec::new(),
+        )));
+    s.children
+        .as_mut_vec()
+        .push(ContentItem::Paragraph(Paragraph::from_line(
+            "Second paragraph".into(),
+        )));
+
+    let item = ContentItem::Session(s);
+    let wire = to_wire_node(&item);
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Session(s) => {
+            // Session must contain three children in original order.
+            let kinds: Vec<&'static str> = s
+                .children
+                .iter()
+                .map(|c| match c {
+                    ContentItem::Paragraph(_) => "paragraph",
+                    ContentItem::BlankLineGroup(_) => "blank",
+                    _ => "other",
+                })
+                .collect();
+            assert_eq!(kinds, vec!["paragraph", "blank", "paragraph"]);
+        }
+        other => panic!("expected Session, got {other:?}"),
+    }
+}
+
+/// Corpus-driven round-trip: parse a handful of representative
+/// fixtures, run forward+reverse, and verify the codec doesn't surface
+/// `UnsupportedKind`. Strict structural-equivalence isn't asserted
+/// because the codec preserves block structure but normalises
+/// representation-only details (see module docs); the bar here is
+/// that real-world include payloads survive a full round trip without
+/// content drops.
+#[test]
+fn corpus_round_trips_without_unsupported_kinds() {
+    use super::to_wire::to_wire_document;
+    use crate::lex::loader::DocumentLoader;
+    use crate::lex::testing::workspace_path;
+
+    let fixtures = [
+        "comms/specs/elements/paragraph.docs/paragraph-01-flat-oneline.lex",
+        "comms/specs/elements/list.docs/list-01-flat-plain.lex",
+        "comms/specs/elements/session.docs/session-01-flat.lex",
+        "comms/specs/elements/definition.docs/definition-01-flat.lex",
+    ];
+
+    for fixture in fixtures {
+        let path = workspace_path(fixture);
+        if !path.exists() {
+            // Skip fixtures whose paths we can't locate (corpus
+            // versions drift); the test still asserts on the others.
+            continue;
+        }
+        let doc = DocumentLoader::from_path(&path)
+            .unwrap_or_else(|e| panic!("could not load {fixture}: {e}"))
+            .parse()
+            .unwrap_or_else(|e| panic!("could not parse {fixture}: {e}"));
+        let wire = to_wire_document(&doc);
+        let WireNode::Document { children, .. } = wire else {
+            panic!("expected WireNode::Document for {fixture}");
+        };
+        let back = from_wire_subtree(&children).unwrap_or_else(|e| {
+            panic!("from_wire_subtree failed for {fixture}: {e}");
+        });
+        assert!(
+            !back.is_empty() || children.is_empty(),
+            "round-trip dropped content for {fixture}"
+        );
     }
 }

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -191,6 +191,25 @@ fn list_item_standalone_to_wire(li: &ListItem) -> WireNode {
 }
 
 fn table_to_wire(t: &Table) -> WireNode {
+    // The wire table format only carries inline content per cell;
+    // there is no slot for `TableCell.children` (block-level content
+    // inside a cell, populated by the parser when a cell contains a
+    // list / definition / nested table). Emitting a `WireNode::Table`
+    // for a table with block-content cells would silently drop that
+    // content, so we surface those as a structural placeholder
+    // instead. The reverse codec recognises the
+    // `lex.internal.unsupported.*` prefix and rejects with
+    // `FromWireError::UnsupportedKind`, making the loss visible.
+    if t.cell_children_iter().next().is_some() {
+        return WireNode::Verbatim {
+            range: range_to_wire(&t.location),
+            origin: origin_string(&t.location),
+            label: "lex.internal.unsupported.table_block_cells".into(),
+            params: Value::Object(Map::new()),
+            body_text: String::new(),
+        };
+    }
+
     let header_rows = u32::try_from(t.header_rows.len()).unwrap_or(u32::MAX);
     let align = table_align_summary(t);
     let rows = t
@@ -216,15 +235,15 @@ fn table_to_wire(t: &Table) -> WireNode {
 }
 
 fn table_cell_to_wire(cell: &TableCell) -> WireTableCell {
-    let inlines = if cell.has_block_content() {
-        // Inlines of a cell that has block-level children are best
-        // reconstructed from the cell's own text content.
-        text_content_to_wire(&cell.content)
-    } else {
-        text_content_to_wire(&cell.content)
-    };
+    // Cells reaching here have already passed the block-content
+    // guard in `table_to_wire`, so `cell.children` is empty by
+    // construction.
+    debug_assert!(
+        !cell.has_block_content(),
+        "table_to_wire must short-circuit block-content cells before reaching table_cell_to_wire"
+    );
     WireTableCell {
-        inlines,
+        inlines: text_content_to_wire(&cell.content),
         colspan: u32::try_from(cell.colspan).unwrap_or(1),
         rowspan: u32::try_from(cell.rowspan).unwrap_or(1),
     }

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -207,6 +207,8 @@ fn table_to_wire(t: &Table) -> WireNode {
             label: "lex.internal.unsupported.table_block_cells".into(),
             params: Value::Object(Map::new()),
             body_text: String::new(),
+            subject: String::new(),
+            mode: "inflow".into(),
         };
     }
 
@@ -251,10 +253,14 @@ fn table_cell_to_wire(cell: &TableCell) -> WireTableCell {
 
 /// Summarise a table's per-cell alignment into a single string. Wire
 /// tables carry one alignment per table; lex-core tracks alignment per
-/// cell. We pick the alignment of the first non-`None` body cell, or
-/// the empty string when no alignment is set anywhere.
+/// cell. We pick the alignment of the first non-`None` *body* cell —
+/// header cells are skipped because their alignment is often a
+/// styling artefact (centered headers over left-aligned columns) and
+/// would mislead the reverse codec, which applies the chosen
+/// alignment to every cell in the table. Returns the empty string
+/// when no body alignment is set anywhere.
 fn table_align_summary(t: &Table) -> String {
-    for row in t.all_rows() {
+    for row in &t.body_rows {
         for cell in &row.cells {
             match cell.align {
                 TableCellAlignment::Left => return "left".into(),
@@ -307,6 +313,8 @@ fn verbatim_to_wire(v: &Verbatim) -> WireNode {
         label,
         params,
         body_text,
+        subject: v.subject.as_string().to_string(),
+        mode: verbatim_mode_name(v.mode).to_string(),
     }
 }
 
@@ -321,6 +329,8 @@ fn verbatim_line_standalone_to_wire(vl: &VerbatimLine) -> WireNode {
         label: String::new(),
         params: Value::Object(Map::new()),
         body_text: vl.content.as_string().to_string(),
+        subject: String::new(),
+        mode: "inflow".into(),
     }
 }
 
@@ -364,5 +374,15 @@ fn decoration_style_name(style: DecorationStyle) -> &'static str {
         DecorationStyle::Numerical => "numerical",
         DecorationStyle::Alphabetical => "alphabetical",
         DecorationStyle::Roman => "roman",
+    }
+}
+
+fn verbatim_mode_name(
+    mode: crate::lex::ast::elements::verbatim::VerbatimBlockMode,
+) -> &'static str {
+    use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+    match mode {
+        VerbatimBlockMode::Inflow => "inflow",
+        VerbatimBlockMode::Fullwidth => "fullwidth",
     }
 }

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -1,20 +1,32 @@
 //! Forward codec: lex-core internal AST → `lex_extension::WireNode`.
 //!
-//! Total over the AST shapes a parsed lex document can produce. Build-up
-//! is incremental: this commit covers the simpler block shapes
-//! (`Document`, `Paragraph`, `Annotation`, `BlankLineGroup`); follow-up
-//! commits on the same PR extend coverage to `Session`, `Definition`,
-//! `List`, `Table`, and `Verbatim`. Variants not yet wired return
-//! [`unsupported_node`] which produces a structural placeholder rather
-//! than panicking; the placeholder round-trips through the reverse
-//! codec to surface the gap as a [`crate::lex::wire::FromWireError`].
+//! Total over the AST shapes a parsed lex document can produce. Every
+//! [`ContentItem`] variant is wired through to a structured [`WireNode`];
+//! variants that have no direct slot in the wire form are mapped to the
+//! closest equivalent (standalone `TextLine` becomes a single-line
+//! [`WireNode::Paragraph`]; `VerbatimLine` outside a block becomes a
+//! [`WireNode::Verbatim`] with an empty label) so that the reverse codec
+//! can reconstruct a structurally equivalent AST.
+//!
+//! See the module-level docs in [`super`] for the documented losses
+//! (annotation slots on inline nodes, document-level title/annotations,
+//! verbatim multi-group bodies, byte-offset spans).
 
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::blank_line_group::BlankLineGroup;
 use crate::lex::ast::elements::content_item::ContentItem;
-use crate::lex::ast::elements::paragraph::Paragraph;
+use crate::lex::ast::elements::definition::Definition;
+use crate::lex::ast::elements::list::{List, ListItem};
+use crate::lex::ast::elements::paragraph::{Paragraph, TextLine};
+use crate::lex::ast::elements::sequence_marker::DecorationStyle;
+use crate::lex::ast::elements::session::Session;
+use crate::lex::ast::elements::table::{Table, TableCell, TableCellAlignment};
+use crate::lex::ast::elements::verbatim::Verbatim;
+use crate::lex::ast::elements::verbatim_line::VerbatimLine;
 use crate::lex::ast::Document;
-use lex_extension::wire::WireNode;
+use lex_extension::wire::{
+    WireFootnote, WireInline, WireListItem, WireNode, WireRow, WireTableCell,
+};
 use serde_json::{Map, Value};
 
 use super::inline::text_content_to_wire;
@@ -41,26 +53,19 @@ pub fn to_wire_document(doc: &Document) -> WireNode {
 }
 
 /// Convert a single `ContentItem` to a `WireNode`.
-///
-/// Variants not yet implemented produce an `Unknown`-shaped placeholder
-/// (see [`unsupported_node`]); the reverse codec surfaces these as
-/// [`super::FromWireError::UnsupportedKind`] so the gap is visible to
-/// callers.
 pub fn to_wire_node(item: &ContentItem) -> WireNode {
     match item {
         ContentItem::Paragraph(p) => paragraph_to_wire(p),
         ContentItem::BlankLineGroup(blg) => blank_to_wire(blg),
         ContentItem::Annotation(a) => annotation_to_wire(a),
-
-        // Coverage built up in follow-up commits.
-        ContentItem::Session(_)
-        | ContentItem::Definition(_)
-        | ContentItem::List(_)
-        | ContentItem::ListItem(_)
-        | ContentItem::TextLine(_)
-        | ContentItem::VerbatimBlock(_)
-        | ContentItem::Table(_)
-        | ContentItem::VerbatimLine(_) => unsupported_node(item),
+        ContentItem::Session(s) => session_to_wire(s),
+        ContentItem::Definition(d) => definition_to_wire(d),
+        ContentItem::List(l) => list_to_wire(l),
+        ContentItem::ListItem(li) => list_item_standalone_to_wire(li),
+        ContentItem::Table(t) => table_to_wire(t),
+        ContentItem::VerbatimBlock(v) => verbatim_to_wire(v),
+        ContentItem::VerbatimLine(vl) => verbatim_line_standalone_to_wire(vl),
+        ContentItem::TextLine(tl) => text_line_standalone_to_wire(tl),
     }
 }
 
@@ -74,7 +79,7 @@ fn paragraph_to_wire(p: &Paragraph) -> WireNode {
     for line_item in &p.lines {
         if let ContentItem::TextLine(line) = line_item {
             if !first_line {
-                inlines.push(lex_extension::wire::WireInline::Text { text: "\n".into() });
+                inlines.push(WireInline::Text { text: "\n".into() });
             }
             inlines.extend(text_content_to_wire(&line.content));
             first_line = false;
@@ -107,6 +112,210 @@ fn annotation_to_wire(a: &Annotation) -> WireNode {
     }
 }
 
+fn session_to_wire(s: &Session) -> WireNode {
+    let children = s.children.iter().map(to_wire_node).collect::<Vec<_>>();
+    WireNode::Session {
+        range: range_to_wire(&s.location),
+        origin: origin_string(&s.location),
+        title: s.title_text().to_string(),
+        marker: s.marker.as_ref().map(|m| m.as_str().to_string()),
+        children,
+    }
+}
+
+fn definition_to_wire(d: &Definition) -> WireNode {
+    let children = d.children.iter().map(to_wire_node).collect::<Vec<_>>();
+    WireNode::Definition {
+        range: range_to_wire(&d.location),
+        origin: origin_string(&d.location),
+        subject: d.subject.as_string().to_string(),
+        children,
+    }
+}
+
+fn list_to_wire(l: &List) -> WireNode {
+    let marker_style = l
+        .marker
+        .as_ref()
+        .map(|m| decoration_style_name(m.style))
+        .unwrap_or("dash")
+        .to_string();
+    let items = l
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            ContentItem::ListItem(li) => Some(list_item_to_wire(li)),
+            _ => None,
+        })
+        .collect();
+    WireNode::List {
+        range: range_to_wire(&l.location),
+        origin: origin_string(&l.location),
+        marker_style,
+        items,
+    }
+}
+
+fn list_item_to_wire(li: &ListItem) -> WireListItem {
+    // Concatenate every TextContent in `text` into a single inline run,
+    // interleaving `\n` separators between continuation lines so a
+    // multi-line list-item body round-trips. The reverse codec splits
+    // the joined run back into its components.
+    let mut inlines = Vec::new();
+    for (i, tc) in li.text.iter().enumerate() {
+        if i > 0 {
+            inlines.push(WireInline::Text { text: "\n".into() });
+        }
+        inlines.extend(text_content_to_wire(tc));
+    }
+    let children = li.children.iter().map(to_wire_node).collect();
+    WireListItem {
+        range: range_to_wire(&li.location),
+        inlines,
+        children,
+    }
+}
+
+/// Wire form for a `ListItem` that appears outside a `List` (which the
+/// parser does not produce, but the codec must still handle to stay
+/// total). Wraps the item as a singleton list with a default marker so
+/// the reverse codec produces a valid `List` rather than a malformed
+/// node.
+fn list_item_standalone_to_wire(li: &ListItem) -> WireNode {
+    WireNode::List {
+        range: range_to_wire(&li.location),
+        origin: origin_string(&li.location),
+        marker_style: "dash".into(),
+        items: vec![list_item_to_wire(li)],
+    }
+}
+
+fn table_to_wire(t: &Table) -> WireNode {
+    let header_rows = u32::try_from(t.header_rows.len()).unwrap_or(u32::MAX);
+    let align = table_align_summary(t);
+    let rows = t
+        .all_rows()
+        .map(|row| WireRow {
+            cells: row.cells.iter().map(table_cell_to_wire).collect(),
+        })
+        .collect();
+    let footnotes = t
+        .footnotes
+        .as_deref()
+        .map(table_footnotes_to_wire)
+        .unwrap_or_default();
+    WireNode::Table {
+        range: range_to_wire(&t.location),
+        origin: origin_string(&t.location),
+        caption: t.subject.as_string().to_string(),
+        header_rows,
+        align,
+        rows,
+        footnotes,
+    }
+}
+
+fn table_cell_to_wire(cell: &TableCell) -> WireTableCell {
+    let inlines = if cell.has_block_content() {
+        // Inlines of a cell that has block-level children are best
+        // reconstructed from the cell's own text content.
+        text_content_to_wire(&cell.content)
+    } else {
+        text_content_to_wire(&cell.content)
+    };
+    WireTableCell {
+        inlines,
+        colspan: u32::try_from(cell.colspan).unwrap_or(1),
+        rowspan: u32::try_from(cell.rowspan).unwrap_or(1),
+    }
+}
+
+/// Summarise a table's per-cell alignment into a single string. Wire
+/// tables carry one alignment per table; lex-core tracks alignment per
+/// cell. We pick the alignment of the first non-`None` body cell, or
+/// the empty string when no alignment is set anywhere.
+fn table_align_summary(t: &Table) -> String {
+    for row in t.all_rows() {
+        for cell in &row.cells {
+            match cell.align {
+                TableCellAlignment::Left => return "left".into(),
+                TableCellAlignment::Center => return "center".into(),
+                TableCellAlignment::Right => return "right".into(),
+                TableCellAlignment::None => {}
+            }
+        }
+    }
+    String::new()
+}
+
+fn table_footnotes_to_wire(footnotes: &List) -> Vec<WireFootnote> {
+    footnotes
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            ContentItem::ListItem(li) => Some(WireFootnote {
+                marker: li.marker.as_string().to_string(),
+                inlines: li
+                    .text
+                    .first()
+                    .map(text_content_to_wire)
+                    .unwrap_or_default(),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn verbatim_to_wire(v: &Verbatim) -> WireNode {
+    let label = v.closing_data.label.value.clone();
+    let params = parameters_to_json(&v.closing_data.parameters);
+    // Body is the first group's content lines joined by `\n`. Multi-
+    // group verbatims collapse to their first group in the wire form;
+    // the documented loss is acceptable for the current codec
+    // consumer (lex.include never returns multi-group verbatims).
+    let body_text = v
+        .children
+        .iter()
+        .filter_map(|item| match item {
+            ContentItem::VerbatimLine(vl) => Some(vl.content.as_string().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    WireNode::Verbatim {
+        range: range_to_wire(&v.location),
+        origin: origin_string(&v.location),
+        label,
+        params,
+        body_text,
+    }
+}
+
+/// Wire form for a `VerbatimLine` that appears outside a verbatim
+/// block. Wraps it as a single-line `Verbatim` carrying an empty label
+/// — the reverse codec recognises the empty label and reconstructs a
+/// `VerbatimLine`.
+fn verbatim_line_standalone_to_wire(vl: &VerbatimLine) -> WireNode {
+    WireNode::Verbatim {
+        range: range_to_wire(&vl.location),
+        origin: origin_string(&vl.location),
+        label: String::new(),
+        params: Value::Object(Map::new()),
+        body_text: vl.content.as_string().to_string(),
+    }
+}
+
+/// Wire form for a `TextLine` that appears outside a `Paragraph`. The
+/// parser doesn't produce this directly, but `to_wire_node` must stay
+/// total, so we wrap it as a single-line paragraph.
+fn text_line_standalone_to_wire(tl: &TextLine) -> WireNode {
+    WireNode::Paragraph {
+        range: range_to_wire(&tl.location),
+        origin: origin_string(&tl.location),
+        inlines: text_content_to_wire(&tl.content),
+    }
+}
+
 fn parameters_to_json(params: &[crate::lex::ast::elements::parameter::Parameter]) -> Value {
     let mut obj = Map::with_capacity(params.len());
     for p in params {
@@ -130,50 +339,11 @@ fn annotation_body_to_json(a: &Annotation) -> Value {
     Value::Object(obj)
 }
 
-/// Placeholder for ContentItem variants not yet wired through the
-/// codec. Emits a `Verbatim` carrying the lex-core node-type name and
-/// no body — the reverse codec (which checks for `lex.internal`-prefix
-/// labels) surfaces this as `FromWireError::UnsupportedKind`.
-///
-/// This keeps the forward codec total without panicking, so partial
-/// coverage doesn't break callers that incidentally encounter an
-/// unsupported shape during testing.
-fn unsupported_node(item: &ContentItem) -> WireNode {
-    let location = match item {
-        ContentItem::Session(s) => &s.location,
-        ContentItem::Definition(d) => &d.location,
-        ContentItem::List(l) => &l.location,
-        ContentItem::ListItem(li) => &li.location,
-        ContentItem::TextLine(tl) => &tl.location,
-        ContentItem::VerbatimBlock(v) => &v.location,
-        ContentItem::Table(t) => &t.location,
-        ContentItem::VerbatimLine(vl) => &vl.location,
-        // The other arms are wired through the direct path; reaching
-        // this branch via them would be a programmer error.
-        _ => unreachable!("unsupported_node only used for unwired variants"),
-    };
-    let kind_name = item_node_type(item);
-    WireNode::Verbatim {
-        range: range_to_wire(location),
-        origin: origin_string(location),
-        label: format!("lex.internal.unsupported.{kind_name}"),
-        params: Value::Object(Map::new()),
-        body_text: String::new(),
-    }
-}
-
-fn item_node_type(item: &ContentItem) -> &'static str {
-    match item {
-        ContentItem::Paragraph(_) => "paragraph",
-        ContentItem::Session(_) => "session",
-        ContentItem::List(_) => "list",
-        ContentItem::ListItem(_) => "list_item",
-        ContentItem::TextLine(_) => "text_line",
-        ContentItem::Definition(_) => "definition",
-        ContentItem::Annotation(_) => "annotation",
-        ContentItem::VerbatimBlock(_) => "verbatim_block",
-        ContentItem::Table(_) => "table",
-        ContentItem::VerbatimLine(_) => "verbatim_line",
-        ContentItem::BlankLineGroup(_) => "blank",
+fn decoration_style_name(style: DecorationStyle) -> &'static str {
+    match style {
+        DecorationStyle::Plain => "dash",
+        DecorationStyle::Numerical => "numerical",
+        DecorationStyle::Alphabetical => "alphabetical",
+        DecorationStyle::Roman => "roman",
     }
 }

--- a/crates/lex-extension/src/wire/ast.rs
+++ b/crates/lex-extension/src/wire/ast.rs
@@ -76,6 +76,19 @@ pub enum WireNode {
         label: String,
         params: serde_json::Value,
         body_text: String,
+        /// The verbatim block's subject (the lead-in line, e.g.
+        /// `Code:`). Empty string for verbatim blocks that have no
+        /// subject (or for the placeholder shape used to flag
+        /// unsupported variants).
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        subject: String,
+        /// Rendering mode: `"inflow"` (content indented relative to
+        /// subject) or `"fullwidth"` (content at column 2). Defaults
+        /// to `"inflow"` on deserialise — matching the parser's
+        /// default mode — when the field is absent from the wire
+        /// payload.
+        #[serde(default = "default_verbatim_mode")]
+        mode: String,
     },
     Table {
         range: Range,
@@ -136,6 +149,10 @@ pub struct WireTableCell {
 
 fn one() -> u32 {
     1
+}
+
+fn default_verbatim_mode() -> String {
+    "inflow".to_string()
 }
 
 /// One footnote attached to a table.
@@ -221,10 +238,38 @@ mod tests {
             label: "rust".into(),
             params: serde_json::json!({}),
             body_text: "fn main() {}".into(),
+            subject: "Code:".into(),
+            mode: "inflow".into(),
         };
         let s = serde_json::to_string(&v).unwrap();
         let back: WireNode = serde_json::from_str(&s).unwrap();
         assert_eq!(back, v);
+    }
+
+    #[test]
+    fn verbatim_mode_field_defaults_to_inflow_on_deserialise() {
+        // A wire payload missing `mode` should round-trip as
+        // "inflow" — the documented default for older producers
+        // that don't emit the field.
+        let payload = r#"{
+            "kind":"verbatim",
+            "range":{"start":[0,0],"end":[4,0]},
+            "label":"rust",
+            "params":{},
+            "body_text":"x"
+        }"#;
+        let v: WireNode = serde_json::from_str(payload).unwrap();
+        match v {
+            WireNode::Verbatim {
+                ref mode,
+                ref subject,
+                ..
+            } => {
+                assert_eq!(mode, "inflow");
+                assert_eq!(subject, "");
+            }
+            _ => panic!("expected Verbatim"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #532. Part of #516.

## Summary

- Adds `LexIncludeHandler` (`crates/lex-core/src/lex/builtins/include.rs`) — the first built-in `LexHandler`. Wraps the existing `Loader` + `parse_no_attach` + `stamp_doc` pipeline and converts the loaded `Document` to a `WireNode` via the codec from PR 3b. Same security defenses as the inline path (path traversal, root escape, size limit, absolute-path rejection).
- Adds `crate::lex::builtins::register_into(&Registry, loader, config)` plus an inline `lex.include` schema (`hooks.resolve = true`, `src` parameter required, `attaches_to: ["annotation"]`).
- Extends the wire AST codec from PR 3b to cover every `ContentItem` variant — `Session`, `Definition`, `List`/`ListItem`, `Table`, `VerbatimBlock`, `VerbatimLine`, standalone `TextLine`. The forward-only `lex.internal.unsupported.<kind>` placeholders are gone; the reverse-side guard remains so a malformed wire input still surfaces `FromWireError::UnsupportedKind`.
- Documents the codec's structural-vs-representational losses (per-cell table alignment, list-item raw markers, multi-group verbatim bodies) in the module docs.

## Scope

**No call-site change.** The legacy `resolve_from_source` path is untouched — existing `lex.include` integration tests continue to flow through it. PR 3d (#533) flips the resolve pass to dispatch via `Registry::dispatch_resolve`, where this handler runs in production.

## Error mapping

`Loader::load` failures and path-resolution failures map onto `HandlerError::Custom` with codes in the wire spec's reserved `-32000..=-32099` range (`-32001` `NotFound`, `-32002` `OutsideRoot` / `RootEscape`, `-32003` `TooLarge`, `-32004` `AbsolutePath`, `-32005` `Io`, `-32000` missing `src`). Each error attaches a JSON `data` payload with the offending path / sizes / root for diagnostic surfaces.

## Test plan

- [x] 14 new unit tests under `lex::builtins::*` cover the happy path, every `LoadError` variant mapping, the missing-`src` guard, the absolute-path rejection, end-to-end dispatch via `Registry::dispatch_resolve`, and a `from_wire_node` round-trip back to typed lex-core AST.
- [x] 8 new per-variant codec round-trip tests for `Session` / `Definition` / `List` / nested `List`-children / `Table` / `Verbatim` / standalone `VerbatimLine` / mixed `Document`.
- [x] Corpus-driven test that parses several `comms/specs/elements/*` fixtures, runs forward + reverse, and asserts no `UnsupportedKind` falls out.
- [x] Full workspace nextest suite green: 1747 tests passing locally; existing `lex.include` integration tests in `lex-core`, `lex-cli`, and `lex-lsp` all still pass via the legacy inline path.
- [x] `scripts/rust-pre-commit` clean (fmt, clippy, build, test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)