### PR TITLE
chore: standardize pre-commit + check scripts

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,34 @@
+# Pre-commit hooks — ordered by priority (lower number runs first).
+# If a priority group fails, later groups are skipped.
+#
+#   1 — Auto-fix:  rustfmt (staged files only, re-staged)
+#   2 — Check:     clippy and tests (parallel, via scripts/check-*)
+#
+# CI runs the same checks via scripts/check. Keep them in sync when
+# adding checks.
+#
+# Setup: `brew install lefthook && lefthook install`
+
+pre-commit:
+  commands:
+    # --- Phase 1: Auto-fix ---
+    # Format ONLY the staged .rs files — not the whole workspace — so
+    # unrelated unstaged edits don't leak into the commit and rustfmt
+    # version drift in untouched files doesn't produce lingering
+    # unstaged diffs after the commit lands.
+    rustfmt:
+      glob: '**/*.rs'
+      run: rustfmt --edition 2021 {staged_files}
+      stage_fixed: true
+      priority: 1
+
+    # --- Phase 2: Checks (parallel) ---
+    clippy:
+      glob: '**/*.{rs,toml}'
+      run: scripts/check-lint
+      priority: 2
+
+    tests:
+      glob: '**/*.{rs,toml}'
+      run: scripts/check-tests
+      priority: 2

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared checks used by both pre-commit hook and CI.
+# Each step is its own script so they can be run individually.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+"$SCRIPT_DIR/check-fmt"
+"$SCRIPT_DIR/check-lint"
+"$SCRIPT_DIR/check-tests"
+
+echo ""
+echo "All checks passed!"

--- a/scripts/check-fmt
+++ b/scripts/check-fmt
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Checking formatting..."
+cargo fmt --all -- --check
+echo "Formatting OK"

--- a/scripts/check-lint
+++ b/scripts/check-lint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running clippy..."
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+echo "Clippy OK"

--- a/scripts/check-tests
+++ b/scripts/check-tests
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running tests..."
+if command -v cargo-nextest &>/dev/null; then
+    cargo nextest run --workspace
+else
+    cargo test --workspace
+fi
+echo "Tests OK"


### PR DESCRIPTION
Adopts the canonical pre-commit + check setup from arthur-debert/release/templates/rust/.

Single entry point everywhere:
- `scripts/check` — used by both pre-commit and CI
- `scripts/check-{fmt,lint,tests}` — runnable individually
- `lefthook.yml` — pre-commit hooks (runs rustfmt on staged .rs files + clippy/tests in parallel)

To install hooks locally after merging:
```
brew install lefthook && lefthook install
```

Verified locally: `./scripts/check` passes in a worktree before pushing.