### PR TITLE
HTML render splice — handler HTML replaces default rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@
 
 ### Added
 
+- **HTML render splice** ([#563](https://github.com/lex-fmt/lex/issues/563)).
+  `lexd convert --to html` (via
+  `lex_babel::serialize_to_html_with_registry`) now actually splices
+  handler-rendered HTML into the output for annotations whose
+  registered handler returns `RenderOut::String`. The default
+  `<!-- lex:label -->` ... body ... `<!-- /lex:label -->` rendering
+  is replaced by the handler's raw HTML; the annotation's body
+  events are suppressed (the handler owns the full rendering of its
+  labelled node). Mechanism: AST-walk and event-walk visit
+  annotations in matching document order; the HTML builder
+  maintains a counter, looks up the matching plan entry on
+  `Event::StartAnnotation`, and emits a sentinel comment that
+  string-replaces with the handler's HTML after DOM serialization.
+  Handler diagnostics from `on_render` continue to surface via
+  `HtmlExportOutcome::diagnostics`.
+  - `RenderOut::WireAst` outputs fall through to default rendering
+    with the existing format-shape-mismatch diagnostic;
+    `WireAst → HTML` conversion is a follow-up.
+  - Document-level annotations (extracted into the IR's synthetic
+    `frontmatter` block before events are emitted) are not splice
+    targets — the existing frontmatter path handles them as
+    metadata. Per-element annotations (the actual extension use
+    case) splice correctly.
+  - Multi-annotation documents with trailing annotations may hit
+    an IR-ordering quirk that breaks the counter-based alignment.
+    Single-annotation documents and clearly-separated annotations
+    work; see test
+    `multi_annotation_splice_is_a_known_limitation` for context.
+
+### Added
+
 - **Resolver machinery** (#546 item A, partial). `lex-extension-host`
   gains a pluggable [`Fetcher`] trait, a `FetcherRegistry`, and a
   content-keyed `ResolverCache` (24-hour TTL for mutable refs,

--- a/crates/lex-babel/src/formats/html/serializer.rs
+++ b/crates/lex-babel/src/formats/html/serializer.rs
@@ -52,22 +52,33 @@ pub fn serialize_to_html(doc: &Document, theme: HtmlTheme) -> Result<String, For
 /// diagnostics (errors, format-shape mismatches, namespace disabled)
 /// surface in the returned [`HtmlExportOutcome::diagnostics`].
 ///
-/// **Status (PR 8):** dispatch + diagnostic surface are wired up; the
-/// actual splice of handler-rendered HTML into the output stream
-/// awaits the IR-events integration in a follow-up (the HTML
-/// serializer collapses all annotations into a synthetic
-/// `frontmatter` block, so there's no per-annotation comment to
-/// post-process). Today this entry point produces the same default
-/// HTML as [`serialize_to_html_with_options`], with the additional
-/// guarantee that handlers' on_render hooks have been invoked and
-/// their diagnostics collected.
+/// For annotations whose handler returns `RenderOut::String`, the
+/// handler's HTML is spliced into the output in place of the
+/// annotation's default rendering (the `<!-- lex:label -->` ...
+/// `<!-- /lex:label -->` comment pair plus any content events
+/// between them). Handlers returning `RenderOut::WireAst` or
+/// `Ok(None)` fall through to the default rendering — wire-AST →
+/// HTML conversion is a follow-up.
+///
+/// Splice mechanism: the AST walker (`dispatch_render`) and the
+/// event walker (`tree_to_events`) visit annotations in matching
+/// document order, so the HTML builder maintains a counter and
+/// indexes into the plan as it sees `Event::StartAnnotation`. When
+/// the plan entry has output, the builder emits a sentinel comment
+/// (`<!--LEX-RENDER-SPLICE:N-->`) and skips events until the
+/// matching `EndAnnotation`; after DOM serialization, the sentinel
+/// is string-replaced with the handler's raw HTML. The skip-state
+/// nests on depth so handlers consume their full subtree (including
+/// any inner labelled annotations — those handlers fired during the
+/// dispatch walk; their results aren't separately spliced because
+/// the outer handler owns the body's rendering).
 pub fn serialize_to_html_with_registry(
     doc: &Document,
     options: HtmlOptions,
     registry: &lex_extension_host::Registry,
 ) -> Result<HtmlExportOutcome, FormatError> {
     let plan = crate::render_dispatch::dispatch_render(doc, registry, "html");
-    let html = serialize_to_html_with_options(doc, options)?;
+    let html = serialize_to_html_with_splice(doc, options, Some(&plan.nodes))?;
     let mut diagnostics = plan
         .nodes
         .iter()
@@ -75,6 +86,100 @@ pub fn serialize_to_html_with_registry(
         .collect::<Vec<_>>();
     diagnostics.extend(plan.root_diagnostics);
     Ok(HtmlExportOutcome { html, diagnostics })
+}
+
+/// Sentinel comment marker emitted by [`build_html_dom`] when a
+/// render-plan entry has output. After DOM serialization, every
+/// occurrence of this comment (with a numeric ID appended) is
+/// replaced with the raw HTML at the corresponding index in the
+/// splice-output buffer.
+///
+/// Comments are used as sentinels because the html5ever DOM doesn't
+/// have a "raw HTML" text-node concept — every text node is HTML-
+/// escaped at serialization. Comments serialize byte-for-byte
+/// (modulo whitespace inside them), so a unique sentinel is reliably
+/// round-trip-able through the DOM → string pass.
+const SPLICE_SENTINEL_PREFIX: &str = "LEX-RENDER-SPLICE:";
+
+/// Internal helper: serialize with an optional splice plan. When
+/// `splice_plan` is `None` this is identical to
+/// [`serialize_to_html_with_options`]; when `Some(&plan)` it threads
+/// the plan through the DOM builder and the post-process replacement
+/// step.
+fn serialize_to_html_with_splice(
+    doc: &Document,
+    options: HtmlOptions,
+    splice_plan: Option<&[crate::render_dispatch::RenderedNode]>,
+) -> Result<String, FormatError> {
+    let ir_doc = crate::to_ir(doc);
+
+    let title = match &ir_doc.title {
+        Some(title_inlines) => {
+            let title_text = ir_inline_to_text(title_inlines);
+            match &ir_doc.subtitle {
+                Some(sub_inlines) => format!("{}: {}", title_text, ir_inline_to_text(sub_inlines)),
+                None => title_text,
+            }
+        }
+        None => "Lex Document".to_string(),
+    };
+
+    let events = tree_to_events(&DocNode::Document(ir_doc));
+
+    // Splice outputs are collected during the DOM build so the
+    // post-process step has them keyed by the sentinel index.
+    let mut splice_outputs: Vec<String> = Vec::new();
+    let dom = build_html_dom_with_splice(&events, splice_plan, &mut splice_outputs)?;
+
+    let html_string = serialize_dom(&dom)?;
+    // Replace each sentinel comment with the handler's raw HTML.
+    // We do the substitution on the inner-body string before the
+    // wrap_in_document call so the wrap doesn't have to know about
+    // splicing.
+    let html_string = replace_splice_sentinels(&html_string, &splice_outputs);
+
+    wrap_in_document(&html_string, &title, &options)
+}
+
+/// Replace every `<!--LEX-RENDER-SPLICE:N-->` sentinel in `html`
+/// with the raw HTML at `outputs[N]`. Tolerates trailing whitespace
+/// in the comment (html5ever doesn't trim, but markup5ever_rcdom
+/// can normalize on serialize). Non-numeric or out-of-range indices
+/// are left in place — that's a programming bug that would surface
+/// as a visible sentinel in the output rather than silent corruption.
+fn replace_splice_sentinels(html: &str, outputs: &[String]) -> String {
+    if outputs.is_empty() {
+        return html.to_string();
+    }
+    let mut out = String::with_capacity(html.len());
+    let mut remaining = html;
+    let pattern_open = format!("<!--{SPLICE_SENTINEL_PREFIX}");
+    while let Some(start) = remaining.find(&pattern_open) {
+        out.push_str(&remaining[..start]);
+        let after_prefix = &remaining[start + pattern_open.len()..];
+        // The ID is decimal digits until `-->`.
+        let Some(end_marker) = after_prefix.find("-->") else {
+            // Malformed sentinel — copy through and continue.
+            out.push_str(&remaining[start..]);
+            remaining = "";
+            break;
+        };
+        let id_str = after_prefix[..end_marker].trim();
+        match id_str.parse::<usize>() {
+            Ok(idx) if idx < outputs.len() => {
+                out.push_str(&outputs[idx]);
+            }
+            _ => {
+                // Out-of-range or non-numeric — leave the sentinel
+                // visible. Surfaces as a noticeable bug in the
+                // rendered output, easier to spot than silent drop.
+                out.push_str(&remaining[start..start + pattern_open.len() + end_marker + 3]);
+            }
+        }
+        remaining = &after_prefix[end_marker + 3..];
+    }
+    out.push_str(remaining);
+    out
 }
 
 /// Result of [`serialize_to_html_with_registry`]: the rendered HTML
@@ -91,38 +196,30 @@ pub fn serialize_to_html_with_options(
     doc: &Document,
     options: HtmlOptions,
 ) -> Result<String, FormatError> {
-    // Step 1: Lex AST → IR (title and subtitle are preserved in IR)
-    let ir_doc = crate::to_ir(doc);
-
-    // Extract title from IR
-    let title = match &ir_doc.title {
-        Some(title_inlines) => {
-            let title_text = ir_inline_to_text(title_inlines);
-            match &ir_doc.subtitle {
-                Some(sub_inlines) => format!("{}: {}", title_text, ir_inline_to_text(sub_inlines)),
-                None => title_text,
-            }
-        }
-        None => "Lex Document".to_string(),
-    };
-
-    // Step 2: IR → Events
-    let events = tree_to_events(&DocNode::Document(ir_doc));
-
-    // Step 3: Events → RcDom (HTML DOM tree)
-    let dom = build_html_dom(&events)?;
-
-    // Step 4: RcDom → HTML string
-    let html_string = serialize_dom(&dom)?;
-
-    // Step 5: Wrap in complete HTML document with CSS
-    let complete_html = wrap_in_document(&html_string, &title, &options)?;
-
-    Ok(complete_html)
+    serialize_to_html_with_splice(doc, options, None)
 }
 
-/// Build an HTML DOM tree from IR events
-fn build_html_dom(events: &[Event]) -> Result<RcDom, FormatError> {
+/// Build an HTML DOM tree from IR events, optionally splicing
+/// handler-rendered HTML in place of default annotation rendering.
+///
+/// When `splice_plan` is `Some(&plan)`, the builder maintains an
+/// annotation counter that advances on every `Event::StartAnnotation`
+/// (mirroring the dispatch walker's order). On entries with output,
+/// it appends a sentinel comment to the DOM, pushes the output into
+/// `splice_outputs`, and enters a skip-state for content events
+/// until the matching `EndAnnotation`. The skip-state nests on
+/// depth so a handled outer annotation's body — including any
+/// inner labelled annotations — is consumed entirely. The
+/// post-process step in [`serialize_to_html_with_splice`] replaces
+/// each sentinel with the corresponding raw HTML.
+///
+/// When `splice_plan` is `None`, the builder behaves exactly as
+/// the original `build_html_dom` did before the splice landing.
+fn build_html_dom_with_splice(
+    events: &[Event],
+    splice_plan: Option<&[crate::render_dispatch::RenderedNode]>,
+    splice_outputs: &mut Vec<String>,
+) -> Result<RcDom, FormatError> {
     let dom = RcDom::default();
 
     // Create document container
@@ -139,7 +236,30 @@ fn build_html_dom(events: &[Event]) -> Result<RcDom, FormatError> {
     // State for heading context
     let mut current_heading: Option<Handle> = None;
 
+    // Splice state. `annotation_idx` advances on every
+    // StartAnnotation event regardless of skip-state, so it stays
+    // aligned with the dispatch walker's plan order (both walks
+    // emit annotations in matching document order — see
+    // `serialize_to_html_with_registry`'s docs for the contract).
+    // `splice_skip_depth` is non-zero while we're inside a
+    // handler-consumed annotation; events arriving in that window
+    // are suppressed so the handler's output replaces them entirely.
+    let mut annotation_idx: usize = 0;
+    let mut splice_skip_depth: usize = 0;
+
     for event in events {
+        // Inside a splice skip region, only Start/EndAnnotation
+        // events are inspected — for nesting depth and counter
+        // bookkeeping. All other events are suppressed so the
+        // handler's output stands alone.
+        if splice_skip_depth > 0
+            && !matches!(
+                event,
+                Event::StartAnnotation { .. } | Event::EndAnnotation { .. }
+            )
+        {
+            continue;
+        }
         match event {
             Event::StartDocument => {
                 // Already created doc_container
@@ -468,18 +588,58 @@ fn build_html_dom(events: &[Event]) -> Result<RcDom, FormatError> {
 
             Event::StartAnnotation { label, parameters } => {
                 current_heading = None;
-                // Create HTML comment
-                let mut comment = format!(" lex:{label}");
-                for (key, value) in parameters {
-                    comment.push_str(&format!(" {key}={value}"));
+                // The annotation counter advances on every Start
+                // regardless of skip-state. Nested annotations
+                // inside a handler-consumed outer still advance the
+                // counter (so the next non-skipped annotation
+                // indexes correctly into the plan); they also bump
+                // skip-depth so we find the matching outer End.
+                let this_idx = annotation_idx;
+                annotation_idx += 1;
+
+                if splice_skip_depth > 0 {
+                    splice_skip_depth += 1;
+                    continue;
                 }
-                comment.push(' ');
-                let comment_node = create_comment(&comment);
-                current_parent.children.borrow_mut().push(comment_node);
+
+                // Check the plan: does this annotation have a
+                // handler-rendered output ready to splice? We match
+                // on label too as a sanity check — if the plan's
+                // entry doesn't agree on the label, the walks have
+                // diverged and we fall through to default rendering
+                // rather than splice the wrong output.
+                let splice_target = splice_plan
+                    .and_then(|plan| plan.get(this_idx))
+                    .filter(|entry| entry.label == *label)
+                    .and_then(|entry| entry.output.as_ref());
+
+                if let Some(rendered_html) = splice_target {
+                    let sentinel_idx = splice_outputs.len();
+                    splice_outputs.push(rendered_html.clone());
+                    let sentinel = format!("{SPLICE_SENTINEL_PREFIX}{sentinel_idx}");
+                    let comment_node = create_comment(&sentinel);
+                    current_parent.children.borrow_mut().push(comment_node);
+                    splice_skip_depth = 1;
+                } else {
+                    // No splice — emit the default lex:label start
+                    // comment as before.
+                    let mut comment = format!(" lex:{label}");
+                    for (key, value) in parameters {
+                        comment.push_str(&format!(" {key}={value}"));
+                    }
+                    comment.push(' ');
+                    let comment_node = create_comment(&comment);
+                    current_parent.children.borrow_mut().push(comment_node);
+                }
             }
 
             Event::EndAnnotation { label } => {
-                // Closing comment
+                if splice_skip_depth > 0 {
+                    splice_skip_depth -= 1;
+                    continue;
+                }
+                // Not in splice — emit the default lex:label end
+                // comment as before.
                 let comment = format!(" /lex:{label} ");
                 let comment_node = create_comment(&comment);
                 current_parent.children.borrow_mut().push(comment_node);

--- a/crates/lex-babel/src/render_dispatch.rs
+++ b/crates/lex-babel/src/render_dispatch.rs
@@ -651,4 +651,233 @@ mod tests {
         assert_eq!(outcome.html, baseline);
         assert!(outcome.diagnostics.is_empty());
     }
+
+    // -- Splice tests (PR for #563). The splice mechanism replaces
+    // the default `<!-- lex:label -->` ... `<!-- /lex:label -->`
+    // comment pair (and any content between) with the handler's raw
+    // HTML when the handler returns `RenderOut::String`. WireAst and
+    // `Ok(None)` continue to fall through to default rendering.
+
+    /// Helper: build a registry + handler that returns a fixed
+    /// String for every render call. The returned HTML is what should
+    /// be spliced in place of the annotation's default rendering.
+    fn registry_with_string_handler(label: &str, html_output: &'static str) -> Registry {
+        struct Fixed(&'static str);
+        impl LexHandler for Fixed {
+            fn on_render(
+                &self,
+                _: &LabelCtx,
+                _: Format,
+            ) -> Result<Option<RenderOut>, HandlerError> {
+                Ok(Some(RenderOut::String {
+                    string: self.0.to_string(),
+                }))
+            }
+        }
+        let registry = Registry::new();
+        registry
+            .register_namespace(
+                label.split_once('.').map(|(ns, _)| ns).unwrap_or(label),
+                vec![schema(label, &["html"])],
+                Box::new(Fixed(html_output)),
+            )
+            .unwrap();
+        registry
+    }
+
+    /// Test fixture: a session-scoped annotation. Top-level
+    /// annotations are extracted into the IR's synthetic
+    /// `frontmatter` block before events are emitted, so they
+    /// don't flow through `Event::StartAnnotation` at all and the
+    /// splice can't operate on them. Per-element annotations (the
+    /// realistic extension use case) go through the event stream.
+    /// Lifting this limitation requires reworking the IR's
+    /// document-annotation handling — out of scope here, tracked
+    /// implicitly under `serialize_to_html_with_registry`'s docs.
+    const DOC_WITH_SCOPED_ANNOTATION: &str =
+        "1. Heading\n\n    :: acme.task ::\n        Body that should be replaced.\n";
+
+    #[test]
+    fn splice_replaces_default_annotation_rendering_with_handler_html() {
+        use crate::formats::html::{serialize_to_html_with_registry, HtmlOptions, HtmlTheme};
+        let doc = parse(DOC_WITH_SCOPED_ANNOTATION);
+        let registry = registry_with_string_handler(
+            "acme.task",
+            "<div class=\"acme-task\">handler-rendered</div>",
+        );
+        let outcome = serialize_to_html_with_registry(
+            &doc,
+            HtmlOptions::new(HtmlTheme::default()),
+            &registry,
+        )
+        .expect("serialise");
+        assert!(
+            outcome
+                .html
+                .contains("<div class=\"acme-task\">handler-rendered</div>"),
+            "handler HTML should be spliced into the output. got:\n{}",
+            outcome.html
+        );
+        // Default comment markers gone for this annotation.
+        assert!(
+            !outcome.html.contains("<!-- lex:acme.task"),
+            "default start comment should be replaced by splice. got:\n{}",
+            outcome.html
+        );
+        assert!(
+            !outcome.html.contains("<!-- /lex:acme.task"),
+            "default end comment should be replaced by splice. got:\n{}",
+            outcome.html
+        );
+    }
+
+    #[test]
+    fn splice_consumes_annotation_body_so_default_content_does_not_render() {
+        use crate::formats::html::{serialize_to_html_with_registry, HtmlOptions, HtmlTheme};
+        // The body paragraph below ("Body that should be replaced.")
+        // must NOT appear in the output — the handler owns the
+        // annotation's full rendering, including its body.
+        let doc = parse(DOC_WITH_SCOPED_ANNOTATION);
+        let registry = registry_with_string_handler("acme.task", "<div>HANDLER</div>");
+        let outcome = serialize_to_html_with_registry(
+            &doc,
+            HtmlOptions::new(HtmlTheme::default()),
+            &registry,
+        )
+        .expect("serialise");
+        assert!(outcome.html.contains("<div>HANDLER</div>"));
+        assert!(
+            !outcome.html.contains("Body that should be replaced."),
+            "annotation body must be suppressed inside the handler-owned region. got:\n{}",
+            outcome.html
+        );
+    }
+
+    #[test]
+    fn no_splice_when_handler_returns_none_falls_through_to_default() {
+        use crate::formats::html::{serialize_to_html_with_registry, HtmlOptions, HtmlTheme};
+        struct AlwaysNone;
+        impl LexHandler for AlwaysNone {
+            fn on_render(
+                &self,
+                _: &LabelCtx,
+                _: Format,
+            ) -> Result<Option<RenderOut>, HandlerError> {
+                Ok(None)
+            }
+        }
+        let doc = parse(DOC_WITH_SCOPED_ANNOTATION);
+        let registry = Registry::new();
+        registry
+            .register_namespace(
+                "acme",
+                vec![schema("acme.task", &["html"])],
+                Box::new(AlwaysNone),
+            )
+            .unwrap();
+        let outcome = serialize_to_html_with_registry(
+            &doc,
+            HtmlOptions::new(HtmlTheme::default()),
+            &registry,
+        )
+        .expect("serialise");
+        // No splice → default comment markers present.
+        assert!(
+            outcome.html.contains("<!-- lex:acme.task"),
+            "Ok(None) should fall through to default rendering. got:\n{}",
+            outcome.html
+        );
+    }
+
+    #[test]
+    fn no_splice_when_handler_returns_wire_ast_with_diagnostic() {
+        use crate::formats::html::{serialize_to_html_with_registry, HtmlOptions, HtmlTheme};
+        use lex_extension::wire::{Range as WireRange, WireNode};
+        use lex_extension::Position;
+        struct WireOnly;
+        impl LexHandler for WireOnly {
+            fn on_render(
+                &self,
+                _: &LabelCtx,
+                _: Format,
+            ) -> Result<Option<RenderOut>, HandlerError> {
+                Ok(Some(RenderOut::WireAst {
+                    ast: WireNode::Paragraph {
+                        range: WireRange::new(Position::new(0, 0), Position::new(0, 0)),
+                        inlines: Vec::new(),
+                        origin: None,
+                    },
+                }))
+            }
+        }
+        let doc = parse(DOC_WITH_SCOPED_ANNOTATION);
+        let registry = Registry::new();
+        registry
+            .register_namespace(
+                "acme",
+                vec![schema("acme.task", &["html"])],
+                Box::new(WireOnly),
+            )
+            .unwrap();
+        let outcome = serialize_to_html_with_registry(
+            &doc,
+            HtmlOptions::new(HtmlTheme::default()),
+            &registry,
+        )
+        .expect("serialise");
+        // Default markers present (WireAst doesn't splice for HTML).
+        assert!(outcome.html.contains("<!-- lex:acme.task"));
+        // Diagnostic surfaces.
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .any(|d| d.contains("WireAst") || d.contains("wire_ast")),
+            "expected WireAst-shape-mismatch diagnostic, got: {:?}",
+            outcome.diagnostics
+        );
+    }
+
+    #[test]
+    fn unregistered_namespace_renders_default_unchanged() {
+        use crate::formats::html::{
+            serialize_to_html, serialize_to_html_with_registry, HtmlOptions, HtmlTheme,
+        };
+        // No namespaces registered — splice has nothing to plan, the
+        // registry-less and registry-aware paths produce identical
+        // output.
+        let doc = parse("1. Heading\n\n    :: unknown.label ::\n        body.\n");
+        let registry = Registry::new();
+        let outcome = serialize_to_html_with_registry(
+            &doc,
+            HtmlOptions::new(HtmlTheme::default()),
+            &registry,
+        )
+        .expect("serialise");
+        let baseline = serialize_to_html(&doc, HtmlTheme::default()).expect("baseline");
+        assert_eq!(outcome.html, baseline);
+    }
+
+    /// Plan-vs-events alignment isn't trivially guaranteed when
+    /// multiple annotations appear in one document: the IR's
+    /// flatten pass can reposition trailing annotations relative
+    /// to their host element, breaking the simple counter-based
+    /// indexing the splice relies on. The two-annotation case is
+    /// real and worth fixing, but the fix needs deeper IR-side
+    /// work to preserve source order through the flatten pass —
+    /// out of scope for the initial splice landing. Tracked at
+    /// the same #563 follow-up that handles WireAst → HTML
+    /// conversion.
+    ///
+    /// For v1, the single-annotation case (the dominant use case)
+    /// works correctly, and the trailing-annotation case is the
+    /// only known divergence. Real extension usage (acme.commenting,
+    /// mit.plasma-specs, etc.) attaches per-element and renders
+    /// cleanly.
+    #[test]
+    fn multi_annotation_splice_is_a_known_limitation() {
+        // No assertion — this test exists so a future implementer
+        // grepping for "multi-annotation" lands here. Promote to a
+        // real assertion when the IR ordering is stabilised.
+    }
 }


### PR DESCRIPTION
Closes #563. \`lexd convert --to html\` now actually splices handler-rendered HTML into the output for annotations whose registered handler returns \`RenderOut::String\`. The default \`<!-- lex:label -->\` ... body ... \`<!-- /lex:label -->\` rendering is replaced by the handler's raw HTML, and the annotation's body events are suppressed (the handler owns the full rendering of its labelled node).

Pairs with **#567** (\`lexd labels emit\`) as the two core feature-completion items from [#546](https://github.com/lex-fmt/lex/issues/546). Both target main; can land in either order.

## Mechanism

| Walk | Order |
|---|---|
| \`dispatch_render\` (AST walk, lex-babel) | builds \`RenderPlan\` of \`(label, output, diagnostic)\` triples |
| \`build_html_dom_with_splice\` (event walk, lex-babel) | maintains a counter, indexes into the plan on each \`Event::StartAnnotation\` |

Both walks visit annotations in matching document order. On a plan entry with output, the builder emits a sentinel comment (\`<!--LEX-RENDER-SPLICE:N-->\`), pushes the handler's HTML to a side buffer, and enters a skip-state that nests on depth. After DOM serialization, \`replace_splice_sentinels\` scans the HTML string and substitutes each sentinel with the buffered raw HTML.

## Why sentinel comments instead of DOM-fragment parsing

html5ever's \`parse_fragment\` would let us merge handler HTML into the RcDom directly, but the Rc-handle gymnastics for moving nodes between DOMs adds complexity for marginal benefit — HTML comments serialize byte-identical through the html5ever pass, so a unique sentinel is reliably round-trip-able through DOM → string. The sentinel approach is ~50 LOC vs. ~150 for fragment parsing.

## Out of scope (follow-ups)

- **\`RenderOut::WireAst\` outputs** fall through to default rendering with the existing format-shape-mismatch diagnostic. WireAst → HTML conversion needs walking every \`WireNode\`/\`WireInline\` variant and rendering each to DOM — its own ~120 LOC piece, tracked in #563's "future work" section.
- **Document-level annotations** (extracted to the IR's synthetic \`frontmatter\` block before events are emitted) are not splice targets. The frontmatter path handles top-level labels as metadata; real extension use cases (acme.commenting, mit.plasma-specs, etc.) attach per-element and splice correctly.
- **Multi-annotation documents with trailing annotations** can hit an IR-ordering quirk that breaks the counter-based alignment. Single-annotation + clearly-separated annotations work. See the \`multi_annotation_splice_is_a_known_limitation\` test note.

## Tests (6 new)

- \`splice_replaces_default_annotation_rendering_with_handler_html\`
- \`splice_consumes_annotation_body_so_default_content_does_not_render\`
- \`no_splice_when_handler_returns_none_falls_through_to_default\`
- \`no_splice_when_handler_returns_wire_ast_with_diagnostic\`
- \`unregistered_namespace_renders_default_unchanged\`
- \`multi_annotation_splice_is_a_known_limitation\` (regression note for the IR ordering issue)

## Test plan

- [x] All 15 \`lex-babel::render_dispatch\` tests pass on macOS.
- [x] All 1982 workspace tests pass on macOS.
- [x] Linux container sweep — same 1980/1982 pass (2 expected LinuxKit landlock failures, green on real Ubuntu CI).
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo clippy --workspace --exclude lex-wasm --all-targets --all-features -- -D warnings\` clean.
- [ ] CI \`Rust CI / Test\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)