### PR TITLE
PR 12a — Linux sandbox via seccomp + landlock

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -59,4 +59,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run sandbox tests
-        run: cargo nextest run -p lex-extension-host sandbox::
+        # Filter expression matches both the unit tests under
+        # `sandbox::` and the `tests/sandbox_enforcement.rs`
+        # integration tests (which are scoped by binary name).
+        run: cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,26 @@
 
 ### Added
 
+- `lex-extension-host::sandbox::LinuxSandbox`: Linux implementation of
+  the `Sandbox` trait (lex#528 PR 12a). Combines `landlock` (filesystem
+  allowlist — dynamic-loader paths + the handler binary itself) and
+  `seccompiler` (network-stack syscall deny) installed via a `pre_exec`
+  hook so the policy applies to the child after `fork()` and survives
+  `execve()`. `supports()` returns `true` only for the
+  `Capabilities::is_pure()` shape; finer capability shapes report
+  unsupported until the schema grows the corresponding fields. Build
+  surface remains MIT/Apache (`landlock` MIT/Apache, `seccompiler`
+  Apache/BSD) — `lex-extension-host` and downstream consumers stay MIT.
 - `lex-extension-host::sandbox`: new module hosting the `Sandbox`
   trait (the OS-level sandbox facade), a `SandboxError` error type,
   and a `NullSandbox` no-op default that reports
   `supports(_) == false` for every capability set on every platform.
   Foundation for the δ-phase trust matrix flip (lex#528): per-OS
-  sandbox implementations (12a Linux via birdcage seccomp+landlock,
-  12b macOS via birdcage sandbox-exec, 12c Windows via Job Objects
-  + restricted tokens) plug in behind this trait; the trust gate
-  consults `Sandbox::supports(caps)` to decide whether a
-  declared-pure handler can auto-trust without a prompt.
+  sandbox implementations (12a Linux via seccomp+landlock, 12b macOS
+  via sandbox-exec, 12c Windows via Job Objects + restricted tokens)
+  plug in behind this trait; the trust gate consults
+  `Sandbox::supports(caps)` to decide whether a declared-pure handler
+  can auto-trust without a prompt.
 - `SubprocessHandler::spawn_with_sandbox` companion to the existing
   `spawn`. Takes `Arc<dyn Sandbox>` so the host can install one
   instance and share it with `TrustGate`. The worker thread calls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,7 +1212,10 @@ dependencies = [
 name = "lex-extension-host"
 version = "0.11.0"
 dependencies = [
+ "landlock",
  "lex-extension",
+ "libc",
+ "seccompiler",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1977,6 +2011,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/crates/lex-extension-host/Cargo.toml
+++ b/crates/lex-extension-host/Cargo.toml
@@ -23,6 +23,15 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, optional = true }
 
+# Linux sandbox impl: seccomp-bpf for syscall filtering (network deny)
+# + landlock for filesystem allowlist. Both crates are MIT/Apache,
+# maintained upstream (AWS / ANSSI), and work on every Linux arch we
+# build on. Pulled in only on Linux targets.
+[target.'cfg(target_os = "linux")'.dependencies]
+seccompiler = "0.5"
+landlock = "0.4"
+libc = "0.2"
+
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/lex-extension-host/src/sandbox/linux.rs
+++ b/crates/lex-extension-host/src/sandbox/linux.rs
@@ -1,0 +1,282 @@
+//! Linux sandbox enforcement for declared-pure handlers.
+//!
+//! Combines two kernel mechanisms:
+//!
+//! - **seccomp** (via the `seccompiler` crate, Apache-2.0 / BSD-3) —
+//!   blocks network-stack syscalls (`socket`, `connect`, `bind`,
+//!   `listen`, `accept`, `sendto`, etc.). Returns `EPERM` so the
+//!   child errors gracefully rather than dying via `SIGSYS`.
+//! - **landlock** (via the `landlock` crate, MIT / Apache-2.0) —
+//!   restricts filesystem reads to a minimal allowlist: the
+//!   dynamic-loader paths plus the handler binary itself. Anything
+//!   not in the allowlist (notably `/etc/passwd` and the workspace
+//!   the host is running over) returns `EACCES`.
+//!
+//! Both policies are installed inside a `pre_exec` hook so they apply
+//! to the child after `fork()` and survive across `execve()`. The
+//! parent host process is unaffected.
+//!
+//! ## Capability shapes
+//!
+//! [`LinuxSandbox::supports`] returns `true` only for the
+//! [`Capabilities::is_pure`] shape (`fs: false, net: false`). Any
+//! finer shape (when [`Capabilities`] grows fields like scoped fs
+//! reads) reports unsupported until we wire the corresponding
+//! allowlist; the trust gate then routes those handlers to the
+//! prompt path and `apply_to` is never called for them.
+//!
+//! ## Fail-closed semantics
+//!
+//! If the kernel reports that landlock is not enforced (older kernel
+//! without the LSM, or build without `CONFIG_SECURITY_LANDLOCK`), we
+//! treat it as a hard error from the `pre_exec` hook so the spawn
+//! fails. A handler advertised as sandbox-isolated must actually be
+//! isolated — silent fallback would defeat the trust gate.
+//!
+//! The module itself is `#[cfg(target_os = "linux")]`-gated in
+//! `super::mod`; no inner cfg is required here.
+
+use std::ffi::OsString;
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+
+use landlock::{
+    AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, ABI,
+};
+use lex_extension::schema::Capabilities;
+use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, TargetArch};
+
+use super::{Sandbox, SandboxError};
+
+/// Linux sandbox built on seccomp (network deny) + landlock
+/// (filesystem allowlist). Installed via a `pre_exec` hook on the
+/// child process so the policy survives `execve()`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LinuxSandbox;
+
+impl Sandbox for LinuxSandbox {
+    fn apply_to(
+        &self,
+        cmd: &mut std::process::Command,
+        caps: Capabilities,
+    ) -> Result<(), SandboxError> {
+        if !caps.is_pure() {
+            return Err(SandboxError::new(format!(
+                "LinuxSandbox only enforces pure capabilities (fs=false, net=false); got {caps:?}"
+            )));
+        }
+        let program: OsString = cmd.get_program().to_owned();
+        // SAFETY: the closure only performs syscalls (seccomp filter
+        // install, landlock ruleset create + restrict_self) plus
+        // allocations needed by the seccompiler/landlock crates.
+        // After fork() the child is single-threaded so allocator
+        // mutexes left by other parent threads cannot deadlock this
+        // path. No locks owned by the parent are touched.
+        unsafe {
+            cmd.pre_exec(move || install_pure_policy(&program));
+        }
+        Ok(())
+    }
+
+    fn supports(&self, caps: Capabilities) -> bool {
+        caps.is_pure()
+    }
+}
+
+/// Apply the seccomp + landlock policies for a pure-capability
+/// handler in the just-forked child, right before `execve()`. Errors
+/// here cause `Command::spawn` to fail; the parent host surfaces them
+/// through the existing `SpawnError::Sandbox` variant.
+///
+/// `pre_exec` swallows the textual `io::Error` message on the way
+/// back to the parent (only the errno is preserved), so we route
+/// diagnostic context through a stderr write before returning. The
+/// child still has the parent's stderr at this point.
+fn install_pure_policy(program: &std::ffi::OsStr) -> io::Result<()> {
+    set_no_new_privs().inspect_err(|e| write_diag("PR_SET_NO_NEW_PRIVS", e))?;
+    install_landlock_fs_allowlist(program).inspect_err(|e| write_diag("landlock", e))?;
+    install_seccomp_network_deny().inspect_err(|e| write_diag("seccomp", e))?;
+    Ok(())
+}
+
+/// Async-signal-safe diagnostic write to stderr from inside
+/// `pre_exec`. Used so the operator gets a specific failure point
+/// instead of a bare `EINVAL` when the kernel lacks landlock support
+/// or the policy install fails at runtime. `eprintln!` is unsafe
+/// post-fork because it acquires the stdio lock; `libc::write` is
+/// not.
+fn write_diag(stage: &str, err: &io::Error) {
+    let msg = format!("lex-extension-host sandbox: {stage} failed: {err}\n");
+    let bytes = msg.as_bytes();
+    // SAFETY: write(2) is async-signal-safe; fd 2 is inherited from
+    // the parent and remains open until execve().
+    unsafe {
+        libc::write(2, bytes.as_ptr() as *const _, bytes.len());
+    }
+}
+
+/// Unprivileged seccomp filter installation requires
+/// `PR_SET_NO_NEW_PRIVS` to be set on the process — without it the
+/// kernel rejects `PR_SET_SECCOMP` with `EPERM`. Landlock also
+/// requires this for unprivileged rulesets. Setting it before either
+/// policy install is the canonical pattern.
+fn set_no_new_privs() -> io::Result<()> {
+    // SAFETY: prctl is a syscall wrapper; no Rust invariants in scope.
+    let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Filesystem allowlist: read access to the dynamic-loader paths +
+/// the handler binary. Everything else is denied (notably the
+/// workspace and `/etc/passwd`).
+///
+/// The path set is intentionally broad enough to cover Debian/Ubuntu,
+/// RHEL/Fedora, Arch, and Alpine layouts. `PathFd::new` silently
+/// drops paths that don't exist on the current distro so the
+/// allowlist is robust to per-distro differences.
+fn install_landlock_fs_allowlist(program: &std::ffi::OsStr) -> io::Result<()> {
+    let abi = ABI::V1;
+    let read_access = AccessFs::from_read(abi);
+
+    let mut allowed: Vec<PathBuf> = [
+        "/lib",
+        "/lib64",
+        "/usr/lib",
+        "/usr/lib64",
+        "/etc/ld.so.cache",
+        "/etc/ld.so.preload",
+        "/proc/self",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .collect();
+    allowed.push(PathBuf::from(program));
+
+    let ruleset = Ruleset::default()
+        .handle_access(read_access)
+        .map_err(landlock_err)?
+        .create()
+        .map_err(landlock_err)?
+        .add_rules(allowed.iter().filter_map(|p| {
+            PathFd::new(p)
+                .ok()
+                .map(|fd| Ok::<_, landlock::RulesetError>(PathBeneath::new(fd, read_access)))
+        }))
+        .map_err(landlock_err)?;
+
+    let status = ruleset.restrict_self().map_err(landlock_err)?;
+    // FullyEnforced — all requested AccessFs bits applied. Common on
+    // modern kernels.
+    // PartiallyEnforced — landlock is active and our rules are
+    // installed; some bits in the ABI we requested are silently
+    // unsupported by this kernel. The bits we care about for the
+    // pure-handler shape (file read on /etc/passwd) are covered by
+    // the supported subset, so this is acceptable.
+    // NotEnforced — landlock isn't applying our rules at all (kernel
+    // built without `CONFIG_SECURITY_LANDLOCK`, or LSM not loaded).
+    // Fail closed.
+    if status.ruleset == RulesetStatus::NotEnforced {
+        return Err(io::Error::other(format!(
+            "landlock not enforced (status: {:?}); kernel missing landlock support",
+            status.ruleset
+        )));
+    }
+    Ok(())
+}
+
+/// Network deny: block the syscalls that open or accept IP sockets.
+/// Everything else passes through. Unmatched syscalls get the
+/// default `Allow` action — the seccomp filter is additive to
+/// landlock's fs enforcement, not a full whitelist.
+fn install_seccomp_network_deny() -> io::Result<()> {
+    use std::collections::BTreeMap;
+
+    // Deny EPERM rather than KILL — we want graceful Err returns in
+    // the child, not SIGSYS crash messages, so the negative-control
+    // tests can distinguish "blocked" from "process died unexpectedly".
+    let deny = SeccompAction::Errno(libc::EPERM as u32);
+
+    let denied_syscalls = [
+        libc::SYS_socket,
+        libc::SYS_connect,
+        libc::SYS_bind,
+        libc::SYS_listen,
+        libc::SYS_accept,
+        libc::SYS_accept4,
+        libc::SYS_sendto,
+        libc::SYS_recvfrom,
+        libc::SYS_sendmsg,
+        libc::SYS_recvmsg,
+    ];
+
+    let mut rules: BTreeMap<i64, Vec<seccompiler::SeccompRule>> = BTreeMap::new();
+    for syscall in denied_syscalls {
+        rules.insert(syscall, Vec::new());
+    }
+
+    let arch: TargetArch = std::env::consts::ARCH
+        .try_into()
+        .map_err(|e| io::Error::other(format!("seccomp arch: {e}")))?;
+
+    let filter = SeccompFilter::new(rules, SeccompAction::Allow, deny, arch)
+        .map_err(|e| io::Error::other(format!("seccomp filter build: {e}")))?;
+
+    let program: BpfProgram = filter
+        .try_into()
+        .map_err(|e| io::Error::other(format!("seccomp compile: {e}")))?;
+
+    seccompiler::apply_filter(&program)
+        .map_err(|e| io::Error::other(format!("seccomp apply: {e}")))?;
+
+    Ok(())
+}
+
+fn landlock_err<E: std::fmt::Display>(e: E) -> io::Error {
+    io::Error::other(format!("landlock: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supports_returns_true_only_for_pure_capabilities() {
+        let s = LinuxSandbox;
+        assert!(s.supports(Capabilities::default()));
+        assert!(!s.supports(Capabilities {
+            fs: true,
+            net: false,
+        }));
+        assert!(!s.supports(Capabilities {
+            fs: false,
+            net: true,
+        }));
+        assert!(!s.supports(Capabilities {
+            fs: true,
+            net: true,
+        }));
+    }
+
+    #[test]
+    fn apply_to_rejects_non_pure_capabilities() {
+        let s = LinuxSandbox;
+        let mut cmd = std::process::Command::new("/bin/true");
+        let err = s
+            .apply_to(
+                &mut cmd,
+                Capabilities {
+                    fs: true,
+                    net: false,
+                },
+            )
+            .expect_err("non-pure caps must be rejected before spawn");
+        assert!(
+            err.to_string().contains("pure capabilities"),
+            "unexpected error message: {err}"
+        );
+    }
+}

--- a/crates/lex-extension-host/src/sandbox/linux.rs
+++ b/crates/lex-extension-host/src/sandbox/linux.rs
@@ -142,11 +142,28 @@ fn install_landlock_fs_allowlist(program: &std::ffi::OsStr) -> io::Result<()> {
     let abi = ABI::V1;
     let read_access = AccessFs::from_read(abi);
 
+    // System paths a typical handler binary needs to read in order to
+    // boot:
+    //
+    // - `/lib`, `/lib64`, `/usr/lib`, `/usr/lib64` — dynamic-loader
+    //   library paths.
+    // - `/etc/ld.so.cache`, `/etc/ld.so.preload` — dynamic-loader
+    //   config.
+    // - `/proc/self` — Rust stdlib reads `/proc/self/exe` and a few
+    //   neighbours during startup.
+    // - `/usr/bin`, `/bin` — common interpreters (`node`,
+    //   `python3`, `bash`, `env`) and basic system utilities. Without
+    //   these, schemas using `command: ["node", "handler.js"]` or a
+    //   shebang script fail to `execve` even when the script itself
+    //   is allowed. The script path adjacent to an interpreter is a
+    //   separate concern tracked at lex#559.
     let mut allowed: Vec<PathBuf> = [
         "/lib",
         "/lib64",
         "/usr/lib",
         "/usr/lib64",
+        "/usr/bin",
+        "/bin",
         "/etc/ld.so.cache",
         "/etc/ld.so.preload",
         "/proc/self",
@@ -200,6 +217,14 @@ fn install_seccomp_network_deny() -> io::Result<()> {
     // tests can distinguish "blocked" from "process died unexpectedly".
     let deny = SeccompAction::Errno(libc::EPERM as u32);
 
+    // `SYS_socket` is the primary gate — a process that can't create
+    // an IP socket can't do networking regardless of which other
+    // syscalls are reachable. The rest are defense-in-depth for the
+    // case where a socket fd is inherited from the parent (not part
+    // of our spawn path today, but cheap to defend against).
+    // `sendmmsg`/`recvmmsg` are the multi-message variants of
+    // `sendmsg`/`recvmsg` and need to be listed explicitly — seccomp
+    // filters on syscall number, not on name.
     let denied_syscalls = [
         libc::SYS_socket,
         libc::SYS_connect,
@@ -211,6 +236,8 @@ fn install_seccomp_network_deny() -> io::Result<()> {
         libc::SYS_recvfrom,
         libc::SYS_sendmsg,
         libc::SYS_recvmsg,
+        libc::SYS_sendmmsg,
+        libc::SYS_recvmmsg,
     ];
 
     let mut rules: BTreeMap<i64, Vec<seccompiler::SeccompRule>> = BTreeMap::new();

--- a/crates/lex-extension-host/src/sandbox/mod.rs
+++ b/crates/lex-extension-host/src/sandbox/mod.rs
@@ -53,7 +53,13 @@ use lex_extension::schema::Capabilities;
 
 mod null;
 
+#[cfg(target_os = "linux")]
+mod linux;
+
 pub use null::NullSandbox;
+
+#[cfg(target_os = "linux")]
+pub use linux::LinuxSandbox;
 
 /// OS-level sandbox enforcement for subprocess handlers.
 ///

--- a/crates/lex-extension-host/tests/sandbox_enforcement.rs
+++ b/crates/lex-extension-host/tests/sandbox_enforcement.rs
@@ -1,0 +1,81 @@
+//! End-to-end sandbox enforcement tests for the per-OS [`Sandbox`]
+//! impls. Drives the probe fixture binaries (`fs_probe`, `net_probe`)
+//! through both the real OS sandbox and [`NullSandbox`] as a negative
+//! control. The test module is an integration test (`tests/`) rather
+//! than a unit test inside `src/` because only integration tests get
+//! the `CARGO_BIN_EXE_*` env vars pointing at the fixture binaries.
+
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+
+use std::net::TcpListener;
+use std::process::Command;
+
+use lex_extension::schema::Capabilities;
+use lex_extension_host::sandbox::{NullSandbox, Sandbox};
+
+#[cfg(target_os = "linux")]
+use lex_extension_host::sandbox::LinuxSandbox;
+
+const FS_PROBE: &str = env!("CARGO_BIN_EXE_lex-extension-host-fixture-fs-probe");
+const NET_PROBE: &str = env!("CARGO_BIN_EXE_lex-extension-host-fixture-net-probe");
+
+/// Spawn `bin` with `args`, installing `sandbox` first. Returns the
+/// child's exit code (panics if the child died via signal so test
+/// failures distinguish "blocked → exit 42" from "killed by SIGSYS").
+fn run_with(sandbox: &dyn Sandbox, bin: &str, args: &[String]) -> i32 {
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    sandbox
+        .apply_to(&mut cmd, Capabilities::default())
+        .expect("apply_to should succeed for pure caps");
+    let status = cmd.status().expect("spawn probe");
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        panic!("probe terminated by signal: {:?}", status.signal());
+    }
+    #[cfg(not(unix))]
+    panic!("probe terminated without exit code");
+}
+
+// -- Negative controls: every OS, exercise NullSandbox to confirm
+// the probe fixtures themselves work on the current runner before we
+// trust the positive assertions on the real impls.
+
+#[test]
+fn fs_probe_succeeds_under_null_sandbox() {
+    assert_eq!(run_with(&NullSandbox, FS_PROBE, &[]), 0);
+}
+
+#[test]
+fn net_probe_succeeds_under_null_sandbox() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind localhost");
+    let addr = listener.local_addr().expect("addr");
+    assert_eq!(
+        run_with(&NullSandbox, NET_PROBE, &[addr.to_string()]),
+        0,
+        "negative control should connect to the localhost listener"
+    );
+}
+
+// -- Linux: LinuxSandbox enforcement.
+
+#[cfg(target_os = "linux")]
+#[test]
+fn fs_probe_is_blocked_under_linux_sandbox() {
+    // /etc/passwd is outside the landlock allowlist → EACCES → exit 42.
+    assert_eq!(run_with(&LinuxSandbox, FS_PROBE, &[]), 42);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn net_probe_is_blocked_under_linux_sandbox() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind localhost");
+    let addr = listener.local_addr().expect("addr");
+    // socket() syscall returns EPERM → TcpStream::connect_timeout
+    // returns Err → exit 42.
+    assert_eq!(run_with(&LinuxSandbox, NET_PROBE, &[addr.to_string()]), 42,);
+}

--- a/scripts/dev/sandbox-test-linux.sh
+++ b/scripts/dev/sandbox-test-linux.sh
@@ -14,6 +14,12 @@
 #   rebuilds are fast across runs.
 # - No --privileged / --cap-add needed: landlock works unprivileged on
 #   kernels ≥5.13 and seccomp filter mode works with no_new_privs.
+# - Caveat: Docker Desktop on macOS uses a LinuxKit kernel that does
+#   NOT enable landlock. Enforcement tests will fail with
+#   "landlock failed: landlock not fully enforced". For the full
+#   suite locally use OrbStack, colima, Lima, or a real Linux host
+#   (these run a stock kernel with landlock). CI's `ubuntu-latest`
+#   has landlock and is the source of truth.
 # - Defaults to the host's native arch (arm64 on Apple Silicon). Set
 #   `SANDBOX_PLATFORM=linux/amd64` to validate the x86_64 path under
 #   emulation.
@@ -33,7 +39,7 @@ if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
 fi
 
 if [[ $# -eq 0 ]]; then
-    set -- cargo nextest run -p lex-extension-host sandbox::
+    set -- cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'
 fi
 
 exec docker run --rm \


### PR DESCRIPTION
Linux backend of the [`Sandbox`](https://github.com/lex-fmt/lex/blob/main/crates/lex-extension-host/src/sandbox/mod.rs) trait introduced in #551. Part of [lex#528](https://github.com/lex-fmt/lex/issues/528). **Stacked on #556 (prep)** — base will auto-rebase to main when that merges.

## What this PR adds

### `lex-extension-host::sandbox::LinuxSandbox`

`#[cfg(target_os = "linux")]` impl of the `Sandbox` trait. Combines two kernel mechanisms installed via a `pre_exec` hook so the policy applies to the child after `fork()` and survives `execve()`:

- **landlock** (`landlock` crate, MIT/Apache, ANSSI) — filesystem reads restricted to a small allowlist: dynamic-loader paths (`/lib`, `/usr/lib`, `/etc/ld.so.cache`, etc.) plus the handler binary itself. `/etc/passwd` and the workspace are denied by default.
- **seccomp-bpf** (`seccompiler` crate, Apache/BSD, AWS) — `socket`, `connect`, `bind`, `listen`, `accept`/`accept4`, `sendto`/`recvfrom`, `sendmsg`/`recvmsg` return `EPERM`. Default action is `Allow` (seccomp is additive on top of landlock, not a full whitelist).

`PR_SET_NO_NEW_PRIVS` is set first — required by both subsystems for unprivileged install. **Fail-closed**: if `restrict_self()` returns `RulesetStatus::NotEnforced` (kernel lacks landlock), the pre_exec returns an error and the spawn fails. A handler advertised as sandbox-isolated must actually be isolated.

`supports()` returns `true` only for `Capabilities::is_pure()` (`fs: false, net: false`). Finer shapes report unsupported; the trust gate routes them to the prompt path before `apply_to` is called.

### Tests

- **`crates/lex-extension-host/src/sandbox/linux.rs`** unit tests: `supports()` matrix + `apply_to` rejection of non-pure caps. Always run.
- **`crates/lex-extension-host/tests/sandbox_enforcement.rs`** integration tests:
  - `fs_probe_succeeds_under_null_sandbox` / `net_probe_succeeds_under_null_sandbox` — negative control, every OS. Confirms the fixtures themselves work on the runner before we trust the positive assertions.
  - `fs_probe_is_blocked_under_linux_sandbox` / `net_probe_is_blocked_under_linux_sandbox` — `#[cfg(target_os = "linux")]`. Spawn the prep fixtures under `LinuxSandbox`, assert exit code 42 (probe's "blocked" signal).

Integration tests live under `tests/` rather than `#[cfg(test)]` modules because `CARGO_BIN_EXE_*` env vars (used to locate the probe binaries) are only set there.

## Licensing

Original plan (per #528 description) was to wrap `birdcage`. `birdcage` is **GPL-3.0-or-later** — pulling it in would force `lex-extension-host` + `lexd` into GPL-derivative territory. `extrasafe` was considered as the MIT alternative but 0.5.1 has arch bugs on aarch64 (references x86-only `Sysno` variants). The direct `landlock` + `seccompiler` combination keeps every transitive crate MIT/Apache and works cleanly on every arch we build on.

## Diagnostics

`std::process::Command` swallows `io::Error` messages on the child→parent path — only the errno survives, so `pre_exec` failures surface to the caller as a bare "Invalid argument" (EINVAL) by default. To preserve operator context, the pre_exec hook writes a single line to fd 2 before returning the error, naming which stage failed. Example:

```
lex-extension-host sandbox: landlock failed: landlock not fully enforced (status: NotEnforced); kernel may be missing landlock support
```

This is the message you'll see if you run the suite under Docker Desktop's LinuxKit kernel (no landlock) — `scripts/dev/sandbox-test-linux.sh` documents the workaround (OrbStack / colima / Lima / native Linux / CI). CI's `ubuntu-latest` has full landlock support and is the source of truth.

## Test plan

- [x] `cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'` on macOS — 9/9 pass (Linux-specific tests cfg'd out)
- [x] `cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'` in Docker Desktop on macOS — 11/13 pass (2 enforcement tests fail with diagnostic "landlock not fully enforced", as expected on LinuxKit)
- [ ] `sandbox-tests.yml` on `ubuntu-latest` (real Ubuntu kernel) — **this PR verifies the actual enforcement**
- [ ] `sandbox-tests.yml` on `macos-14` — Linux tests skipped, neg-controls pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude lex-wasm --all-targets --all-features -- -D warnings` clean
- [x] Full workspace test (pre-commit hook): 1941/1941 pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)