### PR TITLE
fix(babel): emit blank line before verbatim subject (#505)

### DIFF
--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -154,6 +154,20 @@ impl LexSerializer {
         format!("{}.", parts.join("."))
     }
 
+    /// Whether the most recently written line ended with a single `:` —
+    /// i.e. a container subject line (Definition, annotation-with-body,
+    /// verbatim subject). Used to decide whether to emit a blank line
+    /// before a following verbatim subject. `:: foo ::` (annotation
+    /// closing / verbatim closing) ends with `::`, not a lone `:`, and
+    /// so does not count.
+    fn last_emission_ended_with_container_opener_colon(&self) -> bool {
+        if self.consecutive_newlines != 1 {
+            return false;
+        }
+        let trimmed = self.output.trim_end();
+        trimmed.ends_with(':') && !trimmed.ends_with("::")
+    }
+
     fn ensure_blank_lines(&mut self, count: usize) {
         let target_newlines = count + 1;
         while self.consecutive_newlines < target_newlines {
@@ -329,6 +343,23 @@ impl Visitor for LexSerializer {
     }
 
     fn visit_verbatim_block(&mut self, verbatim: &Verbatim) {
+        // Lex requires a blank line between a preceding paragraph and the
+        // subject line that opens a verbatim block — without one, the
+        // re-parser merges the subject into the preceding paragraph and
+        // the verbatim is lost. The parser consumes that blank line as
+        // part of the verbatim's preamble, so it isn't represented as a
+        // `BlankLineGroup` in the AST and no other visitor emits it. See
+        // lex#505.
+        //
+        // Suppress when the verbatim is the first child of a container
+        // whose opener ends with `:` (Definition, list-item with colon
+        // subject, etc.). A blank line at column 0 between a Definition
+        // subject and its body would terminate the Definition, so the
+        // body's first verbatim must follow immediately.
+        if !self.last_emission_ended_with_container_opener_colon() {
+            self.ensure_blank_lines(1);
+        }
+
         let label = &verbatim.closing_data.label.value;
 
         // Try to get formatted content from handler
@@ -738,6 +769,29 @@ mod tests {
         assert!(formatted_2.contains("| A   | B   |"));
         assert!(formatted_2.contains("| --- | --- |"));
         assert!(formatted_2.contains("| 1   | 2   |"));
+    }
+
+    #[test]
+    fn test_round_trip_paragraph_then_verbatim_lex505() {
+        // Regression: Verbatim preceded by a paragraph must keep its leading
+        // blank line through a parse → serialize → parse round-trip. Without
+        // the blank, the re-parser merges the verbatim's subject line into
+        // the prior paragraph and the verbatim is lost. The parser consumes
+        // that blank as part of the verbatim's preamble (it doesn't appear
+        // as a BlankLineGroup in the AST), so the serializer has to emit it.
+        //
+        // Uses a `Title\n=====\n` header so the first line isn't absorbed as
+        // the document title — without it, "Intro paragraph." would become
+        // the doc title and the regression wouldn't be exercised.
+        let source =
+            "Doc\n===\n\nIntro paragraph.\n\nCode Example:\n\n    fn main() {}\n\n:: rust ::\n";
+        let formatted = format_source(source);
+        assert!(
+            formatted.contains("Intro paragraph.\n\nCode Example:"),
+            "expected blank line between paragraph and verbatim subject, got:\n{formatted}"
+        );
+        let formatted_again = format_source(&formatted);
+        assert_text_eq(&formatted, &formatted_again);
     }
 
     #[test]

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -155,11 +155,14 @@ impl LexSerializer {
     }
 
     /// Whether the most recently written line ended with a single `:` —
-    /// i.e. a container subject line (Definition, annotation-with-body,
-    /// verbatim subject). Used to decide whether to emit a blank line
-    /// before a following verbatim subject. `:: foo ::` (annotation
-    /// closing / verbatim closing) ends with `::`, not a lone `:`, and
-    /// so does not count.
+    /// i.e. a `Subject:`-style container opener (Definition subject,
+    /// verbatim group subject, etc.). Used to decide whether to emit a
+    /// blank line before a following verbatim subject: a blank line at
+    /// column 0 between a Definition subject and its body would
+    /// terminate the Definition, so the body's first verbatim must
+    /// follow immediately. Annotation headers (`:: label ::` / `:: label`)
+    /// end with `::` not a lone `:`, so this check correctly leaves them
+    /// out — a verbatim after an annotation does want a leading blank.
     fn last_emission_ended_with_container_opener_colon(&self) -> bool {
         if self.consecutive_newlines != 1 {
             return false;

--- a/crates/lex-cli/tests/integration/includes.rs
+++ b/crates/lex-cli/tests/integration/includes.rs
@@ -293,22 +293,24 @@ fn nearest_lex_toml_walks_upward_to_find_root() {
 /// in prose and a verbatim block.
 #[test]
 fn inspect_preserves_verbatim_when_lex_include_is_only_in_prose() {
-    let dir = fixture_dir(&[(
-        "doc.lex",
-        // Bare `lex.include` mention in prose, no actual annotation.
-        // Followed by a verbatim block which must survive the round trip.
-        "Title\n\
-         =====\n\
-         \n\
-         Some text mentioning `lex.include` in prose.\n\
-         \n\
-         Code Example:\n\
-         \n    fn main() {}\n\
-         \n\
-         :: rust ::\n\
-         \n\
-         End.\n",
-    )]);
+    // Bare `lex.include` mention in prose, no actual annotation, followed
+    // by a verbatim block (subject line + indented body + closing marker)
+    // which must survive the round trip.
+    let fixture = concat!(
+        "Title\n",
+        "=====\n",
+        "\n",
+        "Some text mentioning `lex.include` in prose.\n",
+        "\n",
+        "Code Example:\n",
+        "\n",
+        "    fn main() {}\n",
+        "\n",
+        ":: rust ::\n",
+        "\n",
+        "End.\n",
+    );
+    let dir = fixture_dir(&[("doc.lex", fixture)]);
     let doc = path_in(&dir, "doc.lex");
 
     let default_out = lexd()

--- a/crates/lex-cli/tests/integration/includes.rs
+++ b/crates/lex-cli/tests/integration/includes.rs
@@ -277,6 +277,67 @@ fn nearest_lex_toml_walks_upward_to_find_root() {
         .stdout(predicate::str::contains("Foo body content."));
 }
 
+// ============================================================================
+// Regression: prose mentions of "lex.include" + verbatim blocks
+// ============================================================================
+
+/// `lexd inspect` resolves includes by default, which (before the fix in
+/// lex#505) sent the source through a parse → serialize → re-parse round
+/// trip whenever the literal string `lex.include` appeared anywhere — even
+/// in prose. The serializer dropped the blank line that separates a
+/// paragraph from a verbatim block's subject, and the re-parser then
+/// merged the subject into the paragraph and lost the verbatim.
+///
+/// Asserts that `inspect` (default, includes enabled) produces the same
+/// AST tree as `inspect --no-includes` for a document with `lex.include`
+/// in prose and a verbatim block.
+#[test]
+fn inspect_preserves_verbatim_when_lex_include_is_only_in_prose() {
+    let dir = fixture_dir(&[(
+        "doc.lex",
+        // Bare `lex.include` mention in prose, no actual annotation.
+        // Followed by a verbatim block which must survive the round trip.
+        "Title\n\
+         =====\n\
+         \n\
+         Some text mentioning `lex.include` in prose.\n\
+         \n\
+         Code Example:\n\
+         \n    fn main() {}\n\
+         \n\
+         :: rust ::\n\
+         \n\
+         End.\n",
+    )]);
+    let doc = path_in(&dir, "doc.lex");
+
+    let default_out = lexd()
+        .arg("inspect")
+        .arg(&doc)
+        .output()
+        .expect("run lexd inspect");
+    assert!(default_out.status.success());
+    let default_stdout = String::from_utf8(default_out.stdout).unwrap();
+
+    let noinc_out = lexd()
+        .arg("inspect")
+        .arg("--no-includes")
+        .arg(&doc)
+        .output()
+        .expect("run lexd inspect --no-includes");
+    assert!(noinc_out.status.success());
+    let noinc_stdout = String::from_utf8(noinc_out.stdout).unwrap();
+
+    assert_eq!(
+        default_stdout, noinc_stdout,
+        "inspect with includes resolved must equal --no-includes when no actual lex.include exists.\n--- default ---\n{default_stdout}\n--- --no-includes ---\n{noinc_stdout}"
+    );
+    assert!(
+        default_stdout.contains("𝒱"),
+        "expected verbatim block in inspect output, got:\n{default_stdout}"
+    );
+}
+
 // Ensure the fixture helper doesn't get pruned by dead-code lint when
 // tests change shape during development.
 #[test]


### PR DESCRIPTION
## Summary
- Closes #505.
- The Lex serializer writes a verbatim block's subject line directly after the preceding paragraph; the re-parser then merges that subject into the paragraph and the verbatim — plus everything it bracketed — silently disappears. Triggered any time the literal string `lex.include` appears in a document and `lexd inspect` (or another consumer of `expand_includes_to_source`) round-trips the source.
- `visit_verbatim_block` now calls `ensure_blank_lines(1)` before any group output, suppressed when the verbatim is the first child of a container whose opener ends with a single `:` (Definition, annotation with body, …) — a blank at column 0 between a Definition subject and its body would terminate the Definition. The colon check distinguishes container openers (`Subject:`) from annotation/verbatim closings (`:: foo ::`).

## Why this fixes #505
The original ticket frames the bug as the include resolver dropping nodes, but the resolver itself only walks/splices annotations and is a no-op when no `lex.include` annotation exists. The actual loss happens in the `parse → serialize → re-parse` round trip that `expand_includes_to_source` performs whenever the source contains the literal string `lex.include` (the fast-path check). When the round-trip serializer mangles a verbatim, the inspect transform sees the mangled source and the verbatim is gone.

Reproduction with the `extending-lex` proposal that motivated the ticket: pre-fix, `lexd inspect` reports 3 verbatim blocks; `--no-includes` reports 6. Post-fix both report 4 (counts differ from the ticket because the file has evolved).

## Test plan
- [x] New direct test: `test_round_trip_paragraph_then_verbatim_lex505` in the babel serializer suite — parse → serialize → re-serialize idempotency with the smallest fixture that exercises the round-trip loss.
- [x] New CLI integration test: `inspect_preserves_verbatim_when_lex_include_is_only_in_prose` — asserts `lexd inspect` (default, includes resolved) matches `lexd inspect --no-includes` byte-for-byte for a document with `lex.include` in prose and a verbatim block.
- [x] Existing proptests, including the `Definition → Verbatim` round-trip case that initially caught my first too-aggressive fix, still pass.
- [x] Full workspace `cargo test` clean.
- [x] `cargo clippy --workspace --exclude lex-wasm --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)