### PR TITLE
feat(assembling): NormalizeLabels stage for legacy label rewrite [Phase 2/5 of #570]

### DIFF
--- a/crates/lex-core/src/lex/assembling/stages.rs
+++ b/crates/lex-core/src/lex/assembling/stages.rs
@@ -6,7 +6,9 @@
 pub mod apply_table_config;
 pub mod attach_annotations;
 pub mod attach_root;
+pub mod normalize_labels;
 
 pub use apply_table_config::ApplyTableConfig;
 pub use attach_annotations::AttachAnnotations;
 pub use attach_root::AttachRoot;
+pub use normalize_labels::NormalizeLabels;

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -111,6 +111,7 @@ fn rewrite_in_item(item: &mut ContentItem) {
             }
         }
         ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
+        ContentItem::Table(t) => rewrite_in_table(t),
         _ => {}
     }
     if let Some(attached) = attached_annotations_mut(item) {
@@ -121,6 +122,37 @@ fn rewrite_in_item(item: &mut ContentItem) {
     if let Some(children) = item.children_mut() {
         for child in children.iter_mut() {
             rewrite_in_item(child);
+        }
+    }
+}
+
+fn rewrite_in_table(table: &mut crate::lex::ast::Table) {
+    // `ContentItem::children_mut` returns `None` for tables (their
+    // structure lives in rows/cells, not a flat children list), so an
+    // explicit walk is needed to reach annotations nested inside cells
+    // or footnotes. Without this, a legacy label inside a table cell
+    // would slip through the pipeline untouched.
+    for row in table
+        .header_rows
+        .iter_mut()
+        .chain(table.body_rows.iter_mut())
+    {
+        for cell in row.cells.iter_mut() {
+            for child in cell.children.as_mut_vec().iter_mut() {
+                rewrite_in_item(child);
+            }
+        }
+    }
+    if let Some(footnotes) = table.footnotes.as_mut() {
+        for annotation in footnotes.annotations.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+        // List children are ListItems; their `children` slot reaches
+        // through `children_mut`, but we still need to walk
+        // `list.items` directly because List items use the typed
+        // `items` collection rather than a plain children list.
+        for item in footnotes.items.as_mut_vec().iter_mut() {
+            rewrite_in_item(item);
         }
     }
 }
@@ -377,6 +409,69 @@ mod tests {
         assert_ne!(
             loc.start, loc.end,
             "rewrite must preserve the label's source location, not zero it"
+        );
+    }
+
+    #[test]
+    fn rewrite_recurses_into_table_cell_block_children() {
+        // Regression for Copilot's PR 576 callout: `ContentItem::Table`
+        // returns `None` from `children_mut()` (its structure lives in
+        // rows/cells), so the generic walker won't reach legacy labels
+        // nested inside a cell's block content. Today's parser does
+        // not emit block children in cells — cell annotations land in
+        // the inline `content: TextContent` — but the AST surface
+        // allows it via `TableCell::with_children`, and Phase 3's
+        // wire-up may begin using that slot. Test the contract
+        // directly by building the AST programmatically.
+        use crate::lex::ast::elements::annotation::Annotation;
+        use crate::lex::ast::elements::label::Label;
+        use crate::lex::ast::elements::table::{Table, TableCell, TableRow};
+        use crate::lex::ast::elements::typed_content::ContentElement;
+        use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+        use crate::lex::ast::text_content::TextContent;
+
+        let inner_annotation = Annotation::marker(Label::from_string("title"));
+        let cell = TableCell::new(TextContent::from_string("inline".into(), None))
+            .with_children(vec![ContentElement::Annotation(inner_annotation)]);
+        let row = TableRow::new(vec![cell]);
+        let table = Table::new(
+            TextContent::from_string("Data".into(), None),
+            Vec::new(),
+            vec![row],
+            VerbatimBlockMode::Inflow,
+        );
+
+        let mut doc = Document::new();
+        doc.root
+            .children
+            .as_mut_vec()
+            .push(ContentItem::Table(Box::new(table)));
+
+        let doc = NormalizeLabels::new().run(doc).expect("normalize ok");
+
+        // Reach into the table and confirm the nested annotation got
+        // rewritten.
+        let table = doc
+            .root
+            .children
+            .iter()
+            .find_map(|item| match item {
+                ContentItem::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("table present");
+        let cell = &table.body_rows[0].cells[0];
+        let nested_label = cell
+            .children
+            .iter()
+            .find_map(|item| match item {
+                ContentItem::Annotation(a) => Some(a.data.label.value.as_str()),
+                _ => None,
+            })
+            .expect("nested annotation in cell.children");
+        assert_eq!(
+            nested_label, "lex.metadata.title",
+            "legacy label inside a table cell's block children must be rewritten"
         );
     }
 

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -1,0 +1,403 @@
+//! Normalize legacy bare labels to their canonical `lex.*` form.
+//!
+//! Phase 2 of the label-semantics refactor tracked in
+//! [#570](https://github.com/lex-fmt/lex/issues/570). Walks a parsed
+//! [`Document`] and rewrites annotation labels matching the
+//! pre-extension whitelist (`title`, `author`, `date`, `tags`,
+//! `category`, `template`, `publishing-date`, `front-matter`) plus the
+//! four verbatim labels (`doc.table`, `doc.image`, `doc.video`,
+//! `doc.audio`) to their canonical `lex.metadata.*` / `lex.tabular.*` /
+//! `lex.media.*` equivalents.
+//!
+//! # Activation lifecycle
+//!
+//! In Phase 2 (this PR) the stage is **shipped but not wired** into the
+//! default [`STRING_TO_AST`](crate::lex::transforms::standard::STRING_TO_AST)
+//! pipeline. Activating it here would break the legacy IR paths in
+//! `lex-babel` (`ir/from_lex.rs`'s frontmatter whitelist and
+//! `common/verbatim/VerbatimRegistry`'s handler registrations both
+//! still match on the bare label strings). Phase 3a flips the legacy
+//! paths to canonical names atomically with the wire-up, so both
+//! halves of the bare-label retirement land together. Phase 3b then
+//! deletes the legacy paths.
+//!
+//! # Why warnings are silent
+//!
+//! The issue's Phase 2 spec calls for a "parse-time deprecation
+//! warning" alongside the rewrite. Lex-core has no production
+//! diagnostic-collection vehicle today
+//! ([`Document::diagnostics`](crate::lex::ast::Document::diagnostics) is
+//! pull-based and not wired through the LSP / CLI; the LSP uses
+//! `lex-analysis::diagnostics`). Surfacing a warning therefore either
+//! requires adding storage on the AST (invasive, breaks
+//! `PartialEq`-based test fixtures) or a side channel that the LSP must
+//! opt into. Phase 5 ships the user-facing surface naturally: a
+//! `lexd migrate-labels` subcommand walks raw source, lists every legacy
+//! site by line/column, and offers an in-place rewrite. The rewrite
+//! itself stays silent here.
+
+use crate::lex::ast::elements::annotation::Annotation;
+use crate::lex::ast::elements::content_item::ContentItem;
+use crate::lex::ast::elements::verbatim::Verbatim;
+use crate::lex::ast::Document;
+use crate::lex::transforms::{Runnable, TransformError};
+
+/// Pairings of legacy bare label → canonical `lex.*` form.
+///
+/// Ordering mirrors the legacy whitelist in
+/// `crates/lex-babel/src/ir/from_lex.rs` (metadata first), followed by
+/// the four verbatim labels owned by the legacy
+/// `lex-babel::common::verbatim::VerbatimRegistry`. Anything not in
+/// this table is left untouched — third-party and user-defined labels
+/// are out of scope.
+pub const LEGACY_TO_CANONICAL: &[(&str, &str)] = &[
+    ("title", "lex.metadata.title"),
+    ("author", "lex.metadata.author"),
+    ("date", "lex.metadata.date"),
+    ("tags", "lex.metadata.tags"),
+    ("category", "lex.metadata.category"),
+    ("template", "lex.metadata.template"),
+    ("publishing-date", "lex.metadata.publishing-date"),
+    ("front-matter", "lex.metadata.front-matter"),
+    ("doc.table", "lex.tabular.table"),
+    ("doc.image", "lex.media.image"),
+    ("doc.video", "lex.media.video"),
+    ("doc.audio", "lex.media.audio"),
+];
+
+/// Lookup the canonical form for a legacy label, if any.
+pub fn canonical_for(label: &str) -> Option<&'static str> {
+    LEGACY_TO_CANONICAL
+        .iter()
+        .find(|(legacy, _)| *legacy == label)
+        .map(|(_, canonical)| *canonical)
+}
+
+/// Post-parse pass that rewrites legacy labels to their canonical form.
+pub struct NormalizeLabels;
+
+impl NormalizeLabels {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NormalizeLabels {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Runnable<Document, Document> for NormalizeLabels {
+    fn run(&self, mut input: Document) -> Result<Document, TransformError> {
+        for annotation in input.annotations.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+        for annotation in input.root.annotations.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+        for child in input.root.children.as_mut_vec().iter_mut() {
+            rewrite_in_item(child);
+        }
+        Ok(input)
+    }
+}
+
+fn rewrite_in_item(item: &mut ContentItem) {
+    match item {
+        ContentItem::Annotation(a) => {
+            if let Some(canonical) = canonical_for(&a.data.label.value) {
+                a.data.label.value = canonical.to_string();
+            }
+        }
+        ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
+        _ => {}
+    }
+    if let Some(attached) = attached_annotations_mut(item) {
+        for annotation in attached.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+    }
+    if let Some(children) = item.children_mut() {
+        for child in children.iter_mut() {
+            rewrite_in_item(child);
+        }
+    }
+}
+
+fn rewrite_annotation(annotation: &mut Annotation) {
+    if let Some(canonical) = canonical_for(&annotation.data.label.value) {
+        annotation.data.label.value = canonical.to_string();
+    }
+    for child in annotation.children.as_mut_vec().iter_mut() {
+        rewrite_in_item(child);
+    }
+}
+
+fn rewrite_verbatim_label(verbatim: &mut Verbatim) {
+    if let Some(canonical) = canonical_for(&verbatim.closing_data.label.value) {
+        verbatim.closing_data.label.value = canonical.to_string();
+    }
+}
+
+fn attached_annotations_mut(item: &mut ContentItem) -> Option<&mut Vec<Annotation>> {
+    match item {
+        ContentItem::Session(s) => Some(&mut s.annotations),
+        ContentItem::Paragraph(p) => Some(&mut p.annotations),
+        ContentItem::Definition(d) => Some(&mut d.annotations),
+        ContentItem::List(l) => Some(&mut l.annotations),
+        ContentItem::ListItem(li) => Some(&mut li.annotations),
+        ContentItem::VerbatimBlock(v) => Some(&mut v.annotations),
+        ContentItem::Table(t) => Some(&mut t.annotations),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::transforms::standard::STRING_TO_AST;
+
+    /// Parse + invoke the normalize stage explicitly. Phase 2 ships the
+    /// stage but does not insert it into the default pipeline; tests
+    /// run it manually so we can exercise the rewrite behaviour without
+    /// a production wire-up.
+    fn parse(src: &str) -> Document {
+        let doc = STRING_TO_AST.run(src.to_string()).expect("parse ok");
+        NormalizeLabels::new().run(doc).expect("normalize ok")
+    }
+
+    fn find_first_annotation_label(doc: &Document) -> Option<String> {
+        doc.annotations
+            .first()
+            .map(|a| a.data.label.value.clone())
+            .or_else(|| find_inline_annotation_label(&doc.root.children))
+    }
+
+    fn find_inline_annotation_label(items: &[ContentItem]) -> Option<String> {
+        for item in items {
+            if let ContentItem::Annotation(a) = item {
+                return Some(a.data.label.value.clone());
+            }
+            if let Some(children) = item.children() {
+                if let Some(label) = find_inline_annotation_label(children) {
+                    return Some(label);
+                }
+            }
+        }
+        None
+    }
+
+    fn find_first_verbatim_label(items: &[ContentItem]) -> Option<String> {
+        for item in items {
+            if let ContentItem::VerbatimBlock(v) = item {
+                return Some(v.closing_data.label.value.clone());
+            }
+            if let Some(children) = item.children() {
+                if let Some(label) = find_first_verbatim_label(children) {
+                    return Some(label);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn canonical_for_recognizes_every_legacy_label() {
+        for (legacy, canonical) in LEGACY_TO_CANONICAL {
+            assert_eq!(
+                canonical_for(legacy),
+                Some(*canonical),
+                "lookup must round-trip for {legacy}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_for_returns_none_for_unknown_labels() {
+        assert!(canonical_for("acme.custom").is_none());
+        assert!(canonical_for("lex.include").is_none());
+        assert!(canonical_for("").is_none());
+    }
+
+    #[test]
+    fn legacy_to_canonical_table_covers_phase_1_targets() {
+        // Locks the rewrite set to the 8 metadata + 1 tabular + 3 media
+        // schemas that Phase 1 (#575) registered. If those families grow,
+        // this list grows with them.
+        assert_eq!(LEGACY_TO_CANONICAL.len(), 12);
+        let metadata_count = LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.metadata."))
+            .count();
+        let tabular_count = LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.tabular."))
+            .count();
+        let media_count = LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.media."))
+            .count();
+        assert_eq!(metadata_count, 8);
+        assert_eq!(tabular_count, 1);
+        assert_eq!(media_count, 3);
+    }
+
+    #[test]
+    fn document_level_title_annotation_is_rewritten() {
+        // Annotation single-line form: `:: label :: inline content`.
+        let doc = parse(":: title :: My Document\n\nBody.\n");
+        assert_eq!(
+            find_first_annotation_label(&doc).as_deref(),
+            Some("lex.metadata.title"),
+            "document-level :: title :: must rewrite to lex.metadata.title"
+        );
+    }
+
+    #[test]
+    fn every_metadata_label_rewrites() {
+        for (legacy, canonical) in LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.metadata."))
+        {
+            let src = format!(":: {legacy} :: value\n\nBody.\n");
+            let doc = parse(&src);
+            assert_eq!(
+                find_first_annotation_label(&doc).as_deref(),
+                Some(*canonical),
+                ":: {legacy} :: must rewrite to {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn doc_table_verbatim_rewrites_to_lex_tabular_table() {
+        // Lex verbatim syntax: subject line ending in `:`, indented body,
+        // then `:: label ::` as the closer.
+        let src = "Table:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
+        let doc = parse(src);
+        assert_eq!(
+            find_first_verbatim_label(&doc.root.children).as_deref(),
+            Some("lex.tabular.table"),
+            ":: doc.table :: verbatim must rewrite to lex.tabular.table"
+        );
+    }
+
+    #[test]
+    fn doc_image_verbatim_rewrites_to_lex_media_image() {
+        let src = "Image:\n    alt text\n:: doc.image src=x.png ::\n";
+        let doc = parse(src);
+        assert_eq!(
+            find_first_verbatim_label(&doc.root.children).as_deref(),
+            Some("lex.media.image"),
+        );
+    }
+
+    #[test]
+    fn doc_video_and_audio_verbatims_rewrite() {
+        for (legacy, canonical) in [
+            ("doc.video", "lex.media.video"),
+            ("doc.audio", "lex.media.audio"),
+        ] {
+            let src = format!("Media:\n    caption\n:: {legacy} src=file ::\n");
+            let doc = parse(&src);
+            assert_eq!(
+                find_first_verbatim_label(&doc.root.children).as_deref(),
+                Some(canonical),
+                ":: {legacy} :: must rewrite to {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_legacy_labels_are_left_alone() {
+        let src = ":: acme.custom param=value :: body\n\nBody.\n";
+        let doc = parse(src);
+        let label = find_first_annotation_label(&doc);
+        assert_eq!(
+            label.as_deref(),
+            Some("acme.custom"),
+            "third-party labels must be preserved verbatim"
+        );
+    }
+
+    #[test]
+    fn lex_include_label_is_left_alone() {
+        // Already-canonical lex.* labels must not be rewritten.
+        let src = ":: lex.include src=other.lex ::\n\nBody.\n";
+        let doc = parse(src);
+        let label = find_first_annotation_label(&doc);
+        assert_eq!(label.as_deref(), Some("lex.include"));
+    }
+
+    #[test]
+    fn rewrite_preserves_annotation_parameters() {
+        // The rewrite touches the label only — params and body
+        // content must survive unchanged.
+        let src = ":: author email=alice@example.com :: Alice\n\nBody.\n";
+        let doc = parse(src);
+        let first = doc
+            .annotations
+            .first()
+            .or_else(|| {
+                doc.root.children.iter().find_map(|item| match item {
+                    ContentItem::Annotation(a) => Some(a),
+                    _ => None,
+                })
+            })
+            .expect("annotation parsed");
+        assert_eq!(first.data.label.value, "lex.metadata.author");
+        let email_param = first
+            .data
+            .parameters
+            .iter()
+            .find(|p| p.key == "email")
+            .expect("email param preserved");
+        assert_eq!(email_param.value, "alice@example.com");
+    }
+
+    #[test]
+    fn rewrite_preserves_label_location() {
+        // Range info must round-trip — the LSP relies on label location
+        // for goto-definition and similar features. Rewrite mutates
+        // `label.value` in place without touching `label.location`.
+        let src = ":: title :: T\n\nBody.\n";
+        let doc = parse(src);
+        let first = doc
+            .annotations
+            .first()
+            .or_else(|| {
+                doc.root.children.iter().find_map(|item| match item {
+                    ContentItem::Annotation(a) => Some(a),
+                    _ => None,
+                })
+            })
+            .expect("annotation parsed");
+        let loc = &first.data.label.location;
+        assert_ne!(
+            loc.start, loc.end,
+            "rewrite must preserve the label's source location, not zero it"
+        );
+    }
+
+    #[test]
+    fn rewrite_recurses_into_annotation_children() {
+        // The walker must reach annotations nested inside another
+        // annotation's content body — `rewrite_annotation` calls
+        // `rewrite_in_item` on each child, which in turn handles inline
+        // `ContentItem::Annotation` labels.
+        let src = ":: outer ::\n    :: author :: Alice\n";
+        let doc = parse(src);
+        let outer = doc.annotations.first().expect("outer annotation parsed");
+        // Find the inner annotation in outer's children.
+        let inner_label = outer.children.iter().find_map(|item| match item {
+            ContentItem::Annotation(a) => Some(a.data.label.value.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            inner_label.as_deref(),
+            Some("lex.metadata.author"),
+            "nested annotation inside outer must be rewritten"
+        );
+    }
+}

--- a/crates/lex-core/src/lex/builtins/media.rs
+++ b/crates/lex-core/src/lex/builtins/media.rs
@@ -2,8 +2,8 @@
 //!
 //! The members — `lex.media.image`, `lex.media.video`, `lex.media.audio` —
 //! are the registry-shaped replacements for the legacy `doc.image`,
-//! `doc.video`, and `doc.audio` handlers in
-//! [`crate::common::verbatim::media`](../../../../lex-babel/src/common/verbatim/media.rs).
+//! `doc.video`, and `doc.audio` handlers in `lex-babel`
+//! (`crates/lex-babel/src/common/verbatim/media.rs`).
 //! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
 //! multi-phase migration.
 //!

--- a/crates/lex-core/src/lex/builtins/media.rs
+++ b/crates/lex-core/src/lex/builtins/media.rs
@@ -1,0 +1,225 @@
+//! Schemas for the `lex.media.*` family of verbatim labels.
+//!
+//! The members — `lex.media.image`, `lex.media.video`, `lex.media.audio` —
+//! are the registry-shaped replacements for the legacy `doc.image`,
+//! `doc.video`, and `doc.audio` handlers in
+//! [`crate::common::verbatim::media`](../../../../lex-babel/src/common/verbatim/media.rs).
+//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
+//! multi-phase migration.
+//!
+//! # Phase 1 status
+//!
+//! Schemas only — no `on_resolve` bodies yet. The legacy
+//! `VerbatimRegistry` still converts verbatim params into typed
+//! `DocNode::Image` / `Video` / `Audio` nodes. Phase 2's parse-time
+//! auto-rewrite retargets `:: doc.image ::` &c. at these labels;
+//! Phase 3 deletes the legacy lookup and Phase 4 wires `on_format` so
+//! they round-trip back to Lex source through the registry.
+
+use lex_extension::schema::{
+    BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+};
+use std::collections::BTreeMap;
+
+pub const LEX_MEDIA_IMAGE: &str = "lex.media.image";
+pub const LEX_MEDIA_VIDEO: &str = "lex.media.video";
+pub const LEX_MEDIA_AUDIO: &str = "lex.media.audio";
+
+fn string_param(required: bool, description: &'static str) -> ParamSpec {
+    ParamSpec {
+        ty: ParamType::String,
+        required,
+        default: None,
+        description: Some(description.into()),
+        pattern: None,
+        values: Vec::new(),
+    }
+}
+
+/// Common shape for media labels: verbatim attachment, optional text
+/// body (image uses it as an alt-text fallback; video/audio ignore it),
+/// no hooks until Phase 3.
+fn media_schema(
+    label: &'static str,
+    description: &'static str,
+    params: BTreeMap<String, ParamSpec>,
+    body_description: &'static str,
+) -> Schema {
+    Schema {
+        schema_version: 1,
+        label: label.into(),
+        description: Some(description.into()),
+        params,
+        attaches_to: vec!["verbatim".into()],
+        body: BodyShape {
+            kind: BodyKind::Text,
+            presence: BodyPresence::Optional,
+            description: Some(body_description.into()),
+        },
+        verbatim_label: true,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+pub fn lex_media_image_schema() -> Schema {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "src".into(),
+        string_param(true, "Source URL or path of the image."),
+    );
+    params.insert(
+        "alt".into(),
+        string_param(
+            false,
+            "Alternative text. Falls back to the verbatim body's first non-empty line when omitted.",
+        ),
+    );
+    params.insert(
+        "title".into(),
+        string_param(false, "Tooltip / accessible title for the image."),
+    );
+    media_schema(
+        LEX_MEDIA_IMAGE,
+        "Image media block. The verbatim body, when present, is treated as the \
+         alt-text fallback if no `alt=` parameter is supplied.",
+        params,
+        "Optional alt-text fallback; ignored when an explicit `alt=` parameter is present.",
+    )
+}
+
+pub fn lex_media_video_schema() -> Schema {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "src".into(),
+        string_param(true, "Source URL or path of the video."),
+    );
+    params.insert(
+        "title".into(),
+        string_param(false, "Accessible title for the video."),
+    );
+    params.insert(
+        "poster".into(),
+        string_param(false, "Poster image shown before playback begins."),
+    );
+    media_schema(
+        LEX_MEDIA_VIDEO,
+        "Video media block.",
+        params,
+        "Reserved for renderer-specific extensions; ignored by the built-in renderers.",
+    )
+}
+
+pub fn lex_media_audio_schema() -> Schema {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "src".into(),
+        string_param(true, "Source URL or path of the audio file."),
+    );
+    params.insert(
+        "title".into(),
+        string_param(false, "Accessible title for the audio clip."),
+    );
+    media_schema(
+        LEX_MEDIA_AUDIO,
+        "Audio media block.",
+        params,
+        "Reserved for renderer-specific extensions; ignored by the built-in renderers.",
+    )
+}
+
+/// All `lex.media.*` schemas, in declaration order.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![
+        lex_media_image_schema(),
+        lex_media_video_schema(),
+        lex_media_audio_schema(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_media_schema_is_a_verbatim_label() {
+        for schema in all_schemas() {
+            assert!(
+                schema.verbatim_label,
+                "{} must be a verbatim label",
+                schema.label
+            );
+            assert_eq!(
+                schema.attaches_to,
+                vec!["verbatim".to_string()],
+                "{} attaches to verbatim",
+                schema.label
+            );
+            assert!(
+                schema
+                    .params
+                    .get("src")
+                    .map(|p| p.required)
+                    .unwrap_or(false),
+                "{} must declare `src` as a required parameter",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn image_schema_carries_optional_alt_and_title() {
+        let schema = lex_media_image_schema();
+        let alt = schema.params.get("alt").expect("alt declared");
+        let title = schema.params.get("title").expect("title declared");
+        assert!(!alt.required);
+        assert!(!title.required);
+    }
+
+    #[test]
+    fn video_schema_carries_optional_poster() {
+        let schema = lex_media_video_schema();
+        let poster = schema.params.get("poster").expect("poster declared");
+        assert!(!poster.required);
+    }
+
+    #[test]
+    fn audio_schema_has_no_poster() {
+        let schema = lex_media_audio_schema();
+        assert!(
+            !schema.params.contains_key("poster"),
+            "audio schemas have no poster parameter"
+        );
+    }
+
+    #[test]
+    fn media_schemas_declare_no_hooks_in_phase_1() {
+        for schema in all_schemas() {
+            assert!(
+                !schema.hooks.resolve,
+                "{} resolve must stay off",
+                schema.label
+            );
+            assert!(
+                !schema.hooks.validate,
+                "{} validate must stay off",
+                schema.label
+            );
+            assert!(
+                schema.hooks.render.is_empty(),
+                "{} render must stay off",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn media_schemas_round_trip_through_json() {
+        for schema in all_schemas() {
+            let json = serde_json::to_string(&schema).expect("serialize");
+            let back: Schema = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back, schema, "round trip for {}", schema.label);
+        }
+    }
+}

--- a/crates/lex-core/src/lex/builtins/metadata.rs
+++ b/crates/lex-core/src/lex/builtins/metadata.rs
@@ -1,0 +1,209 @@
+//! Schemas for the `lex.metadata.*` family of document-level labels.
+//!
+//! These are the registry-shaped replacements for the hardcoded
+//! frontmatter-promotion whitelist in
+//! [`crate::ir::from_lex`](../../../../lex-babel/src/ir/from_lex.rs)
+//! (`author`, `title`, `date`, `tags`, `category`, `template`,
+//! `publishing-date`, `front-matter`). Issue
+//! [#570](https://github.com/lex-fmt/lex/issues/570) tracks the multi-phase
+//! migration.
+//!
+//! # Phase 1 status
+//!
+//! Schemas only — no hooks are declared yet. The legacy frontmatter
+//! promotion in `lex-babel` continues to own the IR work. The schemas
+//! exist as registration targets for the Phase 2 parse-time auto-rewrite
+//! (`:: title ::` → `:: lex.metadata.title ::`); Phase 3 retires the
+//! legacy IR path; Phase 4 wires `on_render`/`on_format` so these
+//! labels emit `<title>` / `<meta>` in HTML.
+//!
+//! Every schema in this module shares the same shape — only the
+//! fully-qualified label string differs — so [`metadata_schema`] does
+//! the heavy lifting and each public function is a one-liner.
+
+use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use std::collections::BTreeMap;
+
+/// The eight metadata labels, in the order they appear in the legacy
+/// whitelist (`crates/lex-babel/src/ir/from_lex.rs`). Exposed so the
+/// Phase 2 auto-rewrite can iterate the canonical set without
+/// re-declaring it.
+pub const METADATA_LABELS: &[&str] = &[
+    "lex.metadata.title",
+    "lex.metadata.author",
+    "lex.metadata.date",
+    "lex.metadata.tags",
+    "lex.metadata.category",
+    "lex.metadata.template",
+    "lex.metadata.publishing-date",
+    "lex.metadata.front-matter",
+];
+
+/// Build a metadata schema. Every `lex.metadata.*` label attaches to a
+/// document, carries its value either as the annotation body (text) or
+/// as untyped parameters (the legacy whitelist accepted both), and
+/// declares no privileged capabilities. Hooks are deliberately empty in
+/// Phase 1 — they fill in across Phases 3 + 4.
+fn metadata_schema(label: &'static str, description: &'static str) -> Schema {
+    Schema {
+        schema_version: 1,
+        label: label.into(),
+        description: Some(description.into()),
+        params: BTreeMap::new(),
+        attaches_to: vec!["document".into()],
+        body: BodyShape {
+            kind: BodyKind::Text,
+            presence: BodyPresence::Optional,
+            description: Some(
+                "Annotation body (single-line text) carries the metadata value when no \
+                 explicit parameter is supplied."
+                    .into(),
+            ),
+        },
+        verbatim_label: false,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+pub fn lex_metadata_title_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.title",
+        "Document title. Renders as `<title>` and `<meta name=\"title\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_author_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.author",
+        "Document author. Renders as `<meta name=\"author\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_date_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.date",
+        "Document date. Renders as `<meta name=\"date\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_tags_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.tags",
+        "Document tags (comma-separated). Renders as `<meta name=\"keywords\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_category_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.category",
+        "Document category. Renders as `<meta name=\"category\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_template_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.template",
+        "Template hint for renderers that select a layout per document.",
+    )
+}
+
+pub fn lex_metadata_publishing_date_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.publishing-date",
+        "Publishing date (distinct from authoring `date`). Renders as \
+         `<meta name=\"publishing-date\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_front_matter_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.front-matter",
+        "Catch-all front-matter container for renderer-specific extensions.",
+    )
+}
+
+/// All `lex.metadata.*` schemas, in declaration order.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![
+        lex_metadata_title_schema(),
+        lex_metadata_author_schema(),
+        lex_metadata_date_schema(),
+        lex_metadata_tags_schema(),
+        lex_metadata_category_schema(),
+        lex_metadata_template_schema(),
+        lex_metadata_publishing_date_schema(),
+        lex_metadata_front_matter_schema(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_labels_match_schema_outputs() {
+        let labels: Vec<String> = all_schemas().into_iter().map(|s| s.label).collect();
+        let expected: Vec<String> = METADATA_LABELS.iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(
+            labels, expected,
+            "all_schemas() ordering must mirror METADATA_LABELS so the Phase 2 \
+             auto-rewrite has a single source of truth for the label set"
+        );
+    }
+
+    #[test]
+    fn every_metadata_schema_attaches_to_document() {
+        for schema in all_schemas() {
+            assert_eq!(
+                schema.attaches_to,
+                vec!["document".to_string()],
+                "{} must declare document-scope attachment",
+                schema.label
+            );
+            assert!(
+                !schema.verbatim_label,
+                "{} is an annotation label, not a verbatim label",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_schemas_declare_no_hooks_in_phase_1() {
+        // Phase 1's contract: schemas register but don't intercept. Hook
+        // activation comes in Phases 3 + 4. If a hook flag flips on
+        // unexpectedly, that's a signal a later-phase change leaked
+        // back into the metadata family.
+        for schema in all_schemas() {
+            assert!(
+                !schema.hooks.resolve,
+                "{} resolve hook must stay off in Phase 1",
+                schema.label
+            );
+            assert!(
+                !schema.hooks.validate,
+                "{} validate hook must stay off in Phase 1",
+                schema.label
+            );
+            assert!(
+                schema.hooks.render.is_empty(),
+                "{} render hook must stay off in Phase 1",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_schemas_round_trip_through_json() {
+        // Schema is serde-derived; making sure each label survives the
+        // round trip guards against accidental non-serializable
+        // additions to the shape (`Capabilities`, `HookSet`, etc.).
+        for schema in all_schemas() {
+            let json = serde_json::to_string(&schema).expect("serialize");
+            let back: Schema = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back, schema, "round trip for {}", schema.label);
+        }
+    }
+}

--- a/crates/lex-core/src/lex/builtins/metadata.rs
+++ b/crates/lex-core/src/lex/builtins/metadata.rs
@@ -1,12 +1,11 @@
 //! Schemas for the `lex.metadata.*` family of document-level labels.
 //!
 //! These are the registry-shaped replacements for the hardcoded
-//! frontmatter-promotion whitelist in
-//! [`crate::ir::from_lex`](../../../../lex-babel/src/ir/from_lex.rs)
-//! (`author`, `title`, `date`, `tags`, `category`, `template`,
-//! `publishing-date`, `front-matter`). Issue
-//! [#570](https://github.com/lex-fmt/lex/issues/570) tracks the multi-phase
-//! migration.
+//! frontmatter-promotion whitelist in `lex-babel`
+//! (`crates/lex-babel/src/ir/from_lex.rs`): `author`, `title`, `date`,
+//! `tags`, `category`, `template`, `publishing-date`, `front-matter`.
+//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
+//! multi-phase migration.
 //!
 //! # Phase 1 status
 //!
@@ -18,8 +17,8 @@
 //! labels emit `<title>` / `<meta>` in HTML.
 //!
 //! Every schema in this module shares the same shape — only the
-//! fully-qualified label string differs — so [`metadata_schema`] does
-//! the heavy lifting and each public function is a one-liner.
+//! fully-qualified label string differs — so a private `metadata_schema`
+//! helper does the heavy lifting and each public function is a one-liner.
 
 use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
 use std::collections::BTreeMap;

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -26,7 +26,7 @@
 //!
 //! The single `lex` namespace is shared by every built-in label; the
 //! composite [`LexBuiltinsHandler`] routes each dispatch by
-//! [`LabelCtx::label`](lex_extension::wire::LabelCtx) to the right
+//! [`LabelCtx::label`](lex_extension::wire::LabelCtx::label) to the right
 //! sub-handler.
 
 use std::sync::Arc;

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -8,59 +8,112 @@
 //!
 //! # What ships today
 //!
-//! | Label         | Handler              | Status                            |
-//! |---------------|----------------------|-----------------------------------|
-//! | `lex.include` | [`LexIncludeHandler`] | Registrable; resolve pass still   |
-//! |               |                      | runs through the legacy inline    |
-//! |               |                      | path until PR 3d (#533).          |
+//! | Label family            | Handler                | Status                                |
+//! |-------------------------|------------------------|---------------------------------------|
+//! | `lex.include`           | [`LexIncludeHandler`]  | Registrable; resolve pass still runs  |
+//! |                         |                        | through the legacy inline path until  |
+//! |                         |                        | PR 3d (#533).                         |
+//! | `lex.metadata.*` (×8)   | [`LexBuiltinsHandler`] | Phase 1 of #570 — schemas only.       |
+//! |                         |                        | Legacy frontmatter promotion in       |
+//! |                         |                        | `lex-babel/src/ir/from_lex.rs` still  |
+//! |                         |                        | owns the IR work.                     |
+//! | `lex.tabular.table`     | [`LexBuiltinsHandler`] | Phase 1 of #570 — schema only.        |
+//! |                         |                        | Legacy `VerbatimRegistry::TableHandler` |
+//! |                         |                        | still parses pipe-tables.             |
+//! | `lex.media.{image,…}`   | [`LexBuiltinsHandler`] | Phase 1 of #570 — schemas only.       |
+//! |                         |                        | Legacy `VerbatimRegistry::Image/…`    |
+//! |                         |                        | handlers still build the IR nodes.    |
 //!
-//! Future built-ins (`lex.toc`, …) follow the same shape: one handler
-//! impl per label, registered through [`register_into`].
+//! The single `lex` namespace is shared by every built-in label; the
+//! composite [`LexBuiltinsHandler`] routes each dispatch by
+//! [`LabelCtx::label`](lex_extension::wire::LabelCtx) to the right
+//! sub-handler.
 
 use std::sync::Arc;
 
-use lex_extension::schema::{
-    BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+use lex_extension::{
+    handler::{HandlerError, LexHandler},
+    schema::{
+        BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+    },
+    wire::{LabelCtx, WireNode},
 };
 use lex_extension_host::registry::{Registry, RegistryError};
 
 use crate::lex::includes::{Loader, ResolveConfig};
 
 pub mod include;
+pub mod media;
+pub mod metadata;
+pub mod tabular;
 
 pub use include::LexIncludeHandler;
 
 /// The reserved namespace owned by the lex core. Its prefix is
 /// `lex.` (with the trailing dot), so registered labels look like
-/// `lex.include`, `lex.toc`, etc.
+/// `lex.include`, `lex.metadata.title`, `lex.tabular.table`, etc.
 pub const NAMESPACE: &str = "lex";
+
+/// Composite handler for the `lex.*` namespace.
+///
+/// `Registry::register_namespace` accepts one handler per namespace; the
+/// composite shape lets every `lex.*` built-in live under a single
+/// namespace registration while keeping per-label logic isolated.
+///
+/// Today the only sub-handler with a non-stub implementation is
+/// [`LexIncludeHandler`]; the `lex.metadata.*`, `lex.tabular.*`, and
+/// `lex.media.*` labels register their schemas but their hooks return
+/// the trait's default `Ok(None)` until Phase 3 of #570 moves the
+/// legacy IR transformations into the registry path.
+pub struct LexBuiltinsHandler {
+    include: LexIncludeHandler,
+}
+
+impl LexBuiltinsHandler {
+    pub fn new(loader: Arc<dyn Loader + Send + Sync>, config: ResolveConfig) -> Self {
+        Self {
+            include: LexIncludeHandler::new(loader, config),
+        }
+    }
+}
+
+impl LexHandler for LexBuiltinsHandler {
+    fn on_resolve(&self, ctx: &LabelCtx) -> Result<Option<WireNode>, HandlerError> {
+        match ctx.label.as_str() {
+            "lex.include" => self.include.on_resolve(ctx),
+            // Phase 1 of #570: schemas register but don't intercept.
+            // The legacy IR paths in lex-babel still own the work for
+            // every other `lex.*` label. Phase 3 fills these arms in.
+            _ => Ok(None),
+        }
+    }
+}
 
 /// Register every built-in `lex.*` schema and handler into `registry`.
 ///
-/// The current set is `{ lex.include }`; future built-ins land here as
-/// they're added. The single registration call covers the whole
-/// namespace because [`Registry::register_namespace`] wants every
-/// label for a namespace handed in atomically.
-///
-/// `loader` and `config` flow into [`LexIncludeHandler`] verbatim: the
-/// handler holds them by `Arc` so the registry can be cheaply cloned
-/// and shared across threads. `config.root` should already be
-/// canonicalised by the caller — see
-/// [`ResolveConfig::with_root`](crate::lex::includes::ResolveConfig::with_root).
+/// `loader` and `config` are forwarded verbatim to the composite
+/// handler; today they're consumed only by [`LexIncludeHandler`] but
+/// future built-ins may need filesystem access too (e.g. an asset
+/// resolver for `lex.media.*`).
 pub fn register_into(
     registry: &Registry,
     loader: Arc<dyn Loader + Send + Sync>,
     config: ResolveConfig,
 ) -> Result<(), RegistryError> {
-    let schemas = vec![lex_include_schema()];
-    let handler = Box::new(LexIncludeHandler::new(loader, config));
+    let mut schemas = Vec::with_capacity(13);
+    schemas.push(lex_include_schema());
+    schemas.extend(metadata::all_schemas());
+    schemas.extend(tabular::all_schemas());
+    schemas.extend(media::all_schemas());
+
+    let handler = Box::new(LexBuiltinsHandler::new(loader, config));
     registry.register_namespace(NAMESPACE, schemas, handler)
 }
 
 /// Schema for the `lex.include` label. Inlined here because v1 has
-/// exactly one built-in label; once the YAML schema loader lands in
-/// PR 4 (#520), built-ins will share the same load path as third
-/// parties (a baked-in `lex.yaml` shipped with the crate).
+/// exactly one built-in label of its kind; once the YAML schema loader
+/// lands in PR 4 (#520), built-ins will share the same load path as
+/// third parties (a baked-in `lex.yaml` shipped with the crate).
 pub fn lex_include_schema() -> Schema {
     let mut params = std::collections::BTreeMap::new();
     params.insert(
@@ -118,10 +171,13 @@ mod tests {
     use lex_extension::wire::{AnnotationBody, LabelCtx, NodeRef, Position, Range};
     use std::path::PathBuf;
 
-    fn make_ctx(src: &str, host_origin: Option<&str>) -> LabelCtx {
+    fn make_ctx(label: &str, src: Option<&str>, host_origin: Option<&str>) -> LabelCtx {
         LabelCtx {
-            label: "lex.include".into(),
-            params: serde_json::json!({ "src": src }),
+            label: label.into(),
+            params: match src {
+                Some(s) => serde_json::json!({ "src": s }),
+                None => serde_json::json!({}),
+            },
             body: AnnotationBody::None,
             node: NodeRef {
                 kind: "annotation".into(),
@@ -134,8 +190,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn register_into_attaches_namespace_and_schema() {
+    fn fresh_registry() -> Registry {
         let mut loader = MemoryLoader::new();
         loader.insert(PathBuf::from("/root/inner.lex"), "Hello.\n");
         let registry = Registry::new();
@@ -145,7 +200,12 @@ mod tests {
             ResolveConfig::with_root(PathBuf::from("/root")),
         )
         .expect("registration ok");
+        registry
+    }
 
+    #[test]
+    fn register_into_attaches_namespace_and_schema() {
+        let registry = fresh_registry();
         assert_eq!(registry.namespace_count(), 1);
         assert!(registry.is_namespace_healthy(NAMESPACE));
         let schema = registry
@@ -163,17 +223,8 @@ mod tests {
     fn dispatch_resolve_round_trip_via_registry() {
         // End-to-end through the registry: register handler, dispatch
         // a resolve via dispatch_resolve, get back Some(WireNode).
-        let mut loader = MemoryLoader::new();
-        loader.insert(PathBuf::from("/root/inner.lex"), "Spliced paragraph.\n");
-        let registry = Registry::new();
-        register_into(
-            &registry,
-            Arc::new(loader),
-            ResolveConfig::with_root(PathBuf::from("/root")),
-        )
-        .expect("registration ok");
-
-        let ctx = make_ctx("inner.lex", Some("/root/host.lex"));
+        let registry = fresh_registry();
+        let ctx = make_ctx("lex.include", Some("inner.lex"), Some("/root/host.lex"));
         let wire = registry
             .dispatch_resolve(&ctx)
             .expect("dispatch_resolve ok")
@@ -191,21 +242,18 @@ mod tests {
 
     #[test]
     fn dispatch_resolve_load_error_surfaces_diagnostic() {
-        let loader = MemoryLoader::new();
         let registry = Registry::new();
         register_into(
             &registry,
-            Arc::new(loader),
+            Arc::new(MemoryLoader::new()),
             ResolveConfig::with_root(PathBuf::from("/root")),
         )
         .expect("registration ok");
 
-        let ctx = make_ctx("missing.lex", Some("/root/host.lex"));
+        let ctx = make_ctx("lex.include", Some("missing.lex"), Some("/root/host.lex"));
         let err = registry
             .dispatch_resolve(&ctx)
             .expect_err("registry must surface the load error");
-        // The diagnostic uses `handler.custom` for our `Custom`-coded
-        // errors — see Registry::dispatch's error mapping.
         assert_eq!(err.code.as_deref(), Some("handler.custom"));
         assert!(
             err.message.contains("not found"),
@@ -234,5 +282,113 @@ mod tests {
             ),
             "second register_into must error: {second:?}"
         );
+    }
+
+    #[test]
+    fn metadata_schemas_are_registered() {
+        let registry = fresh_registry();
+        for label in metadata::METADATA_LABELS {
+            let schema = registry
+                .schema_for(label)
+                .unwrap_or_else(|| panic!("schema_for({label}) must be Some"));
+            assert_eq!(schema.label, *label);
+            assert_eq!(schema.attaches_to, vec!["document".to_string()]);
+            assert!(!schema.verbatim_label);
+        }
+    }
+
+    #[test]
+    fn tabular_table_schema_is_registered() {
+        let registry = fresh_registry();
+        let schema = registry
+            .schema_for(tabular::LEX_TABULAR_TABLE)
+            .expect("lex.tabular.table schema must be registered");
+        assert!(schema.verbatim_label);
+        assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+    }
+
+    #[test]
+    fn media_schemas_are_registered() {
+        let registry = fresh_registry();
+        for label in [
+            media::LEX_MEDIA_IMAGE,
+            media::LEX_MEDIA_VIDEO,
+            media::LEX_MEDIA_AUDIO,
+        ] {
+            let schema = registry
+                .schema_for(label)
+                .unwrap_or_else(|| panic!("schema_for({label}) must be Some"));
+            assert!(schema.verbatim_label);
+            assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+            assert!(
+                schema
+                    .params
+                    .get("src")
+                    .map(|p| p.required)
+                    .unwrap_or(false),
+                "{label} must require src"
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_resolve_for_new_schemas_returns_none_in_phase_1() {
+        // Phase 1 contract: schemas register but don't intercept.
+        // Dispatch must succeed (no panic, no error) and return None
+        // so the legacy IR paths continue to own the work until
+        // Phase 3 retires them.
+        let registry = fresh_registry();
+        let labels: Vec<&str> = metadata::METADATA_LABELS
+            .iter()
+            .copied()
+            .chain(std::iter::once(tabular::LEX_TABULAR_TABLE))
+            .chain([
+                media::LEX_MEDIA_IMAGE,
+                media::LEX_MEDIA_VIDEO,
+                media::LEX_MEDIA_AUDIO,
+            ])
+            .collect();
+        for label in labels {
+            let ctx = make_ctx(label, None, None);
+            let result = registry
+                .dispatch_resolve(&ctx)
+                .unwrap_or_else(|e| panic!("dispatch_resolve({label}) errored: {e:?}"));
+            assert!(
+                result.is_none(),
+                "dispatch_resolve({label}) must return None in Phase 1; got Some(...)"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_count_is_one_namespace_with_thirteen_labels() {
+        let registry = fresh_registry();
+        assert_eq!(
+            registry.namespace_count(),
+            1,
+            "all built-ins share the single `lex` namespace"
+        );
+        // 1 include + 8 metadata + 1 tabular + 3 media = 13.
+        let expected_labels = [
+            "lex.include",
+            "lex.metadata.title",
+            "lex.metadata.author",
+            "lex.metadata.date",
+            "lex.metadata.tags",
+            "lex.metadata.category",
+            "lex.metadata.template",
+            "lex.metadata.publishing-date",
+            "lex.metadata.front-matter",
+            "lex.tabular.table",
+            "lex.media.image",
+            "lex.media.video",
+            "lex.media.audio",
+        ];
+        for label in expected_labels {
+            assert!(
+                registry.schema_for(label).is_some(),
+                "expected label {label} to be registered"
+            );
+        }
     }
 }

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -2,7 +2,7 @@
 //!
 //! Today the family has a single member: `lex.tabular.table`, the
 //! registry-shaped replacement for the legacy `doc.table` handler in
-//! [`crate::common::verbatim::table`](../../../../lex-babel/src/common/verbatim/table.rs).
+//! `lex-babel` (`crates/lex-babel/src/common/verbatim/table.rs`).
 //! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
 //! multi-phase migration.
 //!

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -1,0 +1,88 @@
+//! Schema for the `lex.tabular.*` family of verbatim labels.
+//!
+//! Today the family has a single member: `lex.tabular.table`, the
+//! registry-shaped replacement for the legacy `doc.table` handler in
+//! [`crate::common::verbatim::table`](../../../../lex-babel/src/common/verbatim/table.rs).
+//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
+//! multi-phase migration.
+//!
+//! # Phase 1 status
+//!
+//! Schema only — no `on_resolve` body yet. The legacy `VerbatimRegistry`
+//! still parses pipe-table content into a typed `DocNode::Table`.
+//! Phase 2's parse-time auto-rewrite retargets `:: doc.table ::` at
+//! this label; Phase 3 deletes the legacy lookup and moves the
+//! parsing logic into the handler's `on_resolve`.
+
+use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use std::collections::BTreeMap;
+
+/// Fully-qualified label for the canonical tabular table.
+pub const LEX_TABULAR_TABLE: &str = "lex.tabular.table";
+
+pub fn lex_tabular_table_schema() -> Schema {
+    Schema {
+        schema_version: 1,
+        label: LEX_TABULAR_TABLE.into(),
+        description: Some(
+            "Pipe-table verbatim. The verbatim body uses markdown-style pipe-table syntax \
+             (`| col1 | col2 |\\n|------|------|\\n| ... |`) which the resolve hook \
+             parses into a typed table AST node."
+                .into(),
+        ),
+        params: BTreeMap::new(),
+        attaches_to: vec!["verbatim".into()],
+        body: BodyShape {
+            kind: BodyKind::Text,
+            presence: BodyPresence::Required,
+            description: Some(
+                "Pipe-table source: header row, alignment row, then one row per body \
+                 line. Empty body is rejected at resolve time."
+                    .into(),
+            ),
+        },
+        verbatim_label: true,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+/// All `lex.tabular.*` schemas, in declaration order.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![lex_tabular_table_schema()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tabular_table_is_a_verbatim_label() {
+        let schema = lex_tabular_table_schema();
+        assert_eq!(schema.label, LEX_TABULAR_TABLE);
+        assert!(
+            schema.verbatim_label,
+            "tabular.table must be a verbatim label"
+        );
+        assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+        assert_eq!(schema.body.kind, BodyKind::Text);
+        assert_eq!(schema.body.presence, BodyPresence::Required);
+    }
+
+    #[test]
+    fn tabular_schema_declares_no_hooks_in_phase_1() {
+        let schema = lex_tabular_table_schema();
+        assert!(!schema.hooks.resolve);
+        assert!(!schema.hooks.validate);
+        assert!(schema.hooks.render.is_empty());
+    }
+
+    #[test]
+    fn tabular_schema_round_trips_through_json() {
+        let schema = lex_tabular_table_schema();
+        let json = serde_json::to_string(&schema).expect("serialize");
+        let back: Schema = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, schema);
+    }
+}

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -135,6 +135,16 @@ pub static STRING_TO_AST: Lazy<AstTransform> = Lazy::new(|| {
         // Attach annotations as metadata
         doc = AttachAnnotations::new().run(doc)?;
 
+        // Note: `NormalizeLabels` (the #570 Phase 2 label-rewrite stage)
+        // is intentionally NOT inserted here yet. The stage is shipped
+        // as a module so the codec, tests, and a future Phase 3 wiring
+        // can use it; the legacy whitelist in
+        // `lex-babel/src/ir/from_lex.rs` and the `VerbatimRegistry` in
+        // `lex-babel/src/common/verbatim` still match on the bare label
+        // forms (`title`, `doc.table`, …), so activating the rewrite
+        // here would break the legacy IR path. Phase 3a flips the
+        // legacy paths to canonical names atomically with this wire-up.
+
         // Apply table config from :: table :: annotations (header, align)
         doc = crate::lex::assembling::stages::ApplyTableConfig::new().run(doc)?;
 


### PR DESCRIPTION
## Summary

Phase 2 of the label-semantics refactor tracked in #570. Ships the `NormalizeLabels` assembling stage that rewrites the 12 legacy bare-label forms to their canonical `lex.*` equivalents — the canonical forms Phase 1 (#575) registered as built-in schemas.

| Legacy | Canonical |
|---|---|
| `title`, `author`, `date`, `tags`, `category`, `template`, `publishing-date`, `front-matter` | `lex.metadata.*` |
| `doc.table` | `lex.tabular.table` |
| `doc.image`, `doc.video`, `doc.audio` | `lex.media.*` |

The stage walks document-level annotations, root-session annotations, every container kind's attached `.annotations` slot, and inline `ContentItem::Annotation` / `ContentItem::VerbatimBlock` nodes — recursing into annotation bodies — so a nested `:: title :: …` deep in the tree gets rewritten the same as one at the document head.

## Two deliberate Phase-2 scope choices

### 1. Stage shipped but not wired into the production pipeline yet

`STRING_TO_AST` does **not** invoke `NormalizeLabels` in this PR. Activating it here would break the legacy IR paths in `lex-babel`: `ir/from_lex.rs`'s frontmatter whitelist still matches the bare label set (`"title"`, `"author"`, …), and the `VerbatimRegistry` in `common/verbatim/mod.rs` still registers `doc.table` / `doc.image` / `doc.video` / `doc.audio` handlers under their bare names. After a rewrite they'd see `lex.tabular.table` / `lex.media.image` and lookup-miss, producing serialization regressions visible in `lex-babel`'s `test_verbatim_03_table_formatting` etc.

**Phase 3a flips the legacy paths to canonical names atomically with this wire-up** — same PR, no intermediate broken state. Phase 3b then deletes the legacy paths altogether.

### 2. Deprecation-warning emission deferred to Phase 5

The issue's Phase 2 spec mentions "with a parse-time deprecation warning" alongside the rewrite. Lex-core has no production diagnostic-collection vehicle today (`Document::diagnostics` is pull-based and not wired through the LSP or CLI; the LSP uses `lex-analysis::diagnostics`). Surfacing a warning therefore requires either AST storage (invasive, breaks `PartialEq`-based test fixtures) or a side channel that the LSP must opt into.

Phase 5's `lexd migrate-labels` subcommand is a better fit for the user-facing surface: it walks raw source, lists every legacy site by line/column, and offers an in-place rewrite — exactly what an extension author would want when migrating. The rewrite itself stays silent here. Rationale documented in the module header.

## Tests

13 unit tests in `lex-core::lex::assembling::stages::normalize_labels`:
- `canonical_for_*` — table lookup correctness (legacy → canonical, unknown → None)
- `legacy_to_canonical_table_covers_phase_1_targets` — shape lock (8 metadata + 1 tabular + 3 media)
- `document_level_title_annotation_is_rewritten`, `every_metadata_label_rewrites`
- `doc_table_verbatim_rewrites_to_lex_tabular_table`, `doc_image_verbatim_rewrites_to_lex_media_image`, `doc_video_and_audio_verbatims_rewrite`
- `non_legacy_labels_are_left_alone`, `lex_include_label_is_left_alone`
- `rewrite_preserves_annotation_parameters`, `rewrite_preserves_label_location`
- `rewrite_recurses_into_annotation_children`

All tests invoke the stage explicitly via `NormalizeLabels::new().run(doc)`, since the production wire-up is deferred.

## Test plan

- [x] `cargo build -p lex-core` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo nextest run --workspace` — **2053/2053 pass** (13 new + 2040 baseline, no regressions because the stage isn't in the pipeline)
- [x] Pre-commit hook (`scripts/rust-pre-commit`) passes end-to-end

## Stacking

Branches from `feat/refac-label/phase1-builtin-schemas` (PR #575). Targets `refac/label`. Until #575 merges, this PR's diff against `refac/label` includes the Phase 1 commits too; that's expected.

## Roadmap

- ~~Phase 1 (#575)~~: schemas only — merged target.
- **Phase 2 (this PR)**: stage shipped, dormant.
- Phase 3a: wire `NormalizeLabels` into the pipeline + flip legacy paths to canonical names.
- Phase 3b: delete legacy `VerbatimRegistry` + frontmatter promotion.
- Phase 4 (comms + 2 lex): `on_format` reverse hook + `to_lex.rs` registry dispatch.
- Phase 5: hard-deprecate bare labels + `lexd migrate-labels` migration tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)