### PR TITLE
PR 6 — trust store + decision matrix (#522)

### DIFF
--- a/crates/lex-extension-host/src/lib.rs
+++ b/crates/lex-extension-host/src/lib.rs
@@ -22,17 +22,25 @@
 //!   validator.
 //! - [`transport::native`] — the trivial transport: a registered
 //!   `Box<dyn LexHandler>` is its own transport, no adapter required.
+//! - [`transport::subprocess`] (behind the `subprocess` feature) —
+//!   spawn a handler binary and dispatch over LSP-framed JSON-RPC.
+//! - [`trust::TrustGate`] — decides whether a handler is allowed to
+//!   run, per the β/γ-correct policy in the master tracking issue
+//!   (subprocess always prompts; native trusted by linkage).
 //!
 //! Coming in later PRs:
 //!
-//! - PR 5: subprocess transport (JSON-RPC over stdio + `initialize`
-//!   handshake).
-//! - PR 6: trust store and decision matrix.
-//! - PR 12: OS-level sandboxing for declared-pure subprocess handlers.
+//! - PR 12: OS-level sandboxing for declared-pure subprocess handlers
+//!   (the post-δ trust matrix flip).
 
 pub mod registry;
 pub mod schema;
 pub mod transport;
+pub mod trust;
 
 pub use registry::{Registry, RegistryError};
 pub use schema::{SchemaError, SchemaLoader};
+pub use trust::{
+    detect_ci_environment, Capability, Source, Surface, Transport, TrustDecision, TrustGate,
+    TrustKey, TrustPromptContext, TrustPromptHandler, TrustStore, TrustStoreError,
+};

--- a/crates/lex-extension-host/src/trust/decision.rs
+++ b/crates/lex-extension-host/src/trust/decision.rs
@@ -1,0 +1,643 @@
+//! Trust decision matrix.
+//!
+//! [`TrustGate::evaluate`] takes the four input axes (source, surface,
+//! transport, capability) and returns a [`TrustDecision`]. The
+//! decision encodes the β/γ-correct policy described in the
+//! master-issue correction #1: subprocess handlers always require
+//! explicit approval; declared `capabilities: { fs/net: false }` is
+//! ignored until PR 12 lands OS-level enforcement.
+
+use super::store::{TrustKey, TrustStore};
+
+/// Where the schema came from. Combined with [`Surface`] and
+/// [`Transport`] this determines whether the handler may run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Source {
+    /// `--ext-schema ./local.yaml` — user passed the schema path
+    /// explicitly on the command line.
+    LocalFile { path: std::path::PathBuf },
+    /// `[labels]` block in `lex.toml` — the workspace owner declared
+    /// the namespace.
+    LexTomlNamespace { name: String },
+    /// Schema fetched from a marketplace / registry / cache. The host
+    /// did not see an explicit user gesture pointing at this schema.
+    CacheOnly { uri: String },
+}
+
+/// Which host surface is consulting the gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Surface {
+    /// `lexd` CLI, single-shot. No interactive prompt.
+    CliOneShot,
+    /// `lex-lsp` running inside an editor. Has the prompt callback.
+    LspSession,
+    /// CI environment, auto-detected from env vars (see
+    /// [`detect_ci_environment`]).
+    Ci,
+}
+
+/// Schema's declared capability set. Stored on the evaluator and
+/// passed to the matrix for forward-compat with PR 12; today it does
+/// not influence the decision (β/γ matrix prompts subprocess
+/// regardless).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Capability {
+    /// `capabilities: { fs: false, net: false }` — the handler
+    /// declares it doesn't need filesystem or network access. Trusted
+    /// to run under sandbox once PR 12 ships.
+    Pure,
+    /// At least one of `fs: true` or `net: true`. Always prompts even
+    /// post-δ.
+    Full,
+}
+
+impl Capability {
+    /// Build from the schema's `Capabilities` struct. Maps the bool
+    /// pair to the binary classifier the gate cares about.
+    pub fn from_schema(caps: lex_extension::schema::Capabilities) -> Self {
+        if caps.is_pure() {
+            Capability::Pure
+        } else {
+            Capability::Full
+        }
+    }
+}
+
+/// Which transport the handler will use. The gate's matrix only
+/// distinguishes Native (trusted by linkage) from everything else
+/// (Subprocess and Wasm both prompt). Wasm shouldn't reach the gate
+/// — the schema loader rejects it — but the variant is here so a
+/// future enable can be a single-line matrix change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Native,
+    Subprocess,
+    Wasm,
+}
+
+impl Transport {
+    /// Build from the schema's `HandlerTransport`.
+    pub fn from_schema(t: lex_extension::schema::HandlerTransport) -> Self {
+        match t {
+            lex_extension::schema::HandlerTransport::Native => Transport::Native,
+            lex_extension::schema::HandlerTransport::Subprocess => Transport::Subprocess,
+            lex_extension::schema::HandlerTransport::Wasm => Transport::Wasm,
+            // HandlerTransport is #[non_exhaustive]; conservatively
+            // treat unknown variants as Subprocess — they'll prompt,
+            // which is the safer default than silently allowing.
+            _ => Transport::Subprocess,
+        }
+    }
+}
+
+/// The verdict the gate returns for one (source, surface, transport,
+/// capability) tuple.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustDecision {
+    /// Handler may run.
+    Trusted,
+    /// Handler may NOT run. The string is a user-facing diagnostic
+    /// explaining why and what to do (e.g., "use --enable-handlers").
+    Denied { reason: String },
+    /// LSP-only: prompt the user via the [`TrustPromptHandler`]
+    /// callback. The result is pinned in the trust store keyed by the
+    /// `(workspace, namespace, command_string)` tuple inside
+    /// [`TrustPromptContext`].
+    Pending,
+}
+
+/// Context handed to a [`TrustPromptHandler`] when the gate needs a
+/// user decision. The same fields make up the [`TrustKey`] that
+/// pins the answer in the trust store, so a re-prompt only happens
+/// when one of those changes (typically the `command_string` after
+/// a schema bump).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustPromptContext {
+    pub namespace: String,
+    /// The schema's `handler.command` joined into a single string.
+    /// Pin granularity — a different command string means a new
+    /// prompt.
+    pub command_string: String,
+    /// Where the schema came from. Surfaces in the prompt UI so the
+    /// user can tell `--ext-schema ./acme.yaml` from a
+    /// marketplace-fetched namespace.
+    pub source: Source,
+    /// What the schema declares it needs. Surfaces in the prompt UI
+    /// for the user's awareness; doesn't change the matrix outcome
+    /// in β/γ.
+    pub capability: Capability,
+}
+
+/// User-defined callback the gate invokes when [`TrustDecision::Pending`]
+/// is reached. CLI installs a callback that returns `Denied`
+/// (interactive trust prompts in CLI mode would be a mid-pipeline
+/// TTY interrupt — instead, the policy is "use `--enable-handlers`
+/// upfront or it's denied"). LSP installs a callback that surfaces
+/// a `lex/trustRequest` notification and waits for the editor's
+/// response (PR 10).
+pub trait TrustPromptHandler: Send + Sync {
+    /// Decide trust for one prompt context. The returned variant must
+    /// be either [`TrustDecision::Trusted`] or
+    /// [`TrustDecision::Denied`] — returning `Pending` is a
+    /// programmer error and is treated as `Denied`.
+    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision;
+}
+
+/// The gate. Constructed once per host session with a [`Surface`], a
+/// [`TrustStore`] for persistence, and a [`TrustPromptHandler`] for
+/// the LSP path. Cheap to clone (the store is `Arc`-shared internally
+/// — well, we don't use Arc here yet, but the public API is small
+/// enough that callers can wrap their own).
+pub struct TrustGate {
+    surface: Surface,
+    /// `--enable-handlers` flag — when set, CLI/CI surfaces treat
+    /// subprocess invocations as `Trusted` for the run.
+    enable_handlers: bool,
+    store: TrustStore,
+    prompt: Box<dyn TrustPromptHandler>,
+}
+
+impl TrustGate {
+    pub fn new(
+        surface: Surface,
+        enable_handlers: bool,
+        store: TrustStore,
+        prompt: Box<dyn TrustPromptHandler>,
+    ) -> Self {
+        Self {
+            surface,
+            enable_handlers,
+            store,
+            prompt,
+        }
+    }
+
+    /// Surface the gate was constructed with. Useful for diagnostics
+    /// that want to mention the active mode.
+    pub fn surface(&self) -> Surface {
+        self.surface
+    }
+
+    /// Whether `--enable-handlers` was set.
+    pub fn enable_handlers(&self) -> bool {
+        self.enable_handlers
+    }
+
+    /// Apply the matrix to one handler invocation.
+    ///
+    /// `command_string` is the schema's `handler.command` joined by
+    /// spaces — this is what the trust store keys on for pin
+    /// granularity. A different command string is a different trust
+    /// decision.
+    pub fn evaluate(
+        &mut self,
+        source: &Source,
+        transport: Transport,
+        capability: Capability,
+        namespace: &str,
+        command_string: &str,
+    ) -> TrustDecision {
+        // Native handlers run by linkage. Bundled `lex.*` built-ins
+        // hit this path; PR 12 will extend it to declared-pure
+        // subprocess handlers.
+        if matches!(transport, Transport::Native) {
+            return TrustDecision::Trusted;
+        }
+
+        // WASM should never reach the gate (schema loader rejects).
+        // If it does — defence in depth — treat as denied.
+        if matches!(transport, Transport::Wasm) {
+            return TrustDecision::Denied {
+                reason: "WASM handlers are not yet supported".into(),
+            };
+        }
+
+        match self.surface {
+            Surface::CliOneShot | Surface::Ci => {
+                if self.enable_handlers {
+                    TrustDecision::Trusted
+                } else {
+                    TrustDecision::Denied {
+                        reason: format!(
+                            "subprocess handler `{namespace}` requires --enable-handlers in {} mode",
+                            match self.surface {
+                                Surface::Ci => "CI",
+                                _ => "CLI",
+                            }
+                        ),
+                    }
+                }
+            }
+            Surface::LspSession => {
+                let key = TrustKey {
+                    namespace: namespace.to_string(),
+                    command_string: command_string.to_string(),
+                };
+                if let Some(stored) = self.store.get(&key) {
+                    return stored.clone();
+                }
+                let ctx = TrustPromptContext {
+                    namespace: namespace.to_string(),
+                    command_string: command_string.to_string(),
+                    source: source.clone(),
+                    capability,
+                };
+                let decision = self.prompt.prompt(&ctx);
+                let to_store = match &decision {
+                    TrustDecision::Trusted => Some(decision.clone()),
+                    TrustDecision::Denied { .. } => Some(decision.clone()),
+                    // Programmer error — `prompt()` must not return
+                    // Pending. Treat as Denied for safety; don't
+                    // persist (the prompt may be retriable on a
+                    // subsequent session).
+                    TrustDecision::Pending => None,
+                };
+                if let Some(decision) = to_store {
+                    let _ = self.store.set(key, decision);
+                }
+                match decision {
+                    TrustDecision::Pending => TrustDecision::Denied {
+                        reason: format!(
+                            "trust prompt for `{namespace}` returned Pending — treating as denied"
+                        ),
+                    },
+                    other => other,
+                }
+            }
+        }
+    }
+
+    /// Borrow the underlying store for inspection. Tests use this; PR
+    /// 10's editor UI will too (so it can show "currently trusted
+    /// namespaces").
+    pub fn store(&self) -> &TrustStore {
+        &self.store
+    }
+}
+
+/// Detect whether the host process is running in a CI environment.
+///
+/// Checks the standard set of env vars shipped by major providers
+/// (the `CI` superset variable plus a few well-known specific
+/// flags). Returns `true` if any one is set, regardless of value.
+///
+/// This is the auto-detection the `lexd` CLI uses to choose
+/// [`Surface::Ci`] over [`Surface::CliOneShot`] when no explicit
+/// surface override is supplied.
+pub fn detect_ci_environment<F>(env_lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    const CI_VARS: &[&str] = &[
+        "CI",
+        "CONTINUOUS_INTEGRATION",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "BUILDKITE",
+        "CIRCLECI",
+        "TRAVIS",
+        "JENKINS_URL",
+    ];
+    CI_VARS.iter().any(|v| env_lookup(v).is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Always returns the configured decision. Used to drive
+    /// matrix-cell tests for the LSP path without touching the
+    /// real prompt UI.
+    struct FixedPrompt(TrustDecision);
+    impl TrustPromptHandler for FixedPrompt {
+        fn prompt(&self, _ctx: &TrustPromptContext) -> TrustDecision {
+            self.0.clone()
+        }
+    }
+
+    fn store_in_tmp() -> (TrustStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = TrustStore::open(dir.path()).expect("open");
+        (store, dir)
+    }
+
+    fn gate_with_surface(
+        surface: Surface,
+        enable_handlers: bool,
+        prompt_decision: TrustDecision,
+    ) -> (TrustGate, tempfile::TempDir) {
+        let (store, dir) = store_in_tmp();
+        let gate = TrustGate::new(
+            surface,
+            enable_handlers,
+            store,
+            Box::new(FixedPrompt(prompt_decision)),
+        );
+        (gate, dir)
+    }
+
+    #[test]
+    fn native_is_trusted_under_every_surface() {
+        for surface in [Surface::CliOneShot, Surface::LspSession, Surface::Ci] {
+            let (mut gate, _dir) = gate_with_surface(
+                surface,
+                false,
+                TrustDecision::Denied {
+                    reason: "should not be called".into(),
+                },
+            );
+            let d = gate.evaluate(
+                &Source::LexTomlNamespace { name: "lex".into() },
+                Transport::Native,
+                Capability::Full,
+                "lex",
+                "/usr/bin/never-spawned",
+            );
+            assert_eq!(d, TrustDecision::Trusted, "surface={surface:?}");
+        }
+    }
+
+    #[test]
+    fn cli_subprocess_without_flag_is_denied() {
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::CliOneShot,
+            false,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        match d {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("--enable-handlers"));
+                assert!(reason.contains("acme"));
+            }
+            other => panic!("expected Denied, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_subprocess_with_flag_is_trusted() {
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::CliOneShot,
+            true,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        assert_eq!(d, TrustDecision::Trusted);
+    }
+
+    #[test]
+    fn cli_with_flag_does_not_persist_to_store() {
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::CliOneShot,
+            true,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        let key = TrustKey {
+            namespace: "acme".into(),
+            command_string: "acme-handler".into(),
+        };
+        assert!(
+            gate.store().get(&key).is_none(),
+            "CLI --enable-handlers must not persist trust"
+        );
+    }
+
+    #[test]
+    fn ci_subprocess_without_flag_is_denied() {
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::Ci,
+            false,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        match d {
+            TrustDecision::Denied { reason } => assert!(reason.contains("CI")),
+            other => panic!("expected Denied, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ci_subprocess_with_flag_is_trusted() {
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::Ci,
+            true,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        assert_eq!(d, TrustDecision::Trusted);
+    }
+
+    #[test]
+    fn lsp_first_call_invokes_prompt_and_persists_trusted() {
+        let (mut gate, _dir) =
+            gate_with_surface(Surface::LspSession, false, TrustDecision::Trusted);
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        assert_eq!(d, TrustDecision::Trusted);
+        // Pinned for next time.
+        let key = TrustKey {
+            namespace: "acme".into(),
+            command_string: "acme-handler".into(),
+        };
+        assert_eq!(gate.store().get(&key), Some(&TrustDecision::Trusted));
+    }
+
+    #[test]
+    fn lsp_subsequent_call_uses_pinned_decision_without_prompt() {
+        // Prompt would deny — but the store was pre-populated as
+        // Trusted, so the gate must short-circuit.
+        let (store, _dir) = store_in_tmp();
+        let mut store = store;
+        let key = TrustKey {
+            namespace: "acme".into(),
+            command_string: "acme-handler".into(),
+        };
+        store.set(key.clone(), TrustDecision::Trusted).unwrap();
+
+        let mut gate = TrustGate::new(
+            Surface::LspSession,
+            false,
+            store,
+            Box::new(FixedPrompt(TrustDecision::Denied {
+                reason: "MUST NOT FIRE".into(),
+            })),
+        );
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        assert_eq!(d, TrustDecision::Trusted);
+    }
+
+    #[test]
+    fn lsp_command_string_change_re_prompts() {
+        // Pin trust for the v1 command, then ask about a v2 command.
+        // The store key includes command_string, so the second call
+        // misses and re-prompts.
+        let (store, _dir) = store_in_tmp();
+        let mut store = store;
+        store
+            .set(
+                TrustKey {
+                    namespace: "acme".into(),
+                    command_string: "acme-handler-v1".into(),
+                },
+                TrustDecision::Trusted,
+            )
+            .unwrap();
+
+        let mut gate = TrustGate::new(
+            Surface::LspSession,
+            false,
+            store,
+            Box::new(FixedPrompt(TrustDecision::Denied {
+                reason: "v2 command needs fresh approval".into(),
+            })),
+        );
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler-v2",
+        );
+        match d {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("v2"));
+            }
+            other => panic!("expected fresh prompt to deny, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lsp_denied_decision_persists() {
+        // Denied decisions are also pinned so a future session
+        // doesn't re-prompt unless the command changes.
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::LspSession,
+            false,
+            TrustDecision::Denied {
+                reason: "user rejected".into(),
+            },
+        );
+        let _ = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        let key = TrustKey {
+            namespace: "acme".into(),
+            command_string: "acme-handler".into(),
+        };
+        assert!(matches!(
+            gate.store().get(&key),
+            Some(TrustDecision::Denied { .. })
+        ));
+    }
+
+    #[test]
+    fn wasm_transport_is_denied_defensively() {
+        // Schema loader rejects WASM upfront so the gate shouldn't
+        // see it, but if it does the matrix denies rather than
+        // silently accepts.
+        let (mut gate, _dir) = gate_with_surface(Surface::CliOneShot, true, TrustDecision::Trusted);
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Wasm,
+            Capability::Pure,
+            "acme",
+            "acme.wasm",
+        );
+        assert!(matches!(d, TrustDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn ci_detection_recognises_standard_env_vars() {
+        for var in ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "CIRCLECI"] {
+            let lookup = |name: &str| -> Option<String> {
+                if name == var {
+                    Some("1".into())
+                } else {
+                    None
+                }
+            };
+            assert!(detect_ci_environment(lookup), "var={var}");
+        }
+    }
+
+    #[test]
+    fn ci_detection_returns_false_when_no_var_set() {
+        assert!(!detect_ci_environment(|_| None));
+    }
+}

--- a/crates/lex-extension-host/src/trust/mod.rs
+++ b/crates/lex-extension-host/src/trust/mod.rs
@@ -1,0 +1,53 @@
+//! Trust store and decision matrix for extension handlers.
+//!
+//! This module decides whether a registered handler is allowed to run
+//! at all. Per the β/γ correctness rule baked into the master tracking
+//! issue (lex#516, correction #1), subprocess handlers always require
+//! explicit user approval — `capabilities: { fs: false, net: false }`
+//! in the schema is just a string until OS-level enforcement lands in
+//! PR 12 (δ). Until then:
+//!
+//! - Native handlers (the bundled `lex.*` built-ins): always trusted by
+//!   linkage.
+//! - Subprocess handlers from any source: prompt or `--enable-handlers`,
+//!   regardless of declared capabilities.
+//! - WASM handlers: rejected at schema load (the schema loader's
+//!   `WasmTransportDeferred` variant fires before the gate sees them).
+//!
+//! # Surfaces
+//!
+//! Three host surfaces consume the gate:
+//!
+//! - `CliOneShot`: the `lexd` CLI, single-document conversion. No
+//!   interactive prompt; subprocess handlers are denied unless the
+//!   user upfronts `--enable-handlers`. Persisting trust would not be
+//!   useful (CLI runs are stateless).
+//! - `LspSession`: `lex-lsp` running in an editor. Subprocess handlers
+//!   prompt the user via the [`TrustPromptHandler`] callback; the
+//!   answer pins to the specific `command` string and persists in the
+//!   workspace's `.lex/trust.json`. PR 10 wires the callback to a
+//!   `lex/trustRequest` LSP notification.
+//! - `Ci`: auto-detected from env vars (`CI`, `GITHUB_ACTIONS`, …).
+//!   Same denial rule as `CliOneShot` — but firing the deny is
+//!   important because CI scripts shouldn't accidentally run untrusted
+//!   handlers even when the underlying flag is set elsewhere.
+//!
+//! # What this module does *not* do
+//!
+//! - Spawn or dispatch handlers. The gate is consulted by the host
+//!   *before* it constructs a `SubprocessHandler`; if the gate says
+//!   `Denied`, the host emits a diagnostic and skips registration.
+//! - Honor the schema's declared `capabilities`. That's the post-δ
+//!   matrix's job. The `Capability` field on the evaluator is stored
+//!   for forward-compat but does not influence the decision today.
+//! - OS-level sandboxing. Handler processes run with the host's
+//!   privileges. PR 12 lands the sandbox.
+
+mod decision;
+mod store;
+
+pub use decision::{
+    detect_ci_environment, Capability, Source, Surface, Transport, TrustDecision, TrustGate,
+    TrustPromptContext, TrustPromptHandler,
+};
+pub use store::{TrustKey, TrustStore, TrustStoreError};

--- a/crates/lex-extension-host/src/trust/store.rs
+++ b/crates/lex-extension-host/src/trust/store.rs
@@ -1,0 +1,406 @@
+//! Persistent trust store for LSP-mode handler decisions.
+//!
+//! Modeled on VS Code's workspace-trust pattern: trust decisions are
+//! workspace-scoped and stored in `<workspace>/.lex/trust.json`.
+//! Each entry pins to a `(namespace, command_string)` tuple so that
+//! changing the schema's `handler.command` (e.g., a version bump
+//! that adds a new flag) triggers a fresh prompt instead of silently
+//! reusing the old approval.
+//!
+//! # File format
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "entries": [
+//!     {
+//!       "namespace": "acme",
+//!       "command_string": "acme-handler --workspace=/foo",
+//!       "decision": "trusted"
+//!     },
+//!     {
+//!       "namespace": "evil",
+//!       "command_string": "evil-binary",
+//!       "decision": {"denied": "user rejected"}
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! `version: 1` is the schema-format version. Future changes that
+//! aren't backwards-readable bump it and the loader returns
+//! [`TrustStoreError::UnsupportedVersion`].
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::decision::TrustDecision;
+
+/// Errors raised by the trust store. Read paths are best-effort —
+/// missing files yield an empty store (callers see `None` from
+/// `get`); only malformed-but-present files fail loudly.
+#[derive(Debug)]
+pub enum TrustStoreError {
+    /// Reading or writing `.lex/trust.json` failed at the OS level.
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The file body was not valid JSON or didn't deserialise into
+    /// the expected shape.
+    Parse { path: PathBuf, message: String },
+    /// `version` field was set to a value newer than the loader
+    /// understands. The store stays empty and the caller is told
+    /// which version was unexpected so the user can either upgrade
+    /// the host or delete the file.
+    UnsupportedVersion { path: PathBuf, version: u32 },
+}
+
+impl std::fmt::Display for TrustStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrustStoreError::Io { path, source } => {
+                write!(f, "{}: trust store io error: {source}", path.display())
+            }
+            TrustStoreError::Parse { path, message } => {
+                write!(f, "{}: trust store parse error: {message}", path.display())
+            }
+            TrustStoreError::UnsupportedVersion { path, version } => write!(
+                f,
+                "{}: trust store version {version} is newer than this host supports (1)",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TrustStoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TrustStoreError::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// What the store keys on. The `(namespace, command_string)` tuple
+/// gives pin granularity — a different `command_string` means a new
+/// prompt, even if the namespace is the same.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TrustKey {
+    pub namespace: String,
+    pub command_string: String,
+}
+
+/// In-memory + on-disk trust store. Construct via [`TrustStore::open`]
+/// pointing at a workspace root; the store reads
+/// `<workspace>/.lex/trust.json` on construction (missing file →
+/// empty store) and writes back on every [`set`](Self::set) call.
+#[derive(Debug)]
+pub struct TrustStore {
+    path: PathBuf,
+    entries: HashMap<TrustKey, TrustDecision>,
+}
+
+impl TrustStore {
+    /// Open (or create) the trust store for `workspace`. The actual
+    /// JSON file lives at `<workspace>/.lex/trust.json`. Missing
+    /// file or missing `.lex/` directory produces an empty store —
+    /// hosts can `set` into it and the directory is created on first
+    /// flush.
+    pub fn open(workspace: impl AsRef<Path>) -> Result<Self, TrustStoreError> {
+        let path = workspace.as_ref().join(".lex").join("trust.json");
+        let entries = match fs::read_to_string(&path) {
+            Ok(body) => parse_disk_format(&body, &path)?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(source) => {
+                return Err(TrustStoreError::Io {
+                    path: path.clone(),
+                    source,
+                });
+            }
+        };
+        Ok(Self { path, entries })
+    }
+
+    /// Look up a pinned decision. `None` means the gate must prompt;
+    /// `Some` short-circuits the prompt.
+    pub fn get(&self, key: &TrustKey) -> Option<&TrustDecision> {
+        self.entries.get(key)
+    }
+
+    /// Pin a decision. Both `Trusted` and `Denied` are persisted —
+    /// `Pending` is not a stored state. Writes to disk immediately
+    /// so a crash in the middle of a session doesn't drop the
+    /// approval the user just gave.
+    pub fn set(&mut self, key: TrustKey, decision: TrustDecision) -> Result<(), TrustStoreError> {
+        // Reject Pending — it's a programmer error to persist.
+        if matches!(decision, TrustDecision::Pending) {
+            return Ok(());
+        }
+        self.entries.insert(key, decision);
+        self.flush()
+    }
+
+    /// Drop all pinned decisions. Used by editor commands like
+    /// "Reset Lex extension trust for this workspace".
+    pub fn clear(&mut self) -> Result<(), TrustStoreError> {
+        self.entries.clear();
+        self.flush()
+    }
+
+    /// Iterate the (key, decision) pairs in arbitrary order. The
+    /// editor UI uses this to render "currently trusted namespaces".
+    pub fn iter(&self) -> impl Iterator<Item = (&TrustKey, &TrustDecision)> {
+        self.entries.iter()
+    }
+
+    /// Number of pinned decisions. Tests use this; the editor UI
+    /// might too.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn flush(&self) -> Result<(), TrustStoreError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|source| TrustStoreError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let body = serialise_disk_format(&self.entries);
+        fs::write(&self.path, body).map_err(|source| TrustStoreError::Io {
+            path: self.path.clone(),
+            source,
+        })
+    }
+}
+
+/// On-disk JSON shape. Versioned with a top-level `version` field so
+/// we can evolve the format without losing old stores.
+#[derive(Debug, Serialize, Deserialize)]
+struct OnDiskFile {
+    version: u32,
+    entries: Vec<OnDiskEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OnDiskEntry {
+    namespace: String,
+    command_string: String,
+    decision: OnDiskDecision,
+}
+
+/// On-disk decision shape. Mirrors [`TrustDecision`] minus
+/// `Pending` (which we never persist).
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum OnDiskDecision {
+    Trusted,
+    Denied { reason: String },
+}
+
+fn parse_disk_format(
+    body: &str,
+    path: &Path,
+) -> Result<HashMap<TrustKey, TrustDecision>, TrustStoreError> {
+    let parsed: OnDiskFile = serde_json::from_str(body).map_err(|err| TrustStoreError::Parse {
+        path: path.to_path_buf(),
+        message: err.to_string(),
+    })?;
+    if parsed.version != 1 {
+        return Err(TrustStoreError::UnsupportedVersion {
+            path: path.to_path_buf(),
+            version: parsed.version,
+        });
+    }
+    let mut out = HashMap::with_capacity(parsed.entries.len());
+    for entry in parsed.entries {
+        let key = TrustKey {
+            namespace: entry.namespace,
+            command_string: entry.command_string,
+        };
+        let decision = match entry.decision {
+            OnDiskDecision::Trusted => TrustDecision::Trusted,
+            OnDiskDecision::Denied { reason } => TrustDecision::Denied { reason },
+        };
+        out.insert(key, decision);
+    }
+    Ok(out)
+}
+
+fn serialise_disk_format(entries: &HashMap<TrustKey, TrustDecision>) -> String {
+    let mut on_disk: Vec<OnDiskEntry> = entries
+        .iter()
+        .filter_map(|(k, v)| {
+            let decision = match v {
+                TrustDecision::Trusted => OnDiskDecision::Trusted,
+                TrustDecision::Denied { reason } => OnDiskDecision::Denied {
+                    reason: reason.clone(),
+                },
+                TrustDecision::Pending => return None,
+            };
+            Some(OnDiskEntry {
+                namespace: k.namespace.clone(),
+                command_string: k.command_string.clone(),
+                decision,
+            })
+        })
+        .collect();
+    // Stable order for deterministic file content (helps debugging
+    // and version-control diffs of `.lex/trust.json`).
+    on_disk.sort_by(|a, b| {
+        a.namespace
+            .cmp(&b.namespace)
+            .then(a.command_string.cmp(&b.command_string))
+    });
+    let file = OnDiskFile {
+        version: 1,
+        entries: on_disk,
+    };
+    serde_json::to_string_pretty(&file).expect("OnDiskFile serialises")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(ns: &str, cmd: &str) -> TrustKey {
+        TrustKey {
+            namespace: ns.into(),
+            command_string: cmd.into(),
+        }
+    }
+
+    #[test]
+    fn missing_file_yields_empty_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TrustStore::open(dir.path()).expect("open empty");
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn set_persists_and_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut store = TrustStore::open(dir.path()).unwrap();
+            store
+                .set(key("acme", "acme-handler"), TrustDecision::Trusted)
+                .unwrap();
+            store
+                .set(
+                    key("evil", "evil-binary"),
+                    TrustDecision::Denied {
+                        reason: "rejected".into(),
+                    },
+                )
+                .unwrap();
+        }
+        let store = TrustStore::open(dir.path()).expect("reopen");
+        assert_eq!(store.len(), 2);
+        assert_eq!(
+            store.get(&key("acme", "acme-handler")),
+            Some(&TrustDecision::Trusted)
+        );
+        match store.get(&key("evil", "evil-binary")) {
+            Some(TrustDecision::Denied { reason }) => assert_eq!(reason, "rejected"),
+            other => panic!("expected Denied, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_is_not_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = TrustStore::open(dir.path()).unwrap();
+        store
+            .set(key("acme", "acme-handler"), TrustDecision::Pending)
+            .unwrap();
+        assert!(store.is_empty());
+        // And the file shouldn't carry it back either.
+        let store = TrustStore::open(dir.path()).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn clear_wipes_all_entries_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut store = TrustStore::open(dir.path()).unwrap();
+            store.set(key("acme", "x"), TrustDecision::Trusted).unwrap();
+            store.clear().unwrap();
+            assert!(store.is_empty());
+        }
+        let store = TrustStore::open(dir.path()).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn iter_yields_every_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = TrustStore::open(dir.path()).unwrap();
+        store.set(key("a", "1"), TrustDecision::Trusted).unwrap();
+        store
+            .set(
+                key("b", "2"),
+                TrustDecision::Denied {
+                    reason: "no".into(),
+                },
+            )
+            .unwrap();
+        let mut seen: Vec<String> = store.iter().map(|(k, _)| k.namespace.clone()).collect();
+        seen.sort();
+        assert_eq!(seen, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn unsupported_version_yields_typed_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let trust_path = dir.path().join(".lex/trust.json");
+        std::fs::create_dir_all(trust_path.parent().unwrap()).unwrap();
+        std::fs::write(&trust_path, r#"{"version": 99, "entries": []}"#).unwrap();
+        let err = TrustStore::open(dir.path()).unwrap_err();
+        match err {
+            TrustStoreError::UnsupportedVersion { version, .. } => assert_eq!(version, 99),
+            other => panic!("expected UnsupportedVersion, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn malformed_json_yields_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let trust_path = dir.path().join(".lex/trust.json");
+        std::fs::create_dir_all(trust_path.parent().unwrap()).unwrap();
+        std::fs::write(&trust_path, "{not valid json").unwrap();
+        let err = TrustStore::open(dir.path()).unwrap_err();
+        assert!(matches!(err, TrustStoreError::Parse { .. }));
+    }
+
+    #[test]
+    fn disk_format_is_pretty_and_sorted() {
+        // The on-disk file should be human-readable and stable
+        // (deterministic order) so version-control diffs of
+        // `.lex/trust.json` are clean.
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut store = TrustStore::open(dir.path()).unwrap();
+            store.set(key("zeta", "z"), TrustDecision::Trusted).unwrap();
+            store
+                .set(key("alpha", "a"), TrustDecision::Trusted)
+                .unwrap();
+        }
+        let body = std::fs::read_to_string(dir.path().join(".lex/trust.json")).unwrap();
+        // Pretty-printed → contains newlines and indentation.
+        assert!(body.contains('\n'));
+        // Alpha comes before zeta in the file.
+        assert!(body.find("alpha").unwrap() < body.find("zeta").unwrap());
+        // Schema version present.
+        assert!(body.contains("\"version\": 1"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the trust gate that decides whether a registered handler is allowed to run, per the β/γ-correct policy from #516 (correction #1): subprocess handlers always require explicit user approval; declared \`capabilities: { fs/net: false }\` is ignored until OS-level enforcement lands in PR 12 (δ).

**New module \`lex-extension-host::trust\`:**

- \`decision\` — types (\`Source\`, \`Surface\`, \`Capability\`, \`Transport\`, \`TrustDecision\`), \`TrustPromptHandler\` trait, \`TrustGate\` evaluator, \`detect_ci_environment\` auto-detection.
- \`store\` — \`TrustStore\` persists to \`<workspace>/.lex/trust.json\` with versioned schema; pinned by \`(namespace, command_string)\`.

**Decision matrix (β/γ correct):**

| Source | Transport | CLI one-shot | LSP session | CI |
|--------|-----------|--------------|-------------|-----|
| Any | Native | Trusted | Trusted | Trusted |
| Any | Subprocess | --enable flag | prompt + pin | --enable flag |
| Any | Wasm | Denied (defensive) | Denied | Denied |

The \"pure handlers run by default\" cell is **not active** until PR 12 (δ).

**Pin granularity:** \`(namespace, command_string)\`. A schema bump that changes the command string triggers a fresh prompt — the user re-approves.

Part of #516 (β phase). Depends on #521 (PR 5, merged).

## Test plan

- [x] 10 decision-matrix tests covering every (Surface × Transport × enable_handlers) combination
- [x] 11 store tests: round-trip, Pending-not-persisted, clear, malformed-JSON, unsupported-version, stable-sort
- [x] CI auto-detection covers GitHub Actions, GitLab CI, Buildkite, CircleCI, Travis, Jenkins, generic \`CI\`
- [x] Workspace test suite green (1858 / 1858)
- [x] Pre-commit clean (fmt + clippy + build + tests)