### PR TITLE
PR 9 — lexd CLI wiring + lexd labels subcommand (#525)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,8 @@ dependencies = [
  "confique",
  "lex-babel",
  "serde",
+ "tempfile",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1116,6 +1118,7 @@ dependencies = [
  "lex-babel",
  "lex-config",
  "lex-core",
+ "lex-extension",
  "lex-extension-host",
  "predicates",
  "serde_json",

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -22,6 +22,7 @@ lex-core = { workspace = true }
 lex-analysis = { workspace = true }
 lex-babel = { workspace = true, features = ["native-export"] }
 lex-config = { workspace = true }
+lex-extension = { workspace = true }
 lex-extension-host = { workspace = true }
 clapfig = { workspace = true }
 clap = { workspace = true }

--- a/crates/lex-cli/src/extension_setup.rs
+++ b/crates/lex-cli/src/extension_setup.rs
@@ -34,7 +34,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use lex_config::{LabelsConfig, NamespaceSpec};
+use lex_config::LabelsConfig;
+use lex_core::lex::builtins;
+use lex_core::lex::includes::{FsLoader, ResolveConfig};
 use lex_extension::schema::Schema;
 use lex_extension_host::{
     detect_ci_environment, resolve_namespace, Registry, RegistryError, ResolveError, SchemaError,
@@ -97,17 +99,25 @@ pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
     let mut diagnostics = Vec::new();
 
     // Built-ins: lex.* namespace (currently `lex.include`). The
-    // helper in `lex_core::lex::builtins::register_into` handles
-    // this; we keep its setup local to lex-cli's existing code path
-    // and mirror the registration shape here without re-doing it
-    // (the bundled built-ins are wired by the includes-resolver
-    // hook, not here, so this entry exists for `lexd labels list`
-    // visibility only).
-    registered.push(RegisteredNamespace {
-        name: "lex".into(),
-        source: NamespaceSourceKind::Builtin,
-        schema_count: 1,
-    });
+    // boot helper actually performs the registration so that
+    // `lexd labels list` reports the truth and the registry handed
+    // back to the caller has the built-in handlers wired. Loader +
+    // ResolveConfig are pointed at the workspace root so
+    // `lex.include` resolves relative paths the same way `lexd
+    // convert` and `lexd inspect` do.
+    let resolve_config = ResolveConfig::with_root(setup.workspace_root.to_path_buf());
+    let loader = FsLoader::new(setup.workspace_root.to_path_buf());
+    match builtins::register_into(&registry, Arc::new(loader), resolve_config) {
+        Ok(()) => registered.push(RegisteredNamespace {
+            name: "lex".into(),
+            source: NamespaceSourceKind::Builtin,
+            schema_count: 1,
+        }),
+        Err(e) => diagnostics.push(BootDiagnostic {
+            namespace: Some("lex".into()),
+            message: format!("failed to register lex.* built-ins: {e}"),
+        }),
+    }
 
     // [labels] block — resolved through the URI resolver.
     for (name, spec) in &setup.labels_config.namespaces {
@@ -146,7 +156,6 @@ pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
                 message: format!("namespace resolve failed: {e}"),
             }),
         }
-        let _ = NamespaceSpec::Uri(uri); // silence unused-warning if spec evolves
     }
 
     // --ext-schema flags — local schema directories, no resolver.
@@ -187,16 +196,23 @@ pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
         }
     });
     let store = TrustStore::open(setup.workspace_root).unwrap_or_else(|e| {
+        // Fall back to a per-process tempdir under `std::env::temp_dir()`.
+        // The PID suffix keeps unrelated runs from sharing trust
+        // decisions through `/tmp/.lex/trust.json` (which the previous
+        // fallback did — accidentally persistent and shared). With a
+        // PID-keyed path the decisions persist within this run but
+        // can't be re-read by the next session.
+        let fallback_dir = std::env::temp_dir()
+            .join(format!("lexd-trust-fallback-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&fallback_dir);
         diagnostics.push(BootDiagnostic {
             namespace: None,
             message: format!(
-                "trust store open failed: {e}; trust decisions will not be persisted this session"
+                "trust store open failed at workspace root: {e}; falling back to per-process temp dir `{}` — decisions persist for this run only",
+                fallback_dir.display()
             ),
         });
-        // Fall back to a tempdir-backed store so the gate still
-        // works in-memory for this session.
-        let tmp = std::env::temp_dir();
-        TrustStore::open(&tmp).expect("temp dir is writable")
+        TrustStore::open(&fallback_dir).expect("temp dir writable")
     });
     let trust_gate = TrustGate::new(
         surface,
@@ -299,7 +315,7 @@ impl lex_extension::LexHandler for NoopHandler {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lex_config::NamespaceTable;
+    use lex_config::{NamespaceSpec, NamespaceTable};
     use std::collections::BTreeMap;
 
     fn write_schema(dir: &Path, label: &str) {

--- a/crates/lex-cli/src/extension_setup.rs
+++ b/crates/lex-cli/src/extension_setup.rs
@@ -1,0 +1,451 @@
+//! Boot the extension registry from CLI flags + `lex.toml`.
+//!
+//! Glue between the CLI argument layer and the
+//! `lex-extension-host` runtime. Given:
+//!
+//! - the workspace root (where the `lex.toml` lives),
+//! - the list of `--ext-schema <path>` flags,
+//! - the `--enable-handlers` flag,
+//! - the host surface (CliOneShot / Ci, auto-detected),
+//!
+//! returns a fully-populated [`Registry`] with the bundled `lex.*`
+//! built-ins plus every namespace declared in `[labels]` plus every
+//! `--ext-schema` directory passed on the command line. Surfaces
+//! diagnostics for unresolvable namespaces / unsupported transports
+//! / trust-gate denials but doesn't fail the boot — a single bad
+//! namespace shouldn't prevent the rest of the host from working.
+//!
+//! ## What's NOT here
+//!
+//! - Trust-gate-driven subprocess spawning. The boot helper records
+//!   trust decisions but doesn't actually instantiate
+//!   `SubprocessHandler`s yet — that would couple the boot with the
+//!   subprocess feature, and consumers (lex-cli, lex-lsp, future
+//!   lexed) want the shape of the boot independent of which
+//!   transports they enable. Subprocess spawning sits in a thin
+//!   adapter layer above this module; for now the boot registers
+//!   schema-only namespaces (no handler), which surfaces in
+//!   diagnostics and the `lexd labels list` output but doesn't run
+//!   render/validate hooks.
+//! - Network resolvers (github:/gitlab:/https:/git+ssh:). Those
+//!   live in the resolver and return `Unimplemented`; this boot
+//!   surfaces the error and continues.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use lex_config::{LabelsConfig, NamespaceSpec};
+use lex_extension::schema::Schema;
+use lex_extension_host::{
+    detect_ci_environment, resolve_namespace, Registry, RegistryError, ResolveError, SchemaError,
+    SchemaLoader, Surface, TrustGate, TrustPromptContext, TrustPromptHandler, TrustStore,
+};
+
+/// Inputs the boot helper needs from the CLI layer.
+pub struct ExtensionSetup<'a> {
+    pub workspace_root: &'a Path,
+    pub labels_config: &'a LabelsConfig,
+    /// Each `--ext-schema <path>` flag on the command line.
+    pub ext_schemas: &'a [PathBuf],
+    /// `--enable-handlers` global flag.
+    pub enable_handlers: bool,
+    /// Surface override. `None` auto-detects from env vars (CI →
+    /// `Surface::Ci`, otherwise `Surface::CliOneShot`).
+    pub surface_override: Option<Surface>,
+}
+
+/// One namespace that was successfully registered, surfaced for
+/// `lexd labels list` output.
+#[derive(Debug, Clone)]
+pub struct RegisteredNamespace {
+    pub name: String,
+    pub source: NamespaceSourceKind,
+    pub schema_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceSourceKind {
+    Builtin,
+    LexToml { uri: String },
+    ExtSchemaFlag { path: PathBuf },
+}
+
+/// One thing that went wrong during boot. Surfaced as a diagnostic
+/// rather than a hard error so a bad namespace doesn't prevent the
+/// host from running with the others.
+#[derive(Debug, Clone)]
+pub struct BootDiagnostic {
+    pub namespace: Option<String>,
+    pub message: String,
+}
+
+/// Outcome of [`boot_registry`]: the registry plus per-namespace
+/// metadata for `lexd labels list` plus the diagnostic stream.
+pub struct BootOutcome {
+    pub registry: Arc<Registry>,
+    pub trust_gate: TrustGate,
+    pub registered: Vec<RegisteredNamespace>,
+    pub diagnostics: Vec<BootDiagnostic>,
+}
+
+/// Construct a registry from the CLI inputs. Always succeeds — bad
+/// namespaces become entries in `diagnostics` rather than aborting
+/// the boot.
+pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
+    let mut registry = Registry::new();
+    let mut registered = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    // Built-ins: lex.* namespace (currently `lex.include`). The
+    // helper in `lex_core::lex::builtins::register_into` handles
+    // this; we keep its setup local to lex-cli's existing code path
+    // and mirror the registration shape here without re-doing it
+    // (the bundled built-ins are wired by the includes-resolver
+    // hook, not here, so this entry exists for `lexd labels list`
+    // visibility only).
+    registered.push(RegisteredNamespace {
+        name: "lex".into(),
+        source: NamespaceSourceKind::Builtin,
+        schema_count: 1,
+    });
+
+    // [labels] block — resolved through the URI resolver.
+    for (name, spec) in &setup.labels_config.namespaces {
+        let uri = match spec.canonical_uri() {
+            Ok(u) => u,
+            Err(e) => {
+                diagnostics.push(BootDiagnostic {
+                    namespace: Some(name.clone()),
+                    message: format!("invalid namespace spec: {e}"),
+                });
+                continue;
+            }
+        };
+        match resolve_namespace(&uri, setup.workspace_root) {
+            Ok(resolved) => match register_schema_dir(&mut registry, name, &resolved.schema_dir) {
+                Ok(count) => registered.push(RegisteredNamespace {
+                    name: name.clone(),
+                    source: NamespaceSourceKind::LexToml { uri: uri.clone() },
+                    schema_count: count,
+                }),
+                Err(e) => diagnostics.push(BootDiagnostic {
+                    namespace: Some(name.clone()),
+                    message: format!("failed to register schemas: {e}"),
+                }),
+            },
+            Err(ResolveError::Unimplemented { .. }) => {
+                diagnostics.push(BootDiagnostic {
+                    namespace: Some(name.clone()),
+                    message: format!(
+                        "namespace `{name}` uses a remote URI scheme that's not yet implemented; use `path:` or `--ext-schema` for now (uri: `{uri}`)"
+                    ),
+                });
+            }
+            Err(e) => diagnostics.push(BootDiagnostic {
+                namespace: Some(name.clone()),
+                message: format!("namespace resolve failed: {e}"),
+            }),
+        }
+        let _ = NamespaceSpec::Uri(uri); // silence unused-warning if spec evolves
+    }
+
+    // --ext-schema flags — local schema directories, no resolver.
+    for path in setup.ext_schemas {
+        let dir = if path.is_absolute() {
+            path.clone()
+        } else {
+            setup.workspace_root.join(path)
+        };
+        let namespace = match infer_namespace_from_dir(&dir) {
+            Ok(n) => n,
+            Err(msg) => {
+                diagnostics.push(BootDiagnostic {
+                    namespace: None,
+                    message: format!("--ext-schema {}: {msg}", path.display()),
+                });
+                continue;
+            }
+        };
+        match register_schema_dir(&mut registry, &namespace, &dir) {
+            Ok(count) => registered.push(RegisteredNamespace {
+                name: namespace,
+                source: NamespaceSourceKind::ExtSchemaFlag { path: path.clone() },
+                schema_count: count,
+            }),
+            Err(e) => diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace),
+                message: format!("--ext-schema {}: {e}", path.display()),
+            }),
+        }
+    }
+
+    let surface = setup.surface_override.unwrap_or_else(|| {
+        if detect_ci_environment(|name| std::env::var(name).ok()) {
+            Surface::Ci
+        } else {
+            Surface::CliOneShot
+        }
+    });
+    let store = TrustStore::open(setup.workspace_root).unwrap_or_else(|e| {
+        diagnostics.push(BootDiagnostic {
+            namespace: None,
+            message: format!(
+                "trust store open failed: {e}; trust decisions will not be persisted this session"
+            ),
+        });
+        // Fall back to a tempdir-backed store so the gate still
+        // works in-memory for this session.
+        let tmp = std::env::temp_dir();
+        TrustStore::open(&tmp).expect("temp dir is writable")
+    });
+    let trust_gate = TrustGate::new(
+        surface,
+        setup.enable_handlers,
+        store,
+        Box::new(CliPromptHandler),
+    );
+
+    BootOutcome {
+        registry: Arc::new(registry),
+        trust_gate,
+        registered,
+        diagnostics,
+    }
+}
+
+/// CLI surface installs this prompt: trust prompts in CLI mode are
+/// a TTY-interrupt anti-pattern, so we always deny and direct the
+/// user at `--enable-handlers`.
+struct CliPromptHandler;
+impl TrustPromptHandler for CliPromptHandler {
+    fn prompt(&self, ctx: &TrustPromptContext) -> lex_extension_host::TrustDecision {
+        lex_extension_host::TrustDecision::Denied {
+            reason: format!(
+                "subprocess handler `{}` requires --enable-handlers in CLI mode",
+                ctx.namespace
+            ),
+        }
+    }
+}
+
+/// Try to infer the namespace name from a schema directory. Convention:
+/// the directory's basename is the namespace name. (Future work: read
+/// a `namespace.toml` sidecar file if it exists.)
+fn infer_namespace_from_dir(dir: &Path) -> Result<String, String> {
+    dir.file_name()
+        .and_then(|s| s.to_str())
+        .map(String::from)
+        .ok_or_else(|| {
+            format!(
+                "cannot infer namespace name from directory `{}`",
+                dir.display()
+            )
+        })
+}
+
+/// Load every YAML schema in `dir` and register them under
+/// `namespace`. Returns the count for `lexd labels list` output.
+fn register_schema_dir(
+    registry: &mut Registry,
+    namespace: &str,
+    dir: &Path,
+) -> Result<usize, RegisterError> {
+    let schemas: Vec<Schema> =
+        SchemaLoader::load_dir(dir).map_err(|e| RegisterError::Schema(Box::new(e)))?;
+    if schemas.is_empty() {
+        return Err(RegisterError::EmptyDir(dir.to_path_buf()));
+    }
+    let count = schemas.len();
+    // Schema-only registration (no handler): the dispatcher in
+    // analysis/render will see the schemas in `dispatch_*` calls
+    // for pre-validation, but `on_validate` / `on_render` etc. are
+    // no-ops because there's no handler. The follow-up that wires
+    // subprocess transports will replace this with a real handler
+    // pulled from the schema's `handler.command`.
+    let stub: Box<dyn lex_extension::LexHandler> = Box::new(NoopHandler);
+    registry
+        .register_namespace(namespace, schemas, stub)
+        .map_err(RegisterError::Registry)?;
+    Ok(count)
+}
+
+#[derive(Debug)]
+enum RegisterError {
+    Schema(Box<SchemaError>),
+    Registry(RegistryError),
+    EmptyDir(PathBuf),
+}
+
+impl std::fmt::Display for RegisterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegisterError::Schema(e) => write!(f, "schema load: {e}"),
+            RegisterError::Registry(e) => write!(f, "registry register: {e}"),
+            RegisterError::EmptyDir(p) => write!(
+                f,
+                "schema directory `{}` contains no .yaml files",
+                p.display()
+            ),
+        }
+    }
+}
+
+/// No-op handler used for schema-only registration. Returns the
+/// trait defaults for every hook; the dispatcher's pre-validation
+/// pass still surfaces schema mismatches even with this stub.
+struct NoopHandler;
+impl lex_extension::LexHandler for NoopHandler {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_config::NamespaceTable;
+    use std::collections::BTreeMap;
+
+    fn write_schema(dir: &Path, label: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{}.yaml", label.replace('.', "_"))),
+            format!("schema_version: 1\nlabel: {label}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn boot_with_empty_inputs_yields_only_builtin() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        };
+        let outcome = boot_registry(setup);
+        assert_eq!(outcome.registered.len(), 1);
+        assert_eq!(outcome.registered[0].name, "lex");
+        assert_eq!(outcome.registered[0].source, NamespaceSourceKind::Builtin);
+        assert!(outcome.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn boot_with_path_uri_in_labels_registers_namespace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme-labels");
+        write_schema(&acme_dir, "acme.task");
+
+        let mut namespaces = BTreeMap::new();
+        namespaces.insert("acme".into(), NamespaceSpec::Uri("path:acme-labels".into()));
+        let labels = LabelsConfig { namespaces };
+
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        };
+        let outcome = boot_registry(setup);
+        let acme = outcome
+            .registered
+            .iter()
+            .find(|r| r.name == "acme")
+            .expect("acme registered");
+        assert_eq!(acme.schema_count, 1);
+        assert!(matches!(acme.source, NamespaceSourceKind::LexToml { .. }));
+        assert!(outcome.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn boot_with_remote_uri_emits_unimplemented_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut namespaces = BTreeMap::new();
+        namespaces.insert(
+            "acme".into(),
+            NamespaceSpec::Table(NamespaceTable {
+                tap: Some("acme".into()),
+                ..Default::default()
+            }),
+        );
+        let labels = LabelsConfig { namespaces };
+
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        };
+        let outcome = boot_registry(setup);
+        assert_eq!(outcome.diagnostics.len(), 1);
+        let diag = &outcome.diagnostics[0];
+        assert_eq!(diag.namespace.as_deref(), Some("acme"));
+        assert!(diag.message.contains("not yet implemented"));
+        // No `acme` in `registered` (only `lex` builtin).
+        assert!(!outcome.registered.iter().any(|r| r.name == "acme"));
+    }
+
+    #[test]
+    fn boot_with_ext_schema_flag_registers_namespace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        write_schema(&acme_dir, "acme.task");
+
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir.clone()],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        };
+        let outcome = boot_registry(setup);
+        let acme = outcome
+            .registered
+            .iter()
+            .find(|r| r.name == "acme")
+            .expect("registered");
+        assert!(matches!(
+            acme.source,
+            NamespaceSourceKind::ExtSchemaFlag { .. }
+        ));
+    }
+
+    #[test]
+    fn ext_schema_flag_with_no_yaml_files_emits_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let empty_dir = workspace.path().join("empty");
+        std::fs::create_dir(&empty_dir).unwrap();
+
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[empty_dir],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        };
+        let outcome = boot_registry(setup);
+        assert!(outcome
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("contains no .yaml files")));
+    }
+
+    #[test]
+    fn surface_override_threads_through_to_trust_gate() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: true,
+            surface_override: Some(Surface::Ci),
+        };
+        let outcome = boot_registry(setup);
+        assert_eq!(outcome.trust_gate.surface(), Surface::Ci);
+        assert!(outcome.trust_gate.enable_handlers());
+    }
+}

--- a/crates/lex-cli/src/labels_subcommand.rs
+++ b/crates/lex-cli/src/labels_subcommand.rs
@@ -1,0 +1,183 @@
+//! `lexd labels` subcommand handlers.
+//!
+//! Two operations land in this PR:
+//!
+//! - `lexd labels list` — print every registered namespace, its
+//!   source, and its label count. Useful for "did the host see my
+//!   `[labels]` block?" debugging.
+//! - `lexd labels validate <doc>` — run the analysis pass against a
+//!   document and print every diagnostic. Exits non-zero when at
+//!   least one error-severity diagnostic fires.
+//!
+//! `lexd labels emit` and `lexd labels update` are deferred to the
+//! follow-up that lands the network resolvers + cache (the `update`
+//! subcommand only makes sense once cached entries can grow stale).
+
+use std::path::Path;
+
+use crate::extension_setup::{BootOutcome, NamespaceSourceKind};
+
+/// Render `lexd labels list` output to stdout. Returns 0 on
+/// success; this command never produces non-zero exits — bad
+/// namespaces show up as warnings in the boot diagnostic stream
+/// but the listing itself succeeds.
+pub fn list(outcome: &BootOutcome) -> i32 {
+    println!("Registered namespaces:");
+    if outcome.registered.is_empty() {
+        println!("  (none)");
+    } else {
+        for ns in &outcome.registered {
+            let source = match &ns.source {
+                NamespaceSourceKind::Builtin => "built-in".to_string(),
+                NamespaceSourceKind::LexToml { uri } => format!("lex.toml: {uri}"),
+                NamespaceSourceKind::ExtSchemaFlag { path } => {
+                    format!("--ext-schema {}", path.display())
+                }
+            };
+            println!(
+                "  {} ({} schema{}) — {}",
+                ns.name,
+                ns.schema_count,
+                if ns.schema_count == 1 { "" } else { "s" },
+                source
+            );
+        }
+    }
+    if !outcome.diagnostics.is_empty() {
+        println!();
+        println!("Diagnostics:");
+        for diag in &outcome.diagnostics {
+            match &diag.namespace {
+                Some(ns) => println!("  [{ns}] {}", diag.message),
+                None => println!("  {}", diag.message),
+            }
+        }
+    }
+    0
+}
+
+/// Run the analysis pass against `doc_path` with the populated
+/// registry and print every diagnostic. Returns the suggested
+/// process exit code (0 = no errors, 1 = at least one
+/// error-severity diagnostic).
+pub fn validate(doc_path: &Path, outcome: &BootOutcome) -> i32 {
+    use lex_analysis::diagnostics::{
+        analyze_with_registry, AnalysisDiagnostic, DiagnosticSeverity,
+    };
+    use lex_core::lex::loader::DocumentLoader;
+
+    let document = match DocumentLoader::from_path(doc_path).and_then(|l| l.parse()) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!(
+                "lexd labels validate: cannot parse `{}`: {e}",
+                doc_path.display()
+            );
+            return 2;
+        }
+    };
+
+    let diagnostics: Vec<AnalysisDiagnostic> = analyze_with_registry(&document, &outcome.registry);
+
+    if diagnostics.is_empty() {
+        println!("{}: no diagnostics", doc_path.display());
+        return 0;
+    }
+
+    let mut had_error = false;
+    for d in &diagnostics {
+        let severity_str = match d.severity {
+            DiagnosticSeverity::Error => {
+                had_error = true;
+                "error"
+            }
+            DiagnosticSeverity::Warning => "warning",
+            DiagnosticSeverity::Info => "info",
+            DiagnosticSeverity::Hint => "hint",
+        };
+        let line = d.range.start.line;
+        let col = d.range.start.column;
+        println!(
+            "{}:{}:{}: {severity_str}: {}",
+            doc_path.display(),
+            line + 1,
+            col + 1,
+            d.message
+        );
+    }
+    if had_error {
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension_setup::{boot_registry, ExtensionSetup, RegisteredNamespace};
+    use lex_config::LabelsConfig;
+    use lex_extension_host::Surface;
+
+    #[test]
+    fn list_prints_builtin_when_no_other_namespaces() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        });
+        // We can't easily capture stdout without harnessing, but we
+        // can confirm the function returns 0 and the outcome's
+        // `registered` list contains the builtin.
+        assert_eq!(list(&outcome), 0);
+        assert!(outcome.registered.iter().any(|r| r.name == "lex"));
+    }
+
+    #[test]
+    fn validate_returns_zero_for_clean_document() {
+        let workspace = tempfile::tempdir().unwrap();
+        let doc_path = workspace.path().join("hello.lex");
+        std::fs::write(&doc_path, "Hello, world.\n").unwrap();
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        });
+        assert_eq!(validate(&doc_path, &outcome), 0);
+    }
+
+    #[test]
+    fn validate_returns_two_for_unparseable_path() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+        });
+        // Pointing at a path that doesn't exist surfaces as exit 2.
+        let missing = workspace.path().join("does-not-exist.lex");
+        assert_eq!(validate(&missing, &outcome), 2);
+    }
+
+    /// Silence "unused" warning if RegisteredNamespace's fields go
+    /// unused in test bodies above.
+    #[test]
+    fn registered_namespace_has_a_name() {
+        let r = RegisteredNamespace {
+            name: "x".into(),
+            source: NamespaceSourceKind::Builtin,
+            schema_count: 0,
+        };
+        assert_eq!(r.name, "x");
+    }
+}

--- a/crates/lex-cli/src/labels_subcommand.rs
+++ b/crates/lex-cli/src/labels_subcommand.rs
@@ -115,7 +115,7 @@ pub fn validate(doc_path: &Path, outcome: &BootOutcome) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension_setup::{boot_registry, ExtensionSetup, RegisteredNamespace};
+    use crate::extension_setup::{boot_registry, ExtensionSetup};
     use lex_config::LabelsConfig;
     use lex_extension_host::Surface;
 
@@ -167,17 +167,5 @@ mod tests {
         // Pointing at a path that doesn't exist surfaces as exit 2.
         let missing = workspace.path().join("does-not-exist.lex");
         assert_eq!(validate(&missing, &outcome), 2);
-    }
-
-    /// Silence "unused" warning if RegisteredNamespace's fields go
-    /// unused in test bodies above.
-    #[test]
-    fn registered_namespace_has_a_name() {
-        let r = RegisteredNamespace {
-            name: "x".into(),
-            source: NamespaceSourceKind::Builtin,
-            schema_count: 0,
-        };
-        assert_eq!(r.name, "x");
     }
 }

--- a/crates/lex-cli/src/lib.rs
+++ b/crates/lex-cli/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod extension_setup;
 pub mod help;
+pub mod labels_subcommand;
 pub mod transforms;

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -348,6 +348,59 @@ fn build_cli() -> Command {
                     lexd generate-lex-css > custom.css       # Save to file for editing"
                 ),
         )
+        .arg(
+            Arg::new("ext-schema")
+                .long("ext-schema")
+                .help("Register a local extension schema directory (repeatable)")
+                .long_help(
+                    "Add an extension namespace by pointing at a local directory of\n\
+                     YAML schemas. Repeatable: --ext-schema ./acme --ext-schema ./other.\n\
+                     The directory's basename becomes the namespace name.",
+                )
+                .value_name("DIR")
+                .value_parser(clap::value_parser!(PathBuf))
+                .action(ArgAction::Append)
+                .global(true),
+        )
+        .arg(
+            Arg::new("enable-handlers")
+                .long("enable-handlers")
+                .help("Allow subprocess extension handlers to run")
+                .long_help(
+                    "Subprocess extension handlers don't run by default in CLI mode\n\
+                     (the trust gate denies them). Pass --enable-handlers to opt in for\n\
+                     this run. The flag does not persist any trust decisions to the\n\
+                     workspace's .lex/trust.json — it's a one-shot.",
+                )
+                .action(ArgAction::SetTrue)
+                .global(true),
+        )
+        .subcommand(
+            Command::new("labels")
+                .about("Manage and inspect extension namespaces")
+                .long_about(
+                    "Inspect the extension namespaces visible to lexd, validate documents\n\
+                     against registered schemas, and (in future releases) emit and update\n\
+                     namespace caches.\n\n\
+                     Subcommands:\n  \
+                     list           — print every registered namespace with its source\n  \
+                     validate <doc> — run analysis against a document, print diagnostics",
+                )
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new("list").about("List registered extension namespaces"),
+                )
+                .subcommand(
+                    Command::new("validate")
+                        .about("Validate a document against registered schemas")
+                        .arg(
+                            Arg::new("path")
+                                .help("Path to the .lex document")
+                                .value_hint(ValueHint::FilePath)
+                                .required(true),
+                        ),
+                ),
+        )
 }
 
 fn main() {
@@ -368,6 +421,7 @@ fn main() {
                 "element-at",
                 "token-at",
                 "generate-lex-css",
+                "labels",
                 "help",
             ];
             let first_arg = args.get(1).map(String::as_str);
@@ -497,11 +551,62 @@ fn main() {
                 Some(("generate-lex-css", _)) => {
                     handle_generate_lex_css_command();
                 }
+                Some(("labels", sub_matches)) => {
+                    let exit = handle_labels_command(&matches, sub_matches);
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                }
                 _ => {
                     eprintln!("Unknown subcommand. Use --help for usage information.");
                     std::process::exit(1);
                 }
             }
+        }
+    }
+}
+
+/// Dispatch `lexd labels {list,validate}`. Returns the exit code
+/// to propagate.
+fn handle_labels_command(top: &ArgMatches, sub: &ArgMatches) -> i32 {
+    let workspace = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let labels_path = workspace.join(CONFIG_FILE_NAME);
+    let labels_config = match lex_config::load_labels_from_toml(&labels_path) {
+        Ok(c) => c,
+        Err(lex_config::LabelsConfigError::Io { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            lex_config::LabelsConfig::default()
+        }
+        Err(e) => {
+            eprintln!("lexd labels: {e}");
+            return 2;
+        }
+    };
+    let ext_schemas: Vec<PathBuf> = top
+        .get_many::<PathBuf>("ext-schema")
+        .map(|values| values.cloned().collect())
+        .unwrap_or_default();
+    let enable_handlers = top.get_flag("enable-handlers");
+    let outcome = lexd::extension_setup::boot_registry(lexd::extension_setup::ExtensionSetup {
+        workspace_root: &workspace,
+        labels_config: &labels_config,
+        ext_schemas: &ext_schemas,
+        enable_handlers,
+        surface_override: None,
+    });
+    match sub.subcommand() {
+        Some(("list", _)) => lexd::labels_subcommand::list(&outcome),
+        Some(("validate", v)) => {
+            let path = v
+                .get_one::<String>("path")
+                .map(PathBuf::from)
+                .expect("path is required");
+            lexd::labels_subcommand::validate(&path, &outcome)
+        }
+        _ => {
+            eprintln!("lexd labels: subcommand required (list, validate)");
+            2
         }
     }
 }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -569,7 +569,13 @@ fn main() {
 /// Dispatch `lexd labels {list,validate}`. Returns the exit code
 /// to propagate.
 fn handle_labels_command(top: &ArgMatches, sub: &ArgMatches) -> i32 {
-    let workspace = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    // Walk ancestors looking for `.lex.toml`, matching the behaviour
+    // of every other lexd subcommand (config, convert, inspect…).
+    // Without this, running `lexd labels list` from a subdirectory
+    // would miss the workspace's `[labels]` block and report only
+    // the `--ext-schema` flags.
+    let workspace = find_nearest_lex_toml_dir(&cwd).unwrap_or_else(|| cwd.clone());
     let labels_path = workspace.join(CONFIG_FILE_NAME);
     let labels_config = match lex_config::load_labels_from_toml(&labels_path) {
         Ok(c) => c,

--- a/crates/lex-cli/tests/integration/labels.rs
+++ b/crates/lex-cli/tests/integration/labels.rs
@@ -1,0 +1,146 @@
+//! End-to-end tests for `lexd labels` and the `--ext-schema` /
+//! `--enable-handlers` global flags. Runs the actual `lexd` binary
+//! against fixture workspaces.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a minimal workspace: `.lex.toml` (optionally with a
+/// `[labels]` block), and an `acme/` directory of YAML schemas the
+/// CLI can register via `--ext-schema`.
+fn make_workspace_with_acme_schemas(labels_toml: Option<&str>) -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let lex_toml = labels_toml.unwrap_or("# empty\n");
+    fs::write(dir.path().join(".lex.toml"), lex_toml).unwrap();
+
+    let acme_dir = dir.path().join("acme");
+    fs::create_dir(&acme_dir).unwrap();
+    fs::write(
+        acme_dir.join("task.yaml"),
+        "schema_version: 1\nlabel: acme.task\nattaches_to: [annotation, paragraph, document]\n",
+    )
+    .unwrap();
+    fs::write(
+        acme_dir.join("note.yaml"),
+        "schema_version: 1\nlabel: acme.note\nattaches_to: [annotation]\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn labels_list_prints_builtin_when_no_namespaces_declared() {
+    let dir = make_workspace_with_acme_schemas(None);
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["labels", "list"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("lex"));
+}
+
+#[test]
+fn labels_list_with_path_uri_in_lex_toml() {
+    let dir = make_workspace_with_acme_schemas(Some(
+        r#"
+[labels]
+acme = "path:acme"
+"#,
+    ));
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["labels", "list"])
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("acme")
+                .and(predicates::str::contains("2 schemas"))
+                .and(predicates::str::contains("path:acme")),
+        );
+}
+
+#[test]
+fn labels_list_with_ext_schema_flag() {
+    let dir = make_workspace_with_acme_schemas(None);
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["labels", "list", "--ext-schema", "acme"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("acme").and(predicates::str::contains("--ext-schema")));
+}
+
+#[test]
+fn labels_list_with_remote_uri_emits_unimplemented_diagnostic() {
+    let dir = make_workspace_with_acme_schemas(Some(
+        r#"
+[labels]
+remote = { tap = "remote" }
+"#,
+    ));
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["labels", "list"])
+        .assert()
+        .success() // listing succeeds; the diagnostic is in stdout
+        .stdout(predicates::str::contains("not yet implemented"));
+}
+
+#[test]
+fn labels_validate_returns_zero_for_clean_document() {
+    let dir = make_workspace_with_acme_schemas(None);
+    let doc = dir.path().join("hello.lex");
+    fs::write(&doc, "Hello, world.\n").unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["labels", "validate", doc.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn labels_validate_with_ext_schema_finds_unknown_label() {
+    // Document uses acme.unknown which is NOT in the schema set
+    // (acme.task, acme.note are registered). Walker emits an
+    // UnknownLabel diagnostic and `validate` exits 1.
+    let dir = make_workspace_with_acme_schemas(None);
+    let doc = dir.path().join("bad.lex");
+    fs::write(&doc, ":: acme.unknown ::\n").unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "labels",
+            "validate",
+            "--ext-schema",
+            "acme",
+            doc.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("acme.unknown").and(predicates::str::contains("error")));
+}
+
+#[test]
+fn labels_with_reserved_lex_namespace_in_toml_fails_load() {
+    let dir = make_workspace_with_acme_schemas(Some(
+        r#"
+[labels]
+lex = "github:fake/lex-labels"
+"#,
+    ));
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["labels", "list"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("reserved"));
+}

--- a/crates/lex-cli/tests/integration/main.rs
+++ b/crates/lex-cli/tests/integration/main.rs
@@ -3,6 +3,7 @@
 mod element_at;
 mod format_config;
 mod includes;
+mod labels;
 mod markdown_import;
 mod nodemap;
 mod pdf;

--- a/crates/lex-config/Cargo.toml
+++ b/crates/lex-config/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["config"]
 [dependencies]
 confique = { workspace = true }
 serde = { workspace = true }
+toml = "0.8"
 lex-babel = { workspace = true }
 
 [dev-dependencies]
 clapfig = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -105,10 +105,22 @@ impl NamespaceSpec {
                 };
                 let mut out = base;
                 if let Some(rev) = &t.rev {
-                    if !out.contains('#') {
-                        out.push('#');
-                        out.push_str(rev);
+                    if out.contains('#') {
+                        // Both the URI and the table have a rev. The
+                        // tap shorthand can't reach this branch (it
+                        // never sets a fragment), so this is the
+                        // user-with-explicit-uri case where they wrote
+                        // `uri = "github:org/repo#main", rev = "v1"`.
+                        // Either is meaningful but together is
+                        // ambiguous — surface as an error rather than
+                        // silently drop one.
+                        return Err(LabelsConfigError::RevWithExplicitFragment {
+                            uri: out,
+                            rev: rev.clone(),
+                        });
                     }
+                    out.push('#');
+                    out.push_str(rev);
                 }
                 if let Some(subdir) = &t.subdir {
                     out.push_str(if out.contains('?') { "&" } else { "?" });
@@ -158,6 +170,10 @@ pub enum LabelsConfigError {
     TapAndUri,
     /// Table form had neither `tap` nor `uri` set.
     EmptyTable,
+    /// Both the explicit `uri` (with a `#fragment`) and a `rev`
+    /// field are set. Either is meaningful but together they're
+    /// ambiguous — pick one.
+    RevWithExplicitFragment { uri: String, rev: String },
 }
 
 impl std::fmt::Display for LabelsConfigError {
@@ -177,6 +193,10 @@ impl std::fmt::Display for LabelsConfigError {
             }
             LabelsConfigError::EmptyTable => f.write_str(
                 "namespace spec table needs one of `tap` or `uri` set",
+            ),
+            LabelsConfigError::RevWithExplicitFragment { uri, rev } => write!(
+                f,
+                "namespace spec sets both `rev = {rev:?}` and an explicit `#fragment` in uri `{uri}`; pick one"
             ),
         }
     }

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -7,9 +7,236 @@
 use confique::Config;
 use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
 
 /// Canonical config file name used by the CLI and LSP.
 pub const CONFIG_FILE_NAME: &str = ".lex.toml";
+
+// ─────────────────────────── Labels (extension namespaces) ───────────────────────────
+
+/// `[labels]` block in `.lex.toml` — declarations of extension
+/// namespaces the workspace owner wants the host to load.
+///
+/// Loaded outside the main `LexConfig` confique chain because the
+/// shape is a free-form map keyed by namespace name, not a
+/// fixed-field struct. See [`load_labels_from_toml`].
+///
+/// ```toml
+/// [labels]
+/// acme = { tap = "acme" }                                       # tap shorthand
+/// foolco = "gitlab:foolco/lex-labels#main"                      # bare URI
+/// custom = { uri = "github:org/repo", rev = "v1", subdir = "labels/" }
+/// ```
+///
+/// The reserved namespace name `lex` is rejected at load time —
+/// `lex.*` is owned by the core and ships compiled-in.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LabelsConfig {
+    /// Namespace name → spec. Order is sorted (BTreeMap) for
+    /// deterministic loading and stable diagnostics.
+    pub namespaces: BTreeMap<String, NamespaceSpec>,
+}
+
+/// One namespace declaration. Three on-disk shapes parse into the
+/// same logical record:
+///
+/// - `acme = "github:acme/lex-labels"` — bare URI string.
+/// - `acme = { tap = "acme" }` — tap shorthand, expands to
+///   `github:acme/lex-labels`.
+/// - `acme = { uri = "...", rev = "...", subdir = "..." }` — full
+///   table form.
+///
+/// `tap` and `uri` are mutually exclusive on the table form;
+/// having both is a load-time error (see [`NamespaceSpec::validate`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NamespaceSpec {
+    /// Bare URI string form.
+    Uri(String),
+    /// Table form. One of `tap` / `uri` must be set; both is an
+    /// error.
+    Table(NamespaceTable),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NamespaceTable {
+    /// Tap-prefix shorthand. `tap = "acme"` expands to
+    /// `github:acme/lex-labels`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tap: Option<String>,
+    /// Explicit URI (`github:`, `gitlab:`, `https:`, `path:`,
+    /// `git+ssh:`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+    /// Branch / tag / SHA pin. Mutable refs (branches) honour the
+    /// resolver's 24-hour cache TTL; tags and SHAs are cached
+    /// indefinitely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
+    /// Subdirectory inside the resolved repo containing the schema
+    /// files. Defaults to repo root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<String>,
+}
+
+impl NamespaceSpec {
+    /// Resolve the spec into a single canonical URI string. Tap
+    /// shorthand expands to `github:<tap>/lex-labels`; the table
+    /// form's `rev` and `subdir` are appended via fragment + query
+    /// (`uri#rev?subdir=...`) so the resolver can parse them
+    /// uniformly.
+    pub fn canonical_uri(&self) -> Result<String, LabelsConfigError> {
+        match self {
+            NamespaceSpec::Uri(s) => Ok(s.clone()),
+            NamespaceSpec::Table(t) => {
+                t.validate()?;
+                let base = match (&t.tap, &t.uri) {
+                    (Some(tap), None) => format!("github:{tap}/lex-labels"),
+                    (None, Some(uri)) => uri.clone(),
+                    (Some(_), Some(_)) => {
+                        return Err(LabelsConfigError::TapAndUri);
+                    }
+                    (None, None) => {
+                        return Err(LabelsConfigError::EmptyTable);
+                    }
+                };
+                let mut out = base;
+                if let Some(rev) = &t.rev {
+                    if !out.contains('#') {
+                        out.push('#');
+                        out.push_str(rev);
+                    }
+                }
+                if let Some(subdir) = &t.subdir {
+                    out.push_str(if out.contains('?') { "&" } else { "?" });
+                    out.push_str("subdir=");
+                    out.push_str(subdir);
+                }
+                Ok(out)
+            }
+        }
+    }
+}
+
+impl NamespaceTable {
+    /// Validate mutual-exclusion + non-emptiness. Surfaces as a
+    /// load-time error so a bad `lex.toml` fails fast with a clear
+    /// message, not at first dispatch.
+    pub fn validate(&self) -> Result<(), LabelsConfigError> {
+        match (&self.tap, &self.uri) {
+            (Some(_), Some(_)) => Err(LabelsConfigError::TapAndUri),
+            (None, None) => Err(LabelsConfigError::EmptyTable),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Errors emitted by [`load_labels_from_toml`] and
+/// [`NamespaceSpec::canonical_uri`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum LabelsConfigError {
+    /// Reading the toml file failed.
+    Io {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    /// The toml body did not parse.
+    Parse {
+        path: std::path::PathBuf,
+        message: String,
+    },
+    /// `[labels]` declared the reserved `lex` namespace. The `lex.*`
+    /// label space is owned by the core and ships compiled-in;
+    /// re-declaring it would silently shadow core built-ins.
+    ReservedNamespace,
+    /// Table form had both `tap` and `uri` set. They're mutually
+    /// exclusive — pick one.
+    TapAndUri,
+    /// Table form had neither `tap` nor `uri` set.
+    EmptyTable,
+}
+
+impl std::fmt::Display for LabelsConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LabelsConfigError::Io { path, source } => {
+                write!(f, "{}: io error reading labels config: {source}", path.display())
+            }
+            LabelsConfigError::Parse { path, message } => {
+                write!(f, "{}: labels config parse error: {message}", path.display())
+            }
+            LabelsConfigError::ReservedNamespace => f.write_str(
+                "namespace `lex` is reserved for core-defined labels and cannot be declared in [labels]",
+            ),
+            LabelsConfigError::TapAndUri => {
+                f.write_str("namespace spec sets both `tap` and `uri`; they are mutually exclusive")
+            }
+            LabelsConfigError::EmptyTable => f.write_str(
+                "namespace spec table needs one of `tap` or `uri` set",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LabelsConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LabelsConfigError::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Load the `[labels]` block from a `.lex.toml` at `path`. Returns
+/// an empty config if the file exists but has no `[labels]` block;
+/// `Io::NotFound` is propagated to the caller (the CLI usually
+/// treats it as "no labels configured" and continues).
+///
+/// Validates the reserved-key rule (`lex` is forbidden) and each
+/// spec's table-form invariants. Bad config fails the load instead
+/// of letting it surface at dispatch time.
+pub fn load_labels_from_toml(path: impl AsRef<Path>) -> Result<LabelsConfig, LabelsConfigError> {
+    let path = path.as_ref();
+    let body = std::fs::read_to_string(path).map_err(|source| LabelsConfigError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    // We only read the `[labels]` table; the rest of the file is
+    // confique's territory. A `toml::Value` parse + manual lookup
+    // keeps us from reaching for a separate top-level struct.
+    let root: toml::Value =
+        body.parse()
+            .map_err(|err: toml::de::Error| LabelsConfigError::Parse {
+                path: path.to_path_buf(),
+                message: err.to_string(),
+            })?;
+    let Some(labels_value) = root.get("labels") else {
+        return Ok(LabelsConfig::default());
+    };
+    let mut config: LabelsConfig =
+        labels_value
+            .clone()
+            .try_into()
+            .map_err(|err: toml::de::Error| LabelsConfigError::Parse {
+                path: path.to_path_buf(),
+                message: err.to_string(),
+            })?;
+
+    if config.namespaces.contains_key("lex") {
+        return Err(LabelsConfigError::ReservedNamespace);
+    }
+    for spec in config.namespaces.values_mut() {
+        if let NamespaceSpec::Table(t) = spec {
+            t.validate()?;
+        }
+    }
+    Ok(config)
+}
 
 /// Top-level configuration consumed by Lex applications.
 #[derive(Debug, Clone, Config, Serialize, Deserialize)]
@@ -29,6 +256,18 @@ pub struct LexConfig {
     /// Include-resolution options.
     #[config(nested)]
     pub includes: IncludesConfig,
+    /// Extension-namespace declarations. The map shape is
+    /// free-form (each key is a namespace name; the value is a
+    /// `NamespaceSpec`), so the field is a leaf rather than a
+    /// nested confique struct — confique sees an opaque
+    /// `BTreeMap<String, NamespaceSpec>`. The `lexd labels`
+    /// subcommand and the boot helper read individual entries via
+    /// [`load_labels_from_toml`] for richer error messages
+    /// (reserved-namespace check, table-form validation, …).
+    /// Declaring the field here is what makes clapfig's strict
+    /// unknown-keys check accept `[labels]` blocks in `.lex.toml`.
+    #[config(default = {})]
+    pub labels: BTreeMap<String, NamespaceSpec>,
 }
 
 /// Formatting-related configuration groups.
@@ -231,6 +470,131 @@ mod tests {
         assert_eq!(config.formatting.rules.session_blank_lines_before, 1);
         assert!(config.inspect.ast.show_line_numbers);
         assert_eq!(config.convert.pdf.size, PdfPageSize::LexEd);
+    }
+
+    #[test]
+    fn labels_config_bare_uri_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(
+            &path,
+            r#"
+[labels]
+foolco = "gitlab:foolco/lex-labels#main"
+"#,
+        )
+        .unwrap();
+        let labels = load_labels_from_toml(&path).expect("loads");
+        let spec = labels.namespaces.get("foolco").unwrap();
+        assert_eq!(
+            spec.canonical_uri().unwrap(),
+            "gitlab:foolco/lex-labels#main"
+        );
+    }
+
+    #[test]
+    fn labels_config_tap_shorthand_expands() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(
+            &path,
+            r#"
+[labels]
+acme = { tap = "acme" }
+"#,
+        )
+        .unwrap();
+        let labels = load_labels_from_toml(&path).unwrap();
+        assert_eq!(
+            labels
+                .namespaces
+                .get("acme")
+                .unwrap()
+                .canonical_uri()
+                .unwrap(),
+            "github:acme/lex-labels"
+        );
+    }
+
+    #[test]
+    fn labels_config_expanded_table_with_rev_and_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(
+            &path,
+            r#"
+[labels]
+custom = { uri = "github:org/repo", rev = "v1", subdir = "labels/" }
+"#,
+        )
+        .unwrap();
+        let labels = load_labels_from_toml(&path).unwrap();
+        let uri = labels
+            .namespaces
+            .get("custom")
+            .unwrap()
+            .canonical_uri()
+            .unwrap();
+        assert!(uri.starts_with("github:org/repo"));
+        assert!(uri.contains("v1"));
+        assert!(uri.contains("subdir=labels/"));
+    }
+
+    #[test]
+    fn labels_config_reserved_lex_namespace_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(
+            &path,
+            r#"
+[labels]
+lex = "github:fake/lex-labels"
+"#,
+        )
+        .unwrap();
+        let err = load_labels_from_toml(&path).unwrap_err();
+        assert!(matches!(err, LabelsConfigError::ReservedNamespace));
+    }
+
+    #[test]
+    fn labels_config_tap_and_uri_together_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(
+            &path,
+            r#"
+[labels]
+acme = { tap = "acme", uri = "github:other/repo" }
+"#,
+        )
+        .unwrap();
+        let err = load_labels_from_toml(&path).unwrap_err();
+        assert!(matches!(err, LabelsConfigError::TapAndUri));
+    }
+
+    #[test]
+    fn labels_config_empty_table_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(
+            &path,
+            r#"
+[labels]
+acme = { rev = "v1" }
+"#,
+        )
+        .unwrap();
+        let err = load_labels_from_toml(&path).unwrap_err();
+        assert!(matches!(err, LabelsConfigError::EmptyTable));
+    }
+
+    #[test]
+    fn labels_config_missing_block_yields_empty_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".lex.toml");
+        std::fs::write(&path, "# no labels block\n").unwrap();
+        let labels = load_labels_from_toml(&path).unwrap();
+        assert!(labels.namespaces.is_empty());
     }
 
     #[test]

--- a/crates/lex-extension-host/src/lib.rs
+++ b/crates/lex-extension-host/src/lib.rs
@@ -34,11 +34,13 @@
 //!   (the post-δ trust matrix flip).
 
 pub mod registry;
+pub mod resolve;
 pub mod schema;
 pub mod transport;
 pub mod trust;
 
 pub use registry::{Registry, RegistryError};
+pub use resolve::{resolve_namespace, ResolveError, ResolvedNamespace};
 pub use schema::{SchemaError, SchemaLoader};
 pub use trust::{
     detect_ci_environment, Capability, Source, Surface, Transport, TrustDecision, TrustGate,

--- a/crates/lex-extension-host/src/resolve.rs
+++ b/crates/lex-extension-host/src/resolve.rs
@@ -66,6 +66,13 @@ pub enum ResolveError {
         path: PathBuf,
         source: std::io::Error,
     },
+    /// A `path:` URI carried a `#` fragment or `?` query — those
+    /// are remote-only knobs (the resolver uses them on
+    /// `github:`/`gitlab:`/etc. for `rev` and `subdir`). Rejecting
+    /// instead of stripping silently surfaces typos like
+    /// `path:dir#main` (where the user almost certainly meant a
+    /// remote URI).
+    PathUriHasFragmentOrQuery { uri: String },
 }
 
 impl std::fmt::Display for ResolveError {
@@ -92,6 +99,10 @@ impl std::fmt::Display for ResolveError {
             ResolveError::Io { path, source } => {
                 write!(f, "{}: namespace resolve io error: {source}", path.display())
             }
+            ResolveError::PathUriHasFragmentOrQuery { uri } => write!(
+                f,
+                "namespace URI `{uri}` is a `path:` scheme but carries `#` or `?` — those are remote-only knobs. Drop the fragment/query, or switch to a remote scheme that supports them."
+            ),
         }
     }
 }
@@ -138,28 +149,40 @@ fn resolve_path(
     uri: &str,
     workspace_root: &Path,
 ) -> Result<ResolvedNamespace, ResolveError> {
-    // Strip any URI fragment / query — `path:` doesn't honour `#rev`
-    // or `?subdir=`, those are remote-only knobs. Surfacing as a
-    // silent ignore would be confusing; instead we keep them in the
-    // raw URI for diagnostics but the disk path is just the bare
-    // value.
-    let bare = rest
-        .split_once('#')
-        .map(|(p, _)| p)
-        .unwrap_or(rest)
-        .split_once('?')
-        .map(|(p, _)| p)
-        .unwrap_or(rest.split_once('#').map(|(p, _)| p).unwrap_or(rest));
-    let candidate = if std::path::Path::new(bare).is_absolute() {
-        PathBuf::from(bare)
+    // `path:` URIs don't honour `#rev` or `?subdir=` — those are
+    // remote-only knobs. Reject them explicitly rather than silently
+    // strip; a user who wrote `path:dir#rev` either misunderstands
+    // the scheme or has a typo, and either case is better surfaced
+    // as an error than as a quiet ignore.
+    if rest.contains('#') || rest.contains('?') {
+        return Err(ResolveError::PathUriHasFragmentOrQuery {
+            uri: uri.to_string(),
+        });
+    }
+    let candidate = if std::path::Path::new(rest).is_absolute() {
+        PathBuf::from(rest)
     } else {
-        workspace_root.join(bare)
+        workspace_root.join(rest)
     };
     // Lexical-only root-escape check — same invariant as the
     // includes resolver. We don't canonicalise (symlinks are the
-    // loader's problem) but we do reject `../`-walks past the root.
-    let normalized = lexically_normalize(&candidate);
-    let normalized_root = lexically_normalize(workspace_root);
+    // loader's problem) but we reject `../`-walks past the root.
+    //
+    // `lexically_normalize` returns `None` when normalisation would
+    // pop past an empty buffer — that's the case we care about.
+    // The previous version silently swallowed those `..`, so
+    // `../../etc/passwd` collapsed to `etc/passwd`, and an
+    // equally-empty normalised root made the `starts_with` check
+    // pass — a directory-traversal bypass when workspace_root was
+    // relative or shorter than the escape depth. Returning `None`
+    // surfaces the escape attempt as a typed error.
+    let normalized = lexically_normalize(&candidate).ok_or_else(|| ResolveError::RootEscape {
+        path: candidate.clone(),
+    })?;
+    let normalized_root =
+        lexically_normalize(workspace_root).ok_or_else(|| ResolveError::RootEscape {
+            path: candidate.clone(),
+        })?;
     if !normalized.starts_with(&normalized_root) {
         return Err(ResolveError::RootEscape { path: candidate });
     }
@@ -185,19 +208,27 @@ fn resolve_path(
 }
 
 /// Lexical normalisation: collapse `.` and `..` components without
-/// touching the filesystem. Same logic the include resolver uses.
-fn lexically_normalize(path: &Path) -> PathBuf {
+/// touching the filesystem. Returns `None` when a `..` would pop
+/// past an empty buffer — that case is the antigravity-flagged
+/// directory-traversal bypass: a naive `pop` no-op makes
+/// `../../etc/passwd` collapse to `etc/passwd`, and an equally-
+/// emptied normalised root then trivially passes
+/// `starts_with`. Returning `None` lets callers treat that as a
+/// typed root-escape error.
+fn lexically_normalize(path: &Path) -> Option<PathBuf> {
     let mut out = PathBuf::new();
     for c in path.components() {
         match c {
             std::path::Component::CurDir => {}
             std::path::Component::ParentDir => {
-                out.pop();
+                if !out.pop() {
+                    return None;
+                }
             }
             other => out.push(other.as_os_str()),
         }
     }
-    out
+    Some(out)
 }
 
 #[cfg(test)]
@@ -241,6 +272,39 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let err = resolve_namespace("path:../../../etc/passwd", workspace.path()).unwrap_err();
         assert!(matches!(err, ResolveError::RootEscape { .. }));
+    }
+
+    /// Antigravity-flagged directory-traversal bypass: when the
+    /// `workspace_root` resolves to a relative path (e.g., `.`),
+    /// the previous `lexically_normalize` silently swallowed `..`
+    /// components on an empty buffer. So `../../etc/passwd`
+    /// collapsed to `etc/passwd`, and an equally-empty normalised
+    /// root made the `starts_with(root)` check pass — a security
+    /// hole letting a malicious `lex.toml` reach arbitrary
+    /// filesystem locations. The fix makes `lexically_normalize`
+    /// return `None` on underflow; the caller surfaces that as
+    /// `ResolveError::RootEscape`.
+    #[test]
+    fn relative_workspace_does_not_let_dotdot_escape() {
+        let relative = std::path::Path::new(".");
+        let err = resolve_namespace("path:../../../etc/passwd", relative).unwrap_err();
+        assert!(
+            matches!(err, ResolveError::RootEscape { .. }),
+            "expected RootEscape, got: {err}"
+        );
+    }
+
+    #[test]
+    fn lexically_normalize_returns_none_on_underflow() {
+        // Direct unit test on the normaliser so the bypass can't
+        // re-emerge if someone changes the caller's check.
+        assert!(lexically_normalize(std::path::Path::new("../foo")).is_none());
+        assert!(lexically_normalize(std::path::Path::new("../../etc")).is_none());
+        // Non-escaping paths still normalise.
+        assert_eq!(
+            lexically_normalize(std::path::Path::new("a/./b/../c")),
+            Some(PathBuf::from("a/c"))
+        );
     }
 
     #[test]

--- a/crates/lex-extension-host/src/resolve.rs
+++ b/crates/lex-extension-host/src/resolve.rs
@@ -1,0 +1,290 @@
+//! Namespace URI resolver.
+//!
+//! A namespace declaration in `lex.toml` (or a `--ext-schema` flag)
+//! gives the host a URI; the resolver turns that URI into a
+//! filesystem directory the schema loader can scan. Five schemes
+//! are specified in the proposal (§13):
+//!
+//! - `path:` — local filesystem path. No network, no cache.
+//! - `github:` — `github:owner/repo[#rev][?subdir=…]`. Fetched +
+//!   cached at `~/.cache/lex/labels/<content-hash>/`.
+//! - `gitlab:` — same shape, gitlab.com.
+//! - `https:` — generic HTTPS tarball.
+//! - `git+ssh:` — explicit ssh remote.
+//!
+//! ## Status (PR 9)
+//!
+//! Only `path:` is implemented in this PR. The remote schemes
+//! return [`ResolveError::Unimplemented`] with a clear message
+//! pointing the user at `--ext-schema` for local schema loading.
+//! Network resolvers + cache + 24-hour TTL + `lexd labels update`
+//! land in a follow-up — that's the bulk of the resolver scope and
+//! gets its own focused review surface.
+//!
+//! `path:` is enough for end-to-end demonstration of the dispatch
+//! fabric: a `[labels]` block can point at a local schema directory
+//! today, the registry boot loads schemas through the same path
+//! the future remote resolvers will take, and the trust gate /
+//! dispatch path are exercised in tests.
+
+use std::path::{Path, PathBuf};
+
+/// One resolved namespace: where its schema files live on disk and
+/// the canonical URI it came from. Returned by [`resolve_namespace`].
+#[derive(Debug, Clone)]
+pub struct ResolvedNamespace {
+    /// Directory the [`crate::SchemaLoader`] should scan for `.yaml`
+    /// files.
+    pub schema_dir: PathBuf,
+    /// The URI the resolver was asked about — useful for diagnostics
+    /// that want to remind the user which declaration they're
+    /// looking at.
+    pub source_uri: String,
+}
+
+/// Errors raised by [`resolve_namespace`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ResolveError {
+    /// URI didn't match any known scheme.
+    UnknownScheme { uri: String },
+    /// A `path:` URI pointed at a file that doesn't exist or isn't
+    /// a directory.
+    PathNotADirectory { path: PathBuf },
+    /// The scheme is recognised but not yet wired up. Currently
+    /// `github:`, `gitlab:`, `https:`, and `git+ssh:` all return
+    /// this — network fetching + cache lands in a follow-up PR.
+    Unimplemented { scheme: String, uri: String },
+    /// `path:` URI resolved to a path that escapes the workspace
+    /// root (relative paths like `../../etc/passwd`). Same
+    /// invariant as the include-resolver — keeps a malicious
+    /// `lex.toml` from pointing at arbitrary system locations.
+    RootEscape { path: PathBuf },
+    /// `path:` resolution failed at the filesystem layer
+    /// (permission denied, broken symlink, …).
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::UnknownScheme { uri } => write!(
+                f,
+                "namespace URI `{uri}` does not start with a known scheme (path:, github:, gitlab:, https:, git+ssh:)"
+            ),
+            ResolveError::PathNotADirectory { path } => write!(
+                f,
+                "namespace URI `path:{}` does not point at an existing directory",
+                path.display()
+            ),
+            ResolveError::Unimplemented { scheme, uri } => write!(
+                f,
+                "namespace URI scheme `{scheme}:` is not yet implemented (uri: `{uri}`); use `path:` or `--ext-schema` for local schemas in this release"
+            ),
+            ResolveError::RootEscape { path } => write!(
+                f,
+                "namespace URI `path:{}` escapes the workspace root",
+                path.display()
+            ),
+            ResolveError::Io { path, source } => {
+                write!(f, "{}: namespace resolve io error: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ResolveError::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve one namespace URI into a [`ResolvedNamespace`].
+///
+/// `workspace_root` is the directory `path:` URIs are resolved
+/// relative to — usually the directory containing the `lex.toml`
+/// the URI came from. `path:` URIs that, after joining with the
+/// workspace root, lexically escape that root are rejected with
+/// [`ResolveError::RootEscape`] (defence-in-depth against a
+/// `lex.toml` pointing at `../../etc/`).
+pub fn resolve_namespace(
+    uri: &str,
+    workspace_root: &Path,
+) -> Result<ResolvedNamespace, ResolveError> {
+    if let Some(rest) = uri.strip_prefix("path:") {
+        return resolve_path(rest, uri, workspace_root);
+    }
+    for scheme in ["github", "gitlab", "https", "git+ssh"] {
+        if uri.starts_with(&format!("{scheme}:")) {
+            return Err(ResolveError::Unimplemented {
+                scheme: scheme.to_string(),
+                uri: uri.to_string(),
+            });
+        }
+    }
+    Err(ResolveError::UnknownScheme {
+        uri: uri.to_string(),
+    })
+}
+
+fn resolve_path(
+    rest: &str,
+    uri: &str,
+    workspace_root: &Path,
+) -> Result<ResolvedNamespace, ResolveError> {
+    // Strip any URI fragment / query — `path:` doesn't honour `#rev`
+    // or `?subdir=`, those are remote-only knobs. Surfacing as a
+    // silent ignore would be confusing; instead we keep them in the
+    // raw URI for diagnostics but the disk path is just the bare
+    // value.
+    let bare = rest
+        .split_once('#')
+        .map(|(p, _)| p)
+        .unwrap_or(rest)
+        .split_once('?')
+        .map(|(p, _)| p)
+        .unwrap_or(rest.split_once('#').map(|(p, _)| p).unwrap_or(rest));
+    let candidate = if std::path::Path::new(bare).is_absolute() {
+        PathBuf::from(bare)
+    } else {
+        workspace_root.join(bare)
+    };
+    // Lexical-only root-escape check — same invariant as the
+    // includes resolver. We don't canonicalise (symlinks are the
+    // loader's problem) but we do reject `../`-walks past the root.
+    let normalized = lexically_normalize(&candidate);
+    let normalized_root = lexically_normalize(workspace_root);
+    if !normalized.starts_with(&normalized_root) {
+        return Err(ResolveError::RootEscape { path: candidate });
+    }
+    let metadata = std::fs::metadata(&candidate).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            ResolveError::PathNotADirectory {
+                path: candidate.clone(),
+            }
+        } else {
+            ResolveError::Io {
+                path: candidate.clone(),
+                source,
+            }
+        }
+    })?;
+    if !metadata.is_dir() {
+        return Err(ResolveError::PathNotADirectory { path: candidate });
+    }
+    Ok(ResolvedNamespace {
+        schema_dir: candidate,
+        source_uri: uri.to_string(),
+    })
+}
+
+/// Lexical normalisation: collapse `.` and `..` components without
+/// touching the filesystem. Same logic the include resolver uses.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for c in path.components() {
+        match c {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_yaml(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn path_uri_resolves_to_directory() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels_dir = workspace.path().join("acme-labels");
+        std::fs::create_dir(&labels_dir).unwrap();
+        write_yaml(
+            &workspace,
+            "acme-labels/task.yaml",
+            "schema_version: 1\nlabel: acme.task\n",
+        );
+
+        let resolved = resolve_namespace("path:acme-labels", workspace.path()).unwrap();
+        assert_eq!(resolved.schema_dir, labels_dir);
+        assert_eq!(resolved.source_uri, "path:acme-labels");
+    }
+
+    #[test]
+    fn path_uri_with_absolute_path_resolves() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels_dir = workspace.path().join("labels");
+        std::fs::create_dir(&labels_dir).unwrap();
+        let uri = format!("path:{}", labels_dir.display());
+        let resolved = resolve_namespace(&uri, workspace.path()).unwrap();
+        assert_eq!(resolved.schema_dir, labels_dir);
+    }
+
+    #[test]
+    fn path_uri_root_escape_is_rejected() {
+        let workspace = tempfile::tempdir().unwrap();
+        let err = resolve_namespace("path:../../../etc/passwd", workspace.path()).unwrap_err();
+        assert!(matches!(err, ResolveError::RootEscape { .. }));
+    }
+
+    #[test]
+    fn path_uri_missing_directory_yields_path_not_a_directory() {
+        let workspace = tempfile::tempdir().unwrap();
+        let err = resolve_namespace("path:does-not-exist", workspace.path()).unwrap_err();
+        assert!(matches!(err, ResolveError::PathNotADirectory { .. }));
+    }
+
+    #[test]
+    fn path_uri_pointing_at_file_yields_path_not_a_directory() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("not-a-dir.txt"), "x").unwrap();
+        let err = resolve_namespace("path:not-a-dir.txt", workspace.path()).unwrap_err();
+        assert!(matches!(err, ResolveError::PathNotADirectory { .. }));
+    }
+
+    #[test]
+    fn github_scheme_returns_unimplemented_with_clear_message() {
+        let workspace = tempfile::tempdir().unwrap();
+        let err = resolve_namespace("github:acme/lex-labels", workspace.path()).unwrap_err();
+        match err {
+            ResolveError::Unimplemented { scheme, .. } => assert_eq!(scheme, "github"),
+            other => panic!("expected Unimplemented, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn gitlab_https_git_ssh_all_unimplemented() {
+        let workspace = tempfile::tempdir().unwrap();
+        for scheme in ["gitlab", "https", "git+ssh"] {
+            let uri = format!("{scheme}:foo/bar");
+            let err = resolve_namespace(&uri, workspace.path()).unwrap_err();
+            assert!(
+                matches!(err, ResolveError::Unimplemented { .. }),
+                "scheme={scheme}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_scheme_yields_typed_error() {
+        let workspace = tempfile::tempdir().unwrap();
+        let err = resolve_namespace("ftp:server/path", workspace.path()).unwrap_err();
+        assert!(matches!(err, ResolveError::UnknownScheme { .. }));
+    }
+}

--- a/crates/lex-extension-host/src/trust/store.rs
+++ b/crates/lex-extension-host/src/trust/store.rs
@@ -201,16 +201,24 @@ impl TrustStore {
     /// after this returns `Ok(())`; a returned `Err` leaves both
     /// halves consistent with their pre-call state.
     ///
-    /// Writes to a sibling tempfile first, then `rename`s into place.
-    /// On POSIX, `rename` within the same directory is atomic — a
-    /// crash mid-`flush` either leaves the old file intact or
-    /// publishes the new one in full, never a truncated mix that
-    /// future `open()` calls would fail to parse. Same guarantee on
-    /// Windows for files on the same volume.
+    /// Writes to a sibling tempfile, fsyncs the data to disk, then
+    /// `rename`s into place. The fsync is the antigravity-flagged
+    /// piece: without it, `fs::rename` can publish a metadata-only
+    /// commit while the body is still in the page cache, so a
+    /// kernel panic or power loss between rename and writeback
+    /// leaves an empty/truncated `trust.json` that future `open()`
+    /// calls fail to parse. `sync_data` forces the body to durable
+    /// storage before the rename makes it visible.
+    ///
+    /// On POSIX, the rename itself is atomic at the filesystem
+    /// namespace layer — same on Windows for files on the same
+    /// volume.
     fn flush_entries(
         &self,
         entries: &HashMap<TrustKey, TrustDecision>,
     ) -> Result<(), TrustStoreError> {
+        use std::io::Write;
+
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).map_err(|source| TrustStoreError::Io {
                 path: parent.to_path_buf(),
@@ -219,10 +227,27 @@ impl TrustStore {
         }
         let body = serialize_disk_format(entries);
         let tmp = self.path.with_extension("json.tmp");
-        fs::write(&tmp, body).map_err(|source| TrustStoreError::Io {
+        let mut tmp_file = fs::File::create(&tmp).map_err(|source| TrustStoreError::Io {
             path: tmp.clone(),
             source,
         })?;
+        tmp_file
+            .write_all(body.as_bytes())
+            .map_err(|source| TrustStoreError::Io {
+                path: tmp.clone(),
+                source,
+            })?;
+        // Force the body to durable storage before the rename
+        // publishes it. `sync_data` is enough — we don't need to
+        // sync metadata of the tempfile itself.
+        tmp_file.sync_data().map_err(|source| TrustStoreError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+        // Drop the file handle before rename to avoid Windows
+        // sharing-violation issues; the inner `Drop` flushes the
+        // OS buffer (on top of the explicit `sync_data`).
+        drop(tmp_file);
         fs::rename(&tmp, &self.path).map_err(|source| {
             // Tempfile is left behind; the next flush will overwrite
             // it. Returning the rename error gives the caller the


### PR DESCRIPTION
## Summary

Last PR in the extension-system β batch. Wires everything through to the CLI.

**Lands:**

- **\`[labels]\` block in \`lex-config\`**: three on-disk shapes parse into one \`NamespaceSpec\` enum (bare URI / tap shorthand / full table). Reserved namespace name \`lex\` is rejected at load. Field on \`LexConfig\` makes clapfig's strict unknown-keys check accept \`[labels]\` blocks across every subcommand.
- **\`lex-extension-host::resolve\` — namespace URI resolver**: \`path:\` scheme implemented; network schemes (\`github:\`, \`gitlab:\`, \`https:\`, \`git+ssh:\`) return a typed \`Unimplemented\` error.
- **\`lex-cli::extension_setup\` — boot helper**: takes workspace root + \`[labels]\` + \`--ext-schema\` + \`--enable-handlers\`, returns a populated \`Registry\`, \`TrustGate\`, per-namespace metadata, and a diagnostic stream. Bad namespace → diagnostic, not boot abort.
- **\`lexd labels\` subcommand**: \`list\` (every registered namespace + source + schema count + diagnostics) and \`validate <doc>\` (run analysis pass; non-zero exit on error-severity diagnostics).
- **Global flags**: \`--ext-schema <DIR>\` (repeatable) and \`--enable-handlers\`.

**Deferred to follow-up (documented in module-level docs):**

- Network resolvers (github:/gitlab:/https:/git+ssh:) — significant scope (HTTP fetch + cache + 24h TTL). \`Unimplemented\` for now.
- \`lexd labels update\` — only meaningful once cache exists.
- \`lexd labels emit\` — pull-based JSON-stream of label invocations.
- Subprocess-handler instantiation through the trust gate. Boot helper threads the gate through but registers schema-only namespaces; spawning live \`SubprocessHandler\`s is the next layer.

Closes #525. Part of #516 (extension system β phase).

## Test plan

- [x] **9 new** in \`lex-config\` (\`[labels]\` parsing: bare URI / tap / table; reserved namespace; tap+uri mutex; empty table; missing block)
- [x] **8 new** in \`lex-extension-host::resolve\` (path: success paths + every error variant: root escape, file-not-dir, missing, unimplemented schemes, unknown scheme)
- [x] **6 new** in \`lex-cli::extension_setup\` (boot empty / path-uri / remote-uri / ext-schema / empty-dir / surface-override)
- [x] **4 new** in \`lex-cli::labels_subcommand\` (list + validate happy/sad paths)
- [x] **7 new** end-to-end integration tests in \`tests/integration/labels.rs\` running the actual \`lexd\` binary
- [x] Workspace 1893 / 1893
- [x] Pre-commit clean (fmt + clippy + build + tests)