### PR TITLE
PR 12d — δ trust-matrix flip: install OS default sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,38 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Trust-matrix flip (lex#528 PR 12d).** `lex_fmt::boot_registry`
+  now installs the OS-appropriate `Sandbox` on the trust gate (via
+  the new `lex_extension_host::sandbox::os_default()` factory) and
+  passes the same `Arc<dyn Sandbox>` to every
+  `SubprocessHandler::spawn_with_sandbox` call. The effect is
+  per-OS:
+  - **Linux**: declared-pure subprocess handlers (`capabilities: {
+    fs: false, net: false }`) **auto-trust** under the default
+    engine — no prompt, no `--enable-handlers` flag. The kernel
+    enforces the declared capability set via `LinuxSandbox`
+    (seccomp + landlock). This is the user-visible matrix flip
+    promised by §8 of the proposal.
+  - **macOS**: pure handlers continue to **prompt** because
+    `MacosSandbox::supports` is pinned to `false` pending a
+    hardened `(deny default)` SBPL profile. The same prompt UX
+    Windows uses.
+  - **Windows + other**: pure handlers continue to **prompt** —
+    `NullSandbox` is the fallback. `lex#528` PR 12c (Windows Job
+    Objects + restricted tokens) is unscheduled; the trust gate
+    routes those subprocesses to the prompt path until it ships.
+  Full subprocess handlers (any `capabilities` declaring `fs` or
+  `net`) always prompt regardless of OS — `supports` returns
+  `false` for non-pure shapes on every impl.
+
 ### Added
 
+- `lex_extension_host::sandbox::os_default() -> Arc<dyn Sandbox>`:
+  factory selecting the per-target default sandbox. Used by the
+  δ-phase trust-matrix flip (above); also available to embedders
+  building a custom `Engine` who want the same per-OS dispatch.
 - `lex-extension-host::sandbox::MacosSandbox`: macOS implementation of
   the `Sandbox` trait (lex#528 PR 12b). Installs a Sandbox Profile
   Language (SBPL) policy via the libSystem `sandbox_init` API inside

--- a/crates/lex-cli/src/extension_setup.rs
+++ b/crates/lex-cli/src/extension_setup.rs
@@ -65,6 +65,12 @@ mod tests {
     use lex_config::LabelsConfig;
     use lex_extension_host::Surface;
 
+    /// Non-pure capabilities (`fs: true`) so the post-12d trust
+    /// matrix flip doesn't auto-trust this handler on Linux before
+    /// the surface deny path runs. A pure handler under
+    /// `LinuxSandbox` would be `Trusted` regardless of
+    /// `--enable-handlers`, which is the correct new behaviour but
+    /// not what this test is asserting.
     #[test]
     fn cli_subprocess_handler_without_enable_flag_says_enable_handlers() {
         let workspace = tempfile::tempdir().unwrap();
@@ -72,7 +78,7 @@ mod tests {
         std::fs::create_dir_all(&acme_dir).unwrap();
         std::fs::write(
             acme_dir.join("task.yaml"),
-            "schema_version: 1\nlabel: acme.task\nhandler:\n  transport: subprocess\n  command: [\"acme-handler\"]\n",
+            "schema_version: 1\nlabel: acme.task\ncapabilities:\n  fs: true\n  net: false\nhandler:\n  transport: subprocess\n  command: [\"acme-handler\"]\n",
         )
         .unwrap();
 

--- a/crates/lex-extension-host/src/sandbox/mod.rs
+++ b/crates/lex-extension-host/src/sandbox/mod.rs
@@ -48,6 +48,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::sync::Arc;
 
 use lex_extension::schema::Capabilities;
 
@@ -66,6 +67,51 @@ pub use linux::LinuxSandbox;
 
 #[cfg(target_os = "macos")]
 pub use macos::MacosSandbox;
+
+/// Construct the OS-appropriate default [`Sandbox`] for the running
+/// platform. The δ-phase ([lex#528]) trust-matrix flip uses this to
+/// switch the engine's default from [`NullSandbox`] (post-plumbing
+/// stand-in, never enforces) to the per-OS impl on supported
+/// platforms.
+///
+/// Asymmetry by design:
+///
+/// - **Linux**: returns [`LinuxSandbox`]. `supports(pure)` returns
+///   `true`, so the trust gate auto-trusts declared-pure handlers
+///   under this default.
+/// - **macOS**: returns [`MacosSandbox`]. `supports()` returns
+///   `false` for every capability shape until a hardened
+///   `(deny default)` SBPL profile lands, so the trust gate
+///   continues to route pure handlers to the prompt path —
+///   identical UX to Windows. `apply_to` still installs the limited
+///   profile so handlers that do run after a user prompt still get
+///   the partial denies.
+/// - **Other (Windows etc.)**: returns [`NullSandbox`]. No
+///   enforcement, no auto-trust — the trust gate prompts on every
+///   subprocess handler, matching β/γ behaviour for now.
+///
+/// Returned as `Arc<dyn Sandbox>` so the host can install one
+/// instance and share it with both [`crate::TrustGate::set_sandbox`]
+/// and [`crate::transport::SubprocessHandler::spawn_with_sandbox`].
+/// That sharing is load-bearing: the auto-trust decision must be
+/// anchored on the *same* sandbox that actually enforces policy at
+/// spawn time.
+///
+/// [lex#528]: https://github.com/lex-fmt/lex/issues/528
+pub fn os_default() -> Arc<dyn Sandbox> {
+    #[cfg(target_os = "linux")]
+    {
+        Arc::new(LinuxSandbox)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Arc::new(MacosSandbox)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Arc::new(NullSandbox)
+    }
+}
 
 /// OS-level sandbox enforcement for subprocess handlers.
 ///

--- a/crates/lex-fmt/src/setup.rs
+++ b/crates/lex-fmt/src/setup.rs
@@ -181,6 +181,22 @@ pub fn boot_registry(setup: ExtensionSetup<'_>) -> BootOutcome {
         TrustStore::open(&fallback_dir).expect("temp dir writable")
     });
     let mut trust_gate = TrustGate::new(surface, setup.enable_handlers, store, setup.trust_prompt);
+
+    // δ-phase trust-matrix flip (lex#528 PR 12d): install the
+    // OS-appropriate sandbox so declared-pure subprocess handlers
+    // auto-trust under enforced isolation. The same Arc is also
+    // handed to every SubprocessHandler::spawn_with_sandbox call so
+    // the auto-trust decision is anchored on the sandbox that
+    // actually applies policy at spawn time (the contract
+    // documented on TrustGate::set_sandbox).
+    //
+    // Asymmetry: Linux gets LinuxSandbox (supports pure → auto-trust).
+    // macOS gets MacosSandbox (supports always false → prompts) until
+    // a hardened profile lands. Windows + other targets get
+    // NullSandbox (no enforcement → prompts).
+    let sandbox = lex_extension_host::sandbox::os_default();
+    trust_gate.set_sandbox(Arc::clone(&sandbox));
+
     let host_version = setup.host_version;
 
     // Built-ins: lex.* namespace (currently `lex.include`). Native
@@ -486,20 +502,26 @@ fn build_handler(
         }
     }
 
-    // Trusted — spawn the binary.
+    // Trusted — spawn the binary under the same Sandbox the trust
+    // gate consulted to make the auto-trust decision. Pulling the
+    // sandbox off `trust_gate.sandbox()` rather than re-constructing
+    // it guarantees that "what the gate said was safe" and "what the
+    // kernel actually enforces on the child" are the same instance.
+    // See TrustGate::set_sandbox for the contract.
     let labels: Vec<String> = schemas.iter().map(|s| s.label.clone()).collect();
     let env = SpawnEnv {
         workspace_root: Some(workspace_root.display().to_string()),
         lex_cache: None,
         handler_config: None,
     };
-    match SubprocessHandler::spawn(
+    match SubprocessHandler::spawn_with_sandbox(
         handler_spec,
         namespace,
         &labels,
         contract.capabilities,
         host_version,
         &env,
+        trust_gate.sandbox(),
     ) {
         Ok(h) => Box::new(h),
         Err(e) => {
@@ -958,5 +980,52 @@ mod tests {
         let outcome = boot_registry(setup);
         assert_eq!(outcome.trust_gate.surface(), Surface::Ci);
         assert!(outcome.trust_gate.enable_handlers());
+    }
+
+    /// δ-phase trust-matrix flip wiring: after [`boot_registry`], the
+    /// trust gate's sandbox must be the OS-appropriate impl (not the
+    /// pre-δ `NullSandbox`). The per-OS `supports(pure)` result
+    /// confirms which path is installed — Linux's `LinuxSandbox`
+    /// reports `true`, macOS's `MacosSandbox` is pinned to `false`
+    /// pending a hardened profile, and everything else falls back to
+    /// `NullSandbox` (`false`). If this test ever starts asserting
+    /// the wrong direction, the engine is silently auto-trusting (or
+    /// silently prompting) and the user-visible policy has drifted
+    /// from what the host announced.
+    #[test]
+    fn boot_installs_os_default_sandbox() {
+        let workspace = tempfile::tempdir().unwrap();
+        let labels = LabelsConfig::default();
+        let setup = ExtensionSetup {
+            workspace_root: workspace.path(),
+            labels_config: &labels,
+            ext_schemas: &[],
+            enable_handlers: false,
+            surface_override: Some(Surface::CliOneShot),
+            trust_prompt: Box::new(DenyAllPrompt),
+            host_version: "test",
+        };
+        let outcome = boot_registry(setup);
+        let sandbox = outcome.trust_gate.sandbox();
+        let pure = lex_extension::schema::Capabilities::default();
+
+        #[cfg(target_os = "linux")]
+        assert!(
+            sandbox.supports(pure),
+            "Linux default sandbox should support pure capabilities"
+        );
+
+        #[cfg(target_os = "macos")]
+        assert!(
+            !sandbox.supports(pure),
+            "macOS default sandbox is pinned to `supports = false` until \
+             a hardened deny-default SBPL profile lands"
+        );
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        assert!(
+            !sandbox.supports(pure),
+            "Unsupported platforms fall back to NullSandbox"
+        );
     }
 }

--- a/crates/lex-fmt/src/setup.rs
+++ b/crates/lex-fmt/src/setup.rs
@@ -775,11 +775,31 @@ mod tests {
     /// `enable_handlers` the way CLI does), the prompt denies, and
     /// the namespace registers schema-only with the prompt's
     /// rationale surfaced as a diagnostic.
+    ///
+    /// Uses **non-pure** capabilities (`fs: true`) so the post-12d
+    /// trust-matrix flip doesn't auto-trust this handler on Linux
+    /// before the prompt is ever consulted. The default
+    /// [`write_schema_with_subprocess_handler`] writes pure caps,
+    /// which on Linux now route to `LinuxSandbox::supports(pure)
+    /// == true` → `Trusted` → spawn-fail diagnostic instead of the
+    /// prompt-denial diagnostic this test asserts.
     #[test]
     fn subprocess_handler_in_lsp_surface_with_denying_prompt_is_schema_only() {
         let workspace = tempfile::tempdir().unwrap();
         let acme_dir = workspace.path().join("acme");
-        write_schema_with_subprocess_handler(&acme_dir, "acme.task", &["acme-handler"]);
+        std::fs::create_dir_all(&acme_dir).unwrap();
+        std::fs::write(
+            acme_dir.join("acme_task.yaml"),
+            "schema_version: 1\n\
+             label: acme.task\n\
+             capabilities:\n  \
+             fs: true\n  \
+             net: false\n\
+             handler:\n  \
+             transport: subprocess\n  \
+             command: [\"acme-handler\"]\n",
+        )
+        .unwrap();
 
         let labels = LabelsConfig::default();
         let setup = ExtensionSetup {


### PR DESCRIPTION
Closes the δ-phase capability shift for [lex#528](https://github.com/lex-fmt/lex/issues/528) — at least the parts we're shipping in v1. After this, declared-pure subprocess handlers auto-trust under enforced isolation on Linux. macOS + Windows continue to prompt (each for its own reason; see below).

## Summary

- **New factory** `lex_extension_host::sandbox::os_default() -> Arc<dyn Sandbox>` returns the per-target default: `LinuxSandbox` on Linux, `MacosSandbox` on macOS, `NullSandbox` everywhere else. Available to embedders building a custom \`Engine\` too.
- **`lex_fmt::boot_registry`** installs that sandbox on the `TrustGate` and passes the same \`Arc\` to every `SubprocessHandler::spawn_with_sandbox`. Sharing one instance is load-bearing: the auto-trust decision must be anchored on the same sandbox that actually enforces policy at spawn time ([TrustGate::set_sandbox contract](https://github.com/lex-fmt/lex/blob/main/crates/lex-extension-host/src/trust/decision.rs)).
- **`SubprocessHandler::spawn`** call site upgraded to `spawn_with_sandbox(..., trust_gate.sandbox())`.

## Per-OS effect

| OS | Default sandbox | `supports(pure)` | Pure-handler UX |
|---|---|---|---|
| Linux ≥5.13 | `LinuxSandbox` | `true` | **auto-trust** |
| macOS | `MacosSandbox` | `false` (pinned) | prompt |
| Windows | `NullSandbox` | `false` | prompt |
| Other | `NullSandbox` | `false` | prompt |

Non-pure handlers (declaring `fs` or `net`) always prompt regardless of OS — `supports()` returns `false` for non-pure shapes on every impl.

## Why the asymmetry

- **macOS**: `MacosSandbox`'s SBPL profile is `(allow default) (deny network*) (deny file-read* (subpath "/etc"))`. That denies the two operations the probe tests target but still permits writes anywhere and reads outside `/etc`. Auto-trusting on that profile would be the silent privilege escalation the [antigravity review of #558](https://github.com/lex-fmt/lex/pull/558) flagged. `MacosSandbox::supports` returns `false` until a hardened `(deny default)` profile is authored — substantial per-version dyld + mach-lookup allowlist work.
- **Windows**: 12c (Job Objects + restricted tokens) isn't scheduled. `NullSandbox` is the fallback. Trust gate prompts.

## Test

`boot_installs_os_default_sandbox` in `crates/lex-fmt/src/setup.rs` asserts the sandbox on the boot's trust gate matches the per-OS expectation. If the assertion ever inverts (e.g. someone flips `MacosSandbox::supports` back to `caps.is_pure()` without authoring the hardened profile), the engine is silently auto-trusting and the user-visible policy has drifted.

The existing per-OS sandbox enforcement tests in `crates/lex-extension-host/tests/sandbox_enforcement.rs` continue to verify that the impls actually block the syscalls they claim to.

## Out of scope

These are intentionally not in this PR — flagging so they don't get lost:

- **Hardened macOS `(deny default)` SBPL profile** that lets us flip `MacosSandbox::supports` back to `caps.is_pure()`. Requires per-macOS-version tuning. No issue filed yet — would be a follow-up.
- **12c Windows backend** (Job Objects + restricted tokens). Unscheduled per #528.
- **Per-extension install-dir threading** so interpreted handlers can read adjacent scripts on Linux. Tracked at #559.
- **`comms/specs/proposals/extending-lex.lex` §8 paragraph** that currently says "every subprocess prompts until OS-level enforcement is in place" — should be updated to reflect this PR's per-OS asymmetry. Bundling with a comms version bump or the heavier user-facing docs PR follow-up.

## Test plan

- [x] `cargo nextest run -p lex-fmt boot_installs_os_default_sandbox` on macOS — passes (asserts `!supports(pure)`)
- [x] `scripts/dev/sandbox-test-linux.sh cargo nextest run -p lex-fmt boot_installs_os_default_sandbox` — passes (asserts `supports(pure)`)
- [x] `cargo nextest run -p lex-fmt` on macOS — 25/25 pass (no regression in the existing boot_registry / engine_pipeline tests)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude lex-wasm --all-targets --all-features -- -D warnings` clean
- [x] Full workspace test (pre-commit hook): 1946/1946 pass
- [ ] CI `Rust CI / Test` on ubuntu-latest
- [ ] CI `sandbox-tests / Sandbox tests (ubuntu-latest + macos-14)` — both will still run because the dispatch path now indirectly exercises both sandboxes through boot_registry. Note: sandbox-tests workflow's path filter doesn't include `crates/lex-fmt/**`, so it may not fire on this PR; that's a minor follow-up if you want it triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)