### PR TITLE
PR 10b — γ trust prompt: lex-lsp forwards lex/trustRequest to editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,12 @@
   consult the registered extension namespaces' handlers in addition to
   the existing built-in providers. Hover takes precedence over the
   built-in when a registered handler returns content; completion + code
-  actions are additive. Subprocess handlers register schema-only in the
-  LSP today (editor-side trust prompt UI lands in a follow-up);
-  pre-validation, hover, completion, and code actions all keep working
-  through the schema-only path for any namespace the user has already
-  trusted via `lexd labels`.
+  actions are additive. Combined with the trust-prompt forwarding
+  (above), this is the full LSP surface for third-party namespaces:
+  trust untrusted handlers via `lex/trustRequest`, dispatch hooks via
+  the registry, and fall through to built-ins when no namespace
+  matches. The per-editor UI for `lex/trustRequest` lands in
+  coordinated vscode/nvim/lexed releases.
 - `lex-analysis::utils::find_verbatim_at_position`: locates a verbatim
   block whose source range contains the cursor position. Mirror of
   the existing `find_annotation_at_position`; used by extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,25 @@
 
 ### Added
 
+- `lexd-lsp` trust prompt: subprocess handlers that haven't been
+  pinned in `<workspace>/.lex/trust.json` now forward a
+  `lex/trustRequest` LSP custom request to the editor. The editor
+  (vscode / nvim / lexed in the coordinated γ release) renders an
+  editor-native prompt and replies; the response feeds the trust gate
+  and pins the decision for subsequent sessions. Sync→async bridge
+  runs on the boot's `spawn_blocking` thread via
+  `tokio::runtime::Handle::block_on` — the runtime keeps serving
+  other LSP requests while the prompt is open. Replaces 10a's
+  `LspDeferTrustPrompt` stub. Part of the γ phase of the extension
+  system (lex-fmt/lex#516).
 - New `lex-engine` crate: lifts the extension boot helper out of `lex-cli`
   so both `lexd` and `lexd-lsp` can share a single
   `boot_registry(ExtensionSetup { ... }) -> BootOutcome` entry point.
   `ExtensionSetup` now takes a `Box<dyn TrustPromptHandler>` so each host
   installs a prompt that fits its UX (CLI denies with a
-  `--enable-handlers` rationale; LSP defers to the CLI for now and will
-  forward `lex/trustRequest` notifications to editors in a follow-up).
-  Future home of the public `Engine::builder()` facade for embedders
-  (PR 11). Part of the γ phase of the extension system
+  `--enable-handlers` rationale; LSP forwards a `lex/trustRequest` to
+  the editor). Future home of the public `Engine::builder()` facade
+  for embedders (PR 11). Part of the γ phase of the extension system
   (lex-fmt/lex#516).
 - `lexd-lsp` extension dispatch: `textDocument/hover`,
   `textDocument/completion`, and `textDocument/codeAction` requests now

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -168,5 +168,6 @@
 pub mod extension_dispatch;
 pub mod features;
 pub mod server;
+pub mod trust_prompt;
 
 pub use server::LexLanguageServer;

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -37,7 +37,6 @@ use lex_core::lex::builtins as lex_builtins;
 use lex_core::lex::includes::{resolve_from_source, FsLoader, IncludeError, ResolveConfig};
 use lex_core::lex::parsing;
 use lex_extension_host::registry::Registry;
-use lex_extension_host::{TrustDecision, TrustPromptContext, TrustPromptHandler};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tower_lsp::async_trait;
@@ -64,7 +63,9 @@ use tower_lsp::lsp_types::Diagnostic;
 use tower_lsp::lsp_types::MessageType;
 
 #[async_trait]
-pub trait LspClient: Send + Sync + Clone + 'static {
+pub trait LspClient:
+    crate::trust_prompt::LspTrustRequester + Send + Sync + Clone + 'static
+{
     async fn publish_diagnostics(&self, uri: Url, diags: Vec<Diagnostic>, version: Option<i32>);
     async fn show_message(&self, typ: MessageType, message: String);
 }
@@ -267,7 +268,7 @@ fn semantic_tokens_legend() -> SemanticTokensLegend {
 }
 
 pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
-    _client: C,
+    client: C,
     documents: DocumentStore,
     features: Arc<P>,
     workspace_roots: RwLock<Vec<PathBuf>>,
@@ -295,7 +296,7 @@ where
     pub fn with_features(client: C, features: Arc<P>) -> Self {
         let config = load_config(None);
         Self {
-            _client: client,
+            client,
             documents: DocumentStore::default(),
             features,
             workspace_roots: RwLock::new(Vec::new()),
@@ -326,7 +327,13 @@ where
         // handlers — a few hundred milliseconds in the worst case. Run
         // it on the blocking thread pool so the tokio runtime keeps
         // serving other LSP requests while boot runs.
+        //
+        // The trust prompt handler bridges sync→async via
+        // `Handle::block_on` — safe because we're on a blocking-pool
+        // thread, not a runtime worker.
         let workspace_root_owned = workspace_root.clone();
+        let trust_requester = std::sync::Arc::new(self.client.clone());
+        let runtime_handle = tokio::runtime::Handle::current();
         let outcome = match tokio::task::spawn_blocking(move || {
             lex_engine::boot_registry(lex_engine::ExtensionSetup {
                 workspace_root: workspace_root_owned.as_path(),
@@ -341,11 +348,14 @@ where
                 // handler directly.
                 enable_handlers: false,
                 surface_override: Some(lex_extension_host::Surface::LspSession),
-                // 10a stub: deny with a CLI-trust-first rationale.
-                // PR 10b replaces this with a handler that forwards a
-                // `lex/trustRequest` notification to the editor and
-                // awaits the user's decision.
-                trust_prompt: Box::new(LspDeferTrustPrompt),
+                // Forwards `lex/trustRequest` to the editor and awaits
+                // the user's decision. Already-pinned decisions in
+                // `<workspace>/.lex/trust.json` short-circuit before
+                // the prompt fires.
+                trust_prompt: Box::new(crate::trust_prompt::LspPromptHandler::new(
+                    trust_requester,
+                    runtime_handle,
+                )),
                 // Reports `lexd-lsp`'s version to subprocess handlers
                 // in their initialize handshake — what handlers expect
                 // to see, not the `lex-engine` boot crate's version.
@@ -398,7 +408,7 @@ where
             diagnostics.extend(analysis_diags.into_iter().map(to_lsp_diagnostic));
         }
 
-        self._client
+        self.client
             .publish_diagnostics(uri, diagnostics, None)
             .await;
     }
@@ -970,31 +980,6 @@ fn parent_directory_uri(uri: &Url) -> Url {
     base.set_query(None);
     base.set_fragment(None);
     base
-}
-
-/// Trust prompt installed by the LSP boot path in 10a.
-///
-/// PR 10a's scope is the dispatch wiring; the editor-side trust UI
-/// lands in PR 10b along with the comms wire spec for the
-/// `lex/trustRequest` message and the per-editor handlers in
-/// vscode/nvim/lexed. Until then, the LSP defers all trust decisions
-/// to the CLI surface: subprocess handlers that haven't already been
-/// trusted via `lexd labels` (decision persisted at
-/// `<workspace>/.lex/trust.json`) register schema-only with this
-/// rationale. Pre-validation, hover/completion/code-action dispatch,
-/// and the `lex.*` built-ins all keep working.
-struct LspDeferTrustPrompt;
-impl TrustPromptHandler for LspDeferTrustPrompt {
-    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
-        TrustDecision::Denied {
-            reason: format!(
-                "subprocess handler `{}` is not yet trusted in this workspace; \
-                 trust it from the CLI first (run `lexd labels list --enable-handlers` \
-                 in this directory) — editor-side trust prompts land in a follow-up release",
-                ctx.namespace
-            ),
-        }
-    }
 }
 
 #[async_trait]
@@ -1878,6 +1863,21 @@ mod tests {
         async fn publish_diagnostics(&self, _: Url, _: Vec<Diagnostic>, _: Option<i32>) {}
         async fn show_message(&self, _: MessageType, _: String) {}
     }
+    #[async_trait]
+    impl crate::trust_prompt::LspTrustRequester for NoopClient {
+        async fn send_trust_request(
+            &self,
+            _: crate::trust_prompt::TrustRequestParams,
+        ) -> tower_lsp::jsonrpc::Result<crate::trust_prompt::TrustResponse> {
+            // Tests don't exercise the trust prompt path; deny so a
+            // boot path that does reach the prompt has predictable
+            // behavior.
+            Ok(crate::trust_prompt::TrustResponse {
+                decision: "denied".into(),
+                reason: Some("test client".into()),
+            })
+        }
+    }
 
     #[derive(Default)]
     struct MockFeatureProvider {
@@ -2712,6 +2712,20 @@ mod tests {
             self.last_diagnostics.lock().unwrap().push((uri, diags));
         }
         async fn show_message(&self, _: MessageType, _: String) {}
+    }
+    #[async_trait]
+    impl crate::trust_prompt::LspTrustRequester for CapturingClient {
+        async fn send_trust_request(
+            &self,
+            _: crate::trust_prompt::TrustRequestParams,
+        ) -> tower_lsp::jsonrpc::Result<crate::trust_prompt::TrustResponse> {
+            // Tests run with no `[labels]` block; the prompt path is
+            // not exercised.
+            Ok(crate::trust_prompt::TrustResponse {
+                decision: "denied".into(),
+                reason: Some("test client".into()),
+            })
+        }
     }
 
     impl CapturingClient {

--- a/crates/lex-lsp/src/trust_prompt.rs
+++ b/crates/lex-lsp/src/trust_prompt.rs
@@ -1,0 +1,394 @@
+//! LSP custom request for the extension trust prompt.
+//!
+//! When the extension boot path encounters a subprocess handler whose
+//! trust hasn't been pinned in `<workspace>/.lex/trust.json`, the
+//! [`LspPromptHandler`] forwards a `lex/trustRequest` to the LSP
+//! client. The client (vscode / nvim / lexed) renders an editor-native
+//! prompt and replies with the user's decision; the response is fed
+//! back into the trust gate which pins the decision for subsequent
+//! sessions.
+//!
+//! ## Why a request, not a notification
+//!
+//! `lex/trustRequest` needs a response to drive the gate's decision,
+//! so it's an LSP request (server → client → response) rather than a
+//! one-way notification. The wire shape is documented in
+//! `comms/specs/proposals/extending-lex.lex` §γ.
+//!
+//! ## Sync / async bridge
+//!
+//! `TrustPromptHandler::prompt` is sync, but tower-lsp's
+//! [`Client::send_request`] is async. The boot path in
+//! [`crate::server::LexLanguageServer::extension_state`] wraps the
+//! whole boot in `tokio::task::spawn_blocking`, so the prompt runs on
+//! a tokio blocking-pool thread — which means we can call
+//! [`tokio::runtime::Handle::block_on`] without blocking the runtime.
+//! The handle is captured at boot time and held by the prompt handler.
+
+use lex_extension_host::{
+    Capability as TrustCapability, Source as TrustSource, Transport as TrustTransport,
+    TrustDecision, TrustPromptContext, TrustPromptHandler,
+};
+use serde::{Deserialize, Serialize};
+use tower_lsp::async_trait;
+use tower_lsp::jsonrpc::Result as JsonRpcResult;
+use tower_lsp::lsp_types::request::Request;
+
+/// `lex/trustRequest` — server asks the client to render a trust prompt
+/// for a subprocess handler that hasn't been pinned in the workspace
+/// trust store.
+pub enum LexTrustRequest {}
+impl Request for LexTrustRequest {
+    type Params = TrustRequestParams;
+    type Result = TrustResponse;
+    const METHOD: &'static str = "lex/trustRequest";
+}
+
+/// Parameters of a `lex/trustRequest`.
+///
+/// Mirrors [`TrustPromptContext`] one-to-one but with serializable wire
+/// types — `source`, `capability`, and `transport` map onto string
+/// constants (`"lex_toml"`, `"local_file"`, `"subprocess"`, …) so editor
+/// implementations don't need to mirror the Rust enum hierarchy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustRequestParams {
+    /// Namespace name (e.g. `"acme"`).
+    pub namespace: String,
+    /// Joined `handler.command` from the schema YAML — exactly the
+    /// string the gate keys on for trust pinning.
+    pub command_string: String,
+    /// Where the schema came from. One of:
+    /// - `{ "kind": "lex_toml", "name": "<namespace>" }` — declared in
+    ///   `lex.toml`'s `[labels]` block.
+    /// - `{ "kind": "local_file", "path": "<path>" }` — a local schema
+    ///   directory the host opted into.
+    /// - `{ "kind": "cache_only", "uri": "<uri>" }` — schema fetched
+    ///   from a marketplace / registry / cache without an explicit
+    ///   user gesture. Higher trust bar.
+    pub source: TrustRequestSource,
+    /// Declared capability set the handler asked for. Forward-compatible
+    /// string-shaped enum:
+    /// - `"pure"` — handler declared `fs: false, net: false`. Will be
+    ///   eligible for sandbox-enforced auto-trust once PR 12 lands.
+    /// - `"full"` — handler asked for `fs` or `net` access. Always
+    ///   prompts (no sandbox can enforce this in v1).
+    ///
+    /// Future values (`"fs_read"`, `"fs_write"`, etc.) are
+    /// non-breaking; editors should render unknown values as
+    /// "unknown capability" and treat them at least as cautiously as
+    /// `"full"`.
+    pub capability: String,
+    /// Transport: always `"subprocess"` in v1 (native handlers don't
+    /// prompt; WASM is deferred to PR 12).
+    pub transport: String,
+}
+
+/// `source` field shape on the wire. Internally tagged on `kind`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TrustRequestSource {
+    LexToml { name: String },
+    LocalFile { path: String },
+    CacheOnly { uri: String },
+}
+
+/// Response shape for `lex/trustRequest`.
+///
+/// `decision` is `"trusted"` or `"denied"` — string-shaped so future
+/// values (e.g. `"trusted_once"`, `"trusted_for_session"`) are
+/// non-breaking. Unknown values fall back to `"denied"` on the host
+/// side. `reason` is optional and is surfaced as the diagnostic message
+/// when `decision == "denied"`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TrustResponse {
+    pub decision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Trait for sending `lex/trustRequest` to an LSP client. Mockable in
+/// tests; the real impl forwards through tower-lsp's
+/// [`Client::send_request`].
+#[async_trait]
+pub trait LspTrustRequester: Send + Sync + 'static {
+    async fn send_trust_request(&self, params: TrustRequestParams) -> JsonRpcResult<TrustResponse>;
+}
+
+#[async_trait]
+impl LspTrustRequester for tower_lsp::Client {
+    async fn send_trust_request(&self, params: TrustRequestParams) -> JsonRpcResult<TrustResponse> {
+        self.send_request::<LexTrustRequest>(params).await
+    }
+}
+
+/// Convert a [`TrustPromptContext`] into the request payload. The
+/// gate's enums map onto the string-shaped wire constants documented
+/// above.
+fn params_from_ctx(ctx: &TrustPromptContext) -> TrustRequestParams {
+    let source = match &ctx.source {
+        TrustSource::LexTomlNamespace { name } => {
+            TrustRequestSource::LexToml { name: name.clone() }
+        }
+        TrustSource::LocalFile { path } => TrustRequestSource::LocalFile {
+            path: path.display().to_string(),
+        },
+        TrustSource::CacheOnly { uri } => TrustRequestSource::CacheOnly { uri: uri.clone() },
+    };
+    let capability = match ctx.capability {
+        TrustCapability::Pure => "pure",
+        TrustCapability::Full => "full",
+    }
+    .to_string();
+    let transport = "subprocess".to_string();
+    TrustRequestParams {
+        namespace: ctx.namespace.clone(),
+        command_string: ctx.command_string.clone(),
+        source,
+        capability,
+        transport,
+    }
+}
+
+/// [`TrustPromptHandler`] implementation that forwards to an LSP
+/// client. Sync→async bridge runs on the boot's blocking thread via
+/// [`tokio::runtime::Handle::block_on`].
+pub struct LspPromptHandler<R: LspTrustRequester> {
+    requester: std::sync::Arc<R>,
+    runtime_handle: tokio::runtime::Handle,
+}
+
+impl<R: LspTrustRequester> LspPromptHandler<R> {
+    pub fn new(requester: std::sync::Arc<R>, runtime_handle: tokio::runtime::Handle) -> Self {
+        Self {
+            requester,
+            runtime_handle,
+        }
+    }
+}
+
+impl<R: LspTrustRequester> TrustPromptHandler for LspPromptHandler<R> {
+    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
+        let params = params_from_ctx(ctx);
+        let requester = std::sync::Arc::clone(&self.requester);
+        // We're called from a `spawn_blocking` thread (the boot path
+        // wraps `boot_registry`), so `block_on` is safe — it parks
+        // this blocking-pool thread, not the async runtime's worker
+        // threads.
+        let response = self
+            .runtime_handle
+            .block_on(async move { requester.send_trust_request(params).await });
+        match response {
+            Ok(resp) => match resp.decision.as_str() {
+                "trusted" => TrustDecision::Trusted,
+                _ => {
+                    // Anything other than "trusted" — including unknown
+                    // future values — falls back to denied. The reason
+                    // surfaces as the boot diagnostic.
+                    TrustDecision::Denied {
+                        reason: resp.reason.unwrap_or_else(|| {
+                            format!(
+                                "subprocess handler `{}` was not trusted by the editor",
+                                ctx.namespace
+                            )
+                        }),
+                    }
+                }
+            },
+            Err(e) => TrustDecision::Denied {
+                reason: format!(
+                    "subprocess handler `{}` denied: trust request to editor failed ({e})",
+                    ctx.namespace
+                ),
+            },
+        }
+    }
+}
+
+/// `Transport` wire-string mapping. Kept as a free function so the
+/// const can be reused by tests / future request-shaped transports
+/// (WASM, etc.).
+#[allow(dead_code)]
+pub(crate) fn transport_string(t: TrustTransport) -> &'static str {
+    match t {
+        TrustTransport::Native => "native",
+        TrustTransport::Subprocess => "subprocess",
+        TrustTransport::Wasm => "wasm",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+
+    /// Test requester that captures the params it received and returns
+    /// a canned response.
+    struct MockRequester {
+        captured: Mutex<Vec<TrustRequestParams>>,
+        response: Mutex<JsonRpcResult<TrustResponse>>,
+        call_count: AtomicUsize,
+    }
+
+    impl MockRequester {
+        fn new(response: TrustResponse) -> Self {
+            Self {
+                captured: Mutex::new(Vec::new()),
+                response: Mutex::new(Ok(response)),
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn with_error() -> Self {
+            Self {
+                captured: Mutex::new(Vec::new()),
+                response: Mutex::new(Err(tower_lsp::jsonrpc::Error::internal_error())),
+                call_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LspTrustRequester for MockRequester {
+        async fn send_trust_request(
+            &self,
+            params: TrustRequestParams,
+        ) -> JsonRpcResult<TrustResponse> {
+            self.captured.lock().await.push(params);
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            // Clone-or-clone-error-shape via match.
+            let r = self.response.lock().await;
+            match &*r {
+                Ok(resp) => Ok(resp.clone()),
+                Err(e) => Err(e.clone()),
+            }
+        }
+    }
+
+    fn ctx() -> TrustPromptContext {
+        TrustPromptContext {
+            namespace: "acme".into(),
+            command_string: "/usr/local/bin/acme-handler".into(),
+            source: TrustSource::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            capability: TrustCapability::Full,
+        }
+    }
+
+    #[test]
+    fn params_round_trip_through_serde() {
+        let p = TrustRequestParams {
+            namespace: "acme".into(),
+            command_string: "acme-bin".into(),
+            source: TrustRequestSource::LexToml {
+                name: "acme".into(),
+            },
+            capability: "full".into(),
+            transport: "subprocess".into(),
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let back: TrustRequestParams = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn params_from_ctx_local_file_source() {
+        let mut c = ctx();
+        c.source = TrustSource::LocalFile {
+            path: PathBuf::from("/tmp/schemas/acme"),
+        };
+        let p = params_from_ctx(&c);
+        match p.source {
+            TrustRequestSource::LocalFile { path } => {
+                assert!(path.contains("acme"));
+            }
+            _ => panic!("expected LocalFile"),
+        }
+    }
+
+    /// Trusted response from the editor → the prompt returns
+    /// `TrustDecision::Trusted` and the editor saw a single request.
+    #[test]
+    fn prompt_handler_translates_trusted_response() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::new(TrustResponse {
+            decision: "trusted".into(),
+            reason: None,
+        }));
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+
+        // The prompt method calls block_on internally — drive it from
+        // the runtime's spawn_blocking pool (matches production flow).
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+
+        assert!(matches!(decision, TrustDecision::Trusted));
+        assert_eq!(requester.call_count.load(Ordering::SeqCst), 1);
+    }
+
+    /// Denied response with a reason → reason surfaces in the
+    /// `TrustDecision::Denied` diagnostic.
+    #[test]
+    fn prompt_handler_surfaces_denied_reason() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::new(TrustResponse {
+            decision: "denied".into(),
+            reason: Some("user-clicked-deny".into()),
+        }));
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        match decision {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("user-clicked-deny"), "got: {reason}");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    /// Unknown decision string → fall back to denied (forward
+    /// compatibility — future values are non-breaking).
+    #[test]
+    fn prompt_handler_treats_unknown_decision_as_denied() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::new(TrustResponse {
+            decision: "trusted_once".into(),
+            reason: None,
+        }));
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        assert!(matches!(decision, TrustDecision::Denied { .. }));
+    }
+
+    /// Editor-side error (timeout, disconnect, etc.) → denied with a
+    /// "trust request failed" diagnostic. Doesn't crash the boot.
+    #[test]
+    fn prompt_handler_surfaces_request_error_as_denied() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::with_error());
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        match decision {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("trust request"), "got: {reason}");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+}

--- a/crates/lex-lsp/src/trust_prompt.rs
+++ b/crates/lex-lsp/src/trust_prompt.rs
@@ -149,12 +149,22 @@ fn params_from_ctx(ctx: &TrustPromptContext) -> TrustRequestParams {
     }
 }
 
+/// Maximum time we wait for the editor to reply to a `lex/trustRequest`.
+///
+/// Tradeoff: long enough that a distracted user has time to read the
+/// prompt and decide; short enough that a buggy or quietly-dismissed
+/// extension can't pin the boot indefinitely. 60s is the "send a
+/// message in Slack and come back" budget — past this, treating it as
+/// denied is safer than hanging the boot.
+const PROMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// [`TrustPromptHandler`] implementation that forwards to an LSP
 /// client. Sync→async bridge runs on the boot's blocking thread via
 /// [`tokio::runtime::Handle::block_on`].
 pub struct LspPromptHandler<R: LspTrustRequester> {
     requester: std::sync::Arc<R>,
     runtime_handle: tokio::runtime::Handle,
+    timeout: std::time::Duration,
 }
 
 impl<R: LspTrustRequester> LspPromptHandler<R> {
@@ -162,6 +172,22 @@ impl<R: LspTrustRequester> LspPromptHandler<R> {
         Self {
             requester,
             runtime_handle,
+            timeout: PROMPT_TIMEOUT,
+        }
+    }
+
+    /// Construct with a custom timeout. Tests use this to drive the
+    /// timeout-as-denied path without waiting 60 seconds.
+    #[cfg(test)]
+    pub fn with_timeout(
+        requester: std::sync::Arc<R>,
+        runtime_handle: tokio::runtime::Handle,
+        timeout: std::time::Duration,
+    ) -> Self {
+        Self {
+            requester,
+            runtime_handle,
+            timeout,
         }
     }
 }
@@ -170,15 +196,21 @@ impl<R: LspTrustRequester> TrustPromptHandler for LspPromptHandler<R> {
     fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
         let params = params_from_ctx(ctx);
         let requester = std::sync::Arc::clone(&self.requester);
+        let timeout = self.timeout;
         // We're called from a `spawn_blocking` thread (the boot path
         // wraps `boot_registry`), so `block_on` is safe — it parks
         // this blocking-pool thread, not the async runtime's worker
         // threads.
-        let response = self
-            .runtime_handle
-            .block_on(async move { requester.send_trust_request(params).await });
+        //
+        // Wrap the request in `tokio::time::timeout` so a buggy
+        // extension or a prompt the user dismisses without a reply
+        // can't hang the boot indefinitely. On timeout we deny with a
+        // diagnostic, matching the other failure modes.
+        let response = self.runtime_handle.block_on(async move {
+            tokio::time::timeout(timeout, requester.send_trust_request(params)).await
+        });
         match response {
-            Ok(resp) => match resp.decision.as_str() {
+            Ok(Ok(resp)) => match resp.decision.as_str() {
                 "trusted" => TrustDecision::Trusted,
                 _ => {
                     // Anything other than "trusted" — including unknown
@@ -194,10 +226,17 @@ impl<R: LspTrustRequester> TrustPromptHandler for LspPromptHandler<R> {
                     }
                 }
             },
-            Err(e) => TrustDecision::Denied {
+            Ok(Err(e)) => TrustDecision::Denied {
                 reason: format!(
                     "subprocess handler `{}` denied: trust request to editor failed ({e})",
                     ctx.namespace
+                ),
+            },
+            Err(_elapsed) => TrustDecision::Denied {
+                reason: format!(
+                    "subprocess handler `{}` denied: trust request to editor timed out after {}s",
+                    ctx.namespace,
+                    timeout.as_secs()
                 ),
             },
         }
@@ -372,7 +411,49 @@ mod tests {
         assert!(matches!(decision, TrustDecision::Denied { .. }));
     }
 
-    /// Editor-side error (timeout, disconnect, etc.) → denied with a
+    /// Requester that never resolves — simulates a buggy editor that
+    /// receives the request and never replies. The handler must
+    /// time out and treat that as denied so the boot doesn't hang.
+    struct StuckRequester;
+
+    #[async_trait]
+    impl LspTrustRequester for StuckRequester {
+        async fn send_trust_request(&self, _: TrustRequestParams) -> JsonRpcResult<TrustResponse> {
+            // Never resolves on its own; the prompt's tokio::time::timeout
+            // is the only way out.
+            std::future::pending().await
+        }
+    }
+
+    /// Buggy / non-responsive editor → timeout fires → denied with a
+    /// "timed out" diagnostic. Critical: a stuck prompt must NOT pin
+    /// the boot indefinitely.
+    #[test]
+    fn prompt_handler_times_out_when_editor_never_responds() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(StuckRequester);
+        let handler = LspPromptHandler::with_timeout(
+            std::sync::Arc::clone(&requester),
+            rt.handle().clone(),
+            std::time::Duration::from_millis(50),
+        );
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        match decision {
+            TrustDecision::Denied { reason } => {
+                assert!(
+                    reason.contains("timed out"),
+                    "expected 'timed out' diagnostic, got: {reason}"
+                );
+            }
+            other => panic!("expected Denied (timeout), got {other:?}"),
+        }
+    }
+
+    /// Editor-side error (transport, disconnect, etc.) → denied with a
     /// "trust request failed" diagnostic. Doesn't crash the boot.
     #[test]
     fn prompt_handler_surfaces_request_error_as_denied() {

--- a/crates/lex-lsp/tests/integration/robustness_proptest.rs
+++ b/crates/lex-lsp/tests/integration/robustness_proptest.rs
@@ -1,4 +1,5 @@
 use lexd_lsp::server::{DefaultFeatureProvider, LspClient};
+use lexd_lsp::trust_prompt::{LspTrustRequester, TrustRequestParams, TrustResponse};
 use lexd_lsp::LexLanguageServer;
 use proptest::prelude::*;
 use std::sync::Arc;
@@ -18,6 +19,21 @@ use tower_lsp::lsp_types::Diagnostic;
 impl LspClient for MockClient {
     async fn publish_diagnostics(&self, _: Url, _: Vec<Diagnostic>, _: Option<i32>) {}
     async fn show_message(&self, _: tower_lsp::lsp_types::MessageType, _: String) {}
+}
+
+#[async_trait]
+impl LspTrustRequester for MockClient {
+    async fn send_trust_request(
+        &self,
+        _: TrustRequestParams,
+    ) -> tower_lsp::jsonrpc::Result<TrustResponse> {
+        // Proptests don't exercise the trust path; deny is the safe
+        // default that won't spawn subprocesses.
+        Ok(TrustResponse {
+            decision: "denied".into(),
+            reason: Some("proptest mock".into()),
+        })
+    }
 }
 
 proptest! {


### PR DESCRIPTION
Second half of PR 10 (#526). Targets the `pr-10` integration branch — stacks on top of PR 10a (#547, already merged into `pr-10`).

## What lands

PR 10a left a deferring stub in place — every subprocess handler in the LSP was denied unless the user had already trusted it via `lexd labels` (decision pinned in `<workspace>/.lex/trust.json`). This PR replaces the stub with a real \`LspPromptHandler\` that forwards the prompt to the editor as an LSP custom request.

### Wire shape (\`lex/trustRequest\`)

```jsonc
// Server → Client
{
  "namespace": "acme",
  "command_string": "/usr/local/bin/acme-handler",
  "source": { "kind": "lex_toml", "name": "acme" },
  // OR { "kind": "local_file", "path": "..." }
  // OR { "kind": "cache_only", "uri": "..." }
  "capability": "full",   // "pure" | "full" — string-shaped, future values non-breaking
  "transport": "subprocess"
}

// Client → Server (response)
{
  "decision": "trusted",  // "trusted" | "denied" — unknown strings → denied
  "reason": "..."         // optional, surfaced as the boot diagnostic on denied
}
```

Pinning still happens server-side: the gate stores the decision keyed on \`(workspace, namespace, command_string)\` so the editor only prompts once per (workspace × handler-binary).

### Sync/async bridge

The \`TrustPromptHandler\` trait is sync but tower-lsp's \`Client::send_request\` is async. PR 10a's Copilot review caught the runtime-blocking risk and we already wrap \`boot_registry\` in \`tokio::task::spawn_blocking\`. The prompt handler now uses \`Handle::block_on\` to await the editor's response — safe because it runs on a blocking-pool thread, not a runtime worker, so other LSP requests keep flowing while a trust prompt is open.

### Failure modes

| Editor reply | Outcome |
|--------------|---------|
| `decision: "trusted"` | Gate pins; subprocess handler spawns; namespace dispatches normally |
| `decision: "denied"` | Schema-only registration; reason surfaces as boot diagnostic |
| Unknown decision string | Denied (forward-compat: future values non-breaking) |
| Request error (timeout, disconnect, internal_error) | Denied with "trust request to editor failed" diagnostic; boot continues |

### Trait changes

- New \`LspTrustRequester\` trait abstracts \`send_trust_request\` so tests can mock it.
- \`LspClient\` now extends \`LspTrustRequester\` (the real \`tower_lsp::Client\` implements both).
- Test mocks (\`NoopClient\`, \`CapturingClient\`, \`MockClient\` in proptests) now implement \`LspTrustRequester\` returning a denying response so test boot paths can't accidentally spawn subprocesses.

## What's deferred to separate PRs

- **comms wire spec** — separate PR in \`lex-fmt/comms\` documenting \`lex/trustRequest\` in the proposal under §γ.
- **vscode / nvim / lexed editor PRs** — three separate per-editor PRs implementing the trust UI dialog. Coordinated γ release matches the includes-feature release model (2026-05-04 precedent).

## Test plan

- [x] \`cargo build --workspace --exclude lex-wasm\` clean.
- [x] \`cargo nextest run --workspace --exclude lex-wasm\` — 1911 tests pass (1905 from 10a + 6 new in trust_prompt.rs).
- [x] \`cargo clippy --workspace --exclude lex-wasm -- -D warnings\` clean.
- [x] 6 new tests:
    - params serde round-trip
    - \`params_from_ctx\` LocalFile mapping
    - prompt translates trusted response correctly
    - denied response surfaces \`reason\` in diagnostic
    - unknown decision falls back to denied
    - request error falls back to denied with diagnostic
- [x] CHANGELOG entry added.

## Sequencing

After this merges into \`pr-10\`, the umbrella \`pr-10\` → \`main\` PR will be opened for combined review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)