### PR TITLE
PR 12-plumbing — Sandbox trait + NullSandbox + trust-gate wiring (δ phase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,38 +6,41 @@
 
 - `lex-extension-host::sandbox`: new module hosting the `Sandbox`
   trait (the OS-level sandbox facade), a `SandboxError` error type,
-  and a `NullSandbox` no-op default that reports `available() ==
-  false` on every platform. Foundation for the δ-phase trust matrix
-  flip (lex#528): per-OS sandbox implementations (12a Linux via
-  birdcage seccomp+landlock, 12b macOS via birdcage sandbox-exec,
-  12c Windows via Job Objects + restricted tokens) plug in behind
-  this trait; the trust gate consults `Sandbox::available()` to
-  decide whether a declared-pure handler can auto-trust without a
-  prompt.
+  and a `NullSandbox` no-op default that reports
+  `supports(_) == false` for every capability set on every platform.
+  Foundation for the δ-phase trust matrix flip (lex#528): per-OS
+  sandbox implementations (12a Linux via birdcage seccomp+landlock,
+  12b macOS via birdcage sandbox-exec, 12c Windows via Job Objects
+  + restricted tokens) plug in behind this trait; the trust gate
+  consults `Sandbox::supports(caps)` to decide whether a
+  declared-pure handler can auto-trust without a prompt.
 - `SubprocessHandler::spawn_with_sandbox` companion to the existing
-  `spawn`. Threads the sandbox down to the worker thread, which
-  calls `apply_to(&mut cmd, capabilities)` before
-  `cmd.spawn()` so the kernel enforces declared capabilities from
-  the child's first instruction. `spawn` (the existing entry point)
-  now delegates to `spawn_with_sandbox` with `NullSandbox` — no
-  behaviour change for current callers.
+  `spawn`. Takes `Arc<dyn Sandbox>` so the host can install one
+  instance and share it with `TrustGate`. The worker thread calls
+  `apply_to(&mut cmd, capabilities)` before `cmd.spawn()` so the
+  kernel enforces declared capabilities from the child's first
+  instruction. `spawn` (the existing entry point) now delegates to
+  `spawn_with_sandbox` with `NullSandbox` — no behaviour change for
+  current callers.
 - `SpawnError::Sandbox(String)` variant for policy-install failures
-  on the host side. The trust gate (when post-δ auto-trust ships)
-  treats this as a fall-back-to-prompt, never a silent auto-trust.
-- `TrustGate::set_sandbox(Box<dyn Sandbox>)` and `TrustGate::sandbox()`
-  accessor. The default install is `NullSandbox`, so β/γ behaviour
-  is preserved (every subprocess prompts). When PR 12a/b/c land,
-  `lex-engine` swaps in the OS-appropriate impl and PR 12d flips
-  the matrix to consult it.
+  on the host side. Same handling as other spawn errors today;
+  retry-with-prompt path is future work alongside PR 12d.
+- `TrustGate::set_sandbox(Arc<dyn Sandbox>)` and
+  `TrustGate::sandbox()` accessor (returns the Arc by clone). The
+  default install is `NullSandbox`, so β/γ behaviour is preserved
+  (every subprocess prompts). When PR 12a/b/c land, `lex-engine`
+  swaps in the OS-appropriate impl and shares the same Arc across
+  the gate and the transport — guaranteeing the auto-trust decision
+  is anchored on the sandbox that actually enforces policy.
 
 ### Changed
 
 - `TrustGate::evaluate` now short-circuits to `Trusted` for the
   `(transport=Subprocess, capability=Pure)` pair when
-  `sandbox.available()` returns `true`. With `NullSandbox` (the
-  default), this branch is inactive — observable behaviour is
-  unchanged. Tests cover both the unavailable and available paths
-  via a mock sandbox.
+  `sandbox.supports(Capabilities::default())` returns `true`. With
+  `NullSandbox` (the default), this branch is inactive —
+  observable behaviour is unchanged. Tests cover both the
+  supported and unsupported paths via a mock sandbox.
 
 ## [0.11.0] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [Unreleased]
 
+### Added
+
+- `lex-extension-host::sandbox`: new module hosting the `Sandbox`
+  trait (the OS-level sandbox facade), a `SandboxError` error type,
+  and a `NullSandbox` no-op default that reports `available() ==
+  false` on every platform. Foundation for the δ-phase trust matrix
+  flip (lex#528): per-OS sandbox implementations (12a Linux via
+  birdcage seccomp+landlock, 12b macOS via birdcage sandbox-exec,
+  12c Windows via Job Objects + restricted tokens) plug in behind
+  this trait; the trust gate consults `Sandbox::available()` to
+  decide whether a declared-pure handler can auto-trust without a
+  prompt.
+- `SubprocessHandler::spawn_with_sandbox` companion to the existing
+  `spawn`. Threads the sandbox down to the worker thread, which
+  calls `apply_to(&mut cmd, capabilities)` before
+  `cmd.spawn()` so the kernel enforces declared capabilities from
+  the child's first instruction. `spawn` (the existing entry point)
+  now delegates to `spawn_with_sandbox` with `NullSandbox` — no
+  behaviour change for current callers.
+- `SpawnError::Sandbox(String)` variant for policy-install failures
+  on the host side. The trust gate (when post-δ auto-trust ships)
+  treats this as a fall-back-to-prompt, never a silent auto-trust.
+- `TrustGate::set_sandbox(Box<dyn Sandbox>)` and `TrustGate::sandbox()`
+  accessor. The default install is `NullSandbox`, so β/γ behaviour
+  is preserved (every subprocess prompts). When PR 12a/b/c land,
+  `lex-engine` swaps in the OS-appropriate impl and PR 12d flips
+  the matrix to consult it.
+
+### Changed
+
+- `TrustGate::evaluate` now short-circuits to `Trusted` for the
+  `(transport=Subprocess, capability=Pure)` pair when
+  `sandbox.available()` returns `true`. With `NullSandbox` (the
+  default), this branch is inactive — observable behaviour is
+  unchanged. Tests cover both the unavailable and available paths
+  via a mock sandbox.
+
 ## [0.11.0] - 2026-05-10
 
 

--- a/crates/lex-extension-host/src/lib.rs
+++ b/crates/lex-extension-host/src/lib.rs
@@ -27,20 +27,29 @@
 //! - [`trust::TrustGate`] — decides whether a handler is allowed to
 //!   run, per the β/γ-correct policy in the master tracking issue
 //!   (subprocess always prompts; native trusted by linkage).
+//! - [`sandbox::Sandbox`] — OS-level enforcement facade. The
+//!   plumbing-PR default is [`sandbox::NullSandbox`] (no
+//!   enforcement, `available() == false`). Per-OS implementations
+//!   land in follow-up PRs (12a Linux, 12b macOS, 12c Windows); the
+//!   trust matrix flip (PR 12d) consumes [`Sandbox::available`] to
+//!   auto-trust declared-pure handlers under enforced sandboxing.
 //!
 //! Coming in later PRs:
 //!
-//! - PR 12: OS-level sandboxing for declared-pure subprocess handlers
-//!   (the post-δ trust matrix flip).
+//! - PR 12a/b/c: per-OS sandbox enforcement.
+//! - PR 12d: trust matrix flip (auto-trust pure handlers under
+//!   enforced sandbox).
 
 pub mod registry;
 pub mod resolve;
+pub mod sandbox;
 pub mod schema;
 pub mod transport;
 pub mod trust;
 
 pub use registry::{Registry, RegistryError};
 pub use resolve::{resolve_namespace, ResolveError, ResolvedNamespace};
+pub use sandbox::{NullSandbox, Sandbox, SandboxError};
 pub use schema::{SchemaError, SchemaLoader};
 pub use trust::{
     detect_ci_environment, Capability, Source, Surface, Transport, TrustDecision, TrustGate,

--- a/crates/lex-extension-host/src/sandbox/mod.rs
+++ b/crates/lex-extension-host/src/sandbox/mod.rs
@@ -27,9 +27,12 @@
 //!
 //! 1. The host constructs a [`Sandbox`] impl appropriate for the
 //!    running OS (or [`NullSandbox`] when no implementation exists).
-//! 2. [`SubprocessHandler::with_sandbox`] stores the impl on the
-//!    handler.
-//! 3. Before spawning the child process, the handler calls
+//! 2. The host passes the impl into
+//!    [`SubprocessHandler::spawn_with_sandbox`] (or installs it on
+//!    a [`crate::TrustGate`] via [`crate::TrustGate::set_sandbox`]
+//!    for the auto-trust decision); the worker thread moves it in
+//!    by value.
+//! 3. Before spawning the child process, the worker calls
 //!    [`Sandbox::apply_to`] with the declared
 //!    [`lex_extension::schema::Capabilities`]. The impl modifies the
 //!    [`std::process::Command`] in place (env vars, pre-exec hooks
@@ -41,7 +44,7 @@
 //!    preserved as long as [`NullSandbox::available`] returns
 //!    `false`.
 //!
-//! [`SubprocessHandler::with_sandbox`]: crate::transport::SubprocessHandler::with_sandbox
+//! [`SubprocessHandler::spawn_with_sandbox`]: crate::transport::SubprocessHandler::spawn_with_sandbox
 
 use std::error::Error;
 use std::fmt;

--- a/crates/lex-extension-host/src/sandbox/mod.rs
+++ b/crates/lex-extension-host/src/sandbox/mod.rs
@@ -64,83 +64,95 @@ pub use null::NullSandbox;
 pub trait Sandbox: Send + Sync {
     /// Apply the sandbox policy to the command. Called by the
     /// subprocess transport just before `spawn()`. Returns
-    /// [`SandboxError`] if the policy can't be installed (e.g., the
-    /// requested capability isn't enforceable on this platform).
+    /// [`SandboxError`] if a kernel-level call fails during policy
+    /// installation.
+    ///
+    /// ## Contract
+    ///
+    /// - **Do not mutate stdin / stdout / stderr.** The subprocess
+    ///   transport configures those as piped streams owned by tokio's
+    ///   reactor for the JSON-RPC bridge; replacing the descriptors
+    ///   breaks the transport. Implementations may attach Unix
+    ///   pre-exec hooks, set environment variables, modify Windows
+    ///   restricted-token attributes, etc. — anything that doesn't
+    ///   touch the standard I/O streams.
+    /// - **Don't return an error for "this capability isn't
+    ///   supported on this OS".** Communicate that via
+    ///   [`Sandbox::supports`] so the trust gate can route the
+    ///   handler to the prompt path *before* spawn. By the time
+    ///   `apply_to` is called, the trust gate has already returned
+    ///   its final decision; surfacing an unsupported-capability
+    ///   error here is a hard spawn failure, not a fall-back.
+    /// - **Only return [`SandboxError`] for genuine kernel
+    ///   failures** (seccomp install fault, sandbox profile compile
+    ///   error, etc.).
     fn apply_to(
         &self,
         cmd: &mut std::process::Command,
         caps: Capabilities,
     ) -> Result<(), SandboxError>;
 
-    /// True when this impl can enforce the declared capabilities on
-    /// the running platform. The trust gate consults this when
-    /// deciding whether a `pure` handler is eligible for auto-trust:
-    /// only `true` shifts a `Pending` decision to `Trusted` without a
+    /// True when this impl can enforce the supplied capability set
+    /// on the running platform. The trust gate consults this when
+    /// deciding whether a handler is eligible for auto-trust: only
+    /// `true` shifts a `Pending` decision to `Trusted` without a
     /// prompt.
     ///
-    /// [`NullSandbox::available`] always returns `false`. A real
-    /// impl may also return `false` for capability sets it can't
-    /// enforce (e.g., a future stricter capability not yet covered
-    /// on a particular OS).
-    fn available(&self) -> bool;
+    /// Takes the [`Capabilities`] rather than the gate's coarser
+    /// `Capability` (Pure / Full) classifier so the trait stays
+    /// forward-compatible: future granular variants (e.g.
+    /// `fs_read: true, fs_write: false`) can ask the sandbox
+    /// directly whether the running OS implementation covers them.
+    ///
+    /// [`NullSandbox::supports`] always returns `false`. Per-OS
+    /// impls return `false` for capability sets they can't enforce
+    /// even if they support others.
+    fn supports(&self, caps: Capabilities) -> bool;
 }
 
-/// Errors a [`Sandbox`] implementation can surface when applying a
-/// policy.
+/// Errors a [`Sandbox`] implementation can surface when installing a
+/// policy at spawn time. Reserved for genuine kernel failures —
+/// platform-capability mismatches are communicated through
+/// [`Sandbox::supports`] *before* the trust gate decides, not here.
 #[derive(Debug)]
-pub enum SandboxError {
-    /// The requested capability cannot be enforced on this platform.
-    /// E.g., on Windows where syscall-level restrictions don't have
-    /// a 1:1 mechanism. The caller (the trust gate) should treat
-    /// this as "fall back to prompt" rather than auto-trust.
-    Unsupported { detail: String },
-    /// An OS-level call failed during policy installation. The inner
-    /// error captures the OS-specific failure (e.g., seccomp install
-    /// failure, sandbox profile compile error).
-    Os {
-        message: String,
-        source: Option<Box<dyn Error + Send + Sync + 'static>>,
-    },
+pub struct SandboxError {
+    message: String,
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl SandboxError {
+    /// Construct a new sandbox error without a wrapped source. Use
+    /// when the OS-specific failure is already captured in
+    /// `message`.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Construct from a message and a wrapped source error (for
+    /// preserving the original `std::io::Error` from a kernel call,
+    /// etc.).
+    pub fn with_source(
+        message: impl Into<String>,
+        source: Box<dyn Error + Send + Sync + 'static>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            source: Some(source),
+        }
+    }
 }
 
 impl fmt::Display for SandboxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Unsupported { detail } => {
-                write!(
-                    f,
-                    "sandbox capability not supported on this platform: {detail}"
-                )
-            }
-            Self::Os { message, .. } => write!(f, "sandbox apply failed: {message}"),
-        }
+        write!(f, "sandbox apply failed: {}", self.message)
     }
 }
 
 impl Error for SandboxError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Unsupported { .. } => None,
-            Self::Os { source, .. } => source.as_ref().map(|s| s.as_ref() as &dyn Error),
-        }
-    }
-}
-
-impl SandboxError {
-    /// Convenience constructor for an [`SandboxError::Unsupported`]
-    /// error.
-    pub fn unsupported(detail: impl Into<String>) -> Self {
-        Self::Unsupported {
-            detail: detail.into(),
-        }
-    }
-
-    /// Convenience constructor for an [`SandboxError::Os`] error
-    /// without a source.
-    pub fn os(message: impl Into<String>) -> Self {
-        Self::Os {
-            message: message.into(),
-            source: None,
-        }
+        self.source.as_ref().map(|s| s.as_ref() as &dyn Error)
     }
 }

--- a/crates/lex-extension-host/src/sandbox/mod.rs
+++ b/crates/lex-extension-host/src/sandbox/mod.rs
@@ -1,0 +1,143 @@
+//! OS-level sandboxing for subprocess handlers.
+//!
+//! The [`Sandbox`] trait is the facade over per-OS enforcement
+//! mechanisms (Linux seccomp+landlock, macOS sandbox-exec, Windows
+//! Job Objects + restricted tokens). Concrete impls live in sibling
+//! files behind `#[cfg(target_os = "...")]` and a feature flag per
+//! platform; the [`NullSandbox`] no-op fallback ships on every
+//! platform and is the default.
+//!
+//! ## Why a facade
+//!
+//! Each OS exposes a sharply different abstraction:
+//!
+//! - Linux: per-syscall filtering (seccomp) + per-path fs rules
+//!   (landlock). Fine-grained, programmatic.
+//! - macOS: Scheme-based profile (`deny file-read* (subpath ...)`).
+//!   Coarse but expressive. Backed by `sandbox-exec`.
+//! - Windows: Job Objects + restricted tokens + AppContainer +
+//!   Windows Filtering Platform. Per-resource-type, not
+//!   per-syscall.
+//!
+//! Our use case ("spawn this handler subprocess with declared-pure
+//! capabilities") is uniform; the facade isolates the per-OS
+//! asymmetry so the rest of `lex-extension-host` has one API.
+//!
+//! ## Lifecycle
+//!
+//! 1. The host constructs a [`Sandbox`] impl appropriate for the
+//!    running OS (or [`NullSandbox`] when no implementation exists).
+//! 2. [`SubprocessHandler::with_sandbox`] stores the impl on the
+//!    handler.
+//! 3. Before spawning the child process, the handler calls
+//!    [`Sandbox::apply_to`] with the declared
+//!    [`lex_extension::schema::Capabilities`]. The impl modifies the
+//!    [`std::process::Command`] in place (env vars, pre-exec hooks
+//!    on Unix, restricted-token hand-off on Windows) so the kernel
+//!    enforces the declared restrictions on the child.
+//! 4. The trust gate consults [`Sandbox::available`] to decide
+//!    whether a pure handler can auto-trust (post-δ matrix flip in
+//!    PR 12d). Today's β/γ behavior — every subprocess prompts — is
+//!    preserved as long as [`NullSandbox::available`] returns
+//!    `false`.
+//!
+//! [`SubprocessHandler::with_sandbox`]: crate::transport::SubprocessHandler::with_sandbox
+
+use std::error::Error;
+use std::fmt;
+
+use lex_extension::schema::Capabilities;
+
+mod null;
+
+pub use null::NullSandbox;
+
+/// OS-level sandbox enforcement for subprocess handlers.
+///
+/// Implementations modify a `std::process::Command` so that the child
+/// process can only perform the operations the [`Capabilities`]
+/// argument permits. See the [module docs](self) for the lifecycle
+/// and platform-specific notes.
+pub trait Sandbox: Send + Sync {
+    /// Apply the sandbox policy to the command. Called by the
+    /// subprocess transport just before `spawn()`. Returns
+    /// [`SandboxError`] if the policy can't be installed (e.g., the
+    /// requested capability isn't enforceable on this platform).
+    fn apply_to(
+        &self,
+        cmd: &mut std::process::Command,
+        caps: Capabilities,
+    ) -> Result<(), SandboxError>;
+
+    /// True when this impl can enforce the declared capabilities on
+    /// the running platform. The trust gate consults this when
+    /// deciding whether a `pure` handler is eligible for auto-trust:
+    /// only `true` shifts a `Pending` decision to `Trusted` without a
+    /// prompt.
+    ///
+    /// [`NullSandbox::available`] always returns `false`. A real
+    /// impl may also return `false` for capability sets it can't
+    /// enforce (e.g., a future stricter capability not yet covered
+    /// on a particular OS).
+    fn available(&self) -> bool;
+}
+
+/// Errors a [`Sandbox`] implementation can surface when applying a
+/// policy.
+#[derive(Debug)]
+pub enum SandboxError {
+    /// The requested capability cannot be enforced on this platform.
+    /// E.g., on Windows where syscall-level restrictions don't have
+    /// a 1:1 mechanism. The caller (the trust gate) should treat
+    /// this as "fall back to prompt" rather than auto-trust.
+    Unsupported { detail: String },
+    /// An OS-level call failed during policy installation. The inner
+    /// error captures the OS-specific failure (e.g., seccomp install
+    /// failure, sandbox profile compile error).
+    Os {
+        message: String,
+        source: Option<Box<dyn Error + Send + Sync + 'static>>,
+    },
+}
+
+impl fmt::Display for SandboxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported { detail } => {
+                write!(
+                    f,
+                    "sandbox capability not supported on this platform: {detail}"
+                )
+            }
+            Self::Os { message, .. } => write!(f, "sandbox apply failed: {message}"),
+        }
+    }
+}
+
+impl Error for SandboxError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Unsupported { .. } => None,
+            Self::Os { source, .. } => source.as_ref().map(|s| s.as_ref() as &dyn Error),
+        }
+    }
+}
+
+impl SandboxError {
+    /// Convenience constructor for an [`SandboxError::Unsupported`]
+    /// error.
+    pub fn unsupported(detail: impl Into<String>) -> Self {
+        Self::Unsupported {
+            detail: detail.into(),
+        }
+    }
+
+    /// Convenience constructor for an [`SandboxError::Os`] error
+    /// without a source.
+    pub fn os(message: impl Into<String>) -> Self {
+        Self::Os {
+            message: message.into(),
+            source: None,
+        }
+    }
+}

--- a/crates/lex-extension-host/src/sandbox/null.rs
+++ b/crates/lex-extension-host/src/sandbox/null.rs
@@ -1,0 +1,64 @@
+//! [`NullSandbox`] — the no-op fallback used when no OS-specific
+//! sandbox is implemented (or available) for the running platform.
+//!
+//! Behavior: [`Sandbox::apply_to`] makes no changes to the command;
+//! [`Sandbox::available`] returns `false`. This means the trust gate
+//! (when consulted in PR 12d) will keep prompting for every
+//! subprocess handler, exactly as it does today in β/γ.
+//!
+//! The plumbing PR (this one) installs `NullSandbox` as the default
+//! on every platform. Per-OS PRs (12a/b/c) ship concrete impls
+//! behind feature flags and `#[cfg(target_os = ...)]`.
+
+use lex_extension::schema::Capabilities;
+
+use super::{Sandbox, SandboxError};
+
+/// No-op sandbox. Always returns "not available"; never modifies the
+/// command. The default installed by [`SubprocessHandler::with_sandbox`]
+/// when the host doesn't pass a concrete impl.
+///
+/// [`SubprocessHandler::with_sandbox`]: crate::transport::SubprocessHandler::with_sandbox
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullSandbox;
+
+impl Sandbox for NullSandbox {
+    fn apply_to(
+        &self,
+        _cmd: &mut std::process::Command,
+        _caps: Capabilities,
+    ) -> Result<(), SandboxError> {
+        Ok(())
+    }
+
+    fn available(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_sandbox_reports_unavailable() {
+        let s = NullSandbox;
+        assert!(!s.available());
+    }
+
+    #[test]
+    fn null_sandbox_apply_is_a_no_op() {
+        let s = NullSandbox;
+        let mut cmd = std::process::Command::new("true");
+        // Should not error regardless of capability shape.
+        s.apply_to(&mut cmd, Capabilities::default()).unwrap();
+        s.apply_to(
+            &mut cmd,
+            Capabilities {
+                fs: true,
+                net: true,
+            },
+        )
+        .unwrap();
+    }
+}

--- a/crates/lex-extension-host/src/sandbox/null.rs
+++ b/crates/lex-extension-host/src/sandbox/null.rs
@@ -15,10 +15,13 @@ use lex_extension::schema::Capabilities;
 use super::{Sandbox, SandboxError};
 
 /// No-op sandbox. Always returns "not available"; never modifies the
-/// command. The default installed by [`SubprocessHandler::with_sandbox`]
-/// when the host doesn't pass a concrete impl.
+/// command. The default the existing [`SubprocessHandler::spawn`]
+/// passes through to [`SubprocessHandler::spawn_with_sandbox`] when
+/// the host doesn't supply a concrete impl, and the default the
+/// [`crate::TrustGate`] installs via [`crate::TrustGate::new`].
 ///
-/// [`SubprocessHandler::with_sandbox`]: crate::transport::SubprocessHandler::with_sandbox
+/// [`SubprocessHandler::spawn`]: crate::transport::SubprocessHandler::spawn
+/// [`SubprocessHandler::spawn_with_sandbox`]: crate::transport::SubprocessHandler::spawn_with_sandbox
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NullSandbox;
 

--- a/crates/lex-extension-host/src/sandbox/null.rs
+++ b/crates/lex-extension-host/src/sandbox/null.rs
@@ -2,9 +2,10 @@
 //! sandbox is implemented (or available) for the running platform.
 //!
 //! Behavior: [`Sandbox::apply_to`] makes no changes to the command;
-//! [`Sandbox::available`] returns `false`. This means the trust gate
-//! (when consulted in PR 12d) will keep prompting for every
-//! subprocess handler, exactly as it does today in β/γ.
+//! [`Sandbox::supports`] returns `false` for every capability set.
+//! This means the trust gate (when consulted in PR 12d) will keep
+//! prompting for every subprocess handler, exactly as it does today
+//! in β/γ.
 //!
 //! The plumbing PR (this one) installs `NullSandbox` as the default
 //! on every platform. Per-OS PRs (12a/b/c) ship concrete impls
@@ -14,7 +15,7 @@ use lex_extension::schema::Capabilities;
 
 use super::{Sandbox, SandboxError};
 
-/// No-op sandbox. Always returns "not available"; never modifies the
+/// No-op sandbox. Always reports "not supported"; never modifies the
 /// command. The default the existing [`SubprocessHandler::spawn`]
 /// passes through to [`SubprocessHandler::spawn_with_sandbox`] when
 /// the host doesn't supply a concrete impl, and the default the
@@ -34,7 +35,7 @@ impl Sandbox for NullSandbox {
         Ok(())
     }
 
-    fn available(&self) -> bool {
+    fn supports(&self, _caps: Capabilities) -> bool {
         false
     }
 }
@@ -44,9 +45,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn null_sandbox_reports_unavailable() {
+    fn null_sandbox_reports_unsupported_for_every_capability_shape() {
         let s = NullSandbox;
-        assert!(!s.available());
+        assert!(!s.supports(Capabilities::default()));
+        assert!(!s.supports(Capabilities {
+            fs: true,
+            net: false
+        }));
+        assert!(!s.supports(Capabilities {
+            fs: true,
+            net: true
+        }));
     }
 
     #[test]

--- a/crates/lex-extension-host/src/transport/subprocess.rs
+++ b/crates/lex-extension-host/src/transport/subprocess.rs
@@ -144,6 +144,15 @@ pub enum SpawnError {
     /// The child closed stdin/stdout before completing the
     /// `initialize` handshake.
     ChildStreamMissing,
+    /// The OS-level [`Sandbox`] couldn't install its policy on the
+    /// command (e.g., the requested capability isn't enforceable on
+    /// this platform, or a kernel call failed). The child is never
+    /// spawned in this case — the caller (typically the trust gate)
+    /// should treat it as fall-back-to-prompt rather than
+    /// auto-trust.
+    ///
+    /// [`Sandbox`]: crate::sandbox::Sandbox
+    Sandbox(String),
     /// Initialize timed out, errored, or returned an incompatible
     /// `wire_version`.
     Initialize(InitializeError),
@@ -184,6 +193,12 @@ impl std::fmt::Display for SpawnError {
             SpawnError::Spawn(e) => write!(f, "subprocess handler: failed to spawn child: {e}"),
             SpawnError::ChildStreamMissing => {
                 f.write_str("subprocess handler: child closed stdio before initialize")
+            }
+            SpawnError::Sandbox(message) => {
+                write!(
+                    f,
+                    "subprocess handler: sandbox policy install failed: {message}"
+                )
             }
             SpawnError::Initialize(InitializeError::Timeout) => {
                 f.write_str("subprocess handler: initialize handshake timed out")
@@ -290,6 +305,11 @@ impl SubprocessHandler {
     /// report which host they're talking to). `env` provides values
     /// for the `${WORKSPACE_ROOT}` / `${LEX_CACHE}` / `${HANDLER_CONFIG}`
     /// expansions inside `spec.command`.
+    ///
+    /// The child process runs without OS-level sandboxing. To enforce
+    /// declared capabilities at the kernel level (declared-pure
+    /// handlers under post-δ trust-matrix auto-trust), use
+    /// [`Self::spawn_with_sandbox`].
     pub fn spawn(
         spec: &HandlerSpec,
         namespace: &str,
@@ -297,6 +317,41 @@ impl SubprocessHandler {
         capabilities: lex_extension::schema::Capabilities,
         lex_version: &str,
         env: &SpawnEnv,
+    ) -> Result<Self, SpawnError> {
+        Self::spawn_with_sandbox(
+            spec,
+            namespace,
+            labels,
+            capabilities,
+            lex_version,
+            env,
+            Box::new(crate::sandbox::NullSandbox),
+        )
+    }
+
+    /// Spawn a handler subprocess under the supplied OS-level
+    /// [`Sandbox`], then run the `initialize` handshake. The sandbox's
+    /// [`Sandbox::apply_to`] is called against the [`Command`] before
+    /// `spawn()`, so the kernel enforces the declared capability set
+    /// on the child from the first instruction.
+    ///
+    /// `sandbox` carries the per-OS enforcement mechanism (Linux
+    /// seccomp+landlock via `birdcage`, macOS sandbox-exec, Windows
+    /// Job Objects + restricted tokens). For the plumbing PR
+    /// ([lex-fmt/lex#528](https://github.com/lex-fmt/lex/issues/528))
+    /// the only available impl is [`crate::sandbox::NullSandbox`],
+    /// which behaves identically to [`Self::spawn`].
+    ///
+    /// [`Sandbox`]: crate::sandbox::Sandbox
+    /// [`Sandbox::apply_to`]: crate::sandbox::Sandbox::apply_to
+    pub fn spawn_with_sandbox(
+        spec: &HandlerSpec,
+        namespace: &str,
+        labels: &[String],
+        capabilities: lex_extension::schema::Capabilities,
+        lex_version: &str,
+        env: &SpawnEnv,
+        sandbox: Box<dyn crate::sandbox::Sandbox>,
     ) -> Result<Self, SpawnError> {
         if spec.command.is_empty() {
             return Err(SpawnError::EmptyCommand);
@@ -332,8 +387,18 @@ impl SubprocessHandler {
         })
         .expect("InitializeParams serialises");
 
+        let worker_sandbox = sandbox;
+        let worker_caps = capabilities;
         let worker = thread::spawn(move || {
-            run_worker(expanded, init_params, init_tx, cmd_rx, disabled_for_worker);
+            run_worker(
+                expanded,
+                init_params,
+                init_tx,
+                cmd_rx,
+                disabled_for_worker,
+                worker_sandbox,
+                worker_caps,
+            );
         });
 
         let init = init_rx
@@ -620,37 +685,61 @@ impl LexHandler for SubprocessHandler {
 /// Worker entry point. Owns a single-threaded tokio runtime, spawns the
 /// child, runs the initialize handshake, then loops dispatching
 /// commands until shutdown.
+#[allow(clippy::too_many_arguments)]
 fn run_worker(
     argv: Vec<String>,
     init_params: serde_json::Value,
     init_tx: std::sync::mpsc::Sender<Result<InitializeResult, SpawnError>>,
     cmd_rx: mpsc::UnboundedReceiver<WorkerCmd>,
     disabled: Arc<AtomicBool>,
+    sandbox: Box<dyn crate::sandbox::Sandbox>,
+    capabilities: lex_extension::schema::Capabilities,
 ) {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("build current_thread runtime");
     runtime.block_on(async move {
-        worker_main(argv, init_params, init_tx, cmd_rx, disabled).await;
+        worker_main(
+            argv,
+            init_params,
+            init_tx,
+            cmd_rx,
+            disabled,
+            sandbox,
+            capabilities,
+        )
+        .await;
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn worker_main(
     argv: Vec<String>,
     init_params: serde_json::Value,
     init_tx: std::sync::mpsc::Sender<Result<InitializeResult, SpawnError>>,
     mut cmd_rx: mpsc::UnboundedReceiver<WorkerCmd>,
     disabled: Arc<AtomicBool>,
+    sandbox: Box<dyn crate::sandbox::Sandbox>,
+    capabilities: lex_extension::schema::Capabilities,
 ) {
-    let mut child = match Command::new(&argv[0])
-        .args(&argv[1..])
+    // Build the Command first, hand it to the sandbox for in-place
+    // policy installation (env vars, Unix pre-exec hooks, restricted
+    // tokens on Windows), then spawn. Doing the apply_to before
+    // spawn() is the contract — once the child is alive it may have
+    // already issued syscalls we'd want to block, and most kernel
+    // sandboxes can only attach pre-exec.
+    let mut cmd = Command::new(&argv[0]);
+    cmd.args(&argv[1..])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-    {
+        .kill_on_drop(true);
+    if let Err(e) = sandbox.apply_to(cmd.as_std_mut(), capabilities) {
+        let _ = init_tx.send(Err(SpawnError::Sandbox(format!("{e}"))));
+        return;
+    }
+    let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
             let _ = init_tx.send(Err(SpawnError::Spawn(e)));

--- a/crates/lex-extension-host/src/transport/subprocess.rs
+++ b/crates/lex-extension-host/src/transport/subprocess.rs
@@ -147,11 +147,22 @@ pub enum SpawnError {
     /// The OS-level [`Sandbox`] couldn't install its policy on the
     /// command (e.g., the requested capability isn't enforceable on
     /// this platform, or a kernel call failed). The child is never
-    /// spawned in this case — the caller (typically the trust gate)
-    /// should treat it as fall-back-to-prompt rather than
-    /// auto-trust.
+    /// spawned in this case.
+    ///
+    /// Current handling in [`lex_engine::setup::boot_registry`]
+    /// (and any other caller treating spawn failure as terminal):
+    /// the namespace registers schema-only — pre-validation still
+    /// catches typos but no handler runs — and a `BootDiagnostic`
+    /// surfaces the reason. Same shape as other [`SpawnError`]
+    /// variants today. Future revisions (likely landing alongside
+    /// PR 12d's matrix flip) may add a retry-with-prompt path so a
+    /// sandbox install failure on a pure handler can downgrade to
+    /// the prompt-then-pin track instead of registering schema-
+    /// only on the first run; until then, sandbox failures behave
+    /// identically to other spawn failures.
     ///
     /// [`Sandbox`]: crate::sandbox::Sandbox
+    /// [`lex_engine::setup::boot_registry`]: https://docs.rs/lex-engine/latest/lex_engine/setup/fn.boot_registry.html
     Sandbox(String),
     /// Initialize timed out, errored, or returned an incompatible
     /// `wire_version`.

--- a/crates/lex-extension-host/src/transport/subprocess.rs
+++ b/crates/lex-extension-host/src/transport/subprocess.rs
@@ -336,7 +336,7 @@ impl SubprocessHandler {
             capabilities,
             lex_version,
             env,
-            Box::new(crate::sandbox::NullSandbox),
+            std::sync::Arc::new(crate::sandbox::NullSandbox),
         )
     }
 
@@ -362,7 +362,7 @@ impl SubprocessHandler {
         capabilities: lex_extension::schema::Capabilities,
         lex_version: &str,
         env: &SpawnEnv,
-        sandbox: Box<dyn crate::sandbox::Sandbox>,
+        sandbox: std::sync::Arc<dyn crate::sandbox::Sandbox>,
     ) -> Result<Self, SpawnError> {
         if spec.command.is_empty() {
             return Err(SpawnError::EmptyCommand);
@@ -703,7 +703,7 @@ fn run_worker(
     init_tx: std::sync::mpsc::Sender<Result<InitializeResult, SpawnError>>,
     cmd_rx: mpsc::UnboundedReceiver<WorkerCmd>,
     disabled: Arc<AtomicBool>,
-    sandbox: Box<dyn crate::sandbox::Sandbox>,
+    sandbox: std::sync::Arc<dyn crate::sandbox::Sandbox>,
     capabilities: lex_extension::schema::Capabilities,
 ) {
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -731,7 +731,7 @@ async fn worker_main(
     init_tx: std::sync::mpsc::Sender<Result<InitializeResult, SpawnError>>,
     mut cmd_rx: mpsc::UnboundedReceiver<WorkerCmd>,
     disabled: Arc<AtomicBool>,
-    sandbox: Box<dyn crate::sandbox::Sandbox>,
+    sandbox: std::sync::Arc<dyn crate::sandbox::Sandbox>,
     capabilities: lex_extension::schema::Capabilities,
 ) {
     // Build the Command first, hand it to the sandbox for in-place

--- a/crates/lex-extension-host/src/trust/decision.rs
+++ b/crates/lex-extension-host/src/trust/decision.rs
@@ -7,6 +7,8 @@
 //! explicit approval; declared `capabilities: { fs/net: false }` is
 //! ignored until PR 12 lands OS-level enforcement.
 
+use std::sync::Arc;
+
 use super::store::{TrustKey, TrustStore};
 
 /// Where the schema came from. Combined with [`Surface`] and
@@ -159,11 +161,18 @@ pub struct TrustGate {
     prompt: Box<dyn TrustPromptHandler>,
     /// OS-level enforcement available to the host. With
     /// [`crate::sandbox::NullSandbox`] (the default for PR
-    /// 12-plumbing), [`crate::sandbox::Sandbox::available`] returns
-    /// `false` and the post-δ pure-handler auto-trust path is
-    /// inactive — behaviour matches β/γ. PR 12d (the matrix flip)
-    /// becomes a one-line consult here.
-    sandbox: Box<dyn crate::sandbox::Sandbox>,
+    /// 12-plumbing), [`crate::sandbox::Sandbox::supports`] returns
+    /// `false` for every capability set and the post-δ pure-handler
+    /// auto-trust path is inactive — behaviour matches β/γ. PR 12d
+    /// (the matrix flip) becomes a one-line wiring change in
+    /// `lex-engine` to install the OS-appropriate impl here.
+    ///
+    /// Stored as `Arc` so the host can hand the same instance to
+    /// the gate and to [`crate::transport::SubprocessHandler::spawn_with_sandbox`]
+    /// — guaranteeing the gate's auto-trust decision is anchored on
+    /// the same sandbox that will actually enforce the policy at
+    /// spawn time.
+    sandbox: Arc<dyn crate::sandbox::Sandbox>,
 }
 
 impl TrustGate {
@@ -178,26 +187,36 @@ impl TrustGate {
             enable_handlers,
             store,
             prompt,
-            sandbox: Box::new(crate::sandbox::NullSandbox),
+            sandbox: Arc::new(crate::sandbox::NullSandbox),
         }
     }
 
     /// Install an OS-level sandbox for post-δ auto-trust of declared-
     /// pure handlers. Replaces the default
     /// [`crate::sandbox::NullSandbox`]. Today (PR 12-plumbing) the
-    /// gate consults [`crate::sandbox::Sandbox::available`] but the
+    /// gate consults [`crate::sandbox::Sandbox::supports`] but the
     /// only available impls report `false`, so behaviour doesn't
     /// change yet. PR 12a/b/c ship per-OS impls; PR 12d flips the
     /// matrix to actually use the result.
-    pub fn set_sandbox(&mut self, sandbox: Box<dyn crate::sandbox::Sandbox>) {
+    ///
+    /// Takes `Arc<dyn Sandbox>` so the host can hand the same
+    /// instance to [`crate::transport::SubprocessHandler::spawn_with_sandbox`]
+    /// — guaranteeing the auto-trust decision is anchored on the
+    /// sandbox that actually enforces policy at spawn time. Without
+    /// this contract, a host could (e.g.) install a real sandbox on
+    /// the gate but forget to wire it into spawn, silently auto-
+    /// trusting pure handlers that then run unrestrained.
+    pub fn set_sandbox(&mut self, sandbox: Arc<dyn crate::sandbox::Sandbox>) {
         self.sandbox = sandbox;
     }
 
     /// Borrow the sandbox installed on this gate. Mainly here for
     /// host-side diagnostics (e.g., "this workspace would auto-
-    /// trust pure handlers" status output).
-    pub fn sandbox(&self) -> &dyn crate::sandbox::Sandbox {
-        self.sandbox.as_ref()
+    /// trust pure handlers" status output) and for callers that
+    /// need to pass the same instance into
+    /// [`crate::transport::SubprocessHandler::spawn_with_sandbox`].
+    pub fn sandbox(&self) -> Arc<dyn crate::sandbox::Sandbox> {
+        Arc::clone(&self.sandbox)
     }
 
     /// Surface the gate was constructed with. Useful for diagnostics
@@ -243,20 +262,31 @@ impl TrustGate {
         // Post-δ pure-handler auto-trust path (the matrix flip
         // tracked at lex#528 / PR 12d). Only fires when both:
         //   1. the handler declared `pure` capabilities, AND
-        //   2. an OS-level sandbox is available to enforce that
+        //   2. the installed sandbox supports enforcing that
         //      declaration on the running platform.
         //
         // PR 12-plumbing wires this consultation but ships
         // [`crate::sandbox::NullSandbox`] as the default, which
-        // reports `available() == false` everywhere. PR 12a/b/c add
-        // real per-OS impls; PR 12d switches the default install in
-        // `lex-engine` from `NullSandbox` to the OS-appropriate
-        // impl so this branch starts firing.
+        // reports `supports(_) == false` for every capability set.
+        // PR 12a/b/c add real per-OS impls; PR 12d switches the
+        // default install in `lex-engine` from `NullSandbox` to the
+        // OS-appropriate impl so this branch starts firing.
+        //
+        // We pass `Capabilities::default()` to `supports()` because
+        // `Capability::Pure` is exactly the
+        // `Capabilities::is_pure()` classifier — the default-shape
+        // capability set. Future granular capability variants would
+        // pass the actual schema `Capabilities` through `evaluate`
+        // and on to `supports()` here.
         //
         // Independent of `surface`: a pure handler under an enforced
         // sandbox is trustworthy regardless of whether we're in CLI,
         // CI, or LSP mode.
-        if matches!(capability, Capability::Pure) && self.sandbox.available() {
+        if matches!(capability, Capability::Pure)
+            && self
+                .sandbox
+                .supports(lex_extension::schema::Capabilities::default())
+        {
             return TrustDecision::Trusted;
         }
 
@@ -705,12 +735,12 @@ mod tests {
 
     // ───────── Sandbox plumbing (lex#528, PR 12-plumbing) ─────────
 
-    /// Test sandbox impl that reports availability per its
-    /// constructor flag and is a no-op in `apply_to`. Used to drive
-    /// the post-δ auto-trust path without depending on any real OS
-    /// sandbox.
-    struct FixedAvailabilitySandbox(bool);
-    impl crate::sandbox::Sandbox for FixedAvailabilitySandbox {
+    /// Test sandbox impl whose `supports()` returns the configured
+    /// flag for every capability set, and `apply_to` is a no-op.
+    /// Used to drive the post-δ auto-trust path without depending
+    /// on any real OS sandbox.
+    struct FixedSupportSandbox(bool);
+    impl crate::sandbox::Sandbox for FixedSupportSandbox {
         fn apply_to(
             &self,
             _cmd: &mut std::process::Command,
@@ -718,13 +748,13 @@ mod tests {
         ) -> Result<(), crate::sandbox::SandboxError> {
             Ok(())
         }
-        fn available(&self) -> bool {
+        fn supports(&self, _caps: lex_extension::schema::Capabilities) -> bool {
             self.0
         }
     }
 
     #[test]
-    fn default_gate_installs_null_sandbox_which_reports_unavailable() {
+    fn default_gate_installs_null_sandbox_which_supports_nothing() {
         let (gate, _dir) = gate_with_surface(
             Surface::LspSession,
             false,
@@ -732,16 +762,19 @@ mod tests {
                 reason: "n/a".into(),
             },
         );
-        // Default sandbox is NullSandbox, which always reports
-        // unavailable. The post-δ auto-trust branch never fires.
-        assert!(!gate.sandbox().available());
+        // Default sandbox is NullSandbox, which reports supports(_)
+        // == false for every capability set. The post-δ auto-trust
+        // branch never fires.
+        assert!(!gate
+            .sandbox()
+            .supports(lex_extension::schema::Capabilities::default()));
     }
 
     #[test]
-    fn pure_handler_auto_trusts_when_sandbox_available() {
+    fn pure_handler_auto_trusts_when_sandbox_supports_pure() {
         // PR 12d-style behavior, tested with a mock sandbox so the
         // plumbing PR can lock in the contract before any per-OS
-        // impl ships. With sandbox.available() == true and the
+        // impl ships. With sandbox.supports(default) == true and the
         // handler declaring pure capabilities, the gate auto-trusts
         // without consulting the prompt — regardless of surface.
         for surface in [Surface::CliOneShot, Surface::LspSession, Surface::Ci] {
@@ -752,7 +785,7 @@ mod tests {
                     reason: "prompt should not fire".into(),
                 },
             );
-            gate.set_sandbox(Box::new(FixedAvailabilitySandbox(true)));
+            gate.set_sandbox(Arc::new(FixedSupportSandbox(true)));
             let d = gate.evaluate(
                 &Source::LexTomlNamespace {
                     name: "acme".into(),
@@ -779,7 +812,7 @@ mod tests {
                 reason: "n/a".into(),
             },
         );
-        gate.set_sandbox(Box::new(FixedAvailabilitySandbox(true)));
+        gate.set_sandbox(Arc::new(FixedSupportSandbox(true)));
         let d = gate.evaluate(
             &Source::LexTomlNamespace {
                 name: "acme".into(),
@@ -798,10 +831,11 @@ mod tests {
     }
 
     #[test]
-    fn pure_handler_falls_back_to_prompt_when_sandbox_unavailable() {
+    fn pure_handler_falls_back_to_prompt_when_sandbox_unsupported() {
         // The path PR 12-plumbing ships with NullSandbox: pure
-        // handler, but no enforced sandbox, so behaviour matches
-        // β/γ — CLI without the flag is denied, LSP would prompt.
+        // handler, but the sandbox doesn't support that capability
+        // set, so behaviour matches β/γ — CLI without the flag is
+        // denied, LSP would prompt.
         let (mut gate, _dir) = gate_with_surface(
             Surface::CliOneShot,
             false,
@@ -809,7 +843,7 @@ mod tests {
                 reason: "n/a".into(),
             },
         );
-        gate.set_sandbox(Box::new(FixedAvailabilitySandbox(false)));
+        gate.set_sandbox(Arc::new(FixedSupportSandbox(false)));
         let d = gate.evaluate(
             &Source::LexTomlNamespace {
                 name: "acme".into(),
@@ -825,5 +859,28 @@ mod tests {
             }
             other => panic!("expected Denied without enforced sandbox, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn sandbox_arc_is_shared_with_callers() {
+        // The Arc<dyn Sandbox> contract: the gate must hand out the
+        // SAME instance to callers (e.g., `lex-engine` wiring this
+        // through to `SubprocessHandler::spawn_with_sandbox`). If
+        // the gate and the transport were to hold separate
+        // instances, a future bug could silently auto-trust pure
+        // handlers under one config while spawning them under
+        // another.
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::LspSession,
+            false,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        let original: Arc<dyn crate::sandbox::Sandbox> = Arc::new(FixedSupportSandbox(true));
+        gate.set_sandbox(Arc::clone(&original));
+        let from_gate = gate.sandbox();
+        // Same Arc allocation — pointer identity check.
+        assert!(Arc::ptr_eq(&original, &from_gate));
     }
 }

--- a/crates/lex-extension-host/src/trust/decision.rs
+++ b/crates/lex-extension-host/src/trust/decision.rs
@@ -157,6 +157,13 @@ pub struct TrustGate {
     enable_handlers: bool,
     store: TrustStore,
     prompt: Box<dyn TrustPromptHandler>,
+    /// OS-level enforcement available to the host. With
+    /// [`crate::sandbox::NullSandbox`] (the default for PR
+    /// 12-plumbing), [`crate::sandbox::Sandbox::available`] returns
+    /// `false` and the post-δ pure-handler auto-trust path is
+    /// inactive — behaviour matches β/γ. PR 12d (the matrix flip)
+    /// becomes a one-line consult here.
+    sandbox: Box<dyn crate::sandbox::Sandbox>,
 }
 
 impl TrustGate {
@@ -171,7 +178,26 @@ impl TrustGate {
             enable_handlers,
             store,
             prompt,
+            sandbox: Box::new(crate::sandbox::NullSandbox),
         }
+    }
+
+    /// Install an OS-level sandbox for post-δ auto-trust of declared-
+    /// pure handlers. Replaces the default
+    /// [`crate::sandbox::NullSandbox`]. Today (PR 12-plumbing) the
+    /// gate consults [`crate::sandbox::Sandbox::available`] but the
+    /// only available impls report `false`, so behaviour doesn't
+    /// change yet. PR 12a/b/c ship per-OS impls; PR 12d flips the
+    /// matrix to actually use the result.
+    pub fn set_sandbox(&mut self, sandbox: Box<dyn crate::sandbox::Sandbox>) {
+        self.sandbox = sandbox;
+    }
+
+    /// Borrow the sandbox installed on this gate. Mainly here for
+    /// host-side diagnostics (e.g., "this workspace would auto-
+    /// trust pure handlers" status output).
+    pub fn sandbox(&self) -> &dyn crate::sandbox::Sandbox {
+        self.sandbox.as_ref()
     }
 
     /// Surface the gate was constructed with. Useful for diagnostics
@@ -200,8 +226,8 @@ impl TrustGate {
         command_string: &str,
     ) -> TrustDecision {
         // Native handlers run by linkage. Bundled `lex.*` built-ins
-        // hit this path; PR 12 will extend it to declared-pure
-        // subprocess handlers.
+        // hit this path; PR 12d will extend it to declared-pure
+        // subprocess handlers under an enforced sandbox.
         if matches!(transport, Transport::Native) {
             return TrustDecision::Trusted;
         }
@@ -212,6 +238,26 @@ impl TrustGate {
             return TrustDecision::Denied {
                 reason: "WASM handlers are not yet supported".into(),
             };
+        }
+
+        // Post-δ pure-handler auto-trust path (the matrix flip
+        // tracked at lex#528 / PR 12d). Only fires when both:
+        //   1. the handler declared `pure` capabilities, AND
+        //   2. an OS-level sandbox is available to enforce that
+        //      declaration on the running platform.
+        //
+        // PR 12-plumbing wires this consultation but ships
+        // [`crate::sandbox::NullSandbox`] as the default, which
+        // reports `available() == false` everywhere. PR 12a/b/c add
+        // real per-OS impls; PR 12d switches the default install in
+        // `lex-engine` from `NullSandbox` to the OS-appropriate
+        // impl so this branch starts firing.
+        //
+        // Independent of `surface`: a pure handler under an enforced
+        // sandbox is trustworthy regardless of whether we're in CLI,
+        // CI, or LSP mode.
+        if matches!(capability, Capability::Pure) && self.sandbox.available() {
+            return TrustDecision::Trusted;
         }
 
         match self.surface {
@@ -655,5 +701,129 @@ mod tests {
     #[test]
     fn ci_detection_returns_false_when_no_var_set() {
         assert!(!detect_ci_environment(|_| None));
+    }
+
+    // ───────── Sandbox plumbing (lex#528, PR 12-plumbing) ─────────
+
+    /// Test sandbox impl that reports availability per its
+    /// constructor flag and is a no-op in `apply_to`. Used to drive
+    /// the post-δ auto-trust path without depending on any real OS
+    /// sandbox.
+    struct FixedAvailabilitySandbox(bool);
+    impl crate::sandbox::Sandbox for FixedAvailabilitySandbox {
+        fn apply_to(
+            &self,
+            _cmd: &mut std::process::Command,
+            _caps: lex_extension::schema::Capabilities,
+        ) -> Result<(), crate::sandbox::SandboxError> {
+            Ok(())
+        }
+        fn available(&self) -> bool {
+            self.0
+        }
+    }
+
+    #[test]
+    fn default_gate_installs_null_sandbox_which_reports_unavailable() {
+        let (gate, _dir) = gate_with_surface(
+            Surface::LspSession,
+            false,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        // Default sandbox is NullSandbox, which always reports
+        // unavailable. The post-δ auto-trust branch never fires.
+        assert!(!gate.sandbox().available());
+    }
+
+    #[test]
+    fn pure_handler_auto_trusts_when_sandbox_available() {
+        // PR 12d-style behavior, tested with a mock sandbox so the
+        // plumbing PR can lock in the contract before any per-OS
+        // impl ships. With sandbox.available() == true and the
+        // handler declaring pure capabilities, the gate auto-trusts
+        // without consulting the prompt — regardless of surface.
+        for surface in [Surface::CliOneShot, Surface::LspSession, Surface::Ci] {
+            let (mut gate, _dir) = gate_with_surface(
+                surface,
+                false,
+                TrustDecision::Denied {
+                    reason: "prompt should not fire".into(),
+                },
+            );
+            gate.set_sandbox(Box::new(FixedAvailabilitySandbox(true)));
+            let d = gate.evaluate(
+                &Source::LexTomlNamespace {
+                    name: "acme".into(),
+                },
+                Transport::Subprocess,
+                Capability::Pure,
+                "acme",
+                "acme-handler",
+            );
+            assert_eq!(d, TrustDecision::Trusted, "surface={surface:?}");
+        }
+    }
+
+    #[test]
+    fn full_capability_handler_does_not_auto_trust_even_under_sandbox() {
+        // Auto-trust is reserved for `pure` declarations. A handler
+        // that declared `fs: true` or `net: true` still prompts /
+        // requires --enable-handlers, because the sandbox can only
+        // enforce what was declared.
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::CliOneShot,
+            false,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        gate.set_sandbox(Box::new(FixedAvailabilitySandbox(true)));
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Full,
+            "acme",
+            "acme-handler",
+        );
+        match d {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("--enable-handlers"));
+            }
+            other => panic!("expected Denied (full caps still prompts), got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pure_handler_falls_back_to_prompt_when_sandbox_unavailable() {
+        // The path PR 12-plumbing ships with NullSandbox: pure
+        // handler, but no enforced sandbox, so behaviour matches
+        // β/γ — CLI without the flag is denied, LSP would prompt.
+        let (mut gate, _dir) = gate_with_surface(
+            Surface::CliOneShot,
+            false,
+            TrustDecision::Denied {
+                reason: "n/a".into(),
+            },
+        );
+        gate.set_sandbox(Box::new(FixedAvailabilitySandbox(false)));
+        let d = gate.evaluate(
+            &Source::LexTomlNamespace {
+                name: "acme".into(),
+            },
+            Transport::Subprocess,
+            Capability::Pure,
+            "acme",
+            "acme-handler",
+        );
+        match d {
+            TrustDecision::Denied { reason } => {
+                assert!(reason.contains("--enable-handlers"));
+            }
+            other => panic!("expected Denied without enforced sandbox, got: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
First of the δ-phase sandbox stack ([lex#528](https://github.com/lex-fmt/lex/issues/528), master plan [#516](https://github.com/lex-fmt/lex/issues/516)). Adds the abstraction layer + plumbing on every OS but ships \`NullSandbox\` as the only implementation, so observable behaviour is unchanged. Per-OS sandbox impls (12a Linux / 12b macOS / 12c Windows) and the trust-matrix flip (12d) land in follow-up PRs.

## What this PR adds

### \`lex-extension-host::sandbox\` module

- **\`Sandbox\` trait**:
  ```rust
  pub trait Sandbox: Send + Sync {
      fn apply_to(&self, cmd: &mut Command, caps: Capabilities) -> Result<(), SandboxError>;
      fn available(&self) -> bool;
  }
  ```
  The trust gate consults \`available()\` to decide whether a \`pure\` handler can auto-trust without a prompt.
- **\`SandboxError\`** with \`Unsupported\` (capability not enforceable on this OS) and \`Os\` (kernel call failed) variants.
- **\`NullSandbox\`** no-op fallback. \`available()\` returns \`false\`; ships as the default on every platform.

### \`SubprocessHandler::spawn_with_sandbox\`

New constructor that takes \`Box<dyn Sandbox>\` and threads it into the worker. The worker calls \`sandbox.apply_to(cmd.as_std_mut(), capabilities)\` before \`cmd.spawn()\` — Unix pre-exec hooks, env-var policy, restricted-token hand-off all install pre-fork. The existing \`spawn\` is now a thin wrapper passing \`NullSandbox\` for backward compatibility.

\`SpawnError::Sandbox(String)\` variant added for policy-install failures.

### \`TrustGate::set_sandbox\` + \`sandbox()\` accessor

Default installed by \`new()\` is \`NullSandbox\`. \`evaluate()\` adds a post-δ auto-trust branch:

```rust
if Capability::Pure && self.sandbox.available() {
    return TrustDecision::Trusted;
}
```

With \`NullSandbox\` in place, the branch is inactive — observable behaviour is unchanged. Other paths (native always-trusted, WASM denied, CLI flag-gating, LSP prompt) are unchanged.

## Why a facade

Each OS exposes a sharply different abstraction:
- Linux: per-syscall filtering (seccomp) + per-path fs rules (landlock). Fine-grained, programmatic.
- macOS: Scheme-based profile (\`deny file-read* (subpath ...)\`). Coarse but expressive. Backed by \`sandbox-exec\`.
- Windows: Job Objects + restricted tokens + AppContainer + WFP. Per-resource-type, not per-syscall.

Our use case ("spawn this handler with declared-pure capabilities") is uniform; the facade isolates per-OS asymmetry so the rest of \`lex-extension-host\` has one API.

## Sub-PRs (follow-up)

- **PR 12a (Linux)**: wrap \`birdcage\` (seccomp + landlock backend).
- **PR 12b (macOS)**: wrap \`birdcage\` (sandbox-exec backend).
- **PR 12c (Windows)**: custom impl via \`windows\` crate (no mature Rust crate covers Windows).
- **PR 12d**: \`lex-engine\` swaps \`NullSandbox\` for the OS-appropriate impl; trust matrix flips. CHANGELOG callout of the policy change.

Each is independently mergeable, testable on its target CI runner, and parallelizable across per-OS machines/agents.

## Test plan

- [x] 4 new unit tests in \`trust::decision\` covering the plumbing contract:
    - default gate installs \`NullSandbox\` (\`available() == false\`)
    - pure handler under available sandbox auto-trusts across every surface
    - full-capability handler does NOT auto-trust even with sandbox available
    - pure handler falls back to existing β/γ behaviour when sandbox unavailable (β/γ regression guard)
- [x] 2 new unit tests in \`sandbox::null\` covering \`NullSandbox\` availability + no-op \`apply_to\`.
- [x] Full workspace: 1920/1920 tests pass.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo clippy --workspace --exclude lex-wasm -- -D warnings\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)