### PR TITLE
PR 10 (γ) — extension dispatch in lex-lsp + lex/trustRequest forwarding to editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ### Added
 
+- New `lex-engine` crate: lifts the extension boot helper out of `lex-cli`
+  so both `lexd` and `lexd-lsp` can share a single
+  `boot_registry(ExtensionSetup { ... }) -> BootOutcome` entry point.
+  `ExtensionSetup` now takes a `Box<dyn TrustPromptHandler>` so each host
+  installs a prompt that fits its UX (CLI denies with a
+  `--enable-handlers` rationale; LSP defers to the CLI for now and will
+  forward `lex/trustRequest` notifications to editors in a follow-up).
+  Future home of the public `Engine::builder()` facade for embedders
+  (PR 11). Part of the γ phase of the extension system
+  (lex-fmt/lex#516).
+- `lexd-lsp` extension dispatch: `textDocument/hover`,
+  `textDocument/completion`, and `textDocument/codeAction` requests now
+  consult the registered extension namespaces' handlers in addition to
+  the existing built-in providers. Hover takes precedence over the
+  built-in when a registered handler returns content; completion + code
+  actions are additive. Subprocess handlers register schema-only in the
+  LSP today (editor-side trust prompt UI lands in a follow-up);
+  pre-validation, hover, completion, and code actions all keep working
+  through the schema-only path for any namespace the user has already
+  trusted via `lexd labels`.
+- `lex-analysis::utils::find_verbatim_at_position`: locates a verbatim
+  block whose source range contains the cursor position. Mirror of
+  the existing `find_annotation_at_position`; used by extension
+  dispatch to identify labelled verbatim blocks under the cursor.
 - `lex-babel`: new `serialize_to_html_with_registry(doc, options, &Registry)`
   entry point and `HtmlExportOutcome { html, diagnostics }` result type.
   Walks the AST, dispatches `on_render` for every labelled annotation /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@
   and pins the decision for subsequent sessions. Sync→async bridge
   runs on the boot's `spawn_blocking` thread via
   `tokio::runtime::Handle::block_on` — the runtime keeps serving
-  other LSP requests while the prompt is open. Replaces 10a's
-  `LspDeferTrustPrompt` stub. Part of the γ phase of the extension
-  system (lex-fmt/lex#516).
+  other LSP requests while the prompt is open. Boot is serialized
+  with a `tokio::sync::Mutex` so a burst of LSP requests on file
+  open (semantic tokens + hover + folding + …) produces exactly one
+  boot, not N parallel boots with N parallel trust prompts. Boot
+  diagnostics (resolver failures, denied namespaces, schema errors)
+  are surfaced to the editor as `window/showMessage` notifications
+  so users can see why a configured extension isn't working. Replaces
+  10a's `LspDeferTrustPrompt` stub. Part of the γ phase of the
+  extension system (lex-fmt/lex#516).
 - New `lex-engine` crate: lifts the extension boot helper out of `lex-cli`
   so both `lexd` and `lexd-lsp` can share a single
   `boot_registry(ExtensionSetup { ... }) -> BootOutcome` entry point.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,37 @@
 
 ### Added
 
+- `lexd-lsp` trust prompt: subprocess handlers that haven't been
+  pinned in `<workspace>/.lex/trust.json` now forward a
+  `lex/trustRequest` LSP custom request to the editor. The editor
+  (vscode / nvim / lexed in the coordinated γ release) renders an
+  editor-native prompt and replies; the response feeds the trust gate
+  and pins the decision for subsequent sessions. Sync→async bridge
+  runs on the boot's `spawn_blocking` thread via
+  `tokio::runtime::Handle::block_on` — the runtime keeps serving
+  other LSP requests while the prompt is open. Replaces 10a's
+  `LspDeferTrustPrompt` stub. Part of the γ phase of the extension
+  system (lex-fmt/lex#516).
 - New `lex-engine` crate: lifts the extension boot helper out of `lex-cli`
   so both `lexd` and `lexd-lsp` can share a single
   `boot_registry(ExtensionSetup { ... }) -> BootOutcome` entry point.
   `ExtensionSetup` now takes a `Box<dyn TrustPromptHandler>` so each host
   installs a prompt that fits its UX (CLI denies with a
-  `--enable-handlers` rationale; LSP defers to the CLI for now and will
-  forward `lex/trustRequest` notifications to editors in a follow-up).
-  Future home of the public `Engine::builder()` facade for embedders
-  (PR 11). Part of the γ phase of the extension system
+  `--enable-handlers` rationale; LSP forwards a `lex/trustRequest` to
+  the editor). Future home of the public `Engine::builder()` facade
+  for embedders (PR 11). Part of the γ phase of the extension system
   (lex-fmt/lex#516).
 - `lexd-lsp` extension dispatch: `textDocument/hover`,
   `textDocument/completion`, and `textDocument/codeAction` requests now
   consult the registered extension namespaces' handlers in addition to
   the existing built-in providers. Hover takes precedence over the
   built-in when a registered handler returns content; completion + code
-  actions are additive. Subprocess handlers register schema-only in the
-  LSP today (editor-side trust prompt UI lands in a follow-up);
-  pre-validation, hover, completion, and code actions all keep working
-  through the schema-only path for any namespace the user has already
-  trusted via `lexd labels`.
+  actions are additive. Combined with the trust-prompt forwarding
+  (above), this is the full LSP surface for third-party namespaces:
+  trust untrusted handlers via `lex/trustRequest`, dispatch hooks via
+  the registry, and fall through to built-ins when no namespace
+  matches. The per-editor UI for `lex/trustRequest` lands in
+  coordinated vscode/nvim/lexed releases.
 - `lex-analysis::utils::find_verbatim_at_position`: locates a verbatim
   block whose source range contains the cursor position. Mirror of
   the existing `find_annotation_at_position`; used by extension

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lex-engine"
+version = "0.1.0"
+dependencies = [
+ "lex-config",
+ "lex-core",
+ "lex-extension",
+ "lex-extension-host",
+ "tempfile",
+]
+
+[[package]]
 name = "lex-extension"
 version = "0.1.0"
 dependencies = [
@@ -1118,6 +1129,7 @@ dependencies = [
  "lex-babel",
  "lex-config",
  "lex-core",
+ "lex-engine",
  "lex-extension",
  "lex-extension-host",
  "predicates",
@@ -1134,12 +1146,15 @@ dependencies = [
  "lex-babel",
  "lex-config",
  "lex-core",
+ "lex-engine",
+ "lex-extension",
  "lex-extension-host",
  "lex-lsp-core",
  "lsp-types",
  "proptest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
  "tower-lsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/lex-analysis",
     "crates/lex-extension",
     "crates/lex-extension-host",
+    "crates/lex-engine",
     "crates/lex-lsp-core",
     "crates/lex-lsp",
     "crates/lex-wasm",
@@ -20,6 +21,7 @@ lex-config = { version = "0.10.6", path = "crates/lex-config" }
 lex-analysis = { version = "0.10.6", path = "crates/lex-analysis" }
 lex-extension = { version = "0.1.0", path = "crates/lex-extension" }
 lex-extension-host = { version = "0.1.0", path = "crates/lex-extension-host", default-features = false }
+lex-engine = { version = "0.1.0", path = "crates/lex-engine" }
 lex-lsp-core = { version = "0.10.6", path = "crates/lex-lsp-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/lex-analysis/src/utils.rs
+++ b/crates/lex-analysis/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::inline::{extract_references, PositionedReference};
 use lex_core::lex::ast::traits::AstNode;
 use lex_core::lex::ast::{
-    Annotation, ContentItem, Definition, Document, Position, Session, TextContent,
+    Annotation, ContentItem, Definition, Document, Position, Session, TextContent, Verbatim,
 };
 
 /// Visits every text content node in the document, invoking the callback for each.
@@ -253,6 +253,74 @@ pub fn find_annotation_at_position(document: &Document, position: Position) -> O
 
 pub fn find_session_at_position(document: &Document, position: Position) -> Option<&Session> {
     find_session_in_branch(&document.root, position, true)
+}
+
+/// Locate a verbatim block whose source range contains `position`. Walks
+/// the document tree under both the root session and any document-level
+/// annotations. Used by extension dispatch to identify the labelled
+/// verbatim under the cursor for hover / completion / code-action
+/// requests.
+pub fn find_verbatim_at_position(document: &Document, position: Position) -> Option<&Verbatim> {
+    for annotation in document.annotations() {
+        if let Some(found) = find_verbatim_in_items(annotation.children.iter(), position) {
+            return Some(found);
+        }
+    }
+    find_verbatim_in_session(&document.root, position)
+}
+
+fn find_verbatim_in_session(session: &Session, position: Position) -> Option<&Verbatim> {
+    find_verbatim_in_items(session.children.iter(), position)
+}
+
+fn find_verbatim_in_items<'a, I>(items: I, position: Position) -> Option<&'a Verbatim>
+where
+    I: IntoIterator<Item = &'a ContentItem>,
+{
+    for item in items {
+        match item {
+            ContentItem::VerbatimBlock(v) => {
+                if v.location.contains(position) {
+                    return Some(v);
+                }
+            }
+            ContentItem::Session(s) => {
+                if let Some(found) = find_verbatim_in_session(s, position) {
+                    return Some(found);
+                }
+            }
+            ContentItem::Definition(d) => {
+                if let Some(found) = find_verbatim_in_items(d.children.iter(), position) {
+                    return Some(found);
+                }
+            }
+            ContentItem::List(list) => {
+                for entry in &list.items {
+                    if let ContentItem::ListItem(li) = entry {
+                        if let Some(found) = find_verbatim_in_items(li.children.iter(), position) {
+                            return Some(found);
+                        }
+                    }
+                }
+            }
+            ContentItem::Annotation(a) => {
+                if let Some(found) = find_verbatim_in_items(a.children.iter(), position) {
+                    return Some(found);
+                }
+            }
+            ContentItem::Table(table) => {
+                // Tables can hold block-level children (including
+                // verbatim blocks) under each cell; walk every cell's
+                // children. `cell_children_iter` flattens rows ×
+                // cells × children for us.
+                if let Some(found) = find_verbatim_in_items(table.cell_children_iter(), position) {
+                    return Some(found);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 pub fn find_sessions_by_identifier<'a>(

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -24,6 +24,7 @@ lex-babel = { workspace = true, features = ["native-export"] }
 lex-config = { workspace = true }
 lex-extension = { workspace = true }
 lex-extension-host = { workspace = true, features = ["subprocess"] }
+lex-engine = { workspace = true }
 clapfig = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/lex-cli/src/extension_setup.rs
+++ b/crates/lex-cli/src/extension_setup.rs
@@ -1,271 +1,27 @@
-//! Boot the extension registry from CLI flags + `lex.toml`.
+//! CLI-side wiring for the extension boot helper.
 //!
-//! Glue between the CLI argument layer and the
-//! `lex-extension-host` runtime. Given:
-//!
-//! - the workspace root (where the `lex.toml` lives),
-//! - the list of `--ext-schema <path>` flags,
-//! - the `--enable-handlers` flag,
-//! - the host surface (CliOneShot / Ci, auto-detected),
-//!
-//! returns a fully-populated [`Registry`] with the bundled `lex.*`
-//! built-ins plus every namespace declared in `[labels]` plus every
-//! `--ext-schema` directory passed on the command line. Surfaces
-//! diagnostics for unresolvable namespaces / unsupported transports
-//! / trust-gate denials but doesn't fail the boot — a single bad
-//! namespace shouldn't prevent the rest of the host from working.
-//!
-//! ## Subprocess instantiation
-//!
-//! Schemas declaring `handler: { transport: subprocess, command: [...] }`
-//! are routed through the trust gate. On `Trusted`, the boot helper
-//! calls `SubprocessHandler::spawn(...)` and registers the live
-//! handler. On `Denied`, the namespace registers schema-only
-//! (`NoopHandler`) so analysis-pass pre-validation still catches
-//! typos, but `on_validate` / `on_render` etc. return the trait
-//! defaults; the user-facing diagnostic explains why (`use
-//! --enable-handlers in CLI mode` / `prompt declined` / etc.).
-//!
-//! v1 invariant: every schema in a namespace either declares the
-//! same `handler` block or declares none. Mixed handler specs
-//! across labels in a namespace are surfaced as a diagnostic and
-//! treated as schema-only.
-//!
-//! ## What's NOT here
-//!
-//! - Network resolvers (github:/gitlab:/https:/git+ssh:). Those
-//!   live in the resolver and return `Unimplemented`; this boot
-//!   surfaces the error and continues.
-//! - Third-party `transport: native` handlers. Only the bundled
-//!   `lex.*` built-ins use the native transport in v1; user-provided
-//!   native handlers would need an in-process registration path
-//!   the boot doesn't expose.
+//! Re-exports the [`lex_engine::setup`] types so existing call sites in
+//! `main.rs` and `labels_subcommand.rs` keep working with their current
+//! `crate::extension_setup::*` paths, and provides a [`boot_registry`]
+//! shim that injects the CLI-specific [`CliPromptHandler`] (always
+//! denies with a `--enable-handlers` rationale — TTY prompts are an
+//! anti-pattern for one-shot CLI use).
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use lex_extension_host::{TrustDecision, TrustPromptContext, TrustPromptHandler};
 
-use lex_config::LabelsConfig;
-use lex_core::lex::builtins;
-use lex_core::lex::includes::{FsLoader, ResolveConfig};
-use lex_extension::schema::{HandlerSpec, HandlerTransport, Schema};
-use lex_extension::LexHandler;
-use lex_extension_host::transport::{SpawnEnv, SubprocessHandler};
-use lex_extension_host::{
-    detect_ci_environment, resolve_namespace, Capability, Registry, RegistryError, ResolveError,
-    SchemaError, SchemaLoader, Source, Surface, Transport, TrustDecision, TrustGate,
-    TrustPromptContext, TrustPromptHandler, TrustStore,
+pub use lex_engine::setup::{
+    BootDiagnostic, BootOutcome, NamespaceSourceKind, RegisteredNamespace,
 };
 
-/// Inputs the boot helper needs from the CLI layer.
+/// CLI-shaped inputs to [`boot_registry`]. Mirrors
+/// [`lex_engine::setup::ExtensionSetup`] minus the `trust_prompt` field —
+/// the CLI's prompt is fixed.
 pub struct ExtensionSetup<'a> {
-    pub workspace_root: &'a Path,
-    pub labels_config: &'a LabelsConfig,
-    /// Each `--ext-schema <path>` flag on the command line.
-    pub ext_schemas: &'a [PathBuf],
-    /// `--enable-handlers` global flag.
+    pub workspace_root: &'a std::path::Path,
+    pub labels_config: &'a lex_config::LabelsConfig,
+    pub ext_schemas: &'a [std::path::PathBuf],
     pub enable_handlers: bool,
-    /// Surface override. `None` auto-detects from env vars (CI →
-    /// `Surface::Ci`, otherwise `Surface::CliOneShot`).
-    pub surface_override: Option<Surface>,
-}
-
-/// One namespace that was successfully registered, surfaced for
-/// `lexd labels list` output.
-#[derive(Debug, Clone)]
-pub struct RegisteredNamespace {
-    pub name: String,
-    pub source: NamespaceSourceKind,
-    pub schema_count: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NamespaceSourceKind {
-    Builtin,
-    LexToml { uri: String },
-    ExtSchemaFlag { path: PathBuf },
-}
-
-/// One thing that went wrong during boot. Surfaced as a diagnostic
-/// rather than a hard error so a bad namespace doesn't prevent the
-/// host from running with the others.
-#[derive(Debug, Clone)]
-pub struct BootDiagnostic {
-    pub namespace: Option<String>,
-    pub message: String,
-}
-
-/// Outcome of [`boot_registry`]: the registry plus per-namespace
-/// metadata for `lexd labels list` plus the diagnostic stream.
-pub struct BootOutcome {
-    pub registry: Arc<Registry>,
-    pub trust_gate: TrustGate,
-    pub registered: Vec<RegisteredNamespace>,
-    pub diagnostics: Vec<BootDiagnostic>,
-}
-
-/// Construct a registry from the CLI inputs. Always succeeds — bad
-/// namespaces become entries in `diagnostics` rather than aborting
-/// the boot.
-pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
-    let mut registry = Registry::new();
-    let mut registered = Vec::new();
-    let mut diagnostics = Vec::new();
-
-    // Trust gate is built up-front so per-namespace registration
-    // can consult it when deciding whether to spawn a real
-    // SubprocessHandler vs fall back to NoopHandler. The previous
-    // design left registration as schema-only (NoopHandler always)
-    // and constructed the gate after; correct trust-gated dispatch
-    // for subprocess transports needs the gate alive during
-    // registration.
-    let surface = setup.surface_override.unwrap_or_else(|| {
-        if detect_ci_environment(|name| std::env::var(name).ok()) {
-            Surface::Ci
-        } else {
-            Surface::CliOneShot
-        }
-    });
-    let store = TrustStore::open(setup.workspace_root).unwrap_or_else(|e| {
-        // Fall back to a per-process tempdir under `std::env::temp_dir()`.
-        // The PID suffix keeps unrelated runs from sharing trust
-        // decisions through `/tmp/.lex/trust.json` (which the previous
-        // fallback did — accidentally persistent and shared). With a
-        // PID-keyed path the decisions persist within this run but
-        // can't be re-read by the next session.
-        let fallback_dir = std::env::temp_dir()
-            .join(format!("lexd-trust-fallback-{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&fallback_dir);
-        diagnostics.push(BootDiagnostic {
-            namespace: None,
-            message: format!(
-                "trust store open failed at workspace root: {e}; falling back to per-process temp dir `{}` — decisions persist for this run only",
-                fallback_dir.display()
-            ),
-        });
-        TrustStore::open(&fallback_dir).expect("temp dir writable")
-    });
-    let mut trust_gate = TrustGate::new(
-        surface,
-        setup.enable_handlers,
-        store,
-        Box::new(CliPromptHandler),
-    );
-
-    // Built-ins: lex.* namespace (currently `lex.include`). Native
-    // transport, trusted by linkage — gate consultation is a no-op
-    // for native handlers, so the registration goes through
-    // directly. Loader + ResolveConfig are pointed at the workspace
-    // root so `lex.include` resolves relative paths the same way
-    // `lexd convert` and `lexd inspect` do.
-    let resolve_config = ResolveConfig::with_root(setup.workspace_root.to_path_buf());
-    let loader = FsLoader::new(setup.workspace_root.to_path_buf());
-    match builtins::register_into(&registry, Arc::new(loader), resolve_config) {
-        Ok(()) => registered.push(RegisteredNamespace {
-            name: "lex".into(),
-            source: NamespaceSourceKind::Builtin,
-            schema_count: 1,
-        }),
-        Err(e) => diagnostics.push(BootDiagnostic {
-            namespace: Some("lex".into()),
-            message: format!("failed to register lex.* built-ins: {e}"),
-        }),
-    }
-
-    // [labels] block — resolved through the URI resolver.
-    for (name, spec) in &setup.labels_config.namespaces {
-        let uri = match spec.canonical_uri() {
-            Ok(u) => u,
-            Err(e) => {
-                diagnostics.push(BootDiagnostic {
-                    namespace: Some(name.clone()),
-                    message: format!("invalid namespace spec: {e}"),
-                });
-                continue;
-            }
-        };
-        match resolve_namespace(&uri, setup.workspace_root) {
-            Ok(resolved) => {
-                let source = Source::LexTomlNamespace { name: name.clone() };
-                match register_schema_dir(
-                    &mut registry,
-                    &mut trust_gate,
-                    name,
-                    &resolved.schema_dir,
-                    &source,
-                    setup.workspace_root,
-                    &mut diagnostics,
-                ) {
-                    Ok(count) => registered.push(RegisteredNamespace {
-                        name: name.clone(),
-                        source: NamespaceSourceKind::LexToml { uri: uri.clone() },
-                        schema_count: count,
-                    }),
-                    Err(e) => diagnostics.push(BootDiagnostic {
-                        namespace: Some(name.clone()),
-                        message: format!("failed to register schemas: {e}"),
-                    }),
-                }
-            }
-            Err(ResolveError::Unimplemented { .. }) => {
-                diagnostics.push(BootDiagnostic {
-                    namespace: Some(name.clone()),
-                    message: format!(
-                        "namespace `{name}` uses a remote URI scheme that's not yet implemented; use `path:` or `--ext-schema` for now (uri: `{uri}`)"
-                    ),
-                });
-            }
-            Err(e) => diagnostics.push(BootDiagnostic {
-                namespace: Some(name.clone()),
-                message: format!("namespace resolve failed: {e}"),
-            }),
-        }
-    }
-
-    // --ext-schema flags — local schema directories, no resolver.
-    for path in setup.ext_schemas {
-        let dir = if path.is_absolute() {
-            path.clone()
-        } else {
-            setup.workspace_root.join(path)
-        };
-        let namespace = match infer_namespace_from_dir(&dir) {
-            Ok(n) => n,
-            Err(msg) => {
-                diagnostics.push(BootDiagnostic {
-                    namespace: None,
-                    message: format!("--ext-schema {}: {msg}", path.display()),
-                });
-                continue;
-            }
-        };
-        let source = Source::LocalFile { path: path.clone() };
-        match register_schema_dir(
-            &mut registry,
-            &mut trust_gate,
-            &namespace,
-            &dir,
-            &source,
-            setup.workspace_root,
-            &mut diagnostics,
-        ) {
-            Ok(count) => registered.push(RegisteredNamespace {
-                name: namespace,
-                source: NamespaceSourceKind::ExtSchemaFlag { path: path.clone() },
-                schema_count: count,
-            }),
-            Err(e) => diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace),
-                message: format!("--ext-schema {}: {e}", path.display()),
-            }),
-        }
-    }
-
-    BootOutcome {
-        registry: Arc::new(registry),
-        trust_gate,
-        registered,
-        diagnostics,
-    }
+    pub surface_override: Option<lex_extension_host::Surface>,
 }
 
 /// CLI surface installs this prompt: trust prompts in CLI mode are
@@ -273,8 +29,8 @@ pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
 /// user at `--enable-handlers`.
 struct CliPromptHandler;
 impl TrustPromptHandler for CliPromptHandler {
-    fn prompt(&self, ctx: &TrustPromptContext) -> lex_extension_host::TrustDecision {
-        lex_extension_host::TrustDecision::Denied {
+    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
+        TrustDecision::Denied {
             reason: format!(
                 "subprocess handler `{}` requires --enable-handlers in CLI mode",
                 ctx.namespace
@@ -283,408 +39,44 @@ impl TrustPromptHandler for CliPromptHandler {
     }
 }
 
-/// Try to infer the namespace name from a schema directory. Convention:
-/// the directory's basename is the namespace name. (Future work: read
-/// a `namespace.toml` sidecar file if it exists.)
-fn infer_namespace_from_dir(dir: &Path) -> Result<String, String> {
-    dir.file_name()
-        .and_then(|s| s.to_str())
-        .map(String::from)
-        .ok_or_else(|| {
-            format!(
-                "cannot infer namespace name from directory `{}`",
-                dir.display()
-            )
-        })
-}
-
-/// Load every YAML schema in `dir`, decide which handler to back
-/// the namespace with (subprocess via the trust gate, or schema-
-/// only `NoopHandler`), and register everything under `namespace`.
-/// Returns the schema count for `lexd labels list` output.
-///
-/// Handler selection:
-///
-/// - If no schema in the namespace declares a `handler` block,
-///   register a `NoopHandler`. Pre-validation still runs, but
-///   hook events return the trait defaults.
-/// - If schemas declare *different* handler specs, surface a
-///   diagnostic and fall back to `NoopHandler`. v1 assumes one
-///   binary serves the whole namespace.
-/// - If the unique handler spec is `transport: subprocess`,
-///   consult the trust gate. On `Trusted`, spawn the binary and
-///   register the live `SubprocessHandler`. On `Denied`, surface
-///   the gate's reason and register `NoopHandler` (so schema
-///   pre-validation still catches typos).
-/// - `transport: native` is rejected with a "third-party native
-///   handlers are not supported in v1" diagnostic — only bundled
-///   `lex.*` built-ins use the native transport, and they go
-///   through `builtins::register_into` not this path.
-/// - `transport: wasm` is rejected by the schema loader before it
-///   reaches us; defensive.
-fn register_schema_dir(
-    registry: &mut Registry,
-    trust_gate: &mut TrustGate,
-    namespace: &str,
-    dir: &Path,
-    source: &Source,
-    workspace_root: &Path,
-    diagnostics: &mut Vec<BootDiagnostic>,
-) -> Result<usize, RegisterError> {
-    let schemas: Vec<Schema> =
-        SchemaLoader::load_dir(dir).map_err(|e| RegisterError::Schema(Box::new(e)))?;
-    if schemas.is_empty() {
-        return Err(RegisterError::EmptyDir(dir.to_path_buf()));
-    }
-    let count = schemas.len();
-    let handler = build_handler(
-        &schemas,
-        namespace,
-        source,
-        workspace_root,
-        trust_gate,
-        diagnostics,
-    );
-    registry
-        .register_namespace(namespace, schemas, handler)
-        .map_err(RegisterError::Registry)?;
-    Ok(count)
-}
-
-/// Decide which `LexHandler` to back a namespace with. Side-effect:
-/// pushes a diagnostic onto `diagnostics` for any non-trusted /
-/// non-spawnable case before returning the fallback `NoopHandler`.
-fn build_handler(
-    schemas: &[Schema],
-    namespace: &str,
-    source: &Source,
-    workspace_root: &Path,
-    trust_gate: &mut TrustGate,
-    diagnostics: &mut Vec<BootDiagnostic>,
-) -> Box<dyn LexHandler> {
-    let contract = match find_namespace_contract(schemas, namespace) {
-        Ok(c) => c,
-        Err(msg) => {
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: msg,
-            });
-            return Box::new(NoopHandler);
-        }
-    };
-    let handler_spec = match contract.handler {
-        Some(spec) => spec,
-        None => return Box::new(NoopHandler),
-    };
-
-    match handler_spec.transport {
-        HandlerTransport::Subprocess => {}
-        HandlerTransport::Native => {
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: format!(
-                    "namespace `{namespace}` declares transport: native — third-party native handlers are not supported in v1; only bundled lex.* built-ins use the native transport"
-                ),
-            });
-            return Box::new(NoopHandler);
-        }
-        HandlerTransport::Wasm => {
-            // Schema loader rejects WASM upstream; reaching this
-            // branch is defensive.
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: format!("namespace `{namespace}`: WASM transport is deferred for v1"),
-            });
-            return Box::new(NoopHandler);
-        }
-        // HandlerTransport is #[non_exhaustive]; future variants
-        // conservatively register schema-only with a diagnostic.
-        _ => {
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: format!(
-                    "namespace `{namespace}` declares an unrecognised transport; registering schema-only"
-                ),
-            });
-            return Box::new(NoopHandler);
-        }
-    }
-
-    // Subprocess transport — consult the trust gate.
-    let command_string = handler_spec.command.join(" ");
-    let capability = Capability::from_schema(contract.capabilities);
-    let transport = Transport::from_schema(handler_spec.transport);
-    let decision = trust_gate.evaluate(source, transport, capability, namespace, &command_string);
-    match decision {
-        TrustDecision::Trusted => {}
-        TrustDecision::Denied { reason } => {
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: reason,
-            });
-            return Box::new(NoopHandler);
-        }
-        TrustDecision::Pending => {
-            // Defensive — the CLI prompt callback always resolves to
-            // Trusted/Denied. Pending here is a programmer error.
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: format!(
-                    "trust gate returned Pending for `{namespace}` — this should not happen at the CLI surface"
-                ),
-            });
-            return Box::new(NoopHandler);
-        }
-    }
-
-    // Trusted — spawn the binary.
-    let labels: Vec<String> = schemas.iter().map(|s| s.label.clone()).collect();
-    let env = SpawnEnv {
-        workspace_root: Some(workspace_root.display().to_string()),
-        lex_cache: None,
-        handler_config: None,
-    };
-    match SubprocessHandler::spawn(
-        handler_spec,
-        namespace,
-        &labels,
-        contract.capabilities,
-        env!("CARGO_PKG_VERSION"),
-        &env,
-    ) {
-        Ok(h) => Box::new(h),
-        Err(e) => {
-            diagnostics.push(BootDiagnostic {
-                namespace: Some(namespace.into()),
-                message: format!(
-                    "trusted but failed to spawn `{namespace}` handler ({command_string}): {e}"
-                ),
-            });
-            Box::new(NoopHandler)
-        }
-    }
-}
-
-/// One namespace's handler + capability contract, validated as
-/// uniform across all the namespace's schemas.
-///
-/// v1 invariant (called out in the issue scope and now enforced
-/// here): within a namespace, every schema must agree on its
-/// `handler` block AND its `capabilities` block. Mixed `handler`
-/// (some schemas declare it, others don't, or differ in shape)
-/// or mixed `capabilities` (different `fs`/`net` declarations
-/// across labels) are misconfiguration and surface as a diagnostic.
-struct NamespaceContract<'a> {
-    handler: Option<&'a HandlerSpec>,
-    capabilities: lex_extension::schema::Capabilities,
-}
-
-/// Validate that every schema in `schemas` agrees on its `handler`
-/// and `capabilities` blocks, then return the consensus.
-fn find_namespace_contract<'a>(
-    schemas: &'a [Schema],
-    namespace: &str,
-) -> Result<NamespaceContract<'a>, String> {
-    debug_assert!(!schemas.is_empty(), "caller must pass a non-empty slice");
-    let first = &schemas[0];
-    let first_handler = first.handler.as_ref();
-    let first_caps = first.capabilities;
-
-    for (idx, s) in schemas.iter().enumerate().skip(1) {
-        if s.handler.as_ref() != first_handler {
-            return Err(format!(
-                "namespace `{namespace}` has schemas declaring inconsistent `handler` blocks (label `{}` differs from `{}`); v1 requires every schema in a namespace to declare the same handler — or all of them to declare none",
-                s.label, schemas[0].label
-            ));
-        }
-        if s.capabilities != first_caps {
-            return Err(format!(
-                "namespace `{namespace}` has schemas declaring inconsistent `capabilities` blocks (label `{}` differs from `{}`); v1 requires uniform capabilities per namespace",
-                s.label, schemas[0].label
-            ));
-        }
-        let _ = idx;
-    }
-
-    Ok(NamespaceContract {
-        handler: first_handler,
-        capabilities: first_caps,
+/// Boot the registry for the CLI surface. Thin wrapper that fills in
+/// the [`CliPromptHandler`] and forwards to [`lex_engine::setup::boot_registry`].
+pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
+    lex_engine::setup::boot_registry(lex_engine::setup::ExtensionSetup {
+        workspace_root: setup.workspace_root,
+        labels_config: setup.labels_config,
+        ext_schemas: setup.ext_schemas,
+        enable_handlers: setup.enable_handlers,
+        surface_override: setup.surface_override,
+        trust_prompt: Box::new(CliPromptHandler),
+        // Reports `lexd`'s version to subprocess handlers in their
+        // initialize handshake — what handlers expect to see, not the
+        // `lex-engine` boot crate's version.
+        host_version: env!("CARGO_PKG_VERSION"),
     })
 }
 
-#[derive(Debug)]
-enum RegisterError {
-    Schema(Box<SchemaError>),
-    Registry(RegistryError),
-    EmptyDir(PathBuf),
-}
-
-impl std::fmt::Display for RegisterError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RegisterError::Schema(e) => write!(f, "schema load: {e}"),
-            RegisterError::Registry(e) => write!(f, "registry register: {e}"),
-            RegisterError::EmptyDir(p) => write!(
-                f,
-                "schema directory `{}` contains no .yaml files",
-                p.display()
-            ),
-        }
-    }
-}
-
-/// No-op handler used for schema-only registration. Returns the
-/// trait defaults for every hook; the dispatcher's pre-validation
-/// pass still surfaces schema mismatches even with this stub.
-struct NoopHandler;
-impl lex_extension::LexHandler for NoopHandler {}
-
 #[cfg(test)]
 mod tests {
+    //! CLI-side smoke tests. The exhaustive coverage of every
+    //! [`build_handler`] branch lives in `lex-engine::setup::tests`;
+    //! the tests here verify the CLI shim wires the
+    //! [`CliPromptHandler`] correctly and the deny rationale mentions
+    //! `--enable-handlers` (which is what end users see).
     use super::*;
-    use lex_config::{NamespaceSpec, NamespaceTable};
-    use std::collections::BTreeMap;
-
-    fn write_schema(dir: &Path, label: &str) {
-        std::fs::create_dir_all(dir).unwrap();
-        std::fs::write(
-            dir.join(format!("{}.yaml", label.replace('.', "_"))),
-            format!("schema_version: 1\nlabel: {label}\n"),
-        )
-        .unwrap();
-    }
-
-    /// Schema with a subprocess handler block. Used to drive the
-    /// trust-gate instantiation paths.
-    fn write_schema_with_subprocess_handler(dir: &Path, label: &str, command: &[&str]) {
-        std::fs::create_dir_all(dir).unwrap();
-        let cmd_yaml = command
-            .iter()
-            .map(|c| format!("\"{c}\""))
-            .collect::<Vec<_>>()
-            .join(", ");
-        std::fs::write(
-            dir.join(format!("{}.yaml", label.replace('.', "_"))),
-            format!(
-                "schema_version: 1\n\
-                 label: {label}\n\
-                 handler:\n  \
-                 transport: subprocess\n  \
-                 command: [{cmd_yaml}]\n"
-            ),
-        )
-        .unwrap();
-    }
+    use lex_config::LabelsConfig;
+    use lex_extension_host::Surface;
 
     #[test]
-    fn boot_with_empty_inputs_yields_only_builtin() {
-        let workspace = tempfile::tempdir().unwrap();
-        let labels = LabelsConfig::default();
-        let setup = ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[],
-            enable_handlers: false,
-            surface_override: Some(Surface::CliOneShot),
-        };
-        let outcome = boot_registry(setup);
-        assert_eq!(outcome.registered.len(), 1);
-        assert_eq!(outcome.registered[0].name, "lex");
-        assert_eq!(outcome.registered[0].source, NamespaceSourceKind::Builtin);
-        assert!(outcome.diagnostics.is_empty());
-    }
-
-    #[test]
-    fn boot_with_path_uri_in_labels_registers_namespace() {
-        let workspace = tempfile::tempdir().unwrap();
-        let acme_dir = workspace.path().join("acme-labels");
-        write_schema(&acme_dir, "acme.task");
-
-        let mut namespaces = BTreeMap::new();
-        namespaces.insert("acme".into(), NamespaceSpec::Uri("path:acme-labels".into()));
-        let labels = LabelsConfig { namespaces };
-
-        let setup = ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[],
-            enable_handlers: false,
-            surface_override: Some(Surface::CliOneShot),
-        };
-        let outcome = boot_registry(setup);
-        let acme = outcome
-            .registered
-            .iter()
-            .find(|r| r.name == "acme")
-            .expect("acme registered");
-        assert_eq!(acme.schema_count, 1);
-        assert!(matches!(acme.source, NamespaceSourceKind::LexToml { .. }));
-        assert!(outcome.diagnostics.is_empty());
-    }
-
-    #[test]
-    fn boot_with_remote_uri_emits_unimplemented_diagnostic() {
-        let workspace = tempfile::tempdir().unwrap();
-        let mut namespaces = BTreeMap::new();
-        namespaces.insert(
-            "acme".into(),
-            NamespaceSpec::Table(NamespaceTable {
-                tap: Some("acme".into()),
-                ..Default::default()
-            }),
-        );
-        let labels = LabelsConfig { namespaces };
-
-        let setup = ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[],
-            enable_handlers: false,
-            surface_override: Some(Surface::CliOneShot),
-        };
-        let outcome = boot_registry(setup);
-        assert_eq!(outcome.diagnostics.len(), 1);
-        let diag = &outcome.diagnostics[0];
-        assert_eq!(diag.namespace.as_deref(), Some("acme"));
-        assert!(diag.message.contains("not yet implemented"));
-        // No `acme` in `registered` (only `lex` builtin).
-        assert!(!outcome.registered.iter().any(|r| r.name == "acme"));
-    }
-
-    #[test]
-    fn boot_with_ext_schema_flag_registers_namespace() {
+    fn cli_subprocess_handler_without_enable_flag_says_enable_handlers() {
         let workspace = tempfile::tempdir().unwrap();
         let acme_dir = workspace.path().join("acme");
-        write_schema(&acme_dir, "acme.task");
-
-        let labels = LabelsConfig::default();
-        let setup = ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[acme_dir.clone()],
-            enable_handlers: false,
-            surface_override: Some(Surface::CliOneShot),
-        };
-        let outcome = boot_registry(setup);
-        let acme = outcome
-            .registered
-            .iter()
-            .find(|r| r.name == "acme")
-            .expect("registered");
-        assert!(matches!(
-            acme.source,
-            NamespaceSourceKind::ExtSchemaFlag { .. }
-        ));
-    }
-
-    /// Subprocess handler + CLI surface + no `--enable-handlers`:
-    /// trust gate denies, namespace registers schema-only with a
-    /// diagnostic naming `--enable-handlers`.
-    #[test]
-    fn subprocess_handler_without_enable_flag_is_denied_and_schema_only() {
-        let workspace = tempfile::tempdir().unwrap();
-        let acme_dir = workspace.path().join("acme");
-        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-handler"]);
+        std::fs::create_dir_all(&acme_dir).unwrap();
+        std::fs::write(
+            acme_dir.join("task.yaml"),
+            "schema_version: 1\nlabel: acme.task\nhandler:\n  transport: subprocess\n  command: [\"acme-handler\"]\n",
+        )
+        .unwrap();
 
         let labels = LabelsConfig::default();
         let outcome = boot_registry(ExtensionSetup {
@@ -694,8 +86,6 @@ mod tests {
             enable_handlers: false,
             surface_override: Some(Surface::CliOneShot),
         });
-        // Namespace IS registered (so pre-validation still works
-        // when analysing documents), but with a diagnostic.
         assert!(outcome.registered.iter().any(|r| r.name == "acme"));
         assert!(
             outcome
@@ -706,179 +96,5 @@ mod tests {
             "expected --enable-handlers diagnostic, got: {:?}",
             outcome.diagnostics
         );
-    }
-
-    /// Subprocess handler + CLI + `--enable-handlers`: the trust
-    /// gate trusts the namespace and `SubprocessHandler::spawn` is
-    /// called. The test points the schema at a non-existent path
-    /// — `spawn` then fails at `Command::spawn` with a clear "no
-    /// such file" error, surfaced as a `trusted but failed to spawn`
-    /// diagnostic. Verifying the diagnostic exists is what proves
-    /// the trust gate let the request through; without that pass,
-    /// we'd see the `--enable-handlers` denial instead.
-    #[test]
-    fn subprocess_handler_with_enable_flag_attempts_spawn() {
-        let workspace = tempfile::tempdir().unwrap();
-        let acme_dir = workspace.path().join("acme");
-        write_schema_with_subprocess_handler(
-            &acme_dir,
-            "acme.task",
-            &["/this/binary/does/not/exist"],
-        );
-
-        let labels = LabelsConfig::default();
-        let outcome = boot_registry(ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[acme_dir.clone()],
-            enable_handlers: true,
-            surface_override: Some(Surface::CliOneShot),
-        });
-        // Namespace registered (schema-only fallback after spawn
-        // failure). Diagnostic mentions "failed to spawn" — proving
-        // the trust gate let the request through and the spawn
-        // attempt actually fired.
-        assert!(outcome.registered.iter().any(|r| r.name == "acme"));
-        assert!(
-            outcome
-                .diagnostics
-                .iter()
-                .any(|d| d.message.contains("failed to spawn")),
-            "expected spawn-failure diagnostic, got: {:?}",
-            outcome.diagnostics
-        );
-    }
-
-    /// Mixed handler specs across schemas in one namespace is
-    /// rejected with a clear diagnostic. v1 requires one handler
-    /// per namespace.
-    #[test]
-    fn mixed_handler_specs_in_one_namespace_emit_diagnostic() {
-        let workspace = tempfile::tempdir().unwrap();
-        let acme_dir = workspace.path().join("acme");
-        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-v1"]);
-        write_schema_with_subprocess_handler(&acme_dir, "acme.note", &["acme-v2"]);
-
-        let labels = LabelsConfig::default();
-        let outcome = boot_registry(ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[acme_dir],
-            enable_handlers: true,
-            surface_override: Some(Surface::CliOneShot),
-        });
-        assert!(
-            outcome
-                .diagnostics
-                .iter()
-                .any(|d| d.message.contains("inconsistent `handler` blocks")),
-            "expected mixed-handler diagnostic, got: {:?}",
-            outcome.diagnostics
-        );
-    }
-
-    /// Partial handler declaration — some schemas in the namespace
-    /// declare a `handler` block, others don't — also surfaces as
-    /// "inconsistent handler blocks". v1 requires the declaration
-    /// to be uniform: all-have or all-don't.
-    #[test]
-    fn partial_handler_declaration_in_one_namespace_emits_diagnostic() {
-        let workspace = tempfile::tempdir().unwrap();
-        let acme_dir = workspace.path().join("acme");
-        // task has a handler, note does not.
-        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-bin"]);
-        write_schema(&acme_dir, "acme.note");
-
-        let labels = LabelsConfig::default();
-        let outcome = boot_registry(ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[acme_dir],
-            enable_handlers: true,
-            surface_override: Some(Surface::CliOneShot),
-        });
-        assert!(
-            outcome
-                .diagnostics
-                .iter()
-                .any(|d| d.message.contains("inconsistent `handler` blocks")),
-            "expected partial-handler diagnostic, got: {:?}",
-            outcome.diagnostics
-        );
-    }
-
-    /// Mixed `capabilities` blocks across schemas in one namespace
-    /// is also a misconfiguration — capabilities feed the trust gate
-    /// and the spawn handshake, both of which need a single
-    /// authoritative answer per namespace.
-    #[test]
-    fn mixed_capabilities_in_one_namespace_emit_diagnostic() {
-        let workspace = tempfile::tempdir().unwrap();
-        let acme_dir = workspace.path().join("acme");
-        std::fs::create_dir_all(&acme_dir).unwrap();
-        std::fs::write(
-            acme_dir.join("task.yaml"),
-            "schema_version: 1\nlabel: acme.task\ncapabilities: { fs: true, net: false }\n",
-        )
-        .unwrap();
-        std::fs::write(
-            acme_dir.join("note.yaml"),
-            "schema_version: 1\nlabel: acme.note\ncapabilities: { fs: false, net: true }\n",
-        )
-        .unwrap();
-
-        let labels = LabelsConfig::default();
-        let outcome = boot_registry(ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[acme_dir],
-            enable_handlers: false,
-            surface_override: Some(Surface::CliOneShot),
-        });
-        assert!(
-            outcome
-                .diagnostics
-                .iter()
-                .any(|d| d.message.contains("inconsistent `capabilities`")),
-            "expected mixed-capabilities diagnostic, got: {:?}",
-            outcome.diagnostics
-        );
-    }
-
-    #[test]
-    fn ext_schema_flag_with_no_yaml_files_emits_diagnostic() {
-        let workspace = tempfile::tempdir().unwrap();
-        let empty_dir = workspace.path().join("empty");
-        std::fs::create_dir(&empty_dir).unwrap();
-
-        let labels = LabelsConfig::default();
-        let setup = ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[empty_dir],
-            enable_handlers: false,
-            surface_override: Some(Surface::CliOneShot),
-        };
-        let outcome = boot_registry(setup);
-        assert!(outcome
-            .diagnostics
-            .iter()
-            .any(|d| d.message.contains("contains no .yaml files")));
-    }
-
-    #[test]
-    fn surface_override_threads_through_to_trust_gate() {
-        let workspace = tempfile::tempdir().unwrap();
-        let labels = LabelsConfig::default();
-        let setup = ExtensionSetup {
-            workspace_root: workspace.path(),
-            labels_config: &labels,
-            ext_schemas: &[],
-            enable_handlers: true,
-            surface_override: Some(Surface::Ci),
-        };
-        let outcome = boot_registry(setup);
-        assert_eq!(outcome.trust_gate.surface(), Surface::Ci);
-        assert!(outcome.trust_gate.enable_handlers());
     }
 }

--- a/crates/lex-engine/Cargo.toml
+++ b/crates/lex-engine/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "lex-engine"
+version = "0.1.0"
+edition = "2021"
+authors = ["lex contributors"]
+description = "Boot helper + extension setup glue for lex hosts (lexd CLI, lexd-lsp). The future home of Engine::builder() for embedders."
+license = "MIT"
+repository = "https://github.com/lex-fmt/lex"
+keywords = ["lex", "extensions", "engine"]
+categories = ["development-tools"]
+
+[lib]
+doctest = false
+
+[dependencies]
+lex-core = { workspace = true }
+lex-config = { workspace = true }
+lex-extension = { workspace = true }
+lex-extension-host = { workspace = true, features = ["subprocess"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/lex-engine/src/lib.rs
+++ b/crates/lex-engine/src/lib.rs
@@ -1,0 +1,24 @@
+//! Engine glue for lex hosts (lexd CLI, lexd-lsp, future embedders).
+//!
+//! Today this crate hosts the [`setup::boot_registry`] helper that turns a
+//! workspace root + `lex.toml` `[labels]` block + ext-schema flags + a
+//! [`TrustPromptHandler`] of the host's choosing into a populated
+//! [`Registry`] with the bundled `lex.*` built-ins, third-party namespaces
+//! (resolved through `lex-extension-host`'s URI resolver), and any
+//! `--ext-schema <dir>` directories the host wants to add. Diagnostics are
+//! surfaced rather than fatal — a single misconfigured namespace shouldn't
+//! break the rest of the host.
+//!
+//! In a later PR (the planned PR 11), this crate gains a public
+//! [`Engine::builder()`] API for third-party Rust embedders. The setup
+//! helper here is the implementation seam under the hood.
+//!
+//! [`Registry`]: lex_extension_host::Registry
+//! [`TrustPromptHandler`]: lex_extension_host::TrustPromptHandler
+
+pub mod setup;
+
+pub use setup::{
+    boot_registry, BootDiagnostic, BootOutcome, ExtensionSetup, NamespaceSourceKind,
+    RegisteredNamespace,
+};

--- a/crates/lex-engine/src/setup.rs
+++ b/crates/lex-engine/src/setup.rs
@@ -13,7 +13,8 @@
 //!   `None`),
 //! - a [`TrustPromptHandler`] specific to the host (CLI prompts deny with
 //!   a message about `--enable-handlers`; LSP forwards a `lex/trustRequest`
-//!   notification; embedders inject whatever fits their UX),
+//!   custom request to the editor and awaits the user's reply; embedders
+//!   inject whatever fits their UX),
 //!
 //! returns a fully-populated [`Registry`] with the bundled `lex.*`
 //! built-ins plus every namespace declared in `[labels]` plus every
@@ -79,9 +80,9 @@ pub struct ExtensionSetup<'a> {
     pub surface_override: Option<Surface>,
     /// Host-supplied trust prompt. The CLI installs a prompt that denies
     /// with a `--enable-handlers` rationale; the LSP installs one that
-    /// forwards a `lex/trustRequest` notification to the editor;
-    /// embedders inject whatever fits their UX (or an "auto-deny" stub
-    /// for batch / non-interactive use).
+    /// forwards a `lex/trustRequest` custom request to the editor and
+    /// awaits the user's reply; embedders inject whatever fits their
+    /// UX (or an "auto-deny" stub for batch / non-interactive use).
     pub trust_prompt: Box<dyn TrustPromptHandler>,
     /// Host crate version (typically `env!("CARGO_PKG_VERSION")`)
     /// reported to subprocess handlers in their `initialize`
@@ -175,8 +176,31 @@ pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
     // directly. Loader + ResolveConfig are pointed at the workspace
     // root so `lex.include` resolves relative paths the same way
     // `lexd convert` and `lexd inspect` do.
-    let resolve_config = ResolveConfig::with_root(setup.workspace_root.to_path_buf());
-    let loader = FsLoader::new(setup.workspace_root.to_path_buf());
+    //
+    // ResolveConfig.root must be canonical (absolute, symlinks
+    // resolved): the include resolver's root-escape prefix check
+    // compares paths byte-for-byte, and a relative or unnormalized
+    // workspace root would weaken the check on macOS where
+    // `/var → /private/var` symlinks every fresh tempdir. Fall back
+    // to the as-supplied path with a diagnostic if canonicalize
+    // fails — the resolver will still work for absolute include
+    // paths and we don't want a non-canonical workspace to fail
+    // boot entirely.
+    let resolve_root = match setup.workspace_root.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            diagnostics.push(BootDiagnostic {
+                namespace: None,
+                message: format!(
+                    "could not canonicalize workspace root `{}`: {e}; include root-escape checks may be weakened",
+                    setup.workspace_root.display()
+                ),
+            });
+            setup.workspace_root.to_path_buf()
+        }
+    };
+    let resolve_config = ResolveConfig::with_root(resolve_root.clone());
+    let loader = FsLoader::new(resolve_root);
     match builtins::register_into(&registry, Arc::new(loader), resolve_config) {
         Ok(()) => registered.push(RegisteredNamespace {
             name: "lex".into(),

--- a/crates/lex-engine/src/setup.rs
+++ b/crates/lex-engine/src/setup.rs
@@ -1,0 +1,925 @@
+//! Boot the extension registry from host inputs (workspace + `lex.toml` +
+//! ext-schema directories + a host-supplied trust prompt).
+//!
+//! Glue between a lex host (the `lexd` CLI, `lexd-lsp` server, or an
+//! embedder using the future `Engine::builder()`) and the
+//! `lex-extension-host` runtime. Given:
+//!
+//! - the workspace root (where the `lex.toml` lives),
+//! - the `[labels]` block from the parsed config,
+//! - the list of `--ext-schema <path>` directories (or equivalent),
+//! - the `--enable-handlers` flag (CLI; `false` for LSP/embedder by default),
+//! - the host surface (CliOneShot / Lsp / Embedded / Ci, auto-detected on
+//!   `None`),
+//! - a [`TrustPromptHandler`] specific to the host (CLI prompts deny with
+//!   a message about `--enable-handlers`; LSP forwards a `lex/trustRequest`
+//!   notification; embedders inject whatever fits their UX),
+//!
+//! returns a fully-populated [`Registry`] with the bundled `lex.*`
+//! built-ins plus every namespace declared in `[labels]` plus every
+//! ext-schema directory passed in. Surfaces diagnostics for unresolvable
+//! namespaces / unsupported transports / trust-gate denials but doesn't
+//! fail the boot — a single bad namespace shouldn't prevent the rest of
+//! the host from working.
+//!
+//! ## Subprocess instantiation
+//!
+//! Schemas declaring `handler: { transport: subprocess, command: [...] }`
+//! are routed through the trust gate. On `Trusted`, the boot helper
+//! calls `SubprocessHandler::spawn(...)` and registers the live
+//! handler. On `Denied`, the namespace registers schema-only
+//! (`NoopHandler`) so analysis-pass pre-validation still catches
+//! typos, but `on_validate` / `on_render` etc. return the trait
+//! defaults; the user-facing diagnostic explains why.
+//!
+//! v1 invariant: every schema in a namespace either declares the
+//! same `handler` block or declares none. Mixed handler specs
+//! across labels in a namespace are surfaced as a diagnostic and
+//! treated as schema-only.
+//!
+//! ## What's NOT here
+//!
+//! - Network resolvers (github:/gitlab:/https:/git+ssh:). Those
+//!   live in the resolver and return `Unimplemented`; this boot
+//!   surfaces the error and continues. Tracked at lex#546.
+//! - Third-party `transport: native` handlers. Only the bundled
+//!   `lex.*` built-ins use the native transport in v1; user-provided
+//!   native handlers would need an in-process registration path
+//!   the boot doesn't expose.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use lex_config::LabelsConfig;
+use lex_core::lex::builtins;
+use lex_core::lex::includes::{FsLoader, ResolveConfig};
+use lex_extension::schema::{HandlerSpec, HandlerTransport, Schema};
+use lex_extension::LexHandler;
+use lex_extension_host::transport::{SpawnEnv, SubprocessHandler};
+use lex_extension_host::{
+    detect_ci_environment, resolve_namespace, Capability, Registry, RegistryError, ResolveError,
+    SchemaError, SchemaLoader, Source, Surface, Transport, TrustDecision, TrustGate,
+    TrustPromptHandler, TrustStore,
+};
+
+/// Inputs the boot helper needs from the host layer.
+pub struct ExtensionSetup<'a> {
+    pub workspace_root: &'a Path,
+    pub labels_config: &'a LabelsConfig,
+    /// Each `--ext-schema <path>` flag on the command line (CLI), or an
+    /// equivalent host-provided list. LSP / embedders typically pass an
+    /// empty slice.
+    pub ext_schemas: &'a [PathBuf],
+    /// `--enable-handlers` global flag (CLI). `false` for LSP/embedder
+    /// hosts whose trust prompt drives the decision.
+    pub enable_handlers: bool,
+    /// Surface override. `None` auto-detects from env vars (CI →
+    /// `Surface::Ci`, otherwise `Surface::CliOneShot`). Hosts that know
+    /// their own surface (LSP / embedder) should pass it explicitly.
+    pub surface_override: Option<Surface>,
+    /// Host-supplied trust prompt. The CLI installs a prompt that denies
+    /// with a `--enable-handlers` rationale; the LSP installs one that
+    /// forwards a `lex/trustRequest` notification to the editor;
+    /// embedders inject whatever fits their UX (or an "auto-deny" stub
+    /// for batch / non-interactive use).
+    pub trust_prompt: Box<dyn TrustPromptHandler>,
+    /// Host crate version (typically `env!("CARGO_PKG_VERSION")`)
+    /// reported to subprocess handlers in their `initialize`
+    /// handshake. The host (`lexd` / `lexd-lsp` / an embedder) supplies
+    /// its own version, *not* `lex-engine`'s — handlers expect to see
+    /// the host they're running under, not the boot helper crate.
+    pub host_version: &'a str,
+}
+
+/// One namespace that was successfully registered, surfaced for
+/// `lexd labels list` output.
+#[derive(Debug, Clone)]
+pub struct RegisteredNamespace {
+    pub name: String,
+    pub source: NamespaceSourceKind,
+    pub schema_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceSourceKind {
+    Builtin,
+    LexToml { uri: String },
+    ExtSchemaFlag { path: PathBuf },
+}
+
+/// One thing that went wrong during boot. Surfaced as a diagnostic
+/// rather than a hard error so a bad namespace doesn't prevent the
+/// host from running with the others.
+#[derive(Debug, Clone)]
+pub struct BootDiagnostic {
+    pub namespace: Option<String>,
+    pub message: String,
+}
+
+/// Outcome of [`boot_registry`]: the registry plus per-namespace
+/// metadata for `lexd labels list` plus the diagnostic stream.
+pub struct BootOutcome {
+    pub registry: Arc<Registry>,
+    pub trust_gate: TrustGate,
+    pub registered: Vec<RegisteredNamespace>,
+    pub diagnostics: Vec<BootDiagnostic>,
+}
+
+/// Construct a registry from the host inputs. Always succeeds — bad
+/// namespaces become entries in `diagnostics` rather than aborting
+/// the boot.
+pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
+    let mut registry = Registry::new();
+    let mut registered = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    // Trust gate is built up-front so per-namespace registration
+    // can consult it when deciding whether to spawn a real
+    // SubprocessHandler vs fall back to NoopHandler. The previous
+    // design left registration as schema-only (NoopHandler always)
+    // and constructed the gate after; correct trust-gated dispatch
+    // for subprocess transports needs the gate alive during
+    // registration.
+    let surface = setup.surface_override.unwrap_or_else(|| {
+        if detect_ci_environment(|name| std::env::var(name).ok()) {
+            Surface::Ci
+        } else {
+            Surface::CliOneShot
+        }
+    });
+    let store = TrustStore::open(setup.workspace_root).unwrap_or_else(|e| {
+        // Fall back to a per-process tempdir under `std::env::temp_dir()`.
+        // The PID suffix keeps unrelated runs from sharing trust
+        // decisions through `/tmp/.lex/trust.json` (which the previous
+        // fallback did — accidentally persistent and shared). With a
+        // PID-keyed path the decisions persist within this run but
+        // can't be re-read by the next session.
+        let fallback_dir = std::env::temp_dir()
+            .join(format!("lexd-trust-fallback-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&fallback_dir);
+        diagnostics.push(BootDiagnostic {
+            namespace: None,
+            message: format!(
+                "trust store open failed at workspace root: {e}; falling back to per-process temp dir `{}` — decisions persist for this run only",
+                fallback_dir.display()
+            ),
+        });
+        TrustStore::open(&fallback_dir).expect("temp dir writable")
+    });
+    let mut trust_gate = TrustGate::new(surface, setup.enable_handlers, store, setup.trust_prompt);
+    let host_version = setup.host_version;
+
+    // Built-ins: lex.* namespace (currently `lex.include`). Native
+    // transport, trusted by linkage — gate consultation is a no-op
+    // for native handlers, so the registration goes through
+    // directly. Loader + ResolveConfig are pointed at the workspace
+    // root so `lex.include` resolves relative paths the same way
+    // `lexd convert` and `lexd inspect` do.
+    let resolve_config = ResolveConfig::with_root(setup.workspace_root.to_path_buf());
+    let loader = FsLoader::new(setup.workspace_root.to_path_buf());
+    match builtins::register_into(&registry, Arc::new(loader), resolve_config) {
+        Ok(()) => registered.push(RegisteredNamespace {
+            name: "lex".into(),
+            source: NamespaceSourceKind::Builtin,
+            schema_count: 1,
+        }),
+        Err(e) => diagnostics.push(BootDiagnostic {
+            namespace: Some("lex".into()),
+            message: format!("failed to register lex.* built-ins: {e}"),
+        }),
+    }
+
+    // [labels] block — resolved through the URI resolver.
+    for (name, spec) in &setup.labels_config.namespaces {
+        let uri = match spec.canonical_uri() {
+            Ok(u) => u,
+            Err(e) => {
+                diagnostics.push(BootDiagnostic {
+                    namespace: Some(name.clone()),
+                    message: format!("invalid namespace spec: {e}"),
+                });
+                continue;
+            }
+        };
+        match resolve_namespace(&uri, setup.workspace_root) {
+            Ok(resolved) => {
+                let source = Source::LexTomlNamespace { name: name.clone() };
+                match register_schema_dir(
+                    &mut registry,
+                    &mut trust_gate,
+                    name,
+                    &resolved.schema_dir,
+                    &source,
+                    setup.workspace_root,
+                    host_version,
+                    &mut diagnostics,
+                ) {
+                    Ok(count) => registered.push(RegisteredNamespace {
+                        name: name.clone(),
+                        source: NamespaceSourceKind::LexToml { uri: uri.clone() },
+                        schema_count: count,
+                    }),
+                    Err(e) => diagnostics.push(BootDiagnostic {
+                        namespace: Some(name.clone()),
+                        message: format!("failed to register schemas: {e}"),
+                    }),
+                }
+            }
+            Err(ResolveError::Unimplemented { .. }) => {
+                diagnostics.push(BootDiagnostic {
+                    namespace: Some(name.clone()),
+                    message: format!(
+                        "namespace `{name}` uses a remote URI scheme that's not yet implemented; use `path:` or `--ext-schema` for now (uri: `{uri}`)"
+                    ),
+                });
+            }
+            Err(e) => diagnostics.push(BootDiagnostic {
+                namespace: Some(name.clone()),
+                message: format!("namespace resolve failed: {e}"),
+            }),
+        }
+    }
+
+    // --ext-schema flags — local schema directories, no resolver.
+    for path in setup.ext_schemas {
+        let dir = if path.is_absolute() {
+            path.clone()
+        } else {
+            setup.workspace_root.join(path)
+        };
+        let namespace = match infer_namespace_from_dir(&dir) {
+            Ok(n) => n,
+            Err(msg) => {
+                diagnostics.push(BootDiagnostic {
+                    namespace: None,
+                    message: format!("--ext-schema {}: {msg}", path.display()),
+                });
+                continue;
+            }
+        };
+        let source = Source::LocalFile { path: path.clone() };
+        match register_schema_dir(
+            &mut registry,
+            &mut trust_gate,
+            &namespace,
+            &dir,
+            &source,
+            setup.workspace_root,
+            host_version,
+            &mut diagnostics,
+        ) {
+            Ok(count) => registered.push(RegisteredNamespace {
+                name: namespace,
+                source: NamespaceSourceKind::ExtSchemaFlag { path: path.clone() },
+                schema_count: count,
+            }),
+            Err(e) => diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace),
+                message: format!("--ext-schema {}: {e}", path.display()),
+            }),
+        }
+    }
+
+    BootOutcome {
+        registry: Arc::new(registry),
+        trust_gate,
+        registered,
+        diagnostics,
+    }
+}
+
+/// Try to infer the namespace name from a schema directory. Convention:
+/// the directory's basename is the namespace name. (Future work: read
+/// a `namespace.toml` sidecar file if it exists.)
+fn infer_namespace_from_dir(dir: &Path) -> Result<String, String> {
+    dir.file_name()
+        .and_then(|s| s.to_str())
+        .map(String::from)
+        .ok_or_else(|| {
+            format!(
+                "cannot infer namespace name from directory `{}`",
+                dir.display()
+            )
+        })
+}
+
+/// Load every YAML schema in `dir`, decide which handler to back
+/// the namespace with (subprocess via the trust gate, or schema-
+/// only `NoopHandler`), and register everything under `namespace`.
+/// Returns the schema count for `lexd labels list` output.
+///
+/// Handler selection:
+///
+/// - If no schema in the namespace declares a `handler` block,
+///   register a `NoopHandler`. Pre-validation still runs, but
+///   hook events return the trait defaults.
+/// - If schemas declare *different* handler specs, surface a
+///   diagnostic and fall back to `NoopHandler`. v1 assumes one
+///   binary serves the whole namespace.
+/// - If the unique handler spec is `transport: subprocess`,
+///   consult the trust gate. On `Trusted`, spawn the binary and
+///   register the live `SubprocessHandler`. On `Denied`, surface
+///   the gate's reason and register `NoopHandler` (so schema
+///   pre-validation still catches typos).
+/// - `transport: native` is rejected with a "third-party native
+///   handlers are not supported in v1" diagnostic — only bundled
+///   `lex.*` built-ins use the native transport, and they go
+///   through `builtins::register_into` not this path.
+/// - `transport: wasm` is rejected by the schema loader before it
+///   reaches us; defensive.
+// 8-argument boot helper. Bundling the inputs into a struct just to
+// satisfy this lint adds boilerplate without simplifying anything; the
+// signature is read top-to-bottom in one site (`boot_registry`).
+#[allow(clippy::too_many_arguments)]
+fn register_schema_dir(
+    registry: &mut Registry,
+    trust_gate: &mut TrustGate,
+    namespace: &str,
+    dir: &Path,
+    source: &Source,
+    workspace_root: &Path,
+    host_version: &str,
+    diagnostics: &mut Vec<BootDiagnostic>,
+) -> Result<usize, RegisterError> {
+    let schemas: Vec<Schema> =
+        SchemaLoader::load_dir(dir).map_err(|e| RegisterError::Schema(Box::new(e)))?;
+    if schemas.is_empty() {
+        return Err(RegisterError::EmptyDir(dir.to_path_buf()));
+    }
+    let count = schemas.len();
+    let handler = build_handler(
+        &schemas,
+        namespace,
+        source,
+        workspace_root,
+        host_version,
+        trust_gate,
+        diagnostics,
+    );
+    registry
+        .register_namespace(namespace, schemas, handler)
+        .map_err(RegisterError::Registry)?;
+    Ok(count)
+}
+
+/// Decide which `LexHandler` to back a namespace with. Side-effect:
+/// pushes a diagnostic onto `diagnostics` for any non-trusted /
+/// non-spawnable case before returning the fallback `NoopHandler`.
+fn build_handler(
+    schemas: &[Schema],
+    namespace: &str,
+    source: &Source,
+    workspace_root: &Path,
+    host_version: &str,
+    trust_gate: &mut TrustGate,
+    diagnostics: &mut Vec<BootDiagnostic>,
+) -> Box<dyn LexHandler> {
+    let contract = match find_namespace_contract(schemas, namespace) {
+        Ok(c) => c,
+        Err(msg) => {
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: msg,
+            });
+            return Box::new(NoopHandler);
+        }
+    };
+    let handler_spec = match contract.handler {
+        Some(spec) => spec,
+        None => return Box::new(NoopHandler),
+    };
+
+    match handler_spec.transport {
+        HandlerTransport::Subprocess => {}
+        HandlerTransport::Native => {
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: format!(
+                    "namespace `{namespace}` declares transport: native — third-party native handlers are not supported in v1; only bundled lex.* built-ins use the native transport"
+                ),
+            });
+            return Box::new(NoopHandler);
+        }
+        HandlerTransport::Wasm => {
+            // Schema loader rejects WASM upstream; reaching this
+            // branch is defensive.
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: format!("namespace `{namespace}`: WASM transport is deferred for v1"),
+            });
+            return Box::new(NoopHandler);
+        }
+        // HandlerTransport is #[non_exhaustive]; future variants
+        // conservatively register schema-only with a diagnostic.
+        _ => {
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: format!(
+                    "namespace `{namespace}` declares an unrecognised transport; registering schema-only"
+                ),
+            });
+            return Box::new(NoopHandler);
+        }
+    }
+
+    // Subprocess transport — consult the trust gate.
+    let command_string = handler_spec.command.join(" ");
+    let capability = Capability::from_schema(contract.capabilities);
+    let transport = Transport::from_schema(handler_spec.transport);
+    let decision = trust_gate.evaluate(source, transport, capability, namespace, &command_string);
+    match decision {
+        TrustDecision::Trusted => {}
+        TrustDecision::Denied { reason } => {
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: reason,
+            });
+            return Box::new(NoopHandler);
+        }
+        TrustDecision::Pending => {
+            // Defensive — the host's prompt callback should always
+            // resolve to Trusted/Denied. Pending here is a host bug.
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: format!(
+                    "trust gate returned Pending for `{namespace}` — host prompt did not resolve the decision"
+                ),
+            });
+            return Box::new(NoopHandler);
+        }
+    }
+
+    // Trusted — spawn the binary.
+    let labels: Vec<String> = schemas.iter().map(|s| s.label.clone()).collect();
+    let env = SpawnEnv {
+        workspace_root: Some(workspace_root.display().to_string()),
+        lex_cache: None,
+        handler_config: None,
+    };
+    match SubprocessHandler::spawn(
+        handler_spec,
+        namespace,
+        &labels,
+        contract.capabilities,
+        host_version,
+        &env,
+    ) {
+        Ok(h) => Box::new(h),
+        Err(e) => {
+            diagnostics.push(BootDiagnostic {
+                namespace: Some(namespace.into()),
+                message: format!(
+                    "trusted but failed to spawn `{namespace}` handler ({command_string}): {e}"
+                ),
+            });
+            Box::new(NoopHandler)
+        }
+    }
+}
+
+/// One namespace's handler + capability contract, validated as
+/// uniform across all the namespace's schemas.
+///
+/// v1 invariant (called out in the issue scope and now enforced
+/// here): within a namespace, every schema must agree on its
+/// `handler` block AND its `capabilities` block. Mixed `handler`
+/// (some schemas declare it, others don't, or differ in shape)
+/// or mixed `capabilities` (different `fs`/`net` declarations
+/// across labels) are misconfiguration and surface as a diagnostic.
+struct NamespaceContract<'a> {
+    handler: Option<&'a HandlerSpec>,
+    capabilities: lex_extension::schema::Capabilities,
+}
+
+/// Validate that every schema in `schemas` agrees on its `handler`
+/// and `capabilities` blocks, then return the consensus.
+fn find_namespace_contract<'a>(
+    schemas: &'a [Schema],
+    namespace: &str,
+) -> Result<NamespaceContract<'a>, String> {
+    debug_assert!(!schemas.is_empty(), "caller must pass a non-empty slice");
+    let first = &schemas[0];
+    let first_handler = first.handler.as_ref();
+    let first_caps = first.capabilities;
+
+    for s in schemas.iter().skip(1) {
+        if s.handler.as_ref() != first_handler {
+            return Err(format!(
+                "namespace `{namespace}` has schemas declaring inconsistent `handler` blocks (label `{}` differs from `{}`); v1 requires every schema in a namespace to declare the same handler — or all of them to declare none",
+                s.label, schemas[0].label
+            ));
+        }
+        if s.capabilities != first_caps {
+            return Err(format!(
+                "namespace `{namespace}` has schemas declaring inconsistent `capabilities` blocks (label `{}` differs from `{}`); v1 requires uniform capabilities per namespace",
+                s.label, schemas[0].label
+            ));
+        }
+    }
+
+    Ok(NamespaceContract {
+        handler: first_handler,
+        capabilities: first_caps,
+    })
+}
+
+#[derive(Debug)]
+enum RegisterError {
+    Schema(Box<SchemaError>),
+    Registry(RegistryError),
+    EmptyDir(PathBuf),
+}
+
+impl std::fmt::Display for RegisterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegisterError::Schema(e) => write!(f, "schema load: {e}"),
+            RegisterError::Registry(e) => write!(f, "registry register: {e}"),
+            RegisterError::EmptyDir(p) => write!(
+                f,
+                "schema directory `{}` contains no .yaml files",
+                p.display()
+            ),
+        }
+    }
+}
+
+/// No-op handler used for schema-only registration. Returns the
+/// trait defaults for every hook; the dispatcher's pre-validation
+/// pass still surfaces schema mismatches even with this stub.
+struct NoopHandler;
+impl lex_extension::LexHandler for NoopHandler {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_config::{NamespaceSpec, NamespaceTable};
+    use lex_extension_host::TrustPromptContext;
+    use std::collections::BTreeMap;
+
+    /// Test prompt that always denies — equivalent to the CLI's
+    /// `--enable-handlers`-not-set behavior, but free of any CLI
+    /// vocabulary so the tests in this crate stay host-agnostic.
+    struct DenyAllPrompt;
+    impl TrustPromptHandler for DenyAllPrompt {
+        fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
+            TrustDecision::Denied {
+                reason: format!(
+                    "subprocess handler `{}` denied by host (test stub)",
+                    ctx.namespace
+                ),
+            }
+        }
+    }
+
+    fn write_schema(dir: &Path, label: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{}.yaml", label.replace('.', "_"))),
+            format!("schema_version: 1\nlabel: {label}\n"),
+        )
+        .unwrap();
+    }
+
+    /// Schema with a subprocess handler block. Used to drive the
+    /// trust-gate instantiation paths.
+    fn write_schema_with_subprocess_handler(dir: &Path, label: &str, command: &[&str]) {
+        std::fs::create_dir_all(dir).unwrap();
+        let cmd_yaml = command
+            .iter()
+            .map(|c| format!("\"{c}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            dir.join(format!("{}.yaml", label.replace('.', "_"))),
+            format!(
+                "schema_version: 1\n\
+                 label: {label}\n\
+                 handler:\n  \
+                 transport: subprocess\n  \
+                 command: [{cmd_yaml}]\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn boot_with_empty_inputs_yields_only_builtin() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        assert_eq!(outcome.registered.len(), 1);
+        assert_eq!(outcome.registered[0].name, "lex");
+        assert_eq!(outcome.registered[0].source, NamespaceSourceKind::Builtin);
+        assert!(outcome.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn boot_with_path_uri_in_labels_registers_namespace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme-labels");
+        write_schema(&acme_dir, "acme.task");
+
+        let mut namespaces = BTreeMap::new();
+        namespaces.insert("acme".into(), NamespaceSpec::Uri("path:acme-labels".into()));
+        let labels = LabelsConfig { namespaces };
+
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        let acme = outcome
+            .registered
+            .iter()
+            .find(|r| r.name == "acme")
+            .expect("acme registered");
+        assert_eq!(acme.schema_count, 1);
+        assert!(matches!(acme.source, NamespaceSourceKind::LexToml { .. }));
+        assert!(outcome.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn boot_with_remote_uri_emits_unimplemented_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut namespaces = BTreeMap::new();
+        namespaces.insert(
+            "acme".into(),
+            NamespaceSpec::Table(NamespaceTable {
+                tap: Some("acme".into()),
+                ..Default::default()
+            }),
+        );
+        let labels = LabelsConfig { namespaces };
+
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        assert_eq!(outcome.diagnostics.len(), 1);
+        let diag = &outcome.diagnostics[0];
+        assert_eq!(diag.namespace.as_deref(), Some("acme"));
+        assert!(diag.message.contains("not yet implemented"));
+        assert!(!outcome.registered.iter().any(|r| r.name == "acme"));
+    }
+
+    #[test]
+    fn boot_with_ext_schema_flag_registers_namespace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        write_schema(&acme_dir, "acme.task");
+
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir.clone()],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        let acme = outcome
+            .registered
+            .iter()
+            .find(|r| r.name == "acme")
+            .expect("registered");
+        assert!(matches!(
+            acme.source,
+            NamespaceSourceKind::ExtSchemaFlag { .. }
+        ));
+    }
+
+    /// Subprocess handler + LSP surface + denying prompt: the trust
+    /// gate consults the prompt (LSP doesn't short-circuit on
+    /// `enable_handlers` the way CLI does), the prompt denies, and
+    /// the namespace registers schema-only with the prompt's
+    /// rationale surfaced as a diagnostic.
+    #[test]
+    fn subprocess_handler_in_lsp_surface_with_denying_prompt_is_schema_only() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-handler"]);
+
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir.clone()],
+            enable_handlers: false,
+            surface_override: Some(Surface::LspSession),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        // Namespace IS registered (so pre-validation still works
+        // when analysing documents), but with the prompt's reason
+        // as a diagnostic.
+        assert!(outcome.registered.iter().any(|r| r.name == "acme"));
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.namespace.as_deref() == Some("acme")
+                    && d.message.contains("denied by host (test stub)")),
+            "expected prompt's denial reason, got: {:?}",
+            outcome.diagnostics
+        );
+    }
+
+    /// Subprocess handler + `--enable-handlers`: the trust gate
+    /// trusts the namespace and `SubprocessHandler::spawn` is
+    /// called. The test points the schema at a non-existent path
+    /// — `spawn` then fails at `Command::spawn` with a clear "no
+    /// such file" error, surfaced as a `trusted but failed to spawn`
+    /// diagnostic. Verifying the diagnostic exists is what proves
+    /// the trust gate let the request through.
+    #[test]
+    fn subprocess_handler_with_enable_flag_attempts_spawn() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        write_schema_with_subprocess_handler(
+            &acme_dir,
+            "acme.task",
+            &["/this/binary/does/not/exist"],
+        );
+
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir.clone()],
+            enable_handlers: true,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        });
+        assert!(outcome.registered.iter().any(|r| r.name == "acme"));
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("failed to spawn")),
+            "expected spawn-failure diagnostic, got: {:?}",
+            outcome.diagnostics
+        );
+    }
+
+    /// Mixed handler specs across schemas in one namespace is
+    /// rejected with a clear diagnostic. v1 requires one handler
+    /// per namespace.
+    #[test]
+    fn mixed_handler_specs_in_one_namespace_emit_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-v1"]);
+        write_schema_with_subprocess_handler(&acme_dir, "acme.note", &["acme-v2"]);
+
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir],
+            enable_handlers: true,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        });
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("inconsistent `handler` blocks")),
+            "expected mixed-handler diagnostic, got: {:?}",
+            outcome.diagnostics
+        );
+    }
+
+    /// Partial handler declaration — some schemas in the namespace
+    /// declare a `handler` block, others don't — also surfaces as
+    /// "inconsistent handler blocks".
+    #[test]
+    fn partial_handler_declaration_in_one_namespace_emits_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-bin"]);
+        write_schema(&acme_dir, "acme.note");
+
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir],
+            enable_handlers: true,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        });
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("inconsistent `handler` blocks")),
+            "expected partial-handler diagnostic, got: {:?}",
+            outcome.diagnostics
+        );
+    }
+
+    #[test]
+    fn mixed_capabilities_in_one_namespace_emit_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let acme_dir = workspace.path().join("acme");
+        std::fs::create_dir_all(&acme_dir).unwrap();
+        std::fs::write(
+            acme_dir.join("task.yaml"),
+            "schema_version: 1\nlabel: acme.task\ncapabilities: { fs: true, net: false }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            acme_dir.join("note.yaml"),
+            "schema_version: 1\nlabel: acme.note\ncapabilities: { fs: false, net: true }\n",
+        )
+        .unwrap();
+
+        let labels = LabelsConfig::default();
+        let outcome = boot_registry(ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[acme_dir],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        });
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("inconsistent `capabilities`")),
+            "expected mixed-capabilities diagnostic, got: {:?}",
+            outcome.diagnostics
+        );
+    }
+
+    #[test]
+    fn ext_schema_flag_with_no_yaml_files_emits_diagnostic() {
+        let workspace = tempfile::tempdir().unwrap();
+        let empty_dir = workspace.path().join("empty");
+        std::fs::create_dir(&empty_dir).unwrap();
+
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[empty_dir],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        assert!(outcome
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("contains no .yaml files")));
+    }
+
+    #[test]
+    fn surface_override_threads_through_to_trust_gate() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: true,
+            surface_override: Some(Surface::Ci),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        assert_eq!(outcome.trust_gate.surface(), Surface::Ci);
+        assert!(outcome.trust_gate.enable_handlers());
+    }
+}

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -21,7 +21,9 @@ lex-core = { workspace = true }
 lex-analysis = { workspace = true }
 lex-babel = { workspace = true }
 lex-config = { workspace = true }
+lex-extension = { workspace = true }
 lex-extension-host = { workspace = true }
+lex-engine = { workspace = true }
 lex-lsp-core = { workspace = true }
 clapfig = { workspace = true }
 tower-lsp = "0.20"
@@ -34,3 +36,4 @@ serde_json = { workspace = true }
 lex-analysis = { workspace = true, features = ["test-support"] }
 tempfile = { workspace = true }
 proptest = { workspace = true }
+serde_yaml = { workspace = true }

--- a/crates/lex-lsp/src/extension_dispatch.rs
+++ b/crates/lex-lsp/src/extension_dispatch.rs
@@ -1,0 +1,573 @@
+//! LSP-side dispatch into the extension [`Registry`].
+//!
+//! The hover / completion / code-action handlers in [`server`] call the
+//! helpers here to ask the extension registry what it has for the cursor
+//! position. When a labelled annotation or verbatim block at the cursor
+//! has a registered handler, the handler's hook is fired and its wire
+//! output is translated into `lsp_types`. When nothing matches, the
+//! helpers return empty results and the existing built-in providers
+//! handle the request as before — extension dispatch is additive, never
+//! a replacement.
+//!
+//! This module is the LSP analogue of [`lex_analysis::label_dispatch`]
+//! and [`lex_babel::render_dispatch`]: same registry, same `LabelCtx`
+//! construction (via [`lex_core::lex::wire::to_wire_node`]), different
+//! output translation.
+//!
+//! [`server`]: crate::server
+
+use std::sync::Arc;
+
+use lex_analysis::utils::{find_annotation_at_position, find_verbatim_at_position};
+use lex_core::lex::ast::{ContentItem, Document, Position as AstPosition};
+use lex_core::lex::wire::to_wire_node;
+use lex_engine::{BootDiagnostic, BootOutcome, RegisteredNamespace};
+use lex_extension::wire::{HostNodeKind, WireNode};
+use lex_extension::{AnnotationBody, LabelCtx, NodeRef};
+use lex_extension_host::Registry;
+use tower_lsp::lsp_types::{
+    self as lsp, CodeAction as LspCodeAction, CompletionItem as LspCompletionItem,
+    Hover as LspHover, HoverContents, MarkupContent, MarkupKind, Range as LspRange, TextEdit, Url,
+    WorkspaceEdit,
+};
+
+/// Cached state from a single [`lex_engine::boot_registry`] call. Held by
+/// the server for the lifetime of a workspace; rebuilt when the workspace
+/// root changes.
+pub struct LspExtensionState {
+    /// The shared registry consulted on every hover / completion /
+    /// code-action request.
+    pub registry: Arc<Registry>,
+    /// Boot-time diagnostics (resolver failures, denied namespaces,
+    /// schema errors). Stored on boot and currently unsurfaced; PR
+    /// 10b adds `window/showMessage` notifications for the most
+    /// important entries plus a custom request the editor can use to
+    /// display the full list.
+    #[allow(dead_code)]
+    pub boot_diagnostics: Vec<BootDiagnostic>,
+    /// Successfully registered namespaces. Reserved for a future
+    /// "currently loaded extensions" surface.
+    #[allow(dead_code)]
+    pub registered: Vec<RegisteredNamespace>,
+}
+
+impl From<BootOutcome> for LspExtensionState {
+    fn from(outcome: BootOutcome) -> Self {
+        Self {
+            registry: outcome.registry,
+            boot_diagnostics: outcome.diagnostics,
+            registered: outcome.registered,
+        }
+    }
+}
+
+/// Dispatch a hover request through the extension registry.
+///
+/// Returns `Some(hover)` when the cursor is on a labelled annotation or
+/// verbatim block whose registered handler returns hover content; `None`
+/// otherwise. The caller falls back to the built-in hover provider on
+/// `None`.
+pub fn dispatch_hover(
+    document: &Document,
+    position: AstPosition,
+    registry: &Registry,
+) -> Option<LspHover> {
+    if registry.namespace_count() == 0 {
+        return None;
+    }
+    let ctx = build_ctx_at_position(document, position)?;
+    registry.schema_for(&ctx.label)?;
+    match registry.dispatch_hover(&ctx) {
+        Ok(Some(h)) => Some(translate_hover(h)),
+        _ => None,
+    }
+}
+
+/// Dispatch a completion request through the extension registry.
+///
+/// Always returns a (possibly empty) `Vec` — the caller merges these
+/// with the built-in completion candidates rather than picking one or
+/// the other.
+pub fn dispatch_completion(
+    document: &Document,
+    position: AstPosition,
+    registry: &Registry,
+) -> Vec<LspCompletionItem> {
+    if registry.namespace_count() == 0 {
+        return Vec::new();
+    }
+    let Some(ctx) = build_ctx_at_position(document, position) else {
+        return Vec::new();
+    };
+    if registry.schema_for(&ctx.label).is_none() {
+        return Vec::new();
+    }
+    registry
+        .dispatch_completion(&ctx)
+        .into_iter()
+        .map(translate_completion)
+        .collect()
+}
+
+/// Dispatch a code-action request through the extension registry.
+///
+/// `start_position` is the start of the LSP request's selection range;
+/// we use it to identify the labelled node under the cursor. Returns the
+/// (possibly empty) list of handler-supplied code actions; the caller
+/// appends them to the built-in actions.
+pub fn dispatch_code_action(
+    document: &Document,
+    start_position: AstPosition,
+    document_uri: &Url,
+    registry: &Registry,
+) -> Vec<LspCodeAction> {
+    if registry.namespace_count() == 0 {
+        return Vec::new();
+    }
+    let Some(ctx) = build_ctx_at_position(document, start_position) else {
+        return Vec::new();
+    };
+    if registry.schema_for(&ctx.label).is_none() {
+        return Vec::new();
+    }
+    registry
+        .dispatch_code_action(&ctx)
+        .into_iter()
+        .map(|a| translate_code_action(a, document_uri))
+        .collect()
+}
+
+/// Locate a labelled annotation or verbatim block at `position` and
+/// build the [`LabelCtx`] the registry expects. Returns `None` when the
+/// cursor isn't on a labelled node.
+fn build_ctx_at_position(document: &Document, position: AstPosition) -> Option<LabelCtx> {
+    if let Some(annotation) = find_annotation_at_position(document, position) {
+        let label = annotation.data.label.value.clone();
+        if label.is_empty() {
+            return None;
+        }
+        let wire = to_wire_node(&ContentItem::Annotation(annotation.clone()));
+        let WireNode::Annotation {
+            params,
+            body,
+            range,
+            origin,
+            ..
+        } = wire
+        else {
+            return None;
+        };
+        let body = serde_json::from_value::<AnnotationBody>(body).unwrap_or(AnnotationBody::None);
+        return Some(LabelCtx {
+            label,
+            params,
+            body,
+            node: NodeRef {
+                // Annotation-attachment kind: the LSP doesn't currently
+                // track which AST kind contains the annotation (lex-
+                // analysis does, via its walker). For dispatch under the
+                // cursor it's safe to use Annotation as the attached_to
+                // kind — handlers that vary behavior by attachment point
+                // already get the correct WireNode payload regardless.
+                kind: HostNodeKind::Annotation.as_str().to_string(),
+                range,
+                origin,
+            },
+        });
+    }
+    if let Some(v) = find_verbatim_at_position(document, position) {
+        let label = v.closing_data.label.value.clone();
+        if label.is_empty() {
+            return None;
+        }
+        let wire = to_wire_node(&ContentItem::VerbatimBlock(Box::new(v.clone())));
+        let WireNode::Verbatim {
+            params,
+            body_text,
+            range,
+            origin,
+            ..
+        } = wire
+        else {
+            return None;
+        };
+        return Some(LabelCtx {
+            label,
+            params,
+            body: AnnotationBody::Text(body_text),
+            node: NodeRef {
+                kind: HostNodeKind::Verbatim.as_str().to_string(),
+                range,
+                origin,
+            },
+        });
+    }
+    None
+}
+
+fn translate_hover(h: lex_extension::wire::Hover) -> LspHover {
+    use lex_extension::wire::HoverFormat;
+    let kind = match h.format {
+        HoverFormat::Markdown => MarkupKind::Markdown,
+        // Plaintext + future-added variants fall back to PlainText —
+        // the wire format's deserializer already maps unknown values
+        // onto Plaintext, so this match-arm just mirrors that policy.
+        _ => MarkupKind::PlainText,
+    };
+    LspHover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind,
+            value: h.contents,
+        }),
+        range: h.range.map(to_lsp_range),
+    }
+}
+
+fn translate_completion(c: lex_extension::wire::Completion) -> LspCompletionItem {
+    use lex_extension::wire::CompletionKind;
+    let kind = match c.kind {
+        CompletionKind::Value => Some(lsp::CompletionItemKind::VALUE),
+        CompletionKind::Param => Some(lsp::CompletionItemKind::PROPERTY),
+        CompletionKind::Namespace => Some(lsp::CompletionItemKind::MODULE),
+        CompletionKind::Snippet => Some(lsp::CompletionItemKind::SNIPPET),
+        // Future-added variants fall back to Value, matching the wire
+        // deserializer's default-on-unknown policy.
+        _ => Some(lsp::CompletionItemKind::VALUE),
+    };
+    LspCompletionItem {
+        label: c.label,
+        kind,
+        detail: c.detail,
+        documentation: c.doc.map(|d| {
+            lsp::Documentation::MarkupContent(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: d,
+            })
+        }),
+        insert_text: Some(c.insert),
+        ..Default::default()
+    }
+}
+
+fn translate_code_action(a: lex_extension::wire::CodeAction, document_uri: &Url) -> LspCodeAction {
+    use lex_extension::wire::CodeActionKind as WireKind;
+    let kind = match a.kind {
+        WireKind::Quickfix => Some(lsp::CodeActionKind::QUICKFIX),
+        WireKind::Refactor => Some(lsp::CodeActionKind::REFACTOR),
+        WireKind::Source => Some(lsp::CodeActionKind::SOURCE),
+        // Future-added variants fall back to Refactor, matching the
+        // wire deserializer's default-on-unknown policy.
+        _ => Some(lsp::CodeActionKind::REFACTOR),
+    };
+
+    // Group edits by URI: edits without a `uri` field apply to the
+    // request's document; edits with a `uri` apply to that file. The
+    // LSP `WorkspaceEdit.changes` map keys on `Url`, so we collect
+    // per-URI edit lists and assemble them at the end.
+    //
+    // Edits with a `uri` field that fails to parse are *dropped*
+    // rather than re-targeted at the request's document — silently
+    // applying changes to the wrong file would be a destructive
+    // surprise. The handler can resubmit a code action with a valid
+    // URI.
+    let mut changes: std::collections::HashMap<Url, Vec<TextEdit>> =
+        std::collections::HashMap::new();
+    for e in a.edits {
+        let target = match &e.uri {
+            Some(s) => match Url::parse(s) {
+                Ok(u) => u,
+                Err(_) => continue,
+            },
+            None => document_uri.clone(),
+        };
+        changes.entry(target).or_default().push(TextEdit {
+            range: to_lsp_range(e.range),
+            new_text: e.new_text,
+        });
+    }
+    let edit = if changes.is_empty() {
+        None
+    } else {
+        Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        })
+    };
+
+    LspCodeAction {
+        title: a.title,
+        kind,
+        edit,
+        ..Default::default()
+    }
+}
+
+fn to_lsp_range(r: lex_extension::wire::Range) -> LspRange {
+    LspRange {
+        start: lsp::Position {
+            line: r.start.0,
+            character: r.start.1,
+        },
+        end: lsp::Position {
+            line: r.end.0,
+            character: r.end.1,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit-level translation tests + dispatch tests against a fixture
+    //! handler. The server-side wiring (ext_dispatch_* spliced into
+    //! the LSP request handlers) is small enough that these tests
+    //! plus the existing server integration suite cover it.
+    use super::*;
+    use lex_core::lex::parsing::parse_document;
+    use lex_extension::schema::Schema;
+    use lex_extension::wire::{
+        CodeActionKind as WireCodeActionKind, Completion, CompletionKind, HoverFormat,
+        Position as WirePosition, Range as WireRange, TextEdit as WireTextEdit,
+    };
+    use lex_extension::{HandlerError, LexHandler};
+
+    fn r(s_l: u32, s_c: u32, e_l: u32, e_c: u32) -> WireRange {
+        WireRange {
+            start: WirePosition(s_l, s_c),
+            end: WirePosition(e_l, e_c),
+        }
+    }
+
+    /// Fixture handler that returns canned hover / completion /
+    /// code-action content for any label invocation. Used by the
+    /// dispatch tests below to verify the LSP dispatch path forwards
+    /// the request and translates the response correctly.
+    struct FixtureHandler;
+    impl LexHandler for FixtureHandler {
+        fn on_hover(
+            &self,
+            ctx: &LabelCtx,
+        ) -> Result<Option<lex_extension::wire::Hover>, HandlerError> {
+            Ok(Some(lex_extension::wire::Hover {
+                contents: format!("hover for `{}`", ctx.label),
+                format: HoverFormat::Markdown,
+                range: Some(ctx.node.range),
+            }))
+        }
+        fn on_completion(&self, _ctx: &LabelCtx) -> Result<Vec<Completion>, HandlerError> {
+            Ok(vec![Completion {
+                label: "fixture-item".into(),
+                detail: None,
+                doc: None,
+                insert: "fixture-insert".into(),
+                kind: CompletionKind::Snippet,
+            }])
+        }
+        fn on_code_action(
+            &self,
+            _ctx: &LabelCtx,
+        ) -> Result<Vec<lex_extension::wire::CodeAction>, HandlerError> {
+            Ok(vec![lex_extension::wire::CodeAction {
+                title: "Fix it".into(),
+                kind: WireCodeActionKind::Quickfix,
+                edits: vec![WireTextEdit {
+                    range: r(0, 0, 0, 5),
+                    new_text: "x".into(),
+                    uri: None,
+                }],
+            }])
+        }
+    }
+
+    /// Build a Registry containing a single namespace `acme` with one
+    /// schema `acme.task` whose hover/completion/code_action hooks are
+    /// enabled. Returns the registry and the document text whose
+    /// labelled annotation lives at line 0.
+    fn registry_with_fixture() -> (Registry, String) {
+        let yaml = "schema_version: 1\n\
+                    label: acme.task\n\
+                    hooks: { hover: true, completion: true, code_action: true }\n";
+        let schema: Schema = serde_yaml::from_str(yaml).expect("parse fixture schema");
+        let registry = Registry::new();
+        registry
+            .register_namespace("acme", vec![schema], Box::new(FixtureHandler))
+            .expect("register acme");
+
+        let source = ":: acme.task ::\n";
+        (registry, source.into())
+    }
+
+    #[test]
+    fn dispatch_hover_at_labelled_annotation_returns_translated_content() {
+        let (registry, source) = registry_with_fixture();
+        let document = parse_document(&source).expect("parse");
+        let position = AstPosition::new(0, 5); // inside `acme.task`
+        let hover = dispatch_hover(&document, position, &registry).expect("hover content");
+        match hover.contents {
+            HoverContents::Markup(MarkupContent { kind, value }) => {
+                assert_eq!(kind, MarkupKind::Markdown);
+                assert!(value.contains("acme.task"), "got: {value}");
+            }
+            _ => panic!("expected markup"),
+        }
+    }
+
+    #[test]
+    fn dispatch_hover_off_labelled_annotation_returns_none() {
+        let (registry, _) = registry_with_fixture();
+        let document = parse_document("Plain paragraph.\n").expect("parse");
+        let position = AstPosition::new(0, 0);
+        assert!(dispatch_hover(&document, position, &registry).is_none());
+    }
+
+    #[test]
+    fn dispatch_completion_at_labelled_annotation_returns_handler_items() {
+        let (registry, source) = registry_with_fixture();
+        let document = parse_document(&source).expect("parse");
+        let position = AstPosition::new(0, 5);
+        let items = dispatch_completion(&document, position, &registry);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, "fixture-item");
+        assert_eq!(items[0].kind, Some(lsp::CompletionItemKind::SNIPPET));
+    }
+
+    #[test]
+    fn dispatch_code_action_at_labelled_annotation_returns_handler_actions() {
+        let (registry, source) = registry_with_fixture();
+        let document = parse_document(&source).expect("parse");
+        let document_uri = Url::parse("file:///workspace/host.lex").unwrap();
+        let actions =
+            dispatch_code_action(&document, AstPosition::new(0, 5), &document_uri, &registry);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Fix it");
+        let changes = actions[0]
+            .edit
+            .as_ref()
+            .and_then(|e| e.changes.as_ref())
+            .expect("changes");
+        assert!(changes.contains_key(&document_uri));
+    }
+
+    #[test]
+    fn dispatch_with_empty_registry_returns_nothing() {
+        let registry = Registry::new();
+        let document = parse_document(":: acme.task ::\n").expect("parse");
+        let position = AstPosition::new(0, 5);
+        assert!(dispatch_hover(&document, position, &registry).is_none());
+        assert!(dispatch_completion(&document, position, &registry).is_empty());
+        let document_uri = Url::parse("file:///workspace/host.lex").unwrap();
+        assert!(dispatch_code_action(&document, position, &document_uri, &registry).is_empty());
+    }
+
+    #[test]
+    fn translate_hover_markdown_preserves_format_and_range() {
+        let h = lex_extension::wire::Hover {
+            contents: "**bold**".into(),
+            format: HoverFormat::Markdown,
+            range: Some(r(0, 0, 0, 5)),
+        };
+        let out = translate_hover(h);
+        match out.contents {
+            HoverContents::Markup(MarkupContent { kind, value }) => {
+                assert_eq!(kind, MarkupKind::Markdown);
+                assert_eq!(value, "**bold**");
+            }
+            _ => panic!("expected markup"),
+        }
+        assert!(out.range.is_some());
+    }
+
+    #[test]
+    fn translate_completion_preserves_label_insert_kind() {
+        let c = Completion {
+            label: "task".into(),
+            detail: Some("acme.task annotation".into()),
+            doc: Some("docs".into()),
+            insert: ":: acme.task ::".into(),
+            kind: CompletionKind::Snippet,
+        };
+        let out = translate_completion(c);
+        assert_eq!(out.label, "task");
+        assert_eq!(out.kind, Some(lsp::CompletionItemKind::SNIPPET));
+        assert_eq!(out.insert_text.as_deref(), Some(":: acme.task ::"));
+        assert!(out.documentation.is_some());
+    }
+
+    #[test]
+    fn translate_code_action_groups_edits_by_uri() {
+        let document_uri = Url::parse("file:///workspace/host.lex").unwrap();
+        let other_uri = "file:///workspace/other.lex";
+        let a = lex_extension::wire::CodeAction {
+            title: "Fix it".into(),
+            kind: WireCodeActionKind::Quickfix,
+            edits: vec![
+                WireTextEdit {
+                    range: r(0, 0, 0, 5),
+                    new_text: "x".into(),
+                    uri: None,
+                },
+                WireTextEdit {
+                    range: r(1, 0, 1, 5),
+                    new_text: "y".into(),
+                    uri: Some(other_uri.into()),
+                },
+            ],
+        };
+        let out = translate_code_action(a, &document_uri);
+        assert_eq!(out.title, "Fix it");
+        assert_eq!(out.kind, Some(lsp::CodeActionKind::QUICKFIX));
+        let changes = out
+            .edit
+            .as_ref()
+            .and_then(|e| e.changes.as_ref())
+            .expect("changes set");
+        assert_eq!(changes.len(), 2);
+        assert!(changes.contains_key(&document_uri));
+        assert!(changes.contains_key(&Url::parse(other_uri).unwrap()));
+    }
+
+    #[test]
+    fn translate_code_action_drops_edits_with_invalid_uri() {
+        let document_uri = Url::parse("file:///workspace/host.lex").unwrap();
+        let a = lex_extension::wire::CodeAction {
+            title: "Mixed".into(),
+            kind: WireCodeActionKind::Quickfix,
+            edits: vec![
+                // Valid relative-to-document edit — kept.
+                WireTextEdit {
+                    range: r(0, 0, 0, 5),
+                    new_text: "x".into(),
+                    uri: None,
+                },
+                // Garbage URI — dropped (NOT silently retargeted at
+                // the request document).
+                WireTextEdit {
+                    range: r(1, 0, 1, 5),
+                    new_text: "y".into(),
+                    uri: Some("not a url at all".into()),
+                },
+            ],
+        };
+        let out = translate_code_action(a, &document_uri);
+        let changes = out
+            .edit
+            .as_ref()
+            .and_then(|e| e.changes.as_ref())
+            .expect("changes set");
+        assert_eq!(changes.len(), 1, "garbage URI should be dropped");
+        let edits = changes.get(&document_uri).expect("document URI present");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "x");
+    }
+
+    #[test]
+    fn translate_code_action_no_edits_yields_no_workspace_edit() {
+        let document_uri = Url::parse("file:///workspace/host.lex").unwrap();
+        let a = lex_extension::wire::CodeAction {
+            title: "Refactor".into(),
+            kind: WireCodeActionKind::Refactor,
+            edits: vec![],
+        };
+        let out = translate_code_action(a, &document_uri);
+        assert!(out.edit.is_none());
+    }
+}

--- a/crates/lex-lsp/src/extension_dispatch.rs
+++ b/crates/lex-lsp/src/extension_dispatch.rs
@@ -18,8 +18,9 @@
 
 use std::sync::Arc;
 
-use lex_analysis::utils::{find_annotation_at_position, find_verbatim_at_position};
-use lex_core::lex::ast::{ContentItem, Document, Position as AstPosition};
+use lex_core::lex::ast::{
+    Annotation, ContentItem, Document, Position as AstPosition, Session, Verbatim,
+};
 use lex_core::lex::wire::to_wire_node;
 use lex_engine::{BootDiagnostic, BootOutcome, RegisteredNamespace};
 use lex_extension::wire::{HostNodeKind, WireNode};
@@ -137,70 +138,215 @@ pub fn dispatch_code_action(
         .collect()
 }
 
+/// One labelled hit found under the cursor: an annotation paired with
+/// the AST kind of its host (the parent the annotation attaches to),
+/// or a verbatim block (whose host kind is always `Verbatim`).
+///
+/// Mirrors the bookkeeping that `lex_analysis::label_dispatch` does
+/// during diagnostics — without it, every annotation dispatched
+/// through the LSP would report `attached_to: "annotation"`, which
+/// breaks `attaches_to`-sensitive schema pre-validation in the
+/// handler-side hooks.
+enum LabelledHit<'a> {
+    Annotation {
+        ann: &'a Annotation,
+        host_kind: HostNodeKind,
+    },
+    Verbatim {
+        v: &'a Verbatim,
+    },
+}
+
 /// Locate a labelled annotation or verbatim block at `position` and
 /// build the [`LabelCtx`] the registry expects. Returns `None` when the
 /// cursor isn't on a labelled node.
 fn build_ctx_at_position(document: &Document, position: AstPosition) -> Option<LabelCtx> {
-    if let Some(annotation) = find_annotation_at_position(document, position) {
-        let label = annotation.data.label.value.clone();
-        if label.is_empty() {
-            return None;
-        }
-        let wire = to_wire_node(&ContentItem::Annotation(annotation.clone()));
-        let WireNode::Annotation {
-            params,
-            body,
-            range,
-            origin,
-            ..
-        } = wire
-        else {
-            return None;
-        };
-        let body = serde_json::from_value::<AnnotationBody>(body).unwrap_or(AnnotationBody::None);
-        return Some(LabelCtx {
-            label,
-            params,
-            body,
-            node: NodeRef {
-                // Annotation-attachment kind: the LSP doesn't currently
-                // track which AST kind contains the annotation (lex-
-                // analysis does, via its walker). For dispatch under the
-                // cursor it's safe to use Annotation as the attached_to
-                // kind — handlers that vary behavior by attachment point
-                // already get the correct WireNode payload regardless.
-                kind: HostNodeKind::Annotation.as_str().to_string(),
+    let hit = find_labelled_at_position(document, position)?;
+    match hit {
+        LabelledHit::Annotation { ann, host_kind } => {
+            let label = ann.data.label.value.clone();
+            if label.is_empty() {
+                return None;
+            }
+            let wire = to_wire_node(&ContentItem::Annotation(ann.clone()));
+            let WireNode::Annotation {
+                params,
+                body,
                 range,
                 origin,
-            },
-        });
+                ..
+            } = wire
+            else {
+                return None;
+            };
+            let body =
+                serde_json::from_value::<AnnotationBody>(body).unwrap_or(AnnotationBody::None);
+            Some(LabelCtx {
+                label,
+                params,
+                body,
+                node: NodeRef {
+                    // Per wire spec §2.1: `NodeRef.kind` is the host
+                    // AST kind the label attaches to (Document /
+                    // Session / Paragraph / Definition / List /
+                    // ListItem / Annotation), NOT the literal
+                    // "annotation" tag. Pre-validation in the
+                    // host-side dispatcher checks this against the
+                    // schema's `attaches_to`; getting it wrong rejects
+                    // valid invocations.
+                    kind: host_kind.as_str().to_string(),
+                    range,
+                    origin,
+                },
+            })
+        }
+        LabelledHit::Verbatim { v } => {
+            let label = v.closing_data.label.value.clone();
+            if label.is_empty() {
+                return None;
+            }
+            let wire = to_wire_node(&ContentItem::VerbatimBlock(Box::new(v.clone())));
+            let WireNode::Verbatim {
+                params,
+                body_text,
+                range,
+                origin,
+                ..
+            } = wire
+            else {
+                return None;
+            };
+            Some(LabelCtx {
+                label,
+                params,
+                body: AnnotationBody::Text(body_text),
+                node: NodeRef {
+                    kind: HostNodeKind::Verbatim.as_str().to_string(),
+                    range,
+                    origin,
+                },
+            })
+        }
     }
-    if let Some(v) = find_verbatim_at_position(document, position) {
-        let label = v.closing_data.label.value.clone();
-        if label.is_empty() {
-            return None;
+}
+
+/// Walk the document tracking the host kind of each annotation /
+/// verbatim parent, and return the first labelled hit whose source
+/// range contains `position`. Mirrors the `attached_to` bookkeeping in
+/// [`lex_analysis::label_dispatch`].
+fn find_labelled_at_position(
+    document: &Document,
+    position: AstPosition,
+) -> Option<LabelledHit<'_>> {
+    for ann in document.annotations() {
+        if let Some(hit) = visit_annotation(ann, HostNodeKind::Document, position) {
+            return Some(hit);
         }
-        let wire = to_wire_node(&ContentItem::VerbatimBlock(Box::new(v.clone())));
-        let WireNode::Verbatim {
-            params,
-            body_text,
-            range,
-            origin,
-            ..
-        } = wire
-        else {
-            return None;
-        };
-        return Some(LabelCtx {
-            label,
-            params,
-            body: AnnotationBody::Text(body_text),
-            node: NodeRef {
-                kind: HostNodeKind::Verbatim.as_str().to_string(),
-                range,
-                origin,
-            },
-        });
+    }
+    walk_session(&document.root, HostNodeKind::Session, position)
+}
+
+fn walk_session(
+    s: &Session,
+    self_kind: HostNodeKind,
+    position: AstPosition,
+) -> Option<LabelledHit<'_>> {
+    for ann in s.annotations() {
+        if let Some(hit) = visit_annotation(ann, self_kind, position) {
+            return Some(hit);
+        }
+    }
+    for child in s.children.iter() {
+        if let Some(hit) = visit_content(child, position) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
+fn visit_content(item: &ContentItem, position: AstPosition) -> Option<LabelledHit<'_>> {
+    match item {
+        ContentItem::Paragraph(p) => {
+            for ann in p.annotations() {
+                if let Some(hit) = visit_annotation(ann, HostNodeKind::Paragraph, position) {
+                    return Some(hit);
+                }
+            }
+        }
+        ContentItem::Session(s) => return walk_session(s, HostNodeKind::Session, position),
+        ContentItem::Definition(d) => {
+            for ann in d.annotations() {
+                if let Some(hit) = visit_annotation(ann, HostNodeKind::Definition, position) {
+                    return Some(hit);
+                }
+            }
+            for child in d.children.iter() {
+                if let Some(hit) = visit_content(child, position) {
+                    return Some(hit);
+                }
+            }
+        }
+        ContentItem::List(list) => {
+            for ann in list.annotations() {
+                if let Some(hit) = visit_annotation(ann, HostNodeKind::List, position) {
+                    return Some(hit);
+                }
+            }
+            for entry in &list.items {
+                if let ContentItem::ListItem(li) = entry {
+                    for ann in li.annotations() {
+                        if let Some(hit) = visit_annotation(ann, HostNodeKind::ListItem, position) {
+                            return Some(hit);
+                        }
+                    }
+                    for child in li.children.iter() {
+                        if let Some(hit) = visit_content(child, position) {
+                            return Some(hit);
+                        }
+                    }
+                }
+            }
+        }
+        ContentItem::Annotation(a) => {
+            // Standalone annotation node IS its own host (per wire
+            // spec §2.2 — `annotation` is itself a host kind).
+            // Schemas that declare `attaches_to: ["annotation"]` —
+            // notably the `lex.*` built-ins like `lex.include` — rely
+            // on this kind being reported, not `Document` or
+            // `Session`.
+            if let Some(hit) = visit_annotation(a, HostNodeKind::Annotation, position) {
+                return Some(hit);
+            }
+        }
+        ContentItem::Table(table) => {
+            for child in table.cell_children_iter() {
+                if let Some(hit) = visit_content(child, position) {
+                    return Some(hit);
+                }
+            }
+        }
+        ContentItem::VerbatimBlock(v) => {
+            if v.location.contains(position) {
+                return Some(LabelledHit::Verbatim { v: v.as_ref() });
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+fn visit_annotation<'a>(
+    ann: &'a Annotation,
+    host_kind: HostNodeKind,
+    position: AstPosition,
+) -> Option<LabelledHit<'a>> {
+    if ann.header_location().contains(position) {
+        return Some(LabelledHit::Annotation { ann, host_kind });
+    }
+    for child in ann.children.iter() {
+        if let Some(hit) = visit_content(child, position) {
+            return Some(hit);
+        }
     }
     None
 }
@@ -457,6 +603,46 @@ mod tests {
             .and_then(|e| e.changes.as_ref())
             .expect("changes");
         assert!(changes.contains_key(&document_uri));
+    }
+
+    /// `find_labelled_at_position` must surface the cursor's *host
+    /// node kind* — the parent containing the annotation — not the
+    /// literal "annotation" tag. Schema pre-validation in handler
+    /// dispatch checks this against `attaches_to`; getting it wrong
+    /// rejects valid invocations.
+    #[test]
+    fn host_kind_is_document_for_top_level_annotation() {
+        let document = parse_document(":: acme.task ::\n").expect("parse");
+        let hit = find_labelled_at_position(&document, AstPosition::new(0, 5)).expect("hit");
+        match hit {
+            LabelledHit::Annotation { host_kind, .. } => {
+                assert_eq!(host_kind, HostNodeKind::Document);
+            }
+            _ => panic!("expected Annotation, got Verbatim"),
+        }
+    }
+
+    #[test]
+    fn host_kind_is_paragraph_for_paragraph_annotation() {
+        // Annotation attached inline below paragraph text — host_kind
+        // should be Paragraph.
+        let source = "Some paragraph text.\n:: acme.task ::\n";
+        let document = parse_document(source).expect("parse");
+        // Cursor on the annotation header (line 1).
+        let hit = find_labelled_at_position(&document, AstPosition::new(1, 5));
+        if let Some(LabelledHit::Annotation { host_kind, .. }) = hit {
+            // Either Paragraph or Document is plausible depending on
+            // how the parser groups the annotation; assert it's NOT
+            // Annotation (which was the bug).
+            assert_ne!(
+                host_kind,
+                HostNodeKind::Annotation,
+                "annotation host_kind must reflect the AST parent, not the literal tag"
+            );
+        }
+        // If parse made the annotation top-level, the test above
+        // doesn't fire — the assertion is conditional. The other
+        // host_kind tests still cover the document-level case.
     }
 
     #[test]

--- a/crates/lex-lsp/src/extension_dispatch.rs
+++ b/crates/lex-lsp/src/extension_dispatch.rs
@@ -39,10 +39,10 @@ pub struct LspExtensionState {
     /// code-action request.
     pub registry: Arc<Registry>,
     /// Boot-time diagnostics (resolver failures, denied namespaces,
-    /// schema errors). Stored on boot and currently unsurfaced; PR
-    /// 10b adds `window/showMessage` notifications for the most
-    /// important entries plus a custom request the editor can use to
-    /// display the full list.
+    /// schema errors). Surfaced to the editor as
+    /// `window/showMessage` notifications immediately after boot
+    /// (see [`crate::server::LexLanguageServer::extension_state`]),
+    /// and retained here for tests / future inspection requests.
     #[allow(dead_code)]
     pub boot_diagnostics: Vec<BootDiagnostic>,
     /// Successfully registered namespaces. Reserved for a future
@@ -276,7 +276,19 @@ fn translate_code_action(a: lex_extension::wire::CodeAction, document_uri: &Url)
         let target = match &e.uri {
             Some(s) => match Url::parse(s) {
                 Ok(u) => u,
-                Err(_) => continue,
+                Err(parse_err) => {
+                    // Log to stderr so handler authors can see their
+                    // bug in the LSP's log output (vscode / nvim /
+                    // lexed all surface stderr by default). NOT
+                    // forwarded as `window/showMessage` because a
+                    // single buggy handler could spam the editor for
+                    // every code-action request — stderr is the
+                    // right level for protocol-shape errors.
+                    eprintln!(
+                        "[lexd-lsp] dropping code-action edit with invalid uri `{s}`: {parse_err}"
+                    );
+                    continue;
+                }
             },
             None => document_uri.clone(),
         };

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -165,6 +165,7 @@
 //!         Starts the language server on stdin/stdout for editor integration.
 //!
 
+pub mod extension_dispatch;
 pub mod features;
 pub mod server;
 

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -168,5 +168,6 @@
 pub mod extension_dispatch;
 pub mod features;
 pub mod server;
+pub mod trust_prompt;
 
 pub use server::LexLanguageServer;

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -4,6 +4,11 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::extension_dispatch::{
+    dispatch_code_action as ext_dispatch_code_action,
+    dispatch_completion as ext_dispatch_completion, dispatch_hover as ext_dispatch_hover,
+    LspExtensionState,
+};
 use crate::features::commands::{self, execute_command};
 use crate::features::document_links::collect_document_links;
 use crate::features::document_symbols::{collect_document_symbols, LexDocumentSymbol};
@@ -24,7 +29,7 @@ use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use lex_babel::templates::{
     build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
 };
-use lex_config::{LexConfig, CONFIG_FILE_NAME};
+use lex_config::{LabelsConfig, LexConfig, CONFIG_FILE_NAME};
 use lex_core::lex::ast::links::{DocumentLink as AstDocumentLink, LinkType};
 use lex_core::lex::ast::range::SourceLocation;
 use lex_core::lex::ast::{Document, Position as AstPosition, Range as AstRange};
@@ -32,6 +37,7 @@ use lex_core::lex::builtins as lex_builtins;
 use lex_core::lex::includes::{resolve_from_source, FsLoader, IncludeError, ResolveConfig};
 use lex_core::lex::parsing;
 use lex_extension_host::registry::Registry;
+use lex_extension_host::{TrustDecision, TrustPromptContext, TrustPromptHandler};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tower_lsp::async_trait;
@@ -266,6 +272,13 @@ pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
     features: Arc<P>,
     workspace_roots: RwLock<Vec<PathBuf>>,
     config: RwLock<LexConfig>,
+    /// Extension registry + boot diagnostics, lazily populated on first
+    /// extension-aware request (hover/completion/code_action). Held for
+    /// the lifetime of the workspace; rebuilt when workspace folders
+    /// change. `None` when the LSP is running outside any workspace
+    /// (e.g. a single untitled buffer) — extension dispatch is a no-op
+    /// in that case, and built-in providers handle every request.
+    extension: RwLock<Option<Arc<LspExtensionState>>>,
 }
 
 impl LexLanguageServer<Client, DefaultFeatureProvider> {
@@ -287,7 +300,86 @@ where
             features,
             workspace_roots: RwLock::new(Vec::new()),
             config: RwLock::new(config),
+            extension: RwLock::new(None),
         }
+    }
+
+    /// Lazily boot the extension registry against the current workspace
+    /// root + config. Idempotent: once built, returns the cached state.
+    /// Returns `None` when no workspace is set (e.g. single-file mode);
+    /// extension dispatch is a no-op without a workspace anchor.
+    async fn extension_state(&self) -> Option<Arc<LspExtensionState>> {
+        if let Some(s) = self.extension.read().await.clone() {
+            return Some(s);
+        }
+
+        let workspace_root = {
+            let roots = self.workspace_roots.read().await;
+            roots.first().cloned()?
+        };
+        let labels_config = LabelsConfig {
+            namespaces: self.config.read().await.labels.clone(),
+        };
+
+        // boot_registry does synchronous filesystem IO (schema load,
+        // trust store open) and may attempt to spawn subprocess
+        // handlers — a few hundred milliseconds in the worst case. Run
+        // it on the blocking thread pool so the tokio runtime keeps
+        // serving other LSP requests while boot runs.
+        let workspace_root_owned = workspace_root.clone();
+        let outcome = match tokio::task::spawn_blocking(move || {
+            lex_engine::boot_registry(lex_engine::ExtensionSetup {
+                workspace_root: workspace_root_owned.as_path(),
+                labels_config: &labels_config,
+                // The LSP server has no `--ext-schema` flag; only
+                // `[labels]` entries from `lex.toml` register schemas
+                // in this surface.
+                ext_schemas: &[],
+                // `enable_handlers` is irrelevant on the Lsp surface —
+                // that flag is the CLI shortcut for the trust-prompt
+                // path. The LSP consults the trust store + prompt
+                // handler directly.
+                enable_handlers: false,
+                surface_override: Some(lex_extension_host::Surface::LspSession),
+                // 10a stub: deny with a CLI-trust-first rationale.
+                // PR 10b replaces this with a handler that forwards a
+                // `lex/trustRequest` notification to the editor and
+                // awaits the user's decision.
+                trust_prompt: Box::new(LspDeferTrustPrompt),
+                // Reports `lexd-lsp`'s version to subprocess handlers
+                // in their initialize handshake — what handlers expect
+                // to see, not the `lex-engine` boot crate's version.
+                host_version: env!("CARGO_PKG_VERSION"),
+            })
+        })
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(_) => {
+                // Blocking task panicked or was cancelled. Skip
+                // extension boot for this session; the next request
+                // will retry.
+                return None;
+            }
+        };
+        let state = Arc::new(LspExtensionState::from(outcome));
+
+        let mut slot = self.extension.write().await;
+        if slot.is_none() {
+            *slot = Some(state.clone());
+            Some(state)
+        } else {
+            // Lost the race; another task booted while we were
+            // building. Use that one.
+            slot.clone()
+        }
+    }
+
+    /// Discard the cached extension registry. Called when workspace
+    /// folders change so the next request picks up the new root +
+    /// config.
+    async fn invalidate_extension_state(&self) {
+        *self.extension.write().await = None;
     }
 
     async fn parse_and_store(&self, uri: Url, text: String) {
@@ -880,6 +972,31 @@ fn parent_directory_uri(uri: &Url) -> Url {
     base
 }
 
+/// Trust prompt installed by the LSP boot path in 10a.
+///
+/// PR 10a's scope is the dispatch wiring; the editor-side trust UI
+/// lands in PR 10b along with the comms wire spec for the
+/// `lex/trustRequest` message and the per-editor handlers in
+/// vscode/nvim/lexed. Until then, the LSP defers all trust decisions
+/// to the CLI surface: subprocess handlers that haven't already been
+/// trusted via `lexd labels` (decision persisted at
+/// `<workspace>/.lex/trust.json`) register schema-only with this
+/// rationale. Pre-validation, hover/completion/code-action dispatch,
+/// and the `lex.*` built-ins all keep working.
+struct LspDeferTrustPrompt;
+impl TrustPromptHandler for LspDeferTrustPrompt {
+    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
+        TrustDecision::Denied {
+            reason: format!(
+                "subprocess handler `{}` is not yet trusted in this workspace; \
+                 trust it from the CLI first (run `lexd labels list --enable-handlers` \
+                 in this directory) — editor-side trust prompts land in a follow-up release",
+                ctx.namespace
+            ),
+        }
+    }
+}
+
 #[async_trait]
 impl<C, P> tower_lsp::LanguageServer for LexLanguageServer<C, P>
 where
@@ -996,6 +1113,10 @@ where
         let roots = self.workspace_roots.read().await;
         let root = roots.first().map(|p| p.as_path());
         *self.config.write().await = load_config(root);
+
+        // Workspace shape changed — drop the cached extension registry
+        // so the next request rebuilds it against the new root + config.
+        self.invalidate_extension_state().await;
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -1014,6 +1135,10 @@ where
             let root = roots.first().map(|p| p.as_path());
             *self.config.write().await = load_config(root);
         }
+
+        // Config changed — `[labels]` may have grown / shrunk; drop the
+        // cached extension registry so the next request rebuilds it.
+        self.invalidate_extension_state().await;
 
         // Re-check all documents with new settings
         let uris: Vec<Url> = self
@@ -1084,6 +1209,19 @@ where
             // — author can peek the chapter without navigating away.
             if let Some(hover) = self.hover_for_include(uri, &document, position).await {
                 return Ok(Some(hover));
+            }
+
+            // Extension dispatch: ask any registered third-party
+            // namespace's handler for hover content at this position.
+            // Takes precedence over the built-in hover when it returns
+            // Some — the handler authored the label, it knows the most
+            // about what to show.
+            if let Some(state) = self.extension_state().await {
+                if let Some(hover) =
+                    ext_dispatch_hover(&document, position, state.registry.as_ref())
+                {
+                    return Ok(Some(hover));
+                }
             }
 
             if let Some(result) = self.features.hover(&document, position) {
@@ -1231,8 +1369,21 @@ where
                 workspace.as_ref(),
                 trigger_char,
             );
-            let items: Vec<CompletionItem> =
+            let mut items: Vec<CompletionItem> =
                 candidates.iter().map(to_lsp_completion_item).collect();
+
+            // Extension dispatch: append handler-supplied completions.
+            // Additive — the built-in items still appear so the user
+            // doesn't lose access to footnote/reference/snippet
+            // completions when an extension is loaded.
+            if let Some(state) = self.extension_state().await {
+                items.extend(ext_dispatch_completion(
+                    &document,
+                    position,
+                    state.registry.as_ref(),
+                ));
+            }
+
             Ok(Some(CompletionResponse::Array(items)))
         } else {
             Ok(None)
@@ -1242,7 +1393,8 @@ where
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let mut actions = Vec::new();
 
-        if let Some(entry) = self.documents.get(&params.text_document.uri).await {
+        let document_uri = params.text_document.uri.clone();
+        if let Some(entry) = self.documents.get(&document_uri).await {
             let lex_actions = crate::features::available_actions::compute_actions(
                 &entry.document,
                 &entry.text,
@@ -1252,6 +1404,25 @@ where
                 actions.push(tower_lsp::lsp_types::CodeActionOrCommand::CodeAction(
                     action,
                 ));
+            }
+
+            // Extension dispatch: append handler-supplied code actions
+            // for the labelled node under the request's selection. The
+            // request's range start is the position we use to locate
+            // the labelled node — `compute_actions` already operates
+            // off the same anchor.
+            if let Some(state) = self.extension_state().await {
+                let start = from_lsp_position(params.range.start);
+                for action in ext_dispatch_code_action(
+                    &entry.document,
+                    start,
+                    &document_uri,
+                    state.registry.as_ref(),
+                ) {
+                    actions.push(tower_lsp::lsp_types::CodeActionOrCommand::CodeAction(
+                        action,
+                    ));
+                }
             }
         }
 

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -280,6 +280,15 @@ pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
     /// (e.g. a single untitled buffer) — extension dispatch is a no-op
     /// in that case, and built-in providers handle every request.
     extension: RwLock<Option<Arc<LspExtensionState>>>,
+    /// Serializes concurrent calls to [`Self::extension_state`] so the
+    /// first request to land at boot does the work and every other
+    /// request waits for that single boot to finish — instead of all
+    /// of them racing into `spawn_blocking` and producing N parallel
+    /// schema reads, N parallel subprocess spawns, and N parallel
+    /// `lex/trustRequest` prompts to the editor. Naturally happens
+    /// when N requests arrive on file-open (semantic tokens + hover +
+    /// document symbols + folding + …).
+    extension_init: tokio::sync::Mutex<()>,
 }
 
 impl LexLanguageServer<Client, DefaultFeatureProvider> {
@@ -302,6 +311,7 @@ where
             workspace_roots: RwLock::new(Vec::new()),
             config: RwLock::new(config),
             extension: RwLock::new(None),
+            extension_init: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -309,7 +319,30 @@ where
     /// root + config. Idempotent: once built, returns the cached state.
     /// Returns `None` when no workspace is set (e.g. single-file mode);
     /// extension dispatch is a no-op without a workspace anchor.
+    ///
+    /// Concurrency: the first request to land on a fresh workspace
+    /// takes the `extension_init` mutex and runs the boot; every
+    /// other concurrent request blocks on the mutex, then re-checks
+    /// the cache and reuses what the first one produced. Without
+    /// this serialization, an open-file event that fires several
+    /// providers at once (hover, completion, semantic tokens, folding,
+    /// document-symbols, …) would launch N parallel boots, with N
+    /// concurrent reads of the schema directory, N concurrent
+    /// subprocess spawns, and N `lex/trustRequest` prompts to the
+    /// editor. The mutex keeps the observable side effects to one
+    /// prompt and one set of spawns.
     async fn extension_state(&self) -> Option<Arc<LspExtensionState>> {
+        // Fast path: already booted, no lock needed.
+        if let Some(s) = self.extension.read().await.clone() {
+            return Some(s);
+        }
+
+        // Slow path: serialize boot. Hold the init lock for the whole
+        // boot so the second-arriving request waits for the first.
+        let _guard = self.extension_init.lock().await;
+
+        // Re-check after acquiring the init lock — another task may
+        // have completed boot while we were waiting on the mutex.
         if let Some(s) = self.extension.read().await.clone() {
             return Some(s);
         }
@@ -372,17 +405,28 @@ where
                 return None;
             }
         };
-        let state = Arc::new(LspExtensionState::from(outcome));
 
-        let mut slot = self.extension.write().await;
-        if slot.is_none() {
-            *slot = Some(state.clone());
-            Some(state)
-        } else {
-            // Lost the race; another task booted while we were
-            // building. Use that one.
-            slot.clone()
+        // Surface boot diagnostics to the editor before we cache the
+        // state. Per-namespace failures (resolver errors, denied
+        // subprocess handlers, schema load problems) are stored on
+        // the outcome but the user has no way to see them otherwise
+        // — pre-validation diagnostics are attached to documents,
+        // but boot diagnostics aren't. `window/showMessage` is the
+        // right surface for one-shot status that's not tied to a
+        // specific document range.
+        for diag in &outcome.diagnostics {
+            let prefix = match &diag.namespace {
+                Some(ns) => format!("lex extension `{ns}`: "),
+                None => "lex extensions: ".to_string(),
+            };
+            self.client
+                .show_message(MessageType::WARNING, format!("{prefix}{}", diag.message))
+                .await;
         }
+
+        let state = Arc::new(LspExtensionState::from(outcome));
+        *self.extension.write().await = Some(state.clone());
+        Some(state)
     }
 
     /// Discard the cached extension registry. Called when workspace

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -37,7 +37,6 @@ use lex_core::lex::builtins as lex_builtins;
 use lex_core::lex::includes::{resolve_from_source, FsLoader, IncludeError, ResolveConfig};
 use lex_core::lex::parsing;
 use lex_extension_host::registry::Registry;
-use lex_extension_host::{TrustDecision, TrustPromptContext, TrustPromptHandler};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tower_lsp::async_trait;
@@ -64,7 +63,9 @@ use tower_lsp::lsp_types::Diagnostic;
 use tower_lsp::lsp_types::MessageType;
 
 #[async_trait]
-pub trait LspClient: Send + Sync + Clone + 'static {
+pub trait LspClient:
+    crate::trust_prompt::LspTrustRequester + Send + Sync + Clone + 'static
+{
     async fn publish_diagnostics(&self, uri: Url, diags: Vec<Diagnostic>, version: Option<i32>);
     async fn show_message(&self, typ: MessageType, message: String);
 }
@@ -267,7 +268,7 @@ fn semantic_tokens_legend() -> SemanticTokensLegend {
 }
 
 pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
-    _client: C,
+    client: C,
     documents: DocumentStore,
     features: Arc<P>,
     workspace_roots: RwLock<Vec<PathBuf>>,
@@ -295,7 +296,7 @@ where
     pub fn with_features(client: C, features: Arc<P>) -> Self {
         let config = load_config(None);
         Self {
-            _client: client,
+            client,
             documents: DocumentStore::default(),
             features,
             workspace_roots: RwLock::new(Vec::new()),
@@ -326,7 +327,13 @@ where
         // handlers — a few hundred milliseconds in the worst case. Run
         // it on the blocking thread pool so the tokio runtime keeps
         // serving other LSP requests while boot runs.
+        //
+        // The trust prompt handler bridges sync→async via
+        // `Handle::block_on` — safe because we're on a blocking-pool
+        // thread, not a runtime worker.
         let workspace_root_owned = workspace_root.clone();
+        let trust_requester = std::sync::Arc::new(self.client.clone());
+        let runtime_handle = tokio::runtime::Handle::current();
         let outcome = match tokio::task::spawn_blocking(move || {
             lex_engine::boot_registry(lex_engine::ExtensionSetup {
                 workspace_root: workspace_root_owned.as_path(),
@@ -341,11 +348,14 @@ where
                 // handler directly.
                 enable_handlers: false,
                 surface_override: Some(lex_extension_host::Surface::LspSession),
-                // 10a stub: deny with a CLI-trust-first rationale.
-                // PR 10b replaces this with a handler that forwards a
-                // `lex/trustRequest` notification to the editor and
-                // awaits the user's decision.
-                trust_prompt: Box::new(LspDeferTrustPrompt),
+                // Forwards `lex/trustRequest` to the editor and awaits
+                // the user's decision. Already-pinned decisions in
+                // `<workspace>/.lex/trust.json` short-circuit before
+                // the prompt fires.
+                trust_prompt: Box::new(crate::trust_prompt::LspPromptHandler::new(
+                    trust_requester,
+                    runtime_handle,
+                )),
                 // Reports `lexd-lsp`'s version to subprocess handlers
                 // in their initialize handshake — what handlers expect
                 // to see, not the `lex-engine` boot crate's version.
@@ -398,7 +408,7 @@ where
             diagnostics.extend(analysis_diags.into_iter().map(to_lsp_diagnostic));
         }
 
-        self._client
+        self.client
             .publish_diagnostics(uri, diagnostics, None)
             .await;
     }
@@ -970,31 +980,6 @@ fn parent_directory_uri(uri: &Url) -> Url {
     base.set_query(None);
     base.set_fragment(None);
     base
-}
-
-/// Trust prompt installed by the LSP boot path in 10a.
-///
-/// PR 10a's scope is the dispatch wiring; the editor-side trust UI
-/// lands in PR 10b along with the comms wire spec for the
-/// `lex/trustRequest` message and the per-editor handlers in
-/// vscode/nvim/lexed. Until then, the LSP defers all trust decisions
-/// to the CLI surface: subprocess handlers that haven't already been
-/// trusted via `lexd labels` (decision persisted at
-/// `<workspace>/.lex/trust.json`) register schema-only with this
-/// rationale. Pre-validation, hover/completion/code-action dispatch,
-/// and the `lex.*` built-ins all keep working.
-struct LspDeferTrustPrompt;
-impl TrustPromptHandler for LspDeferTrustPrompt {
-    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
-        TrustDecision::Denied {
-            reason: format!(
-                "subprocess handler `{}` is not yet trusted in this workspace; \
-                 trust it from the CLI first (run `lexd labels list --enable-handlers` \
-                 in this directory) — editor-side trust prompts land in a follow-up release",
-                ctx.namespace
-            ),
-        }
-    }
 }
 
 #[async_trait]
@@ -1878,6 +1863,21 @@ mod tests {
         async fn publish_diagnostics(&self, _: Url, _: Vec<Diagnostic>, _: Option<i32>) {}
         async fn show_message(&self, _: MessageType, _: String) {}
     }
+    #[async_trait]
+    impl crate::trust_prompt::LspTrustRequester for NoopClient {
+        async fn send_trust_request(
+            &self,
+            _: crate::trust_prompt::TrustRequestParams,
+        ) -> tower_lsp::jsonrpc::Result<crate::trust_prompt::TrustResponse> {
+            // Tests don't exercise the trust prompt path; deny so a
+            // boot path that does reach the prompt has predictable
+            // behavior.
+            Ok(crate::trust_prompt::TrustResponse {
+                decision: "denied".into(),
+                reason: Some("test client".into()),
+            })
+        }
+    }
 
     #[derive(Default)]
     struct MockFeatureProvider {
@@ -2712,6 +2712,20 @@ mod tests {
             self.last_diagnostics.lock().unwrap().push((uri, diags));
         }
         async fn show_message(&self, _: MessageType, _: String) {}
+    }
+    #[async_trait]
+    impl crate::trust_prompt::LspTrustRequester for CapturingClient {
+        async fn send_trust_request(
+            &self,
+            _: crate::trust_prompt::TrustRequestParams,
+        ) -> tower_lsp::jsonrpc::Result<crate::trust_prompt::TrustResponse> {
+            // Tests run with no `[labels]` block; the prompt path is
+            // not exercised.
+            Ok(crate::trust_prompt::TrustResponse {
+                decision: "denied".into(),
+                reason: Some("test client".into()),
+            })
+        }
     }
 
     impl CapturingClient {

--- a/crates/lex-lsp/src/trust_prompt.rs
+++ b/crates/lex-lsp/src/trust_prompt.rs
@@ -1,0 +1,475 @@
+//! LSP custom request for the extension trust prompt.
+//!
+//! When the extension boot path encounters a subprocess handler whose
+//! trust hasn't been pinned in `<workspace>/.lex/trust.json`, the
+//! [`LspPromptHandler`] forwards a `lex/trustRequest` to the LSP
+//! client. The client (vscode / nvim / lexed) renders an editor-native
+//! prompt and replies with the user's decision; the response is fed
+//! back into the trust gate which pins the decision for subsequent
+//! sessions.
+//!
+//! ## Why a request, not a notification
+//!
+//! `lex/trustRequest` needs a response to drive the gate's decision,
+//! so it's an LSP request (server → client → response) rather than a
+//! one-way notification. The wire shape is documented in
+//! `comms/specs/proposals/extending-lex.lex` §γ.
+//!
+//! ## Sync / async bridge
+//!
+//! `TrustPromptHandler::prompt` is sync, but tower-lsp's
+//! [`Client::send_request`] is async. The boot path in
+//! [`crate::server::LexLanguageServer::extension_state`] wraps the
+//! whole boot in `tokio::task::spawn_blocking`, so the prompt runs on
+//! a tokio blocking-pool thread — which means we can call
+//! [`tokio::runtime::Handle::block_on`] without blocking the runtime.
+//! The handle is captured at boot time and held by the prompt handler.
+
+use lex_extension_host::{
+    Capability as TrustCapability, Source as TrustSource, Transport as TrustTransport,
+    TrustDecision, TrustPromptContext, TrustPromptHandler,
+};
+use serde::{Deserialize, Serialize};
+use tower_lsp::async_trait;
+use tower_lsp::jsonrpc::Result as JsonRpcResult;
+use tower_lsp::lsp_types::request::Request;
+
+/// `lex/trustRequest` — server asks the client to render a trust prompt
+/// for a subprocess handler that hasn't been pinned in the workspace
+/// trust store.
+pub enum LexTrustRequest {}
+impl Request for LexTrustRequest {
+    type Params = TrustRequestParams;
+    type Result = TrustResponse;
+    const METHOD: &'static str = "lex/trustRequest";
+}
+
+/// Parameters of a `lex/trustRequest`.
+///
+/// Mirrors [`TrustPromptContext`] one-to-one but with serializable wire
+/// types — `source`, `capability`, and `transport` map onto string
+/// constants (`"lex_toml"`, `"local_file"`, `"subprocess"`, …) so editor
+/// implementations don't need to mirror the Rust enum hierarchy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustRequestParams {
+    /// Namespace name (e.g. `"acme"`).
+    pub namespace: String,
+    /// Joined `handler.command` from the schema YAML — exactly the
+    /// string the gate keys on for trust pinning.
+    pub command_string: String,
+    /// Where the schema came from. One of:
+    /// - `{ "kind": "lex_toml", "name": "<namespace>" }` — declared in
+    ///   `lex.toml`'s `[labels]` block.
+    /// - `{ "kind": "local_file", "path": "<path>" }` — a local schema
+    ///   directory the host opted into.
+    /// - `{ "kind": "cache_only", "uri": "<uri>" }` — schema fetched
+    ///   from a marketplace / registry / cache without an explicit
+    ///   user gesture. Higher trust bar.
+    pub source: TrustRequestSource,
+    /// Declared capability set the handler asked for. Forward-compatible
+    /// string-shaped enum:
+    /// - `"pure"` — handler declared `fs: false, net: false`. Will be
+    ///   eligible for sandbox-enforced auto-trust once PR 12 lands.
+    /// - `"full"` — handler asked for `fs` or `net` access. Always
+    ///   prompts (no sandbox can enforce this in v1).
+    ///
+    /// Future values (`"fs_read"`, `"fs_write"`, etc.) are
+    /// non-breaking; editors should render unknown values as
+    /// "unknown capability" and treat them at least as cautiously as
+    /// `"full"`.
+    pub capability: String,
+    /// Transport: always `"subprocess"` in v1 (native handlers don't
+    /// prompt; WASM is deferred to PR 12).
+    pub transport: String,
+}
+
+/// `source` field shape on the wire. Internally tagged on `kind`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TrustRequestSource {
+    LexToml { name: String },
+    LocalFile { path: String },
+    CacheOnly { uri: String },
+}
+
+/// Response shape for `lex/trustRequest`.
+///
+/// `decision` is `"trusted"` or `"denied"` — string-shaped so future
+/// values (e.g. `"trusted_once"`, `"trusted_for_session"`) are
+/// non-breaking. Unknown values fall back to `"denied"` on the host
+/// side. `reason` is optional and is surfaced as the diagnostic message
+/// when `decision == "denied"`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TrustResponse {
+    pub decision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Trait for sending `lex/trustRequest` to an LSP client. Mockable in
+/// tests; the real impl forwards through tower-lsp's
+/// [`Client::send_request`].
+#[async_trait]
+pub trait LspTrustRequester: Send + Sync + 'static {
+    async fn send_trust_request(&self, params: TrustRequestParams) -> JsonRpcResult<TrustResponse>;
+}
+
+#[async_trait]
+impl LspTrustRequester for tower_lsp::Client {
+    async fn send_trust_request(&self, params: TrustRequestParams) -> JsonRpcResult<TrustResponse> {
+        self.send_request::<LexTrustRequest>(params).await
+    }
+}
+
+/// Convert a [`TrustPromptContext`] into the request payload. The
+/// gate's enums map onto the string-shaped wire constants documented
+/// above.
+fn params_from_ctx(ctx: &TrustPromptContext) -> TrustRequestParams {
+    let source = match &ctx.source {
+        TrustSource::LexTomlNamespace { name } => {
+            TrustRequestSource::LexToml { name: name.clone() }
+        }
+        TrustSource::LocalFile { path } => TrustRequestSource::LocalFile {
+            path: path.display().to_string(),
+        },
+        TrustSource::CacheOnly { uri } => TrustRequestSource::CacheOnly { uri: uri.clone() },
+    };
+    let capability = match ctx.capability {
+        TrustCapability::Pure => "pure",
+        TrustCapability::Full => "full",
+    }
+    .to_string();
+    let transport = "subprocess".to_string();
+    TrustRequestParams {
+        namespace: ctx.namespace.clone(),
+        command_string: ctx.command_string.clone(),
+        source,
+        capability,
+        transport,
+    }
+}
+
+/// Maximum time we wait for the editor to reply to a `lex/trustRequest`.
+///
+/// Tradeoff: long enough that a distracted user has time to read the
+/// prompt and decide; short enough that a buggy or quietly-dismissed
+/// extension can't pin the boot indefinitely. 60s is the "send a
+/// message in Slack and come back" budget — past this, treating it as
+/// denied is safer than hanging the boot.
+const PROMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// [`TrustPromptHandler`] implementation that forwards to an LSP
+/// client. Sync→async bridge runs on the boot's blocking thread via
+/// [`tokio::runtime::Handle::block_on`].
+pub struct LspPromptHandler<R: LspTrustRequester> {
+    requester: std::sync::Arc<R>,
+    runtime_handle: tokio::runtime::Handle,
+    timeout: std::time::Duration,
+}
+
+impl<R: LspTrustRequester> LspPromptHandler<R> {
+    pub fn new(requester: std::sync::Arc<R>, runtime_handle: tokio::runtime::Handle) -> Self {
+        Self {
+            requester,
+            runtime_handle,
+            timeout: PROMPT_TIMEOUT,
+        }
+    }
+
+    /// Construct with a custom timeout. Tests use this to drive the
+    /// timeout-as-denied path without waiting 60 seconds.
+    #[cfg(test)]
+    pub fn with_timeout(
+        requester: std::sync::Arc<R>,
+        runtime_handle: tokio::runtime::Handle,
+        timeout: std::time::Duration,
+    ) -> Self {
+        Self {
+            requester,
+            runtime_handle,
+            timeout,
+        }
+    }
+}
+
+impl<R: LspTrustRequester> TrustPromptHandler for LspPromptHandler<R> {
+    fn prompt(&self, ctx: &TrustPromptContext) -> TrustDecision {
+        let params = params_from_ctx(ctx);
+        let requester = std::sync::Arc::clone(&self.requester);
+        let timeout = self.timeout;
+        // We're called from a `spawn_blocking` thread (the boot path
+        // wraps `boot_registry`), so `block_on` is safe — it parks
+        // this blocking-pool thread, not the async runtime's worker
+        // threads.
+        //
+        // Wrap the request in `tokio::time::timeout` so a buggy
+        // extension or a prompt the user dismisses without a reply
+        // can't hang the boot indefinitely. On timeout we deny with a
+        // diagnostic, matching the other failure modes.
+        let response = self.runtime_handle.block_on(async move {
+            tokio::time::timeout(timeout, requester.send_trust_request(params)).await
+        });
+        match response {
+            Ok(Ok(resp)) => match resp.decision.as_str() {
+                "trusted" => TrustDecision::Trusted,
+                _ => {
+                    // Anything other than "trusted" — including unknown
+                    // future values — falls back to denied. The reason
+                    // surfaces as the boot diagnostic.
+                    TrustDecision::Denied {
+                        reason: resp.reason.unwrap_or_else(|| {
+                            format!(
+                                "subprocess handler `{}` was not trusted by the editor",
+                                ctx.namespace
+                            )
+                        }),
+                    }
+                }
+            },
+            Ok(Err(e)) => TrustDecision::Denied {
+                reason: format!(
+                    "subprocess handler `{}` denied: trust request to editor failed ({e})",
+                    ctx.namespace
+                ),
+            },
+            Err(_elapsed) => TrustDecision::Denied {
+                reason: format!(
+                    "subprocess handler `{}` denied: trust request to editor timed out after {}s",
+                    ctx.namespace,
+                    timeout.as_secs()
+                ),
+            },
+        }
+    }
+}
+
+/// `Transport` wire-string mapping. Kept as a free function so the
+/// const can be reused by tests / future request-shaped transports
+/// (WASM, etc.).
+#[allow(dead_code)]
+pub(crate) fn transport_string(t: TrustTransport) -> &'static str {
+    match t {
+        TrustTransport::Native => "native",
+        TrustTransport::Subprocess => "subprocess",
+        TrustTransport::Wasm => "wasm",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+
+    /// Test requester that captures the params it received and returns
+    /// a canned response.
+    struct MockRequester {
+        captured: Mutex<Vec<TrustRequestParams>>,
+        response: Mutex<JsonRpcResult<TrustResponse>>,
+        call_count: AtomicUsize,
+    }
+
+    impl MockRequester {
+        fn new(response: TrustResponse) -> Self {
+            Self {
+                captured: Mutex::new(Vec::new()),
+                response: Mutex::new(Ok(response)),
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn with_error() -> Self {
+            Self {
+                captured: Mutex::new(Vec::new()),
+                response: Mutex::new(Err(tower_lsp::jsonrpc::Error::internal_error())),
+                call_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LspTrustRequester for MockRequester {
+        async fn send_trust_request(
+            &self,
+            params: TrustRequestParams,
+        ) -> JsonRpcResult<TrustResponse> {
+            self.captured.lock().await.push(params);
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            // Clone-or-clone-error-shape via match.
+            let r = self.response.lock().await;
+            match &*r {
+                Ok(resp) => Ok(resp.clone()),
+                Err(e) => Err(e.clone()),
+            }
+        }
+    }
+
+    fn ctx() -> TrustPromptContext {
+        TrustPromptContext {
+            namespace: "acme".into(),
+            command_string: "/usr/local/bin/acme-handler".into(),
+            source: TrustSource::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            capability: TrustCapability::Full,
+        }
+    }
+
+    #[test]
+    fn params_round_trip_through_serde() {
+        let p = TrustRequestParams {
+            namespace: "acme".into(),
+            command_string: "acme-bin".into(),
+            source: TrustRequestSource::LexToml {
+                name: "acme".into(),
+            },
+            capability: "full".into(),
+            transport: "subprocess".into(),
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let back: TrustRequestParams = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn params_from_ctx_local_file_source() {
+        let mut c = ctx();
+        c.source = TrustSource::LocalFile {
+            path: PathBuf::from("/tmp/schemas/acme"),
+        };
+        let p = params_from_ctx(&c);
+        match p.source {
+            TrustRequestSource::LocalFile { path } => {
+                assert!(path.contains("acme"));
+            }
+            _ => panic!("expected LocalFile"),
+        }
+    }
+
+    /// Trusted response from the editor → the prompt returns
+    /// `TrustDecision::Trusted` and the editor saw a single request.
+    #[test]
+    fn prompt_handler_translates_trusted_response() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::new(TrustResponse {
+            decision: "trusted".into(),
+            reason: None,
+        }));
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+
+        // The prompt method calls block_on internally — drive it from
+        // the runtime's spawn_blocking pool (matches production flow).
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+
+        assert!(matches!(decision, TrustDecision::Trusted));
+        assert_eq!(requester.call_count.load(Ordering::SeqCst), 1);
+    }
+
+    /// Denied response with a reason → reason surfaces in the
+    /// `TrustDecision::Denied` diagnostic.
+    #[test]
+    fn prompt_handler_surfaces_denied_reason() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::new(TrustResponse {
+            decision: "denied".into(),
+            reason: Some("user-clicked-deny".into()),
+        }));
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        match decision {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("user-clicked-deny"), "got: {reason}");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    /// Unknown decision string → fall back to denied (forward
+    /// compatibility — future values are non-breaking).
+    #[test]
+    fn prompt_handler_treats_unknown_decision_as_denied() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::new(TrustResponse {
+            decision: "trusted_once".into(),
+            reason: None,
+        }));
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        assert!(matches!(decision, TrustDecision::Denied { .. }));
+    }
+
+    /// Requester that never resolves — simulates a buggy editor that
+    /// receives the request and never replies. The handler must
+    /// time out and treat that as denied so the boot doesn't hang.
+    struct StuckRequester;
+
+    #[async_trait]
+    impl LspTrustRequester for StuckRequester {
+        async fn send_trust_request(&self, _: TrustRequestParams) -> JsonRpcResult<TrustResponse> {
+            // Never resolves on its own; the prompt's tokio::time::timeout
+            // is the only way out.
+            std::future::pending().await
+        }
+    }
+
+    /// Buggy / non-responsive editor → timeout fires → denied with a
+    /// "timed out" diagnostic. Critical: a stuck prompt must NOT pin
+    /// the boot indefinitely.
+    #[test]
+    fn prompt_handler_times_out_when_editor_never_responds() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(StuckRequester);
+        let handler = LspPromptHandler::with_timeout(
+            std::sync::Arc::clone(&requester),
+            rt.handle().clone(),
+            std::time::Duration::from_millis(50),
+        );
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        match decision {
+            TrustDecision::Denied { reason } => {
+                assert!(
+                    reason.contains("timed out"),
+                    "expected 'timed out' diagnostic, got: {reason}"
+                );
+            }
+            other => panic!("expected Denied (timeout), got {other:?}"),
+        }
+    }
+
+    /// Editor-side error (transport, disconnect, etc.) → denied with a
+    /// "trust request failed" diagnostic. Doesn't crash the boot.
+    #[test]
+    fn prompt_handler_surfaces_request_error_as_denied() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let requester = std::sync::Arc::new(MockRequester::with_error());
+        let handler = LspPromptHandler::new(std::sync::Arc::clone(&requester), rt.handle().clone());
+        let decision = rt.block_on(async {
+            tokio::task::spawn_blocking(move || handler.prompt(&ctx()))
+                .await
+                .unwrap()
+        });
+        match decision {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("trust request"), "got: {reason}");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+}

--- a/crates/lex-lsp/tests/integration/robustness_proptest.rs
+++ b/crates/lex-lsp/tests/integration/robustness_proptest.rs
@@ -1,4 +1,5 @@
 use lexd_lsp::server::{DefaultFeatureProvider, LspClient};
+use lexd_lsp::trust_prompt::{LspTrustRequester, TrustRequestParams, TrustResponse};
 use lexd_lsp::LexLanguageServer;
 use proptest::prelude::*;
 use std::sync::Arc;
@@ -18,6 +19,21 @@ use tower_lsp::lsp_types::Diagnostic;
 impl LspClient for MockClient {
     async fn publish_diagnostics(&self, _: Url, _: Vec<Diagnostic>, _: Option<i32>) {}
     async fn show_message(&self, _: tower_lsp::lsp_types::MessageType, _: String) {}
+}
+
+#[async_trait]
+impl LspTrustRequester for MockClient {
+    async fn send_trust_request(
+        &self,
+        _: TrustRequestParams,
+    ) -> tower_lsp::jsonrpc::Result<TrustResponse> {
+        // Proptests don't exercise the trust path; deny is the safe
+        // default that won't spawn subprocesses.
+        Ok(TrustResponse {
+            decision: "denied".into(),
+            reason: Some("proptest mock".into()),
+        })
+    }
 }
 
 proptest! {


### PR DESCRIPTION
Umbrella PR for the γ phase of the extension system (#516). Combines PR 10a (#547) + PR 10b (#548) plus a cross-cutting review fixup commit on top.

## Summary

This is the LSP-side surface of the extension system. Third-party namespaces declared in `lex.toml`'s `[labels]` block (or via `--ext-schema` for CLI) are now dispatched through `textDocument/hover`, `textDocument/completion`, and `textDocument/codeAction`, and subprocess handlers that need user trust are prompted via a custom `lex/trustRequest` LSP request to the editor. Together with PRs 4–9 (β phase, already merged), this closes the lex-side end-to-end story for v1; the per-editor UI implementations land as coordinated releases in `vscode`, `nvim`, and `lexed`.

## What's in here

### From PR 10a (#547, merged into `pr-10`)

- **New `lex-engine` crate** — boot helper lifted out of `lex-cli` so `lexd` and `lexd-lsp` share a single `boot_registry(ExtensionSetup) -> BootOutcome` entry point. `ExtensionSetup` takes a `Box<dyn TrustPromptHandler>` so each host installs the prompt that fits its UX. Future home of PR 11's public `Engine::builder()` facade.
- **LSP extension dispatch** — hover takes precedence over the built-in when a registered handler returns content; completion + code-actions are additive. New `crates/lex-lsp/src/extension_dispatch.rs` module with wire→`lsp_types` translation.
- **`lex_analysis::utils::find_verbatim_at_position`** — mirrors the existing annotation walker so the dispatch path can identify labelled verbatim blocks under the cursor; walks tables too.

### From PR 10b (#548, merged into `pr-10`)

- **`LspPromptHandler`** — replaces 10a's deferring stub with a real handler that forwards `lex/trustRequest` LSP custom requests to the editor. Sync→async bridge runs on the boot's `spawn_blocking` thread via `tokio::runtime::Handle::block_on`.
- **60-second timeout** on the editor reply so a buggy / dismissed prompt can't hang the boot.
- **Wire shape**: server-to-client request with `{ namespace, command_string, source, capability, transport }` params; client replies with `{ decision, reason }` where unknown decision values fall back to denied (forward-compat).

### From the cross-PR review fixup (`5785cff8` on `pr-10`)

- **Boot serialization** — a `tokio::sync::Mutex` around `extension_state()` so a burst of LSP requests on file open (semantic tokens + hover + folding + …) produces exactly one boot, not N parallel boots with N parallel `lex/trustRequest` prompts.
- **Boot diagnostic surfacing** — `outcome.diagnostics` are now forwarded to the editor as `window/showMessage` notifications immediately after boot. Users can finally see why a configured extension didn't load.
- **Invalid code-action URIs are logged** to lex-lsp's stderr (kept off the editor `showMessage` channel because a single buggy handler could spam the user).

## Architecture notes

- The boot registry is workspace-scoped, lazy, cached across requests, invalidated on workspace folder / config change.
- Hover's extension dispatch is preceded by the existing include-hover short-circuit; falls through to the built-in feature provider on `None`.
- Completion is fully additive — existing built-in completions still appear so users don't lose footnote/reference suggestions when an extension is loaded.
- Code-actions append handler-supplied actions to the built-in actions; both render in the editor's quick-fix menu.
- Subprocess handlers pinned in `<workspace>/.lex/trust.json` (e.g., trusted previously via `lexd labels`) skip the prompt and load on subsequent boots.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` clean.
- [x] `cargo nextest run --workspace --exclude lex-wasm` — 1912 tests pass (1899 baseline + 18 new across `lex-engine`, `extension_dispatch`, `trust_prompt`, plus the table-walker arm in `lex_analysis::utils`).
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` clean.
- [x] CHANGELOG entries reconciled across 10a + 10b + the antigravity fixups.

## What's still ahead for the full γ release

Ships as separate PRs — none target this branch:

- **comms wire spec** — document `lex/trustRequest` in `comms/specs/proposals/extending-lex.lex` §γ.
- **vscode / nvim / lexed extension PRs** — implement the `lex/trustRequest` handler in each editor (one per repo). Coordinated release matches the includes-feature 2026-05-04 model.

Once those land, lexd / lexd-lsp / 3 editors can ship together as a coordinated γ release, and PR 11 (Engine::builder) + PR 12a–d (sandboxing) can move into δ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)