### PR TITLE
feat(lsp): extract-to-include — server validator + workspace command (#497)

### DIFF
--- a/crates/lex-lsp/src/features/commands.rs
+++ b/crates/lex-lsp/src/features/commands.rs
@@ -20,6 +20,7 @@ pub const COMMAND_TABLE_FORMAT: &str = "lex.table.format";
 pub const COMMAND_TABLE_NEXT_CELL: &str = "lex.table.next_cell";
 pub const COMMAND_TABLE_PREVIOUS_CELL: &str = "lex.table.previous_cell";
 pub const COMMAND_FORMATS_LIST: &str = "lex.formats.list";
+pub const COMMAND_EXTRACT_TO_INCLUDE: &str = "lex.extractToInclude";
 
 pub fn execute_command(command: &str, arguments: &[Value]) -> Result<Option<Value>> {
     match command {

--- a/crates/lex-lsp/src/features/extract.rs
+++ b/crates/lex-lsp/src/features/extract.rs
@@ -3,8 +3,8 @@
 //!
 //! Selecting a section of a Lex document and "extracting" it splits the
 //! selection out into a new file referenced via `:: lex.include src="..." ::`.
-//! All path validation, indent normalization, and the host's container-policy
-//! pre-check live here in Rust (called from the LSP server) so the per-editor
+//! All path validation, indent normalization, and a Lex-fragment parse
+//! check live here in Rust (called from the LSP server) so the per-editor
 //! shims stay thin — see lex#497.
 //!
 //! Two entry points:
@@ -14,10 +14,16 @@
 //!   [`ExtractError`] variant so the editor displays a clear message.
 //!
 //! * [`build_extract_workspace_edit`] — runs validation, indent-shifts the
-//!   selection so its shallowest non-blank line lands at column 0, performs
-//!   the container-policy pre-check, and constructs an atomic
+//!   selection so its shallowest non-blank line lands at column 0, parses
+//!   the shifted text as a Lex fragment, and constructs an atomic
 //!   [`WorkspaceEdit`] containing (1) `CreateFile` for the target and (2)
 //!   `TextEdit` replacing the selection with the include annotation.
+//!
+//! The full `GeneralContainer` host-policy check (e.g. rejecting a Session
+//! selected for extraction into a Definition body) is deferred — the
+//! [`ExtractError::ContainerPolicy`] variant is reserved for it. The
+//! current fragment-parse check covers the common authoring mistakes
+//! (selection that doesn't parse cleanly when shifted to column 0).
 
 use std::path::{Path, PathBuf};
 
@@ -27,23 +33,30 @@ use tower_lsp::lsp_types::{
     TextEdit, Url, WorkspaceEdit,
 };
 
-/// Distinct failure modes from path validation and container-policy
-/// pre-check. Each variant maps to a user-facing message in
-/// [`ExtractError::message`].
+/// Distinct failure modes for the extract operation. Each variant maps
+/// to a user-facing message in [`ExtractError::message`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExtractError {
     /// `src` was the empty string.
     EmptyPath,
     /// `src` looked like a URL (`https://…`, `file://…`, …).
     UrlScheme { scheme: String },
-    /// `src` was platform-absolute (`/abs/path` on Unix, `C:\…` on Windows).
-    /// Lex include paths must be relative or root-absolute (leading `/`
-    /// meaning "from the configured includes root").
+    /// `src` is platform-absolute in a way the resolver rejects up
+    /// front. In practice this fires on Windows-shaped absolute paths
+    /// (e.g. `C:\foo`). On Unix a leading `/` is root-absolute per the
+    /// Lex spec (resolved under the includes root) and lands in
+    /// [`Self::EscapesRoot`] only if it normalizes outside that root,
+    /// so `AbsolutePath` is effectively Windows-only there.
     AbsolutePath { src: String },
     /// `src` lexically normalizes outside the includes root.
     EscapesRoot { src: String },
     /// The target file already exists on disk — refuse to overwrite.
     TargetExists { path: PathBuf },
+    /// The target's parent directory does not exist. Directory
+    /// auto-creation is explicitly out of scope, so we fail fast here
+    /// rather than producing an opaque `CreateFile`-time failure in
+    /// the editor (whose atomicity guarantees vary).
+    ParentDirMissing { path: PathBuf },
     /// The host document URI is not a `file://` URL (e.g. stdin, `inmemory:`).
     InvalidHostUri,
     /// The host document sits outside the configured includes root — we
@@ -78,6 +91,10 @@ impl ExtractError {
             }
             Self::TargetExists { path } => format!(
                 "Target file `{}` already exists. Choose a different name to avoid overwriting it.",
+                path.display()
+            ),
+            Self::ParentDirMissing { path } => format!(
+                "Target directory `{}` does not exist. Create it first (extract does not auto-create directories).",
                 path.display()
             ),
             Self::InvalidHostUri => {
@@ -129,10 +146,21 @@ pub fn validate_include_path(
     match lex_core::lex::includes::resolve_file_reference(src, Some(host_path), includes_root) {
         Ok(normalized) => {
             if normalized.exists() {
-                Err(ExtractError::TargetExists { path: normalized })
-            } else {
-                Ok(normalized)
+                return Err(ExtractError::TargetExists { path: normalized });
             }
+            // Fail fast if the parent directory is missing. Editors apply
+            // a CreateFile op against a non-existent parent inconsistently
+            // (vscode silently aborts the whole WorkspaceEdit, others
+            // surface a generic LSP error); surfacing a typed
+            // ExtractError here keeps the editor-side message actionable.
+            if let Some(parent) = normalized.parent() {
+                if !parent.as_os_str().is_empty() && !parent.exists() {
+                    return Err(ExtractError::ParentDirMissing {
+                        path: parent.to_path_buf(),
+                    });
+                }
+            }
+            Ok(normalized)
         }
         Err(lex_core::lex::includes::IncludeError::AbsolutePath { .. }) => {
             Err(ExtractError::AbsolutePath {
@@ -228,10 +256,14 @@ fn leading_space_count(line: &str) -> usize {
 }
 
 /// Build the atomic [`WorkspaceEdit`] for an extract operation. Runs
-/// validation, indent-shifts the selection, performs the container-policy
-/// pre-check, and assembles the edit as a single document-changes vector
-/// so the editor applies the file creation and selection replacement
-/// together.
+/// validation, indent-shifts the selection, parses the shifted text as
+/// a Lex fragment (surfaces [`ExtractError::ParseFailed`] on failure),
+/// and assembles the edit as a single document-changes vector so the
+/// editor applies the file creation and selection replacement together.
+///
+/// The deeper [`ExtractError::ContainerPolicy`] check (host-side
+/// `GeneralContainer` validity for the included content) is reserved
+/// for a follow-up and is currently never produced.
 ///
 /// `selection_text` is the verbatim selected slice of the host document
 /// (the editor extracts it before invoking the command). `host_indent`
@@ -255,10 +287,12 @@ pub fn build_extract_workspace_edit(
 
     let (shifted, _original_indent) = indent_shift(selection_text);
 
-    // Container-policy pre-check: the shifted selection must parse as a
-    // valid Lex document fragment. Parse errors are surfaced as
-    // `ParseFailed` so the user sees an actionable message instead of a
-    // mysterious "extract failed" notification.
+    // Parse pre-check: the shifted selection must parse as a valid Lex
+    // document fragment on its own. This catches selections that break
+    // structure when re-indented to column 0 (e.g. mid-list slices, or
+    // verbatim closings without their opener). The deeper
+    // host-container-policy check (`GeneralContainer` rules for where
+    // the extracted content can sit) is deferred — see module docs.
     if let Err(e) = lex_core::lex::parsing::parse_document(&shifted) {
         return Err(ExtractError::ParseFailed {
             message: e.to_string(),
@@ -402,6 +436,33 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_missing_parent_directory() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        // `subdir/` does not exist under tmp, so creating `subdir/foo.lex`
+        // would fail at CreateFile time. We should catch that up front.
+        let err = validate_include_path("subdir/foo.lex", &host, tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ExtractError::ParentDirMissing { .. }),
+            "expected ParentDirMissing, got {err:?}"
+        );
+        assert!(err.message().contains("does not exist"));
+    }
+
+    #[test]
+    fn validate_accepts_existing_parent_directory() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        std::fs::create_dir_all(tmp.path().join("subdir")).unwrap();
+        let resolved = validate_include_path("subdir/foo.lex", &host, tmp.path()).unwrap();
+        assert!(resolved.starts_with(tmp.path()));
+        assert_eq!(
+            resolved.file_name().and_then(|n| n.to_str()),
+            Some("foo.lex")
+        );
+    }
+
+    #[test]
     fn validate_rejects_existing_target() {
         let tmp = TempDir::new().unwrap();
         let host = host_in(tmp.path(), "doc.lex");
@@ -442,6 +503,9 @@ mod tests {
             },
             ExtractError::TargetExists {
                 path: PathBuf::from("/x"),
+            },
+            ExtractError::ParentDirMissing {
+                path: PathBuf::from("/missing"),
             },
             ExtractError::InvalidHostUri,
             ExtractError::HostNotUnderRoot,

--- a/crates/lex-lsp/src/features/extract.rs
+++ b/crates/lex-lsp/src/features/extract.rs
@@ -1,0 +1,623 @@
+//! Extract-to-include: server-side machinery for the `lex.extractToInclude`
+//! workspace command.
+//!
+//! Selecting a section of a Lex document and "extracting" it splits the
+//! selection out into a new file referenced via `:: lex.include src="..." ::`.
+//! All path validation, indent normalization, and the host's container-policy
+//! pre-check live here in Rust (called from the LSP server) so the per-editor
+//! shims stay thin — see lex#497.
+//!
+//! Two entry points:
+//!
+//! * [`validate_include_path`] — pure path/URL/existence validation against
+//!   the configured includes root. Surfaces every failure mode as a distinct
+//!   [`ExtractError`] variant so the editor displays a clear message.
+//!
+//! * [`build_extract_workspace_edit`] — runs validation, indent-shifts the
+//!   selection so its shallowest non-blank line lands at column 0, performs
+//!   the container-policy pre-check, and constructs an atomic
+//!   [`WorkspaceEdit`] containing (1) `CreateFile` for the target and (2)
+//!   `TextEdit` replacing the selection with the include annotation.
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::{
+    CreateFile, CreateFileOptions, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Position, Range, ResourceOp, TextDocumentEdit,
+    TextEdit, Url, WorkspaceEdit,
+};
+
+/// Distinct failure modes from path validation and container-policy
+/// pre-check. Each variant maps to a user-facing message in
+/// [`ExtractError::message`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExtractError {
+    /// `src` was the empty string.
+    EmptyPath,
+    /// `src` looked like a URL (`https://…`, `file://…`, …).
+    UrlScheme { scheme: String },
+    /// `src` was platform-absolute (`/abs/path` on Unix, `C:\…` on Windows).
+    /// Lex include paths must be relative or root-absolute (leading `/`
+    /// meaning "from the configured includes root").
+    AbsolutePath { src: String },
+    /// `src` lexically normalizes outside the includes root.
+    EscapesRoot { src: String },
+    /// The target file already exists on disk — refuse to overwrite.
+    TargetExists { path: PathBuf },
+    /// The host document URI is not a `file://` URL (e.g. stdin, `inmemory:`).
+    InvalidHostUri,
+    /// The host document sits outside the configured includes root — we
+    /// can't compute a sensible relative target without it.
+    HostNotUnderRoot,
+    /// Selection was empty or whitespace-only.
+    SelectionEmpty,
+    /// Selection didn't parse as valid Lex once indent-shifted.
+    ParseFailed { message: String },
+    /// Indent-shifted selection cannot legally sit at the host's container
+    /// position — e.g. a `Session` selected for extraction into a `Definition`
+    /// body. Carries a human-readable reason.
+    ContainerPolicy { reason: String },
+}
+
+impl ExtractError {
+    /// Human-readable message suitable for direct display in an editor
+    /// error notification. Each variant returns a distinct string so the
+    /// editor can show actionable feedback without re-implementing the
+    /// rule.
+    pub fn message(&self) -> String {
+        match self {
+            Self::EmptyPath => "Include path cannot be empty.".to_string(),
+            Self::UrlScheme { scheme } => {
+                format!("Include path must not be a URL (got scheme `{scheme}:`).")
+            }
+            Self::AbsolutePath { src } => format!(
+                "Include path `{src}` must not be platform-absolute. Use a relative path or a root-absolute `/path` (relative to the includes root)."
+            ),
+            Self::EscapesRoot { src } => {
+                format!("Include path `{src}` resolves outside the configured includes root.")
+            }
+            Self::TargetExists { path } => format!(
+                "Target file `{}` already exists. Choose a different name to avoid overwriting it.",
+                path.display()
+            ),
+            Self::InvalidHostUri => {
+                "Extract requires a file-backed document (got a non-file URI).".to_string()
+            }
+            Self::HostNotUnderRoot => {
+                "Host document is outside the configured includes root.".to_string()
+            }
+            Self::SelectionEmpty => "Selection is empty.".to_string(),
+            Self::ParseFailed { message } => {
+                format!("Selection does not parse as a valid Lex fragment: {message}")
+            }
+            Self::ContainerPolicy { reason } => reason.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for ExtractError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message())
+    }
+}
+
+impl std::error::Error for ExtractError {}
+
+/// Validate that `src` is a usable include path: non-empty, not a URL,
+/// not platform-absolute, lexically normalizes inside `includes_root`,
+/// and doesn't point at an existing file.
+///
+/// `host_path` is the canonical filesystem path of the host document —
+/// relative `src` values resolve against its parent directory. The
+/// returned path is the lexically normalized absolute target.
+///
+/// Filesystem touch is intentional: the existence check needs `Path::exists`.
+/// Everything else is lexical to keep behavior stable under symlinks and
+/// non-canonical roots.
+pub fn validate_include_path(
+    src: &str,
+    host_path: &Path,
+    includes_root: &Path,
+) -> Result<PathBuf, ExtractError> {
+    if src.is_empty() {
+        return Err(ExtractError::EmptyPath);
+    }
+    if let Some(scheme) = url_scheme(src) {
+        return Err(ExtractError::UrlScheme { scheme });
+    }
+
+    match lex_core::lex::includes::resolve_file_reference(src, Some(host_path), includes_root) {
+        Ok(normalized) => {
+            if normalized.exists() {
+                Err(ExtractError::TargetExists { path: normalized })
+            } else {
+                Ok(normalized)
+            }
+        }
+        Err(lex_core::lex::includes::IncludeError::AbsolutePath { .. }) => {
+            Err(ExtractError::AbsolutePath {
+                src: src.to_string(),
+            })
+        }
+        Err(lex_core::lex::includes::IncludeError::RootEscape { .. }) => {
+            Err(ExtractError::EscapesRoot {
+                src: src.to_string(),
+            })
+        }
+        Err(other) => Err(ExtractError::ParseFailed {
+            message: other.to_string(),
+        }),
+    }
+}
+
+/// Return the URL scheme (e.g. `https`, `file`) if `src` looks like one.
+/// RFC 3986 scheme: ALPHA *(ALPHA / DIGIT / "+" / "-" / ".").
+///
+/// Single-letter prefixes (e.g. `c:foo`) and short non-alpha prefixes don't
+/// count — they're plain relative paths or Windows drive references handled
+/// downstream by `AbsolutePath`.
+fn url_scheme(src: &str) -> Option<String> {
+    let (scheme, rest) = src.split_once(':')?;
+    if rest.is_empty() {
+        return None;
+    }
+    if scheme.len() < 2 {
+        return None;
+    }
+    let mut chars = scheme.chars();
+    let first = chars.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+        return None;
+    }
+    Some(scheme.to_string())
+}
+
+/// Indent-normalize `text` so the shallowest non-blank line lands at
+/// column 0 while deeper lines keep their relative indentation. Returns
+/// `(shifted_text, original_min_indent)`.
+///
+/// Blank/whitespace-only lines are preserved verbatim in length-zero form
+/// (a single newline) so the shifted text doesn't carry trailing
+/// whitespace from the source's original indent depth.
+pub fn indent_shift(text: &str) -> (String, usize) {
+    let min_indent = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(leading_space_count)
+        .min()
+        .unwrap_or(0);
+
+    let mut shifted = String::with_capacity(text.len());
+    let mut iter = text.lines().peekable();
+    while let Some(line) = iter.next() {
+        if line.trim().is_empty() {
+            shifted.push_str(line.trim_end_matches([' ', '\t']));
+        } else {
+            let cut = line
+                .char_indices()
+                .scan(0usize, |col, (byte_idx, ch)| {
+                    if *col >= min_indent {
+                        Some((byte_idx, ch, true))
+                    } else if ch == ' ' {
+                        *col += 1;
+                        Some((byte_idx, ch, false))
+                    } else {
+                        // Non-space (e.g. tab) before reaching min_indent: stop
+                        // counting and keep the rest verbatim. Mixed-tab cases
+                        // are rare in Lex (4-space indent only) and aren't
+                        // worth surprising the user over.
+                        Some((byte_idx, ch, true))
+                    }
+                })
+                .find_map(|(idx, _, done)| if done { Some(idx) } else { None })
+                .unwrap_or(line.len());
+            shifted.push_str(&line[cut..]);
+        }
+        if iter.peek().is_some() || text.ends_with('\n') {
+            shifted.push('\n');
+        }
+    }
+    (shifted, min_indent)
+}
+
+fn leading_space_count(line: &str) -> usize {
+    line.chars().take_while(|c| *c == ' ').count()
+}
+
+/// Build the atomic [`WorkspaceEdit`] for an extract operation. Runs
+/// validation, indent-shifts the selection, performs the container-policy
+/// pre-check, and assembles the edit as a single document-changes vector
+/// so the editor applies the file creation and selection replacement
+/// together.
+///
+/// `selection_text` is the verbatim selected slice of the host document
+/// (the editor extracts it before invoking the command). `host_indent`
+/// is the column at which the selection's first line starts — used to
+/// indent the inserted `:: lex.include ::` annotation back to that
+/// position so the replacement preserves the host's structure.
+pub fn build_extract_workspace_edit(
+    host_uri: &Url,
+    host_path: &Path,
+    selection_range: Range,
+    selection_text: &str,
+    host_indent: usize,
+    src: &str,
+    includes_root: &Path,
+) -> Result<WorkspaceEdit, ExtractError> {
+    if selection_text.trim().is_empty() {
+        return Err(ExtractError::SelectionEmpty);
+    }
+
+    let target_path = validate_include_path(src, host_path, includes_root)?;
+
+    let (shifted, _original_indent) = indent_shift(selection_text);
+
+    // Container-policy pre-check: the shifted selection must parse as a
+    // valid Lex document fragment. Parse errors are surfaced as
+    // `ParseFailed` so the user sees an actionable message instead of a
+    // mysterious "extract failed" notification.
+    if let Err(e) = lex_core::lex::parsing::parse_document(&shifted) {
+        return Err(ExtractError::ParseFailed {
+            message: e.to_string(),
+        });
+    }
+
+    let target_uri = Url::from_file_path(&target_path).map_err(|_| ExtractError::InvalidHostUri)?;
+
+    let replacement = format!(
+        "{indent}:: lex.include src=\"{src}\" ::",
+        indent = " ".repeat(host_indent)
+    );
+
+    let create_op = ResourceOp::Create(CreateFile {
+        uri: target_uri.clone(),
+        options: Some(CreateFileOptions {
+            overwrite: Some(false),
+            ignore_if_exists: Some(false),
+        }),
+        annotation_id: None,
+    });
+
+    let text_doc_edit = TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: host_uri.clone(),
+            version: None,
+        },
+        edits: vec![OneOf::Left(TextEdit {
+            range: selection_range,
+            new_text: replacement,
+        })],
+    };
+
+    // Ensure the file-creation includes the extracted content. The LSP
+    // `CreateFile` op itself only creates an empty file; the content lands
+    // via a TextDocumentEdit whose URI points at the just-created file.
+    let target_text_edit = TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: target_uri,
+            version: None,
+        },
+        edits: vec![OneOf::Left(TextEdit {
+            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            new_text: shifted,
+        })],
+    };
+
+    Ok(WorkspaceEdit {
+        document_changes: Some(DocumentChanges::Operations(vec![
+            DocumentChangeOperation::Op(create_op),
+            DocumentChangeOperation::Edit(target_text_edit),
+            DocumentChangeOperation::Edit(text_doc_edit),
+        ])),
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn host_in(root: &Path, rel: &str) -> PathBuf {
+        let p = root.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&p, "").unwrap();
+        p
+    }
+
+    // ---- validate_include_path ---------------------------------------------
+
+    #[test]
+    fn validate_rejects_empty_path() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let err = validate_include_path("", &host, tmp.path()).unwrap_err();
+        assert_eq!(err, ExtractError::EmptyPath);
+        assert!(err.message().contains("empty"));
+    }
+
+    #[test]
+    fn validate_rejects_url_scheme() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let err = validate_include_path("https://example/foo.lex", &host, tmp.path()).unwrap_err();
+        assert!(matches!(err, ExtractError::UrlScheme { ref scheme } if scheme == "https"));
+        assert!(err.message().contains("URL"));
+    }
+
+    #[test]
+    fn validate_rejects_file_url() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let err = validate_include_path("file:///abs/foo.lex", &host, tmp.path()).unwrap_err();
+        assert!(matches!(err, ExtractError::UrlScheme { .. }));
+    }
+
+    /// On Unix, a leading `/` is treated as *root-absolute* by the Lex
+    /// include resolver (relative to the includes root), so `/abs/path`
+    /// is a valid include path — not an `AbsolutePath` error. The
+    /// `AbsolutePath` variant exists for Windows-style platform-absolute
+    /// paths like `C:\foo`, which on Windows would hit
+    /// `Path::is_absolute() == true` without a leading `/`.
+    #[cfg(unix)]
+    #[test]
+    fn validate_unix_root_absolute_path_is_valid() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let ok = validate_include_path("/inside_root.lex", &host, tmp.path()).unwrap();
+        assert!(ok.starts_with(tmp.path()));
+        assert_eq!(
+            ok.file_name().and_then(|n| n.to_str()),
+            Some("inside_root.lex")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_rejects_absolute_path() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let err = validate_include_path("C:\\extract_target.lex", &host, tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ExtractError::AbsolutePath { .. }),
+            "expected AbsolutePath, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_root_escape_via_dotdot() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "sub/doc.lex");
+        // `../../escape.lex` from `sub/doc.lex` resolves above tmp/, outside the root.
+        let err = validate_include_path("../../escape.lex", &host, tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ExtractError::EscapesRoot { .. }),
+            "expected EscapesRoot, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_existing_target() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let target = tmp.path().join("existing.lex");
+        std::fs::write(&target, "content").unwrap();
+        let err = validate_include_path("existing.lex", &host, tmp.path()).unwrap_err();
+        assert!(
+            matches!(err, ExtractError::TargetExists { .. }),
+            "expected TargetExists, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_valid_relative_path() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let resolved = validate_include_path("chapter.lex", &host, tmp.path()).unwrap();
+        // Compare via lexical equality — the result is normalized.
+        assert_eq!(
+            resolved.file_name().and_then(|n| n.to_str()),
+            Some("chapter.lex")
+        );
+        assert!(resolved.starts_with(tmp.path()));
+    }
+
+    #[test]
+    fn error_messages_are_distinct_per_variant() {
+        let variants = [
+            ExtractError::EmptyPath,
+            ExtractError::UrlScheme {
+                scheme: "https".to_string(),
+            },
+            ExtractError::AbsolutePath {
+                src: "/abs".to_string(),
+            },
+            ExtractError::EscapesRoot {
+                src: "../x".to_string(),
+            },
+            ExtractError::TargetExists {
+                path: PathBuf::from("/x"),
+            },
+            ExtractError::InvalidHostUri,
+            ExtractError::HostNotUnderRoot,
+            ExtractError::SelectionEmpty,
+            ExtractError::ParseFailed {
+                message: "oops".to_string(),
+            },
+            ExtractError::ContainerPolicy {
+                reason: "no sessions inside definitions".to_string(),
+            },
+        ];
+        let messages: Vec<String> = variants.iter().map(|v| v.message()).collect();
+        let unique: std::collections::HashSet<&String> = messages.iter().collect();
+        assert_eq!(
+            unique.len(),
+            messages.len(),
+            "every ExtractError variant must produce a distinct message; got {messages:?}"
+        );
+    }
+
+    // ---- indent_shift ------------------------------------------------------
+
+    #[test]
+    fn indent_shift_zero_indent_is_noop() {
+        let (out, min) = indent_shift("Line 1\nLine 2\n");
+        assert_eq!(out, "Line 1\nLine 2\n");
+        assert_eq!(min, 0);
+    }
+
+    #[test]
+    fn indent_shift_drops_uniform_indent() {
+        let (out, min) = indent_shift("    Line 1\n    Line 2\n");
+        assert_eq!(out, "Line 1\nLine 2\n");
+        assert_eq!(min, 4);
+    }
+
+    #[test]
+    fn indent_shift_preserves_relative_indent() {
+        let src = "        Outer\n            Inner\n        Outer2\n";
+        let (out, min) = indent_shift(src);
+        assert_eq!(out, "Outer\n    Inner\nOuter2\n");
+        assert_eq!(min, 8);
+    }
+
+    #[test]
+    fn indent_shift_ignores_blank_lines_for_min() {
+        // The blank line in the middle shouldn't count as zero-indent.
+        let src = "    Line 1\n\n    Line 2\n";
+        let (out, min) = indent_shift(src);
+        assert_eq!(out, "Line 1\n\nLine 2\n");
+        assert_eq!(min, 4);
+    }
+
+    #[test]
+    fn indent_shift_handles_12_column_indent() {
+        let src = "            Deeply\n            indented\n";
+        let (out, min) = indent_shift(src);
+        assert_eq!(out, "Deeply\nindented\n");
+        assert_eq!(min, 12);
+    }
+
+    #[test]
+    fn indent_shift_no_trailing_newline_preserved() {
+        let (out, min) = indent_shift("    no-newline");
+        assert_eq!(out, "no-newline");
+        assert_eq!(min, 4);
+    }
+
+    // ---- build_extract_workspace_edit --------------------------------------
+
+    #[test]
+    fn build_workspace_edit_rejects_empty_selection() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let host_uri = Url::from_file_path(&host).unwrap();
+        let err = build_extract_workspace_edit(
+            &host_uri,
+            &host,
+            Range::new(Position::new(0, 0), Position::new(0, 0)),
+            "   \n",
+            0,
+            "out.lex",
+            tmp.path(),
+        )
+        .unwrap_err();
+        assert_eq!(err, ExtractError::SelectionEmpty);
+    }
+
+    #[test]
+    fn build_workspace_edit_emits_create_and_edit() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let host_uri = Url::from_file_path(&host).unwrap();
+        let edit = build_extract_workspace_edit(
+            &host_uri,
+            &host,
+            Range::new(Position::new(2, 4), Position::new(5, 0)),
+            "    Hello.\n    World.\n",
+            4,
+            "extracted.lex",
+            tmp.path(),
+        )
+        .unwrap();
+
+        let ops = match edit.document_changes.unwrap() {
+            DocumentChanges::Operations(ops) => ops,
+            _ => panic!("expected operations"),
+        };
+        assert_eq!(
+            ops.len(),
+            3,
+            "expected create + target-content + host-replace"
+        );
+        match &ops[0] {
+            DocumentChangeOperation::Op(ResourceOp::Create(c)) => {
+                assert!(c.uri.path().ends_with("extracted.lex"));
+            }
+            _ => panic!("first op must be CreateFile"),
+        }
+    }
+
+    #[test]
+    fn build_workspace_edit_indent_shifts_selection_content() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let host_uri = Url::from_file_path(&host).unwrap();
+        let edit = build_extract_workspace_edit(
+            &host_uri,
+            &host,
+            Range::new(Position::new(0, 4), Position::new(2, 0)),
+            "    Line 1\n    Line 2\n",
+            4,
+            "out.lex",
+            tmp.path(),
+        )
+        .unwrap();
+        let ops = match edit.document_changes.unwrap() {
+            DocumentChanges::Operations(ops) => ops,
+            _ => panic!("expected operations"),
+        };
+        let target_content = match &ops[1] {
+            DocumentChangeOperation::Edit(edit) => match &edit.edits[0] {
+                OneOf::Left(e) => e.new_text.clone(),
+                _ => panic!("unexpected edit shape"),
+            },
+            _ => panic!("expected TextDocumentEdit"),
+        };
+        assert_eq!(target_content, "Line 1\nLine 2\n");
+    }
+
+    #[test]
+    fn build_workspace_edit_writes_include_annotation_at_host_indent() {
+        let tmp = TempDir::new().unwrap();
+        let host = host_in(tmp.path(), "doc.lex");
+        let host_uri = Url::from_file_path(&host).unwrap();
+        let edit = build_extract_workspace_edit(
+            &host_uri,
+            &host,
+            Range::new(Position::new(0, 8), Position::new(2, 0)),
+            "        Line 1\n        Line 2\n",
+            8,
+            "out.lex",
+            tmp.path(),
+        )
+        .unwrap();
+        let ops = match edit.document_changes.unwrap() {
+            DocumentChanges::Operations(ops) => ops,
+            _ => panic!("expected operations"),
+        };
+        let host_replace = match &ops[2] {
+            DocumentChangeOperation::Edit(edit) => match &edit.edits[0] {
+                OneOf::Left(e) => e.new_text.clone(),
+                _ => panic!("unexpected edit shape"),
+            },
+            _ => panic!("expected TextDocumentEdit"),
+        };
+        assert_eq!(host_replace, "        :: lex.include src=\"out.lex\" ::");
+    }
+}

--- a/crates/lex-lsp/src/features/mod.rs
+++ b/crates/lex-lsp/src/features/mod.rs
@@ -1,5 +1,6 @@
 // Tower-lsp-specific features that stay in this crate.
 pub mod commands;
+pub mod extract;
 
 // Re-exported sync features. These live in `lex-lsp-core` so they can be
 // shared with `lex-wasm`; we re-export them here so server.rs and the rest

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -12,6 +12,7 @@ use crate::extension_dispatch::{
 use crate::features::commands::{self, execute_command};
 use crate::features::document_links::collect_document_links;
 use crate::features::document_symbols::{collect_document_symbols, LexDocumentSymbol};
+use crate::features::extract::{self, ExtractError};
 use crate::features::folding_ranges::{folding_ranges as collect_folding_ranges, LexFoldingRange};
 use crate::features::formatting::{self, LineRange as FormattingLineRange, TextEditSpan};
 use crate::features::go_to_definition::goto_definition;
@@ -1094,6 +1095,7 @@ where
                     commands::COMMAND_TABLE_NEXT_CELL.to_string(),
                     commands::COMMAND_TABLE_PREVIOUS_CELL.to_string(),
                     commands::COMMAND_FORMATS_LIST.to_string(),
+                    commands::COMMAND_EXTRACT_TO_INCLUDE.to_string(),
                 ],
                 work_done_progress_options: WorkDoneProgressOptions::default(),
             }),
@@ -1641,11 +1643,116 @@ where
                 }
                 Ok(None)
             }
+            commands::COMMAND_EXTRACT_TO_INCLUDE => {
+                self.handle_extract_to_include(&params.arguments).await
+            }
             _ => self
                 .features
                 .execute_command(&params.command, &params.arguments),
         }
     }
+}
+
+impl<C, P> LexLanguageServer<C, P>
+where
+    C: LspClient,
+    P: FeatureProvider,
+{
+    /// Handler for `lex.extractToInclude`. Args: `{ uri, range, src }`.
+    ///
+    /// Returns a `WorkspaceEdit` JSON value the editor applies atomically
+    /// (file creation + selection replacement). All validation failures
+    /// surface as `invalid_params` errors carrying the
+    /// [`ExtractError::message`] string for direct display.
+    async fn handle_extract_to_include(&self, arguments: &[Value]) -> Result<Option<Value>> {
+        let uri_str = arguments
+            .first()
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::invalid_params("Missing 'uri' argument"))?;
+        let range_val = arguments
+            .get(1)
+            .ok_or_else(|| Error::invalid_params("Missing 'range' argument"))?;
+        let src = arguments
+            .get(2)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::invalid_params("Missing 'src' argument"))?;
+
+        let uri = Url::parse(uri_str)
+            .map_err(|_| Error::invalid_params(format!("Invalid uri: {uri_str}")))?;
+        let range: Range = serde_json::from_value(range_val.clone())
+            .map_err(|e| Error::invalid_params(format!("Invalid range: {e}")))?;
+
+        let host_path = uri
+            .to_file_path()
+            .map_err(|_| Error::invalid_params(ExtractError::InvalidHostUri.message()))?;
+        let host_path = absolutize_path(&host_path);
+
+        let entry = self
+            .document_entry(&uri)
+            .await
+            .ok_or_else(|| Error::invalid_params("Document not open in the server"))?;
+
+        let selection_text = slice_text_by_range(&entry.text, range)
+            .ok_or_else(|| Error::invalid_params("Selection range out of bounds"))?;
+
+        let host_indent = range.start.character as usize;
+
+        let cfg = self.config.read().await;
+        let inc_root = inc_root_for(&host_path, &cfg);
+        drop(cfg);
+
+        let edit = extract::build_extract_workspace_edit(
+            &uri,
+            &host_path,
+            range,
+            &selection_text,
+            host_indent,
+            src,
+            &inc_root,
+        )
+        .map_err(|e| Error::invalid_params(e.message()))?;
+
+        Ok(Some(
+            serde_json::to_value(edit).map_err(|_| Error::internal_error())?,
+        ))
+    }
+}
+
+/// Slice `text` by an LSP `Range`. Returns `None` when the range falls
+/// outside the document. Treats `character` as a code-unit offset
+/// matching the rest of the server (see `from_lsp_position`).
+fn slice_text_by_range(text: &str, range: Range) -> Option<String> {
+    let start_line = range.start.line as usize;
+    let end_line = range.end.line as usize;
+    let start_col = range.start.character as usize;
+    let end_col = range.end.character as usize;
+    if start_line > end_line || (start_line == end_line && start_col > end_col) {
+        return None;
+    }
+
+    let lines: Vec<&str> = text.split_inclusive('\n').collect();
+    if end_line >= lines.len() && !(end_line == lines.len() && end_col == 0) {
+        return None;
+    }
+
+    let mut out = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        if i < start_line || i > end_line {
+            continue;
+        }
+        let line_chars: Vec<char> = line.chars().collect();
+        let from = if i == start_line { start_col } else { 0 };
+        let to = if i == end_line {
+            end_col
+        } else {
+            line_chars.len()
+        };
+        if from > line_chars.len() || to > line_chars.len() {
+            return None;
+        }
+        out.extend(line_chars[from..to].iter());
+    }
+    Some(out)
 }
 
 /// Compute the include-resolution root for an entry document.
@@ -3145,6 +3252,129 @@ mod tests {
         assert!(
             response.is_none(),
             "goto-def must return None for missing targets, got {response:?}"
+        );
+    }
+
+    // ========================================================================
+    // lex.extractToInclude — end-to-end via executeCommand (lex#497)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn extract_to_include_returns_workspace_edit_with_create_and_replace() {
+        let host_text = "Doc\n===\n\n1. Section\n\n    Some content.\n    More content.\n";
+        let (server, _client, uri, dir) =
+            open_in_tempdir(&[("main.lex", host_text)], "main.lex").await;
+
+        // Select the indented body of the section — lines 5–6, column 4–end.
+        let range = Range::new(Position::new(5, 4), Position::new(7, 0));
+        let result = server
+            .execute_command(ExecuteCommandParams {
+                command: commands::COMMAND_EXTRACT_TO_INCLUDE.to_string(),
+                arguments: vec![
+                    Value::String(uri.to_string()),
+                    serde_json::to_value(range).unwrap(),
+                    Value::String("section-body.lex".to_string()),
+                ],
+                work_done_progress_params: Default::default(),
+            })
+            .await
+            .unwrap()
+            .expect("extract command should return WorkspaceEdit");
+
+        let edit: tower_lsp::lsp_types::WorkspaceEdit = serde_json::from_value(result).unwrap();
+        let ops = match edit.document_changes.unwrap() {
+            tower_lsp::lsp_types::DocumentChanges::Operations(ops) => ops,
+            _ => panic!("expected operations"),
+        };
+        assert_eq!(ops.len(), 3, "create + target-content + host-replace");
+
+        // First op: create target.
+        match &ops[0] {
+            tower_lsp::lsp_types::DocumentChangeOperation::Op(
+                tower_lsp::lsp_types::ResourceOp::Create(c),
+            ) => {
+                assert!(c.uri.path().ends_with("section-body.lex"));
+            }
+            other => panic!("expected CreateFile, got {other:?}"),
+        }
+
+        // Second op writes the indent-shifted selection into the target.
+        let target_text = match &ops[1] {
+            tower_lsp::lsp_types::DocumentChangeOperation::Edit(e) => match &e.edits[0] {
+                OneOf::Left(t) => t.new_text.clone(),
+                _ => panic!("unexpected edit shape"),
+            },
+            _ => panic!("expected TextDocumentEdit for target"),
+        };
+        assert!(
+            target_text.contains("Some content.") && target_text.contains("More content."),
+            "target should hold the extracted body, got: {target_text:?}"
+        );
+        // Indent-shifted: should start at column 0.
+        assert!(
+            target_text.starts_with("Some content."),
+            "expected indent shift to drop leading 4 spaces, got: {target_text:?}"
+        );
+
+        // Third op replaces the host range with `:: lex.include ::` at indent 4.
+        let host_replace = match &ops[2] {
+            tower_lsp::lsp_types::DocumentChangeOperation::Edit(e) => match &e.edits[0] {
+                OneOf::Left(t) => t.new_text.clone(),
+                _ => panic!("unexpected edit shape"),
+            },
+            _ => panic!("expected TextDocumentEdit for host"),
+        };
+        assert_eq!(
+            host_replace,
+            "    :: lex.include src=\"section-body.lex\" ::"
+        );
+
+        // Keep dir alive until end of test.
+        drop(dir);
+    }
+
+    #[tokio::test]
+    async fn extract_to_include_surfaces_validation_errors_as_invalid_params() {
+        let host_text = "Doc\n===\n\n    Body text.\n";
+        let (server, _client, uri, _dir) =
+            open_in_tempdir(&[("main.lex", host_text)], "main.lex").await;
+
+        let range = Range::new(Position::new(3, 4), Position::new(4, 0));
+        let err = server
+            .execute_command(ExecuteCommandParams {
+                command: commands::COMMAND_EXTRACT_TO_INCLUDE.to_string(),
+                arguments: vec![
+                    Value::String(uri.to_string()),
+                    serde_json::to_value(range).unwrap(),
+                    Value::String("https://elsewhere/foo.lex".to_string()),
+                ],
+                work_done_progress_params: Default::default(),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            err.message.contains("URL"),
+            "expected URL-scheme error message, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_to_include_capability_advertises_command() {
+        let provider = Arc::new(MockFeatureProvider::default());
+        let server = LexLanguageServer::with_features(NoopClient, provider);
+        let init = server
+            .initialize(InitializeParams::default())
+            .await
+            .unwrap();
+        let advertised = init
+            .capabilities
+            .execute_command_provider
+            .expect("execute_command_provider")
+            .commands;
+        assert!(
+            advertised.contains(&commands::COMMAND_EXTRACT_TO_INCLUDE.to_string()),
+            "extractToInclude must be in advertised commands, got: {advertised:?}"
         );
     }
 

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1658,7 +1658,8 @@ where
     C: LspClient,
     P: FeatureProvider,
 {
-    /// Handler for `lex.extractToInclude`. Args: `{ uri, range, src }`.
+    /// Handler for `lex.extractToInclude`. Args are **positional**:
+    /// `[uri: string, range: lsp.Range, src: string]`.
     ///
     /// Returns a `WorkspaceEdit` JSON value the editor applies atomically
     /// (file creation + selection replacement). All validation failures
@@ -1719,8 +1720,13 @@ where
 }
 
 /// Slice `text` by an LSP `Range`. Returns `None` when the range falls
-/// outside the document. Treats `character` as a code-unit offset
-/// matching the rest of the server (see `from_lsp_position`).
+/// outside the document or splits a multi-byte character.
+///
+/// `character` is treated as a **UTF-8 byte offset** to match the rest
+/// of the server: lex-core's `LineColumnLocator::byte_to_position`
+/// computes `column = byte_offset - line_start`, and `to_lsp_position`
+/// forwards that value to LSP as-is. Using char offsets here would
+/// mis-slice any selection containing multi-byte characters.
 fn slice_text_by_range(text: &str, range: Range) -> Option<String> {
     let start_line = range.start.line as usize;
     let end_line = range.end.line as usize;
@@ -1740,17 +1746,22 @@ fn slice_text_by_range(text: &str, range: Range) -> Option<String> {
         if i < start_line || i > end_line {
             continue;
         }
-        let line_chars: Vec<char> = line.chars().collect();
+        let line_bytes = line.as_bytes();
         let from = if i == start_line { start_col } else { 0 };
         let to = if i == end_line {
             end_col
         } else {
-            line_chars.len()
+            line_bytes.len()
         };
-        if from > line_chars.len() || to > line_chars.len() {
+        if from > line_bytes.len() || to > line_bytes.len() {
             return None;
         }
-        out.extend(line_chars[from..to].iter());
+        // Reject ranges that cut a UTF-8 character in half rather than
+        // returning a string with replacement characters.
+        if !line.is_char_boundary(from) || !line.is_char_boundary(to) {
+            return None;
+        }
+        out.push_str(&line[from..to]);
     }
     Some(out)
 }
@@ -3375,6 +3386,30 @@ mod tests {
         assert!(
             advertised.contains(&commands::COMMAND_EXTRACT_TO_INCLUDE.to_string()),
             "extractToInclude must be in advertised commands, got: {advertised:?}"
+        );
+    }
+
+    /// `slice_text_by_range` treats `Range.character` as a UTF-8 byte
+    /// offset, matching lex-core's `LineColumnLocator::byte_to_position`
+    /// (which sets `column = byte_offset - line_start`). Char-based
+    /// slicing would mis-slice selections containing multi-byte chars;
+    /// this test pins the byte semantics.
+    #[test]
+    fn slice_text_by_range_uses_utf8_byte_offsets() {
+        let text = "café\nrestaurant\n";
+        // The é is 2 UTF-8 bytes, so "café" occupies bytes 0..5.
+        let range = Range::new(Position::new(0, 0), Position::new(0, 5));
+        assert_eq!(slice_text_by_range(text, range).as_deref(), Some("café"));
+
+        // Mid-character byte offset (between the two bytes of é) is rejected.
+        let bad = Range::new(Position::new(0, 0), Position::new(0, 4));
+        assert!(slice_text_by_range(text, bad).is_none());
+
+        // Multi-line slice with non-ASCII in the source.
+        let multi = Range::new(Position::new(0, 0), Position::new(1, 10));
+        assert_eq!(
+            slice_text_by_range(text, multi).as_deref(),
+            Some("café\nrestaurant")
         );
     }
 


### PR DESCRIPTION
## Summary
- Implements the server-side half of #497. Editor wiring is tracked separately at #498.
- New module `crates/lex-lsp/src/features/extract.rs` exposing `validate_include_path` (pure path/URL/existence check against the configured includes root) and `build_extract_workspace_edit` (validate → indent-shift selection → parse-based pre-check → atomic `WorkspaceEdit` with `CreateFile` + target-content `TextEdit` + host-replace `TextEdit`).
- Registers `lex.extractToInclude` as a workspace command. Server dispatch lives in `LexLanguageServer::handle_extract_to_include`; it pulls the document text from `DocumentStore`, slices it by the supplied LSP `Range`, reads `includes_root` from server config, and forwards to `build_extract_workspace_edit`. `ExtractError` variants surface as LSP `invalid_params` errors carrying distinct human-readable messages.

## ExtractError variants
Each maps to a distinct user-facing message:
- `EmptyPath`, `UrlScheme { scheme }`, `AbsolutePath { src }` (Windows-only on platforms; root-absolute `/path` is valid on Unix per Lex spec), `EscapesRoot { src }`, `TargetExists { path }`
- Plus end-to-end flow: `InvalidHostUri`, `HostNotUnderRoot`, `SelectionEmpty`, `ParseFailed { message }`, `ContainerPolicy { reason }`

## What's deferred (not blocking #497)
- Optional `lex/validateIncludePath` custom request for live-validation in editor prompts (ticket marks as opt-in).
- Deeper `GeneralContainer` policy check — current pre-check parses the indent-shifted selection as a valid Lex fragment, which is sufficient for v1. Host-side container policy (e.g., rejecting a Session selected for extraction into a Definition body) needs `GeneralContainer` wired in.
- Editor wiring (#498).

## Test plan
- [x] 18 unit tests in `features::extract::tests` covering the 5 validator failure modes, distinct messages across all 10 variants, 5 `indent_shift` cases (0/4/12-column indent, blank-line handling, trailing-newline preservation), and 4 `build_extract_workspace_edit` cases (rejection, op shape, indent shift, host-indent preservation).
- [x] 3 server-level integration tests via `open_in_tempdir` scaffolding: end-to-end `executeCommand` → `WorkspaceEdit`, error path, capability advertisement.
- [x] Full workspace `cargo test` clean.
- [x] `cargo clippy -p lexd-lsp --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)