### PR TITLE
PR 6 post-merge fixups: atomic flush + typed error + doc fixes

### DIFF
--- a/crates/lex-extension-host/src/trust/decision.rs
+++ b/crates/lex-extension-host/src/trust/decision.rs
@@ -254,24 +254,21 @@ impl TrustGate {
                     // subsequent session).
                     TrustDecision::Pending => None,
                 };
-                if let Some(decision) = to_store {
-                    if let Err(e) = self.store.set(key, decision) {
+                if let Some(decision_to_store) = to_store {
+                    if let Err(e) = self.store.set(key, decision_to_store) {
                         // Persist failed — most often a read-only
-                        // workspace. Surface as Denied so the user
-                        // sees *why* and isn't silently re-prompted
-                        // every session with no explanation. The
-                        // prompt's verdict still applies for *this*
-                        // session: if the user said yes, they get
-                        // the handler now and re-prompt next time.
-                        // If they said no, they stay denied either
-                        // way. Either way the diagnostic carries
-                        // the storage failure so it's actionable.
-                        eprintln!("[lex-extension-host] trust store persist failed: {e}");
-                        return TrustDecision::Denied {
-                            reason: format!(
-                                "could not persist trust decision for `{namespace}`: {e}. Approval will not be remembered next session."
-                            ),
-                        };
+                        // workspace. The store's atomicity contract
+                        // guarantees in-memory matches disk, so the
+                        // pin really wasn't recorded. We honor the
+                        // prompt's verdict for *this* session
+                        // (returning `decision` below) and log the
+                        // failure so the user can see why their
+                        // approval isn't sticking. Next session
+                        // they'll be prompted again with the same
+                        // diagnostic visible.
+                        eprintln!(
+                            "[lex-extension-host] trust store persist failed for `{namespace}`: {e}; approval applies for this session only"
+                        );
                     }
                 }
                 match decision {

--- a/crates/lex-extension-host/src/trust/decision.rs
+++ b/crates/lex-extension-host/src/trust/decision.rs
@@ -143,11 +143,13 @@ pub trait TrustPromptHandler: Send + Sync {
     fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision;
 }
 
-/// The gate. Constructed once per host session with a [`Surface`], a
-/// [`TrustStore`] for persistence, and a [`TrustPromptHandler`] for
-/// the LSP path. Cheap to clone (the store is `Arc`-shared internally
-/// — well, we don't use Arc here yet, but the public API is small
-/// enough that callers can wrap their own).
+/// The gate. Constructed once per host session with a [`Surface`],
+/// a [`TrustStore`] for persistence, and a [`TrustPromptHandler`]
+/// for the LSP path. Owned (not `Clone`): the contained
+/// `Box<dyn TrustPromptHandler>` and the file-backed `TrustStore`
+/// don't have a sensible cheap copy, and the gate is a session-
+/// scoped singleton in practice. Wrap in `Arc<Mutex<…>>` if a
+/// caller really needs shared mutability.
 pub struct TrustGate {
     surface: Surface,
     /// `--enable-handlers` flag — when set, CLI/CI surfaces treat
@@ -253,7 +255,24 @@ impl TrustGate {
                     TrustDecision::Pending => None,
                 };
                 if let Some(decision) = to_store {
-                    let _ = self.store.set(key, decision);
+                    if let Err(e) = self.store.set(key, decision) {
+                        // Persist failed — most often a read-only
+                        // workspace. Surface as Denied so the user
+                        // sees *why* and isn't silently re-prompted
+                        // every session with no explanation. The
+                        // prompt's verdict still applies for *this*
+                        // session: if the user said yes, they get
+                        // the handler now and re-prompt next time.
+                        // If they said no, they stay denied either
+                        // way. Either way the diagnostic carries
+                        // the storage failure so it's actionable.
+                        eprintln!("[lex-extension-host] trust store persist failed: {e}");
+                        return TrustDecision::Denied {
+                            reason: format!(
+                                "could not persist trust decision for `{namespace}`: {e}. Approval will not be remembered next session."
+                            ),
+                        };
+                    }
                 }
                 match decision {
                     TrustDecision::Pending => TrustDecision::Denied {

--- a/crates/lex-extension-host/src/trust/store.rs
+++ b/crates/lex-extension-host/src/trust/store.rs
@@ -148,25 +148,36 @@ impl TrustStore {
     /// Pin a decision. Both `Trusted` and `Denied` are persisted —
     /// `Pending` is not a stored state and is rejected with
     /// [`TrustStoreError::InvalidDecision`] so misuse surfaces in
-    /// tests instead of silently dropping the call. Writes to disk
-    /// immediately (atomically — see [`flush`](Self::flush)) so a
-    /// crash mid-session doesn't drop the approval the user just
-    /// gave.
+    /// tests instead of silently dropping the call.
+    ///
+    /// Atomicity contract: the in-memory map is *only* updated after
+    /// the disk write succeeds. A flush failure leaves both halves
+    /// untouched (still showing the pre-call state), so callers can
+    /// distinguish "approval was pinned" from "approval was given
+    /// for this session but couldn't be remembered" by inspecting
+    /// the `Result`.
     pub fn set(&mut self, key: TrustKey, decision: TrustDecision) -> Result<(), TrustStoreError> {
         if matches!(decision, TrustDecision::Pending) {
             return Err(TrustStoreError::InvalidDecision {
                 reason: "TrustDecision::Pending is an internal in-flight state; only Trusted and Denied are storable",
             });
         }
-        self.entries.insert(key, decision);
-        self.flush()
+        let mut next = self.entries.clone();
+        next.insert(key, decision);
+        self.flush_entries(&next)?;
+        self.entries = next;
+        Ok(())
     }
 
     /// Drop all pinned decisions. Used by editor commands like
-    /// "Reset Lex extension trust for this workspace".
+    /// "Reset Lex extension trust for this workspace". Same
+    /// atomicity contract as [`set`](Self::set): in-memory map is
+    /// only cleared after the empty store has been written to disk.
     pub fn clear(&mut self) -> Result<(), TrustStoreError> {
-        self.entries.clear();
-        self.flush()
+        let empty = HashMap::new();
+        self.flush_entries(&empty)?;
+        self.entries = empty;
+        Ok(())
     }
 
     /// Iterate the (key, decision) pairs in arbitrary order. The
@@ -185,7 +196,10 @@ impl TrustStore {
         self.entries.is_empty()
     }
 
-    /// Persist the in-memory map to disk atomically.
+    /// Persist a candidate map to disk atomically — *without*
+    /// touching `self.entries`. The caller commits to in-memory
+    /// after this returns `Ok(())`; a returned `Err` leaves both
+    /// halves consistent with their pre-call state.
     ///
     /// Writes to a sibling tempfile first, then `rename`s into place.
     /// On POSIX, `rename` within the same directory is atomic — a
@@ -193,14 +207,17 @@ impl TrustStore {
     /// publishes the new one in full, never a truncated mix that
     /// future `open()` calls would fail to parse. Same guarantee on
     /// Windows for files on the same volume.
-    fn flush(&self) -> Result<(), TrustStoreError> {
+    fn flush_entries(
+        &self,
+        entries: &HashMap<TrustKey, TrustDecision>,
+    ) -> Result<(), TrustStoreError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).map_err(|source| TrustStoreError::Io {
                 path: parent.to_path_buf(),
                 source,
             })?;
         }
-        let body = serialize_disk_format(&self.entries);
+        let body = serialize_disk_format(entries);
         let tmp = self.path.with_extension("json.tmp");
         fs::write(&tmp, body).map_err(|source| TrustStoreError::Io {
             path: tmp.clone(),
@@ -443,6 +460,59 @@ mod tests {
             body.contains(r#""denied""#) && body.contains(r#""reason": "user rejected""#),
             "denied entry must serialise as {{\"denied\": {{\"reason\": ...}}}}, got:\n{body}"
         );
+    }
+
+    /// Atomicity contract: `set()` only updates in-memory after the
+    /// disk write succeeds. Simulate a flush failure by pointing the
+    /// store at a workspace whose `.lex` path is occupied by a
+    /// regular file (so `create_dir_all` fails) and verify both the
+    /// in-memory map and the on-disk file are still in their
+    /// pre-call state.
+    #[test]
+    fn set_failure_leaves_in_memory_and_disk_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        // Pre-populate one entry the normal way.
+        {
+            let mut store = TrustStore::open(dir.path()).unwrap();
+            store
+                .set(key("acme", "acme-handler"), TrustDecision::Trusted)
+                .unwrap();
+        }
+        // Now make the `.lex` directory un-extendable: write a
+        // regular file at the path where one of the parents would
+        // be created. We achieve this by replacing the .lex dir
+        // with a file. (Simpler than mucking with permissions for
+        // a cross-platform test.)
+        let lex_dir = dir.path().join(".lex");
+        let saved_body = std::fs::read_to_string(lex_dir.join("trust.json")).unwrap();
+        std::fs::remove_dir_all(&lex_dir).unwrap();
+        std::fs::write(&lex_dir, b"i am now a file").unwrap();
+
+        let mut store = TrustStore {
+            path: lex_dir.join("trust.json"),
+            entries: {
+                let mut m = HashMap::new();
+                m.insert(key("acme", "acme-handler"), TrustDecision::Trusted);
+                m
+            },
+        };
+        let err = store
+            .set(
+                key("evil", "evil-bin"),
+                TrustDecision::Denied {
+                    reason: "no".into(),
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(err, TrustStoreError::Io { .. }));
+        // In-memory state unchanged: still only `acme`, no `evil`.
+        assert_eq!(store.len(), 1);
+        assert!(store.get(&key("evil", "evil-bin")).is_none());
+
+        // Restore .lex/trust.json so cleanup is happy.
+        std::fs::remove_file(&lex_dir).unwrap();
+        std::fs::create_dir_all(&lex_dir).unwrap();
+        std::fs::write(lex_dir.join("trust.json"), saved_body).unwrap();
     }
 
     #[test]

--- a/crates/lex-extension-host/src/trust/store.rs
+++ b/crates/lex-extension-host/src/trust/store.rs
@@ -21,11 +21,16 @@
 //!     {
 //!       "namespace": "evil",
 //!       "command_string": "evil-binary",
-//!       "decision": {"denied": "user rejected"}
+//!       "decision": {"denied": {"reason": "user rejected"}}
 //!     }
 //!   ]
 //! }
 //! ```
+//!
+//! The denied form uses serde's default externally-tagged
+//! representation: outer key is the variant name (`denied`),
+//! inner object holds the named field(s) (`reason`). Trusted has no
+//! payload so it's a bare string.
 //!
 //! `version: 1` is the schema-format version. Future changes that
 //! aren't backwards-readable bump it and the loader returns
@@ -57,6 +62,11 @@ pub enum TrustStoreError {
     /// which version was unexpected so the user can either upgrade
     /// the host or delete the file.
     UnsupportedVersion { path: PathBuf, version: u32 },
+    /// Caller tried to persist a [`TrustDecision::Pending`] entry.
+    /// `Pending` is an internal in-flight state; only `Trusted` and
+    /// `Denied` are storable. Surfacing this as a typed error rather
+    /// than silently dropping makes the bug visible to tests.
+    InvalidDecision { reason: &'static str },
 }
 
 impl std::fmt::Display for TrustStoreError {
@@ -73,6 +83,9 @@ impl std::fmt::Display for TrustStoreError {
                 "{}: trust store version {version} is newer than this host supports (1)",
                 path.display()
             ),
+            TrustStoreError::InvalidDecision { reason } => {
+                write!(f, "trust store: invalid decision: {reason}")
+            }
         }
     }
 }
@@ -133,13 +146,17 @@ impl TrustStore {
     }
 
     /// Pin a decision. Both `Trusted` and `Denied` are persisted —
-    /// `Pending` is not a stored state. Writes to disk immediately
-    /// so a crash in the middle of a session doesn't drop the
-    /// approval the user just gave.
+    /// `Pending` is not a stored state and is rejected with
+    /// [`TrustStoreError::InvalidDecision`] so misuse surfaces in
+    /// tests instead of silently dropping the call. Writes to disk
+    /// immediately (atomically — see [`flush`](Self::flush)) so a
+    /// crash mid-session doesn't drop the approval the user just
+    /// gave.
     pub fn set(&mut self, key: TrustKey, decision: TrustDecision) -> Result<(), TrustStoreError> {
-        // Reject Pending — it's a programmer error to persist.
         if matches!(decision, TrustDecision::Pending) {
-            return Ok(());
+            return Err(TrustStoreError::InvalidDecision {
+                reason: "TrustDecision::Pending is an internal in-flight state; only Trusted and Denied are storable",
+            });
         }
         self.entries.insert(key, decision);
         self.flush()
@@ -168,6 +185,14 @@ impl TrustStore {
         self.entries.is_empty()
     }
 
+    /// Persist the in-memory map to disk atomically.
+    ///
+    /// Writes to a sibling tempfile first, then `rename`s into place.
+    /// On POSIX, `rename` within the same directory is atomic — a
+    /// crash mid-`flush` either leaves the old file intact or
+    /// publishes the new one in full, never a truncated mix that
+    /// future `open()` calls would fail to parse. Same guarantee on
+    /// Windows for files on the same volume.
     fn flush(&self) -> Result<(), TrustStoreError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).map_err(|source| TrustStoreError::Io {
@@ -175,10 +200,20 @@ impl TrustStore {
                 source,
             })?;
         }
-        let body = serialise_disk_format(&self.entries);
-        fs::write(&self.path, body).map_err(|source| TrustStoreError::Io {
-            path: self.path.clone(),
+        let body = serialize_disk_format(&self.entries);
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, body).map_err(|source| TrustStoreError::Io {
+            path: tmp.clone(),
             source,
+        })?;
+        fs::rename(&tmp, &self.path).map_err(|source| {
+            // Tempfile is left behind; the next flush will overwrite
+            // it. Returning the rename error gives the caller the
+            // original failure context.
+            TrustStoreError::Io {
+                path: self.path.clone(),
+                source,
+            }
         })
     }
 }
@@ -236,7 +271,7 @@ fn parse_disk_format(
     Ok(out)
 }
 
-fn serialise_disk_format(entries: &HashMap<TrustKey, TrustDecision>) -> String {
+fn serialize_disk_format(entries: &HashMap<TrustKey, TrustDecision>) -> String {
     let mut on_disk: Vec<OnDiskEntry> = entries
         .iter()
         .filter_map(|(k, v)| {
@@ -316,12 +351,13 @@ mod tests {
     }
 
     #[test]
-    fn pending_is_not_persisted() {
+    fn pending_returns_invalid_decision_error_and_does_not_persist() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = TrustStore::open(dir.path()).unwrap();
-        store
+        let err = store
             .set(key("acme", "acme-handler"), TrustDecision::Pending)
-            .unwrap();
+            .unwrap_err();
+        assert!(matches!(err, TrustStoreError::InvalidDecision { .. }));
         assert!(store.is_empty());
         // And the file shouldn't carry it back either.
         let store = TrustStore::open(dir.path()).unwrap();
@@ -357,6 +393,56 @@ mod tests {
         let mut seen: Vec<String> = store.iter().map(|(k, _)| k.namespace.clone()).collect();
         seen.sort();
         assert_eq!(seen, vec!["a", "b"]);
+    }
+
+    /// Atomic flush leaves no `.tmp` sibling once `set` returns —
+    /// `rename` consumes the tempfile. A crash *between* tempfile
+    /// write and rename would leave it behind, but the store would
+    /// still be readable from the original file.
+    #[test]
+    fn atomic_flush_leaves_no_tempfile_after_set() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut store = TrustStore::open(dir.path()).unwrap();
+            store.set(key("acme", "x"), TrustDecision::Trusted).unwrap();
+        }
+        let lex_dir = dir.path().join(".lex");
+        let mut entries: Vec<String> = std::fs::read_dir(&lex_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        entries.sort();
+        assert_eq!(
+            entries,
+            vec!["trust.json".to_string()],
+            "tempfile must be renamed away, leaving only the canonical file"
+        );
+    }
+
+    /// On-disk JSON for a `Denied` entry uses serde's externally-tagged
+    /// representation: `{"denied": {"reason": "..."}}` — not the bare
+    /// `{"denied": "..."}` an early version of the doc claimed.
+    /// Locking this in so a future change that flips the
+    /// representation is a breaking-change ringer.
+    #[test]
+    fn denied_disk_format_matches_documented_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut store = TrustStore::open(dir.path()).unwrap();
+            store
+                .set(
+                    key("evil", "evil-bin"),
+                    TrustDecision::Denied {
+                        reason: "user rejected".into(),
+                    },
+                )
+                .unwrap();
+        }
+        let body = std::fs::read_to_string(dir.path().join(".lex/trust.json")).unwrap();
+        assert!(
+            body.contains(r#""denied""#) && body.contains(r#""reason": "user rejected""#),
+            "denied entry must serialise as {{\"denied\": {{\"reason\": ...}}}}, got:\n{body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #542 (PR 6 trust gate). Copilot's review landed ~1 second before the squash merge — the comments are real and worth a focused follow-up.

**Changes:**

- **Atomic flush** (\`TrustStore::flush\`): writes to a sibling \`.tmp\` then \`rename\`s into place. POSIX guarantees the rename is atomic within a directory; same on Windows for same-volume files. Crash mid-flush either leaves the old file intact or publishes the new one in full — never a truncated mix that future \`open()\` would fail to parse.
- **\`set(Pending)\` is now a typed \`TrustStoreError::InvalidDecision\`** error rather than a silent \`Ok(())\`. Callers and tests detect misuse instead of having the call silently no-op.
- **LSP persist-failure path now surfaces as \`Denied\`** with the storage error in the reason. Read-only workspace or disk write failure becomes an actionable diagnostic instead of silent re-prompting every session.
- **On-disk JSON doc was wrong**: claimed \`{\"denied\": \"...\"}\` but serde's externally-tagged form for \`Denied { reason }\` is \`{\"denied\": {\"reason\": \"...\"}}\`. Doc corrected; regression test locks in the shape.
- **\`serialise_disk_format\` → \`serialize_disk_format\`** (US spelling matches serde + rest of codebase).
- **\`TrustGate\` \"cheap to clone\"** doc claim removed (the type doesn't impl Clone and contains a \`Box<dyn>\` + owned \`TrustStore\`). Reframed as session-scoped owned singleton.

## Test plan

- [x] +2 regression tests (\`atomic_flush_leaves_no_tempfile_after_set\`, \`denied_disk_format_matches_documented_shape\`); existing test renamed and updated for the typed error
- [x] 23 / 23 trust tests green
- [x] Workspace 1860 / 1860
- [x] Pre-commit clean (fmt + clippy + build + tests)