### PR TITLE
Sandbox prep — dev container, CI workflow, probe fixtures

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -1,0 +1,62 @@
+name: Sandbox Tests
+
+# Per-OS sandbox tests for lex-extension-host.
+#
+# Path-filtered so PRs that don't touch sandbox code don't burn macOS
+# minutes. Always runs on push to main so we catch regressions from
+# unrelated changes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/lex-extension-host/src/sandbox/**'
+      - 'crates/lex-extension-host/tests/fixtures/fs_probe.rs'
+      - 'crates/lex-extension-host/tests/fixtures/net_probe.rs'
+      - 'crates/lex-extension-host/tests/sandbox_enforcement.rs'
+      - 'crates/lex-extension-host/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/sandbox-tests.yml'
+  # No `branches:` filter on pull_request — stacked PRs whose base is
+  # a feature branch (not `main`) should still get sandbox CI signal.
+  # The `paths:` filter alone keeps the workflow cheap on unrelated
+  # PRs.
+  pull_request:
+    paths:
+      - 'crates/lex-extension-host/src/sandbox/**'
+      - 'crates/lex-extension-host/tests/fixtures/fs_probe.rs'
+      - 'crates/lex-extension-host/tests/fixtures/net_probe.rs'
+      - 'crates/lex-extension-host/tests/sandbox_enforcement.rs'
+      - 'crates/lex-extension-host/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/sandbox-tests.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sandbox:
+    name: Sandbox tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: sandbox-${{ matrix.os }}
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run sandbox tests
+        run: cargo nextest run -p lex-extension-host sandbox::

--- a/crates/lex-extension-host/Cargo.toml
+++ b/crates/lex-extension-host/Cargo.toml
@@ -35,3 +35,18 @@ tempfile = { workspace = true }
 name = "lex-extension-host-fixture-handler"
 path = "tests/fixtures/fixture_handler.rs"
 required-features = ["subprocess"]
+
+# Sandbox test fixtures: standalone binaries that attempt one privileged
+# operation each and exit with a known code. Spawned directly via
+# `std::process::Command` with a `Sandbox` impl applied. Same feature
+# gating as the JSON-RPC fixture above — built only as part of the
+# subprocess-test toolchain.
+[[bin]]
+name = "lex-extension-host-fixture-fs-probe"
+path = "tests/fixtures/fs_probe.rs"
+required-features = ["subprocess"]
+
+[[bin]]
+name = "lex-extension-host-fixture-net-probe"
+path = "tests/fixtures/net_probe.rs"
+required-features = ["subprocess"]

--- a/crates/lex-extension-host/tests/fixtures/fs_probe.rs
+++ b/crates/lex-extension-host/tests/fixtures/fs_probe.rs
@@ -1,0 +1,22 @@
+//! Filesystem-probe test fixture for the sandbox suite.
+//!
+//! Tries to read `/etc/passwd`. Exits 0 on success, 42 on EPERM /
+//! EACCES / not-found. Used by sandbox tests to assert that a
+//! `pure`-capability handler running under an enforced sandbox cannot
+//! reach the filesystem, with `NullSandbox` providing the negative
+//! control (exit 0 means the fixture itself works).
+//!
+//! /etc/passwd is chosen because it exists with mode 0644 on every
+//! Linux distribution and macOS install we target, so the negative
+//! control is reliable across CI runners.
+
+use std::fs::File;
+
+const EXIT_BLOCKED: i32 = 42;
+
+fn main() {
+    match File::open("/etc/passwd") {
+        Ok(_) => std::process::exit(0),
+        Err(_) => std::process::exit(EXIT_BLOCKED),
+    }
+}

--- a/crates/lex-extension-host/tests/fixtures/net_probe.rs
+++ b/crates/lex-extension-host/tests/fixtures/net_probe.rs
@@ -1,0 +1,23 @@
+//! Network-probe test fixture for the sandbox suite.
+//!
+//! Attempts a TCP connect to the address passed in argv[1]. Exits 0
+//! on success, 42 on any error. Tests pass a localhost listener's
+//! address so the negative control (NullSandbox: exit 0) works on
+//! offline CI runners.
+//!
+//! Usage: net_probe <host:port>
+
+use std::net::TcpStream;
+use std::time::Duration;
+
+const EXIT_BLOCKED: i32 = 42;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn main() {
+    let addr = std::env::args().nth(1).expect("missing addr argv");
+    let parsed: std::net::SocketAddr = addr.parse().expect("addr must be host:port");
+    match TcpStream::connect_timeout(&parsed, CONNECT_TIMEOUT) {
+        Ok(_) => std::process::exit(0),
+        Err(_) => std::process::exit(EXIT_BLOCKED),
+    }
+}

--- a/scripts/dev/Dockerfile.sandbox
+++ b/scripts/dev/Dockerfile.sandbox
@@ -1,0 +1,32 @@
+# Linux dev container for exercising the sandbox tests on a macOS host.
+#
+# Used by scripts/dev/sandbox-test-linux.sh. CI runs the same tests on
+# ubuntu-latest directly; this image only exists so a contributor on
+# macOS can run the Linux-only sandbox suite locally without spinning
+# up a VM.
+#
+# Pinned to the workspace's rust-toolchain.toml channel. Birdcage uses
+# pure-Rust seccomp + landlock crates, so no native dev packages are
+# required beyond what the kernel exposes (landlock ≥5.13, seccomp
+# filter mode + no_new_privs).
+FROM rust:1.88-bookworm
+
+# Match rust-toolchain.toml targets so `cargo build` doesn't trigger a
+# rustup network fetch on first run.
+RUN rustup target add wasm32-unknown-unknown
+
+# Use the prebuilt binary — `cargo install cargo-nextest` from source
+# now requires rust ≥1.91 on the latest release, which doesn't match
+# our pinned toolchain. Architecture is detected at build time so the
+# image works on both Apple Silicon (arm64) hosts and amd64 hosts.
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-gnu ;; \
+        aarch64) triple=aarch64-unknown-linux-gnu ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://get.nexte.st/latest/${triple}.tar.gz" \
+        | tar -xz -C /usr/local/cargo/bin
+
+WORKDIR /work

--- a/scripts/dev/sandbox-test-linux.sh
+++ b/scripts/dev/sandbox-test-linux.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run sandbox tests inside a Linux container — for macOS contributors
+# who need to exercise the seccomp+landlock path without a VM. CI runs
+# the same suite on ubuntu-latest directly via .github/workflows/sandbox-tests.yml.
+#
+# Usage:
+#   scripts/dev/sandbox-test-linux.sh                # nextest sandbox:: in lex-extension-host
+#   scripts/dev/sandbox-test-linux.sh <cmd> [args]   # run an arbitrary command in the container
+#
+# Notes:
+# - The image is built on first run; subsequent runs reuse it. To force
+#   a rebuild, `docker rmi lex-sandbox-dev:latest` first.
+# - Named volumes cache /target and the cargo registry so incremental
+#   rebuilds are fast across runs.
+# - No --privileged / --cap-add needed: landlock works unprivileged on
+#   kernels ≥5.13 and seccomp filter mode works with no_new_privs.
+# - Defaults to the host's native arch (arm64 on Apple Silicon). Set
+#   `SANDBOX_PLATFORM=linux/amd64` to validate the x86_64 path under
+#   emulation.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE="lex-sandbox-dev:latest"
+DOCKERFILE="$REPO_ROOT/scripts/dev/Dockerfile.sandbox"
+PLATFORM_FLAG=()
+if [[ -n "${SANDBOX_PLATFORM:-}" ]]; then
+    PLATFORM_FLAG=(--platform "$SANDBOX_PLATFORM")
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/scripts/dev"
+fi
+
+if [[ $# -eq 0 ]]; then
+    set -- cargo nextest run -p lex-extension-host sandbox::
+fi
+
+exec docker run --rm \
+    "${PLATFORM_FLAG[@]}" \
+    -v "$REPO_ROOT:/work" \
+    -v lex-sandbox-target:/target \
+    -v lex-sandbox-cargo-registry:/usr/local/cargo/registry \
+    -e CARGO_TARGET_DIR=/target \
+    -w /work \
+    "$IMAGE" \
+    "$@"


### PR DESCRIPTION
## Summary

Prep tooling for PR 12a (Linux) and 12b (macOS) of [#528](https://github.com/lex-fmt/lex/issues/528). No sandbox impl yet — this is the infrastructure that 12a/12b plug into.

- **`scripts/dev/Dockerfile.sandbox`** + **`scripts/dev/sandbox-test-linux.sh`** — one-command Linux test loop for contributors on macOS. Unprivileged container (landlock + seccomp filter mode work without `--privileged` on modern kernels). Named volumes cache `target/` + cargo registry for fast incremental rebuilds. Verified locally: 107 lex-extension-host tests pass inside the container; the wrapper round-trips edits between macOS host and Linux container.
- **`.github/workflows/sandbox-tests.yml`** — path-filtered workflow running `cargo nextest sandbox::` on `ubuntu-latest` + `macos-14`. Triggers only when sandbox code changes (so unrelated PRs don't burn macOS minutes), plus on push to `main` for regression coverage.
- **`tests/fixtures/{fs_probe,net_probe}.rs`** — standalone fixture bins that attempt one privileged operation each and exit `0` (succeeded) or `42` (blocked). 12a/12b's tests will spawn them with a `Sandbox` impl applied and assert blocked vs. `NullSandbox`-as-control.

`cargo nextest sandbox::` currently finds the 2 existing `NullSandbox` tests on every OS (passing). PR 12a will add Linux-cfg-gated tests behind `BirdcageSandbox`; 12b adds the macOS-cfg-gated counterparts.

## Test plan

- [x] `docker build` + `docker run cargo nextest run -p lex-extension-host` — 107/107 pass on linux/arm64
- [x] `scripts/dev/sandbox-test-linux.sh` — 2/2 NullSandbox tests pass via the wrapper
- [x] `cargo nextest run -p lex-extension-host sandbox::` on macOS — 2/2 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude lex-wasm --all-targets --all-features -- -D warnings` clean
- [x] Full workspace test (pre-commit hook): 1939/1939 pass
- [ ] `sandbox-tests.yml` triggers on this PR (path filter includes `.github/workflows/sandbox-tests.yml` itself + `Cargo.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)