### PR TITLE
feat(builtins): implement on_format for lex.tabular.* + lex.media.* [Phase 4b/5 of #570]

### DIFF
--- a/crates/lex-analysis/src/completion.rs
+++ b/crates/lex-analysis/src/completion.rs
@@ -654,8 +654,12 @@ Code sample:
 
     #[test]
     fn verbatim_src_completion_offers_known_paths() {
+        // #570 Phase 3b activated `NormalizeLabels`, so `:: doc.image ::`
+        // in `SAMPLE_DOC` is rewritten to its canonical form before
+        // this test sees the parsed AST. Look up the verbatim under
+        // the canonical name.
         let document = parse_sample();
-        let verbatim = find_verbatim(&document, "doc.image");
+        let verbatim = find_verbatim(&document, "lex.media.image");
         let param = verbatim
             .closing_data
             .parameters

--- a/crates/lex-babel/src/common/flat_to_nested.rs
+++ b/crates/lex-babel/src/common/flat_to_nested.rs
@@ -528,6 +528,7 @@ pub fn events_to_tree(events: &[Event]) -> Result<Document, ConversionError> {
             title: None,
             subtitle: None,
             children: vec![],
+            document_annotations: vec![],
         });
     }
 
@@ -541,6 +542,7 @@ pub fn events_to_tree(events: &[Event]) -> Result<Document, ConversionError> {
                 title: None,
                 subtitle: None,
                 children: vec![],
+                document_annotations: vec![],
             }));
         }
         Some(other) => {
@@ -554,6 +556,7 @@ pub fn events_to_tree(events: &[Event]) -> Result<Document, ConversionError> {
                 title: None,
                 subtitle: None,
                 children: vec![],
+                document_annotations: vec![],
             })
         }
     }
@@ -1305,6 +1308,7 @@ mod tests {
                     content: vec![InlineContent::Text("Content".to_string())],
                 })],
             })],
+            document_annotations: vec![],
         };
 
         // Convert to events
@@ -1356,6 +1360,7 @@ mod tests {
                     }),
                 ],
             })],
+            document_annotations: vec![],
         };
 
         let events = tree_to_events(&DocNode::Document(original_doc.clone()));

--- a/crates/lex-babel/src/common/flat_to_nested.rs
+++ b/crates/lex-babel/src/common/flat_to_nested.rs
@@ -586,6 +586,15 @@ pub fn events_to_tree(events: &[Event]) -> Result<Document, ConversionError> {
                     if event_iter.peek().is_some() {
                         return Err(ConversionError::ExtraEvents);
                     }
+                    // Phase 3a of #570: `Document::document_annotations`
+                    // stays empty on this path. The event stream
+                    // doesn't yet distinguish document-scope
+                    // annotations from inline ones — every
+                    // StartAnnotation under StartDocument lands in
+                    // `children` as today. Phase 3b adds the
+                    // scope marker (or formalises a position
+                    // contract) atomically with the legacy-path
+                    // retirement.
                     return Ok(doc);
                 } else {
                     return Err(ConversionError::MismatchedEvents {
@@ -1292,6 +1301,48 @@ mod tests {
             result,
             Err(ConversionError::MismatchedEvents { .. })
         ));
+    }
+
+    #[test]
+    fn document_annotations_event_stream_is_one_way_in_phase_3a() {
+        // Phase 3a of #570 is *additive*. `tree_to_events` deliberately
+        // does not emit `document_annotations`, and `events_to_tree`
+        // initializes the slot empty. This locks the contract:
+        // anything in `document_annotations` on the IR side is lost
+        // when the document travels through the event stream, and
+        // every annotation in the event stream lands in `children` as
+        // it always has. Phase 3b adds the scope marker that lets the
+        // events stream distinguish the two — atomically with the
+        // legacy-path retirement so downstream serializers see exactly
+        // one copy.
+        use crate::ir::nodes::Annotation;
+        use crate::ir::to_events::tree_to_events;
+
+        let original = Document {
+            title: None,
+            subtitle: None,
+            children: vec![DocNode::Paragraph(Paragraph {
+                content: vec![InlineContent::Text("Body.".to_string())],
+            })],
+            document_annotations: vec![Annotation {
+                label: "lex.metadata.author".to_string(),
+                parameters: vec![("name".to_string(), "Alice".to_string())],
+                content: vec![],
+            }],
+        };
+
+        let events = tree_to_events(&DocNode::Document(original.clone()));
+        let doc = events_to_tree(&events).expect("events round-trip");
+
+        // The annotation was dropped on the way to events.
+        assert!(
+            doc.document_annotations.is_empty(),
+            "Phase 3a: events stream loses document_annotations (by design)"
+        );
+        // Body paragraph survives — only the document-scope slot was
+        // not encoded.
+        assert_eq!(doc.children.len(), 1);
+        assert!(matches!(doc.children[0], DocNode::Paragraph(_)));
     }
 
     #[test]

--- a/crates/lex-babel/src/common/nested_to_flat.rs
+++ b/crates/lex-babel/src/common/nested_to_flat.rs
@@ -309,6 +309,7 @@ mod tests {
                     })],
                 }),
             ],
+            document_annotations: vec![],
         })
     }
 

--- a/crates/lex-babel/src/common/nested_to_flat.rs
+++ b/crates/lex-babel/src/common/nested_to_flat.rs
@@ -47,6 +47,15 @@ pub fn tree_to_events(root_node: &DocNode) -> Vec<Event> {
 fn walk_node(node: &DocNode, events: &mut Vec<Event>) {
     match node {
         DocNode::Document(Document { children, .. }) => {
+            // Phase 3a of #570: `document_annotations` is intentionally
+            // NOT emitted into the event stream by this pass. The
+            // event stream doesn't yet have a way to distinguish
+            // document-scope annotations from inline ones — Phase 3b
+            // adds the scope marker (or position contract) atomically
+            // with the source-of-truth flip. Until then, IR Documents
+            // carrying `document_annotations` lose them when they
+            // travel through events; this is documented on the IR
+            // `Document` struct.
             events.push(Event::StartDocument);
             for child in children {
                 walk_node(child, events);

--- a/crates/lex-babel/src/common/verbatim/media.rs
+++ b/crates/lex-babel/src/common/verbatim/media.rs
@@ -7,7 +7,10 @@ pub struct ImageHandler;
 
 impl VerbatimHandler for ImageHandler {
     fn label(&self) -> &str {
-        "doc.image"
+        // #570 Phase 3b: canonical label. Legacy `doc.image` is still
+        // registered as an alias in `VerbatimRegistry::default_with_standard`
+        // so legacy-shaped IR continues to route to this handler.
+        "lex.media.image"
     }
 
     fn to_ir(&self, content: &str, params: &HashMap<String, String>) -> Option<DocNode> {
@@ -48,7 +51,9 @@ pub struct VideoHandler;
 
 impl VerbatimHandler for VideoHandler {
     fn label(&self) -> &str {
-        "doc.video"
+        // #570 Phase 3b: canonical label. Legacy alias `doc.video`
+        // registered in `VerbatimRegistry::default_with_standard`.
+        "lex.media.video"
     }
 
     fn to_ir(&self, _content: &str, params: &HashMap<String, String>) -> Option<DocNode> {
@@ -81,7 +86,9 @@ pub struct AudioHandler;
 
 impl VerbatimHandler for AudioHandler {
     fn label(&self) -> &str {
-        "doc.audio"
+        // #570 Phase 3b: canonical label. Legacy alias `doc.audio`
+        // registered in `VerbatimRegistry::default_with_standard`.
+        "lex.media.audio"
     }
 
     fn to_ir(&self, _content: &str, params: &HashMap<String, String>) -> Option<DocNode> {

--- a/crates/lex-babel/src/common/verbatim/mod.rs
+++ b/crates/lex-babel/src/common/verbatim/mod.rs
@@ -111,8 +111,27 @@ impl VerbatimRegistry {
     }
 
     /// Creates a registry with standard handlers (e.g. doc.table) pre-registered.
+    ///
+    /// #570 Phase 3b activated the [`NormalizeLabels`] pass that
+    /// rewrites bare `doc.table` / `doc.image` / `doc.video` /
+    /// `doc.audio` to their canonical `lex.tabular.*` / `lex.media.*`
+    /// forms before this lookup runs. The canonical labels are the
+    /// keys we register today. The legacy bare labels stay registered
+    /// alongside so any IR built outside `STRING_TO_AST` (e.g. an
+    /// embedder hand-building a Verbatim with the legacy label, or a
+    /// non-Lex format adapter feeding the same registry) continues
+    /// to work. Both paths point at the same handler.
+    ///
+    /// [`NormalizeLabels`]: lex_core::lex::assembling::stages::NormalizeLabels
     pub fn default_with_standard() -> Self {
         let mut registry = Self::new();
+        // Canonical (#570 Phase 3b) — what `STRING_TO_AST` produces.
+        registry.register("lex.tabular.table", Box::new(table::TableHandler));
+        registry.register("lex.media.image", Box::new(media::ImageHandler));
+        registry.register("lex.media.video", Box::new(media::VideoHandler));
+        registry.register("lex.media.audio", Box::new(media::AudioHandler));
+        // Legacy aliases — accept inputs that didn't go through
+        // `NormalizeLabels` (embedder-built IR, alternate format adapters).
         registry.register("doc.table", Box::new(table::TableHandler));
         registry.register("doc.image", Box::new(media::ImageHandler));
         registry.register("doc.video", Box::new(media::VideoHandler));

--- a/crates/lex-babel/src/common/verbatim/table.rs
+++ b/crates/lex-babel/src/common/verbatim/table.rs
@@ -12,7 +12,9 @@ pub struct TableHandler;
 
 impl VerbatimHandler for TableHandler {
     fn label(&self) -> &str {
-        "doc.table"
+        // #570 Phase 3b: canonical label. Legacy alias `doc.table`
+        // registered in `VerbatimRegistry::default_with_standard`.
+        "lex.tabular.table"
     }
 
     fn to_ir(&self, content: &str, _params: &HashMap<String, String>) -> Option<DocNode> {

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -802,6 +802,14 @@ mod tests {
         // NOTE: The user's original input had dedented marker "::  doc.table ::".
         // This caused it to be parsed as Definition + Document Annotation.
         // The fix is to indent the marker to match the subject.
+        //
+        // #570 Phase 3b activated `NormalizeLabels`, so the document
+        // annotation's label `doc.table` is rewritten to its canonical
+        // form `lex.tabular.table` before serialization. The footer
+        // assertion looks for the canonical form. Phase 5 ships
+        // `lexd migrate-labels` for source-level migration; this is
+        // the parser-side equivalent for files that already flow
+        // through `format`.
         let source = "  The Table:\n    | Markup Language | Great |\n    |--------------------|--------|\n    | Markdown | No |\n    | Lex | Yes |\n  ::  doc.table ::\n";
 
         let formatted = format_source(source);
@@ -814,7 +822,9 @@ mod tests {
         let separator = formatted
             .find("| --------------- | ----- |")
             .expect("Separator not found");
-        let footer_start = formatted.find(":: doc.table").expect("Footer not found");
+        let footer_start = formatted
+            .find(":: lex.tabular.table")
+            .expect("Footer not found");
 
         assert!(table_start < separator);
         assert!(separator < footer_start);

--- a/crates/lex-babel/src/formats/rfc_xml/parser.rs
+++ b/crates/lex-babel/src/formats/rfc_xml/parser.rs
@@ -59,6 +59,7 @@ pub fn parse_to_ir(source: &str) -> Result<Document, FormatError> {
         title: None,
         subtitle: None,
         children: vec![root_heading],
+        document_annotations: vec![],
     })
 }
 

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -131,10 +131,38 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
         children.insert(0, frontmatter);
     }
 
+    // Phase 3a of #570: populate the first-class `document_annotations`
+    // slot in parallel with the legacy frontmatter promotion above.
+    // This is additive — downstream serializers continue to read the
+    // synthetic `frontmatter` annotation from `children`. Phase 3b
+    // makes `document_annotations` the source of truth and deletes the
+    // promotion.
+    let document_annotations = doc.annotations.iter().map(ir_annotation_from_lex).collect();
+
     Document {
         title,
         subtitle,
         children,
+        document_annotations,
+    }
+}
+
+/// Build an IR `Annotation` directly from a lex-core annotation, without
+/// the `DocNode` enum wrapper that [`from_lex_annotation`] returns. Used
+/// by [`from_lex_document`] to populate `Document::document_annotations`.
+fn ir_annotation_from_lex(annotation: &LexAnnotation) -> Annotation {
+    let label = annotation.data.label.value.clone();
+    let parameters = annotation
+        .data
+        .parameters
+        .iter()
+        .map(|p| (p.key.clone(), p.value.clone()))
+        .collect();
+    let content = convert_children(&annotation.children, 2);
+    Annotation {
+        label,
+        parameters,
+        content,
     }
 }
 
@@ -633,5 +661,89 @@ mod tests {
 
         assert_eq!(ir_doc.children.len(), 1);
         assert!(matches!(ir_doc.children[0], DocNode::Paragraph(_)));
+    }
+
+    /// Build a lex-core document with one document-scope annotation
+    /// attached. Used by Phase 3a tests for the new
+    /// `Document::document_annotations` slot.
+    fn doc_with_one_annotation(label: &str, value: &str) -> LexDocument {
+        use lex_core::lex::ast::elements::annotation::Annotation as LexAnnotation;
+        use lex_core::lex::ast::elements::label::Label;
+        use lex_core::lex::ast::elements::paragraph::Paragraph;
+        use lex_core::lex::ast::elements::typed_content::ContentElement;
+
+        let body = ContentElement::Paragraph(Paragraph::from_line(value.to_string()));
+        let ann = LexAnnotation::new(Label::from_string(label), Vec::new(), vec![body]);
+        let mut doc = LexDocument::new();
+        doc.annotations.push(ann);
+        doc
+    }
+
+    #[test]
+    fn document_annotations_field_is_populated_from_lex_document() {
+        // Phase 3a contract: `from_lex_document` must populate the new
+        // `document_annotations: Vec<Annotation>` slot from every
+        // annotation in `doc.annotations` (the lex-core
+        // document-scope slot). The synthetic `frontmatter`
+        // annotation that the legacy promotion inserts into
+        // `children` is *additive* in Phase 3a — Phase 3b removes it.
+        let doc = doc_with_one_annotation("acme.custom", "Body text.");
+        let ir_doc = from_lex_document(&doc);
+
+        assert_eq!(
+            ir_doc.document_annotations.len(),
+            1,
+            "one document-scope annotation must populate document_annotations"
+        );
+        let ann = &ir_doc.document_annotations[0];
+        assert_eq!(ann.label, "acme.custom");
+        assert_eq!(ann.content.len(), 1);
+    }
+
+    #[test]
+    fn document_annotations_empty_when_no_document_scope_annotations() {
+        // No document-scope annotations → empty slot. Phase 3a must
+        // not synthesize anything here on its own.
+        let doc = LexDocument::with_content(vec![ContentItem::Paragraph(LexParagraph::from_line(
+            "Body only.".to_string(),
+        ))]);
+        let ir_doc = from_lex_document(&doc);
+        assert!(
+            ir_doc.document_annotations.is_empty(),
+            "empty input must produce empty document_annotations"
+        );
+    }
+
+    #[test]
+    fn legacy_frontmatter_promotion_still_runs_alongside_document_annotations() {
+        // Phase 3a is additive — the synthetic `frontmatter` annotation
+        // that the legacy promotion inserts must still appear in
+        // `children` so downstream serializers keep their existing
+        // shape. Phase 3b retires this duplication.
+        let doc = doc_with_one_annotation("author", "Alice");
+        let ir_doc = from_lex_document(&doc);
+
+        // New slot populated with the raw annotation.
+        assert_eq!(ir_doc.document_annotations.len(), 1);
+        assert_eq!(ir_doc.document_annotations[0].label, "author");
+
+        // Legacy frontmatter promotion still synthesizes the
+        // `frontmatter` annotation in children, with the value
+        // collected into a parameter under the bare key.
+        let frontmatter = ir_doc.children.iter().find_map(|c| match c {
+            DocNode::Annotation(a) if a.label == "frontmatter" => Some(a),
+            _ => None,
+        });
+        let frontmatter = frontmatter.expect("legacy frontmatter promotion still runs in Phase 3a");
+        let author_value = frontmatter
+            .parameters
+            .iter()
+            .find(|(k, _)| k == "author")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(
+            author_value,
+            Some("Alice"),
+            "legacy frontmatter param must still carry the annotation body under the bare label"
+        );
     }
 }

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -42,9 +42,21 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
 
     let mut parameters = Vec::new();
 
-    // 1. Process document-level annotations
+    // 1. Process document-level annotations.
+    //
+    // Strip the `lex.metadata.` prefix (#570 Phase 3b) when building
+    // the parameter key so document-level annotations rewritten by
+    // `NormalizeLabels` still produce the short-form keys downstream
+    // HTML serializers consume (`<meta name="title">`, not
+    // `<meta name="lex.metadata.title">`).
     for ann in &doc.annotations {
-        let key = ann.data.label.value.clone();
+        let key = ann
+            .data
+            .label
+            .value
+            .strip_prefix("lex.metadata.")
+            .unwrap_or(ann.data.label.value.as_str())
+            .to_string();
         let value = if !ann.children.is_empty() {
             let mut text = String::new();
             for child in &ann.children {
@@ -69,8 +81,24 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
     // 2. Scan children for metadata annotations (e.g. attached to first element)
     let mut indices_to_remove = Vec::new();
 
-    // Whitelist of labels to treat as frontmatter
+    // Whitelist of labels to treat as frontmatter. #570 Phase 3b
+    // activated `NormalizeLabels` (lex-core) which rewrites bare
+    // labels to their canonical `lex.metadata.*` form before this
+    // pass runs, so the canonical names are what we match against.
+    // The legacy bare names stay in the list as aliases so IR built
+    // outside `STRING_TO_AST` (markdown imports, hand-built AST,
+    // alternate format adapters) continues to work.
     let metadata_labels = [
+        // Canonical (#570 Phase 3b).
+        "lex.metadata.author",
+        "lex.metadata.publishing-date",
+        "lex.metadata.title",
+        "lex.metadata.date",
+        "lex.metadata.tags",
+        "lex.metadata.category",
+        "lex.metadata.template",
+        "lex.metadata.front-matter",
+        // Legacy aliases.
         "author",
         "publishing-date",
         "title",
@@ -84,8 +112,17 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
     for (i, child) in children.iter().enumerate() {
         if let DocNode::Annotation(ann) = child {
             if metadata_labels.contains(&ann.label.as_str()) {
-                // It's metadata!
-                let key = ann.label.clone();
+                // It's metadata! Strip the `lex.metadata.` prefix when
+                // building the key so the frontmatter annotation's
+                // parameter keys stay in the legacy short form
+                // (`title`, `author`, …) — that preserves the HTML
+                // comment shape (`<meta name="title">`) downstream
+                // serializers emit.
+                let key = ann
+                    .label
+                    .strip_prefix("lex.metadata.")
+                    .unwrap_or(ann.label.as_str())
+                    .to_string();
                 // Extract value (content or params)
                 let value = if !ann.content.is_empty() {
                     // Flatten content
@@ -711,6 +748,54 @@ mod tests {
         assert!(
             ir_doc.document_annotations.is_empty(),
             "empty input must produce empty document_annotations"
+        );
+    }
+
+    #[test]
+    fn normalize_labels_pipeline_writes_canonical_labels_into_ast() {
+        // #570 Phase 3b regression: confirm the activated
+        // `NormalizeLabels` pass produces a Document whose annotations
+        // carry canonical `lex.metadata.*` labels by the time
+        // `from_lex_document` sees them.
+        use lex_core::lex::transforms::standard::STRING_TO_AST;
+
+        let lex_doc = STRING_TO_AST
+            .run(":: title :: My Doc\n\nBody.\n".to_string())
+            .expect("parse ok");
+        // After NormalizeLabels, the title annotation is canonical.
+        let title_in_ast = lex_doc
+            .annotations
+            .first()
+            .or_else(|| {
+                lex_doc.root.children.iter().find_map(|item| match item {
+                    lex_core::lex::ast::ContentItem::Annotation(a) => Some(a),
+                    _ => None,
+                })
+            })
+            .expect("title annotation parsed");
+        assert_eq!(
+            title_in_ast.data.label.value, "lex.metadata.title",
+            "NormalizeLabels is wired into STRING_TO_AST"
+        );
+        // And `from_lex_document` still promotes it into the
+        // frontmatter (legacy whitelist accepts the canonical form).
+        let ir = from_lex_document(&lex_doc);
+        let frontmatter = ir.children.iter().find_map(|c| match c {
+            DocNode::Annotation(a) if a.label == "frontmatter" => Some(a),
+            _ => None,
+        });
+        let frontmatter = frontmatter.expect("frontmatter still synthesized in Phase 3b");
+        // The key is the *short* form so the HTML comment output stays
+        // backwards-compatible. The prefix-strip in `from_lex_document`
+        // handles this.
+        let has_title_key = frontmatter
+            .parameters
+            .iter()
+            .any(|(k, _)| k == "title" || k == "frontmatter.title");
+        assert!(
+            has_title_key,
+            "frontmatter param key must be the short form (`title`), got {:?}",
+            frontmatter.parameters
         );
     }
 

--- a/crates/lex-babel/src/ir/nodes.rs
+++ b/crates/lex-babel/src/ir/nodes.rs
@@ -24,6 +24,14 @@ pub struct Document {
     pub title: Option<Vec<InlineContent>>,
     pub subtitle: Option<Vec<InlineContent>>,
     pub children: Vec<DocNode>,
+    /// Document-scope annotations (i.e. annotations attached directly
+    /// to the document, not nested inside any block). Phase 3a of #570
+    /// adds this slot as a first-class home for them; the synthetic
+    /// `frontmatter` annotation that legacy `from_lex_document`
+    /// inserts into [`children`](Self::children) remains in place
+    /// during this phase so downstream serializers see the same shape
+    /// they always have. Phase 3b retires the legacy promotion.
+    pub document_annotations: Vec<Annotation>,
 }
 
 /// Represents a heading with a specific level.

--- a/crates/lex-babel/src/ir/nodes.rs
+++ b/crates/lex-babel/src/ir/nodes.rs
@@ -25,12 +25,18 @@ pub struct Document {
     pub subtitle: Option<Vec<InlineContent>>,
     pub children: Vec<DocNode>,
     /// Document-scope annotations (i.e. annotations attached directly
-    /// to the document, not nested inside any block). Phase 3a of #570
-    /// adds this slot as a first-class home for them; the synthetic
-    /// `frontmatter` annotation that legacy `from_lex_document`
-    /// inserts into [`children`](Self::children) remains in place
-    /// during this phase so downstream serializers see the same shape
-    /// they always have. Phase 3b retires the legacy promotion.
+    /// to the document, not nested inside any block).
+    ///
+    /// Phase 3a of #570 adds this slot as a first-class home for them.
+    /// In this phase the slot is populated **one-way** from
+    /// `from_lex_document` (lex → IR direction); `to_lex_document`,
+    /// `tree_to_events`, and `events_to_tree` do **not** consume or
+    /// emit it. The legacy frontmatter promotion in
+    /// `from_lex_document` continues to synthesize a `frontmatter`
+    /// annotation into [`children`](Self::children), and downstream
+    /// serializers keep reading from there — emitting both would
+    /// double-write. Phase 3b retires the promotion and wires the new
+    /// slot through every consumer atomically.
     pub document_annotations: Vec<Annotation>,
 }
 

--- a/crates/lex-babel/src/ir/nodes.rs
+++ b/crates/lex-babel/src/ir/nodes.rs
@@ -27,16 +27,17 @@ pub struct Document {
     /// Document-scope annotations (i.e. annotations attached directly
     /// to the document, not nested inside any block).
     ///
-    /// Phase 3a of #570 adds this slot as a first-class home for them.
-    /// In this phase the slot is populated **one-way** from
-    /// `from_lex_document` (lex → IR direction); `to_lex_document`,
-    /// `tree_to_events`, and `events_to_tree` do **not** consume or
-    /// emit it. The legacy frontmatter promotion in
-    /// `from_lex_document` continues to synthesize a `frontmatter`
-    /// annotation into [`children`](Self::children), and downstream
-    /// serializers keep reading from there — emitting both would
-    /// double-write. Phase 3b retires the promotion and wires the new
-    /// slot through every consumer atomically.
+    /// Phase 3a of #570 added this slot as a first-class home for them.
+    /// The slot is populated **one-way** from `from_lex_document`
+    /// (lex → IR direction); `to_lex_document`, `tree_to_events`, and
+    /// `events_to_tree` do **not** consume or emit it today. The
+    /// legacy frontmatter promotion in `from_lex_document` continues
+    /// to synthesize a `frontmatter` annotation into
+    /// [`children`](Self::children), and downstream serializers keep
+    /// reading from there — emitting both would double-write.
+    /// A follow-up phase (after #570 Phase 4's render hooks land)
+    /// retires the promotion and wires the new slot through every
+    /// consumer atomically.
     pub document_annotations: Vec<Annotation>,
 }
 

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -19,17 +19,18 @@ use super::nodes::{
 
 /// Converts an IR document to a Lex document.
 ///
-/// **Phase 3a note (#570):** `Document::document_annotations` is *not*
+/// **`document_annotations` note (#570):** the new IR slot is *not*
 /// emitted back into `lex_doc.annotations` on this path. The legacy
 /// frontmatter promotion in `from_lex_document` still synthesizes a
 /// `frontmatter` annotation into `children`, and downstream Lex
 /// serializers expect to see it there — emitting both would
-/// double-write. Phase 3b retires the promotion and flips the
-/// source-of-truth to `document_annotations` atomically; the
-/// [`to_lex_annotation_raw`] helper introduced here is wired into
-/// production then. Until that flip, `document_annotations` is a
-/// one-way slot: populated by `from_lex_document`, consumed only by
-/// embedders that read it directly.
+/// double-write. A follow-up to Phase 3b retires the promotion and
+/// flips the source-of-truth to `document_annotations` atomically;
+/// the [`to_lex_annotation_raw`] helper introduced in Phase 3a is
+/// wired into production then. Until that flip,
+/// `document_annotations` is a one-way slot: populated by
+/// `from_lex_document`, consumed only by embedders that read it
+/// directly.
 pub fn to_lex_document(doc: &Document) -> LexDocument {
     let mut children = Vec::new();
 

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -18,6 +18,18 @@ use super::nodes::{
 };
 
 /// Converts an IR document to a Lex document.
+///
+/// **Phase 3a note (#570):** `Document::document_annotations` is *not*
+/// emitted back into `lex_doc.annotations` on this path. The legacy
+/// frontmatter promotion in `from_lex_document` still synthesizes a
+/// `frontmatter` annotation into `children`, and downstream Lex
+/// serializers expect to see it there — emitting both would
+/// double-write. Phase 3b retires the promotion and flips the
+/// source-of-truth to `document_annotations` atomically; the
+/// [`to_lex_annotation_raw`] helper introduced here is wired into
+/// production then. Until that flip, `document_annotations` is a
+/// one-way slot: populated by `from_lex_document`, consumed only by
+/// embedders that read it directly.
 pub fn to_lex_document(doc: &Document) -> LexDocument {
     let mut children = Vec::new();
 
@@ -44,6 +56,39 @@ pub fn to_lex_document(doc: &Document) -> LexDocument {
     }
 
     lex_doc
+}
+
+/// Build a `LexAnnotation` directly from an IR `Annotation`, mirroring
+/// what [`to_lex_annotation`] does but without wrapping the result in
+/// [`LexContentItem::Annotation`].
+///
+/// Shipped in Phase 3a (#570) ready for Phase 3b to wire it into
+/// [`to_lex_document`]: when that PR retires the legacy frontmatter
+/// promotion, `to_lex_document` will iterate `document_annotations`
+/// through this helper to populate `lex_doc.annotations`. Until then
+/// it is dead code in production, exercised only by the Phase-3a
+/// contract test that confirms the helper produces the expected
+/// shape.
+#[allow(dead_code)]
+fn to_lex_annotation_raw(ann: &Annotation) -> LexAnnotation {
+    let label = Label::new(ann.label.clone());
+    let parameters: Vec<Parameter> = ann
+        .parameters
+        .iter()
+        .map(|(k, v)| Parameter {
+            key: k.clone(),
+            value: v.clone(),
+            location: default_range(),
+        })
+        .collect();
+
+    let mut child_items = Vec::new();
+    for child in &ann.content {
+        child_items.extend(to_lex_content_items(child, 1));
+    }
+
+    let children = to_content_elements(child_items);
+    LexAnnotation::new(label, parameters, children)
 }
 
 /// Converts an IR DocNode to one or more Lex ContentItems.
@@ -625,5 +670,43 @@ mod tests {
 
         // Document should have root session with our content
         assert!(!lex_doc.root.children.is_empty());
+    }
+
+    #[test]
+    fn to_lex_document_drops_document_annotations_in_phase_3a() {
+        // Phase 3a of #570 is *additive*. `document_annotations` is
+        // populated on the lex → IR direction (via `from_lex_document`)
+        // but consumed only by embedders that read the slot directly;
+        // `to_lex_document` deliberately ignores it, because the
+        // legacy frontmatter promotion that runs *before* this stage
+        // already synthesizes a `frontmatter` annotation into
+        // `children`, and downstream Lex serializers expect exactly
+        // one copy. Phase 3b retires the legacy promotion and wires
+        // `to_lex_annotation_raw` into `to_lex_document` atomically.
+        // This test locks the Phase 3a behaviour so a premature flip
+        // can't sneak in.
+        use crate::ir::nodes::Annotation;
+
+        let ir_doc = Document {
+            title: None,
+            subtitle: None,
+            children: vec![],
+            document_annotations: vec![Annotation {
+                label: "lex.metadata.author".to_string(),
+                parameters: vec![("name".to_string(), "Alice".to_string())],
+                content: vec![],
+            }],
+        };
+
+        let lex_doc = to_lex_document(&ir_doc);
+        assert!(
+            lex_doc.annotations.is_empty(),
+            "Phase 3a contract: to_lex_document leaves lex_doc.annotations empty"
+        );
+
+        // Sanity: the helper exists and produces a non-empty result —
+        // Phase 3b uses it.
+        let raw = to_lex_annotation_raw(&ir_doc.document_annotations[0]);
+        assert_eq!(raw.data.label.value, "lex.metadata.author");
     }
 }

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -618,6 +618,7 @@ mod tests {
                     content: vec![InlineContent::Text("Second paragraph".to_string())],
                 }),
             ],
+            document_annotations: vec![],
         };
 
         let lex_doc = to_lex_document(&ir_doc);

--- a/crates/lex-babel/tests/common/mod.rs
+++ b/crates/lex-babel/tests/common/mod.rs
@@ -43,6 +43,7 @@ fn create_test_tree() -> DocNode {
                 ],
             }),
         ],
+        document_annotations: vec![],
     })
 }
 

--- a/crates/lex-core/src/lex/assembling/stages.rs
+++ b/crates/lex-core/src/lex/assembling/stages.rs
@@ -6,7 +6,9 @@
 pub mod apply_table_config;
 pub mod attach_annotations;
 pub mod attach_root;
+pub mod normalize_labels;
 
 pub use apply_table_config::ApplyTableConfig;
 pub use attach_annotations::AttachAnnotations;
 pub use attach_root::AttachRoot;
+pub use normalize_labels::NormalizeLabels;

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -11,15 +11,19 @@
 //!
 //! # Activation lifecycle
 //!
-//! In Phase 2 (this PR) the stage is **shipped but not wired** into the
-//! default [`STRING_TO_AST`](crate::lex::transforms::standard::STRING_TO_AST)
-//! pipeline. Activating it here would break the legacy IR paths in
-//! `lex-babel` (`ir/from_lex.rs`'s frontmatter whitelist and
-//! `common/verbatim/VerbatimRegistry`'s handler registrations both
-//! still match on the bare label strings). Phase 3a flips the legacy
-//! paths to canonical names atomically with the wire-up, so both
-//! halves of the bare-label retirement land together. Phase 3b then
-//! deletes the legacy paths.
+//! Phase 2 of #570 shipped this stage as a module without wiring it
+//! into the default
+//! [`STRING_TO_AST`](crate::lex::transforms::standard::STRING_TO_AST)
+//! pipeline. **Phase 3b wired it up**: the rewrite now runs between
+//! `AttachAnnotations` and `ApplyTableConfig`, so every Document
+//! emitted by `STRING_TO_AST` carries canonical labels. The legacy
+//! whitelists in `lex-babel` (`ir/from_lex.rs`'s frontmatter
+//! promotion and `common/verbatim/VerbatimRegistry`'s handler
+//! registrations) were updated in the same PR to recognize the
+//! canonical names — both halves of the bare-label flip landed
+//! together so no intermediate state was broken. A follow-up phase
+//! retires the legacy paths altogether once render hooks (#570
+//! Phase 4) are live.
 //!
 //! # Why warnings are silent
 //!
@@ -190,10 +194,11 @@ mod tests {
     use super::*;
     use crate::lex::transforms::standard::STRING_TO_AST;
 
-    /// Parse + invoke the normalize stage explicitly. Phase 2 ships the
-    /// stage but does not insert it into the default pipeline; tests
-    /// run it manually so we can exercise the rewrite behaviour without
-    /// a production wire-up.
+    /// Parse + invoke the normalize stage explicitly. `STRING_TO_AST`
+    /// already runs `NormalizeLabels` after Phase 3b's wire-up, so
+    /// the second call here is idempotent — kept so the tests stay
+    /// readable as direct exercises of the stage's behaviour rather
+    /// than depending on pipeline order.
     fn parse(src: &str) -> Document {
         let doc = STRING_TO_AST.run(src.to_string()).expect("parse ok");
         NormalizeLabels::new().run(doc).expect("normalize ok")

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -111,6 +111,7 @@ fn rewrite_in_item(item: &mut ContentItem) {
             }
         }
         ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
+        ContentItem::Table(t) => rewrite_in_table(t),
         _ => {}
     }
     if let Some(attached) = attached_annotations_mut(item) {
@@ -121,6 +122,37 @@ fn rewrite_in_item(item: &mut ContentItem) {
     if let Some(children) = item.children_mut() {
         for child in children.iter_mut() {
             rewrite_in_item(child);
+        }
+    }
+}
+
+fn rewrite_in_table(table: &mut crate::lex::ast::Table) {
+    // `ContentItem::children_mut` returns `None` for tables (their
+    // structure lives in rows/cells, not a flat children list), so an
+    // explicit walk is needed to reach annotations nested inside cells
+    // or footnotes. Without this, a legacy label inside a table cell
+    // would slip through the pipeline untouched.
+    for row in table
+        .header_rows
+        .iter_mut()
+        .chain(table.body_rows.iter_mut())
+    {
+        for cell in row.cells.iter_mut() {
+            for child in cell.children.as_mut_vec().iter_mut() {
+                rewrite_in_item(child);
+            }
+        }
+    }
+    if let Some(footnotes) = table.footnotes.as_mut() {
+        for annotation in footnotes.annotations.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+        // List children are ListItems; their `children` slot reaches
+        // through `children_mut`, but we still need to walk
+        // `list.items` directly because List items use the typed
+        // `items` collection rather than a plain children list.
+        for item in footnotes.items.as_mut_vec().iter_mut() {
+            rewrite_in_item(item);
         }
     }
 }
@@ -377,6 +409,69 @@ mod tests {
         assert_ne!(
             loc.start, loc.end,
             "rewrite must preserve the label's source location, not zero it"
+        );
+    }
+
+    #[test]
+    fn rewrite_recurses_into_table_cell_block_children() {
+        // Regression for Copilot's PR 576 callout: `ContentItem::Table`
+        // returns `None` from `children_mut()` (its structure lives in
+        // rows/cells), so the generic walker won't reach legacy labels
+        // nested inside a cell's block content. Today's parser does
+        // not emit block children in cells — cell annotations land in
+        // the inline `content: TextContent` — but the AST surface
+        // allows it via `TableCell::with_children`, and Phase 3's
+        // wire-up may begin using that slot. Test the contract
+        // directly by building the AST programmatically.
+        use crate::lex::ast::elements::annotation::Annotation;
+        use crate::lex::ast::elements::label::Label;
+        use crate::lex::ast::elements::table::{Table, TableCell, TableRow};
+        use crate::lex::ast::elements::typed_content::ContentElement;
+        use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+        use crate::lex::ast::text_content::TextContent;
+
+        let inner_annotation = Annotation::marker(Label::from_string("title"));
+        let cell = TableCell::new(TextContent::from_string("inline".into(), None))
+            .with_children(vec![ContentElement::Annotation(inner_annotation)]);
+        let row = TableRow::new(vec![cell]);
+        let table = Table::new(
+            TextContent::from_string("Data".into(), None),
+            Vec::new(),
+            vec![row],
+            VerbatimBlockMode::Inflow,
+        );
+
+        let mut doc = Document::new();
+        doc.root
+            .children
+            .as_mut_vec()
+            .push(ContentItem::Table(Box::new(table)));
+
+        let doc = NormalizeLabels::new().run(doc).expect("normalize ok");
+
+        // Reach into the table and confirm the nested annotation got
+        // rewritten.
+        let table = doc
+            .root
+            .children
+            .iter()
+            .find_map(|item| match item {
+                ContentItem::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("table present");
+        let cell = &table.body_rows[0].cells[0];
+        let nested_label = cell
+            .children
+            .iter()
+            .find_map(|item| match item {
+                ContentItem::Annotation(a) => Some(a.data.label.value.as_str()),
+                _ => None,
+            })
+            .expect("nested annotation in cell.children");
+        assert_eq!(
+            nested_label, "lex.metadata.title",
+            "legacy label inside a table cell's block children must be rewritten"
         );
     }
 

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -1,0 +1,403 @@
+//! Normalize legacy bare labels to their canonical `lex.*` form.
+//!
+//! Phase 2 of the label-semantics refactor tracked in
+//! [#570](https://github.com/lex-fmt/lex/issues/570). Walks a parsed
+//! [`Document`] and rewrites annotation labels matching the
+//! pre-extension whitelist (`title`, `author`, `date`, `tags`,
+//! `category`, `template`, `publishing-date`, `front-matter`) plus the
+//! four verbatim labels (`doc.table`, `doc.image`, `doc.video`,
+//! `doc.audio`) to their canonical `lex.metadata.*` / `lex.tabular.*` /
+//! `lex.media.*` equivalents.
+//!
+//! # Activation lifecycle
+//!
+//! In Phase 2 (this PR) the stage is **shipped but not wired** into the
+//! default [`STRING_TO_AST`](crate::lex::transforms::standard::STRING_TO_AST)
+//! pipeline. Activating it here would break the legacy IR paths in
+//! `lex-babel` (`ir/from_lex.rs`'s frontmatter whitelist and
+//! `common/verbatim/VerbatimRegistry`'s handler registrations both
+//! still match on the bare label strings). Phase 3a flips the legacy
+//! paths to canonical names atomically with the wire-up, so both
+//! halves of the bare-label retirement land together. Phase 3b then
+//! deletes the legacy paths.
+//!
+//! # Why warnings are silent
+//!
+//! The issue's Phase 2 spec calls for a "parse-time deprecation
+//! warning" alongside the rewrite. Lex-core has no production
+//! diagnostic-collection vehicle today
+//! ([`Document::diagnostics`](crate::lex::ast::Document::diagnostics) is
+//! pull-based and not wired through the LSP / CLI; the LSP uses
+//! `lex-analysis::diagnostics`). Surfacing a warning therefore either
+//! requires adding storage on the AST (invasive, breaks
+//! `PartialEq`-based test fixtures) or a side channel that the LSP must
+//! opt into. Phase 5 ships the user-facing surface naturally: a
+//! `lexd migrate-labels` subcommand walks raw source, lists every legacy
+//! site by line/column, and offers an in-place rewrite. The rewrite
+//! itself stays silent here.
+
+use crate::lex::ast::elements::annotation::Annotation;
+use crate::lex::ast::elements::content_item::ContentItem;
+use crate::lex::ast::elements::verbatim::Verbatim;
+use crate::lex::ast::Document;
+use crate::lex::transforms::{Runnable, TransformError};
+
+/// Pairings of legacy bare label → canonical `lex.*` form.
+///
+/// Ordering mirrors the legacy whitelist in
+/// `crates/lex-babel/src/ir/from_lex.rs` (metadata first), followed by
+/// the four verbatim labels owned by the legacy
+/// `lex-babel::common::verbatim::VerbatimRegistry`. Anything not in
+/// this table is left untouched — third-party and user-defined labels
+/// are out of scope.
+pub const LEGACY_TO_CANONICAL: &[(&str, &str)] = &[
+    ("title", "lex.metadata.title"),
+    ("author", "lex.metadata.author"),
+    ("date", "lex.metadata.date"),
+    ("tags", "lex.metadata.tags"),
+    ("category", "lex.metadata.category"),
+    ("template", "lex.metadata.template"),
+    ("publishing-date", "lex.metadata.publishing-date"),
+    ("front-matter", "lex.metadata.front-matter"),
+    ("doc.table", "lex.tabular.table"),
+    ("doc.image", "lex.media.image"),
+    ("doc.video", "lex.media.video"),
+    ("doc.audio", "lex.media.audio"),
+];
+
+/// Lookup the canonical form for a legacy label, if any.
+pub fn canonical_for(label: &str) -> Option<&'static str> {
+    LEGACY_TO_CANONICAL
+        .iter()
+        .find(|(legacy, _)| *legacy == label)
+        .map(|(_, canonical)| *canonical)
+}
+
+/// Post-parse pass that rewrites legacy labels to their canonical form.
+pub struct NormalizeLabels;
+
+impl NormalizeLabels {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NormalizeLabels {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Runnable<Document, Document> for NormalizeLabels {
+    fn run(&self, mut input: Document) -> Result<Document, TransformError> {
+        for annotation in input.annotations.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+        for annotation in input.root.annotations.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+        for child in input.root.children.as_mut_vec().iter_mut() {
+            rewrite_in_item(child);
+        }
+        Ok(input)
+    }
+}
+
+fn rewrite_in_item(item: &mut ContentItem) {
+    match item {
+        ContentItem::Annotation(a) => {
+            if let Some(canonical) = canonical_for(&a.data.label.value) {
+                a.data.label.value = canonical.to_string();
+            }
+        }
+        ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
+        _ => {}
+    }
+    if let Some(attached) = attached_annotations_mut(item) {
+        for annotation in attached.iter_mut() {
+            rewrite_annotation(annotation);
+        }
+    }
+    if let Some(children) = item.children_mut() {
+        for child in children.iter_mut() {
+            rewrite_in_item(child);
+        }
+    }
+}
+
+fn rewrite_annotation(annotation: &mut Annotation) {
+    if let Some(canonical) = canonical_for(&annotation.data.label.value) {
+        annotation.data.label.value = canonical.to_string();
+    }
+    for child in annotation.children.as_mut_vec().iter_mut() {
+        rewrite_in_item(child);
+    }
+}
+
+fn rewrite_verbatim_label(verbatim: &mut Verbatim) {
+    if let Some(canonical) = canonical_for(&verbatim.closing_data.label.value) {
+        verbatim.closing_data.label.value = canonical.to_string();
+    }
+}
+
+fn attached_annotations_mut(item: &mut ContentItem) -> Option<&mut Vec<Annotation>> {
+    match item {
+        ContentItem::Session(s) => Some(&mut s.annotations),
+        ContentItem::Paragraph(p) => Some(&mut p.annotations),
+        ContentItem::Definition(d) => Some(&mut d.annotations),
+        ContentItem::List(l) => Some(&mut l.annotations),
+        ContentItem::ListItem(li) => Some(&mut li.annotations),
+        ContentItem::VerbatimBlock(v) => Some(&mut v.annotations),
+        ContentItem::Table(t) => Some(&mut t.annotations),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::transforms::standard::STRING_TO_AST;
+
+    /// Parse + invoke the normalize stage explicitly. Phase 2 ships the
+    /// stage but does not insert it into the default pipeline; tests
+    /// run it manually so we can exercise the rewrite behaviour without
+    /// a production wire-up.
+    fn parse(src: &str) -> Document {
+        let doc = STRING_TO_AST.run(src.to_string()).expect("parse ok");
+        NormalizeLabels::new().run(doc).expect("normalize ok")
+    }
+
+    fn find_first_annotation_label(doc: &Document) -> Option<String> {
+        doc.annotations
+            .first()
+            .map(|a| a.data.label.value.clone())
+            .or_else(|| find_inline_annotation_label(&doc.root.children))
+    }
+
+    fn find_inline_annotation_label(items: &[ContentItem]) -> Option<String> {
+        for item in items {
+            if let ContentItem::Annotation(a) = item {
+                return Some(a.data.label.value.clone());
+            }
+            if let Some(children) = item.children() {
+                if let Some(label) = find_inline_annotation_label(children) {
+                    return Some(label);
+                }
+            }
+        }
+        None
+    }
+
+    fn find_first_verbatim_label(items: &[ContentItem]) -> Option<String> {
+        for item in items {
+            if let ContentItem::VerbatimBlock(v) = item {
+                return Some(v.closing_data.label.value.clone());
+            }
+            if let Some(children) = item.children() {
+                if let Some(label) = find_first_verbatim_label(children) {
+                    return Some(label);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn canonical_for_recognizes_every_legacy_label() {
+        for (legacy, canonical) in LEGACY_TO_CANONICAL {
+            assert_eq!(
+                canonical_for(legacy),
+                Some(*canonical),
+                "lookup must round-trip for {legacy}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_for_returns_none_for_unknown_labels() {
+        assert!(canonical_for("acme.custom").is_none());
+        assert!(canonical_for("lex.include").is_none());
+        assert!(canonical_for("").is_none());
+    }
+
+    #[test]
+    fn legacy_to_canonical_table_covers_phase_1_targets() {
+        // Locks the rewrite set to the 8 metadata + 1 tabular + 3 media
+        // schemas that Phase 1 (#575) registered. If those families grow,
+        // this list grows with them.
+        assert_eq!(LEGACY_TO_CANONICAL.len(), 12);
+        let metadata_count = LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.metadata."))
+            .count();
+        let tabular_count = LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.tabular."))
+            .count();
+        let media_count = LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.media."))
+            .count();
+        assert_eq!(metadata_count, 8);
+        assert_eq!(tabular_count, 1);
+        assert_eq!(media_count, 3);
+    }
+
+    #[test]
+    fn document_level_title_annotation_is_rewritten() {
+        // Annotation single-line form: `:: label :: inline content`.
+        let doc = parse(":: title :: My Document\n\nBody.\n");
+        assert_eq!(
+            find_first_annotation_label(&doc).as_deref(),
+            Some("lex.metadata.title"),
+            "document-level :: title :: must rewrite to lex.metadata.title"
+        );
+    }
+
+    #[test]
+    fn every_metadata_label_rewrites() {
+        for (legacy, canonical) in LEGACY_TO_CANONICAL
+            .iter()
+            .filter(|(_, c)| c.starts_with("lex.metadata."))
+        {
+            let src = format!(":: {legacy} :: value\n\nBody.\n");
+            let doc = parse(&src);
+            assert_eq!(
+                find_first_annotation_label(&doc).as_deref(),
+                Some(*canonical),
+                ":: {legacy} :: must rewrite to {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn doc_table_verbatim_rewrites_to_lex_tabular_table() {
+        // Lex verbatim syntax: subject line ending in `:`, indented body,
+        // then `:: label ::` as the closer.
+        let src = "Table:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
+        let doc = parse(src);
+        assert_eq!(
+            find_first_verbatim_label(&doc.root.children).as_deref(),
+            Some("lex.tabular.table"),
+            ":: doc.table :: verbatim must rewrite to lex.tabular.table"
+        );
+    }
+
+    #[test]
+    fn doc_image_verbatim_rewrites_to_lex_media_image() {
+        let src = "Image:\n    alt text\n:: doc.image src=x.png ::\n";
+        let doc = parse(src);
+        assert_eq!(
+            find_first_verbatim_label(&doc.root.children).as_deref(),
+            Some("lex.media.image"),
+        );
+    }
+
+    #[test]
+    fn doc_video_and_audio_verbatims_rewrite() {
+        for (legacy, canonical) in [
+            ("doc.video", "lex.media.video"),
+            ("doc.audio", "lex.media.audio"),
+        ] {
+            let src = format!("Media:\n    caption\n:: {legacy} src=file ::\n");
+            let doc = parse(&src);
+            assert_eq!(
+                find_first_verbatim_label(&doc.root.children).as_deref(),
+                Some(canonical),
+                ":: {legacy} :: must rewrite to {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_legacy_labels_are_left_alone() {
+        let src = ":: acme.custom param=value :: body\n\nBody.\n";
+        let doc = parse(src);
+        let label = find_first_annotation_label(&doc);
+        assert_eq!(
+            label.as_deref(),
+            Some("acme.custom"),
+            "third-party labels must be preserved verbatim"
+        );
+    }
+
+    #[test]
+    fn lex_include_label_is_left_alone() {
+        // Already-canonical lex.* labels must not be rewritten.
+        let src = ":: lex.include src=other.lex ::\n\nBody.\n";
+        let doc = parse(src);
+        let label = find_first_annotation_label(&doc);
+        assert_eq!(label.as_deref(), Some("lex.include"));
+    }
+
+    #[test]
+    fn rewrite_preserves_annotation_parameters() {
+        // The rewrite touches the label only — params and body
+        // content must survive unchanged.
+        let src = ":: author email=alice@example.com :: Alice\n\nBody.\n";
+        let doc = parse(src);
+        let first = doc
+            .annotations
+            .first()
+            .or_else(|| {
+                doc.root.children.iter().find_map(|item| match item {
+                    ContentItem::Annotation(a) => Some(a),
+                    _ => None,
+                })
+            })
+            .expect("annotation parsed");
+        assert_eq!(first.data.label.value, "lex.metadata.author");
+        let email_param = first
+            .data
+            .parameters
+            .iter()
+            .find(|p| p.key == "email")
+            .expect("email param preserved");
+        assert_eq!(email_param.value, "alice@example.com");
+    }
+
+    #[test]
+    fn rewrite_preserves_label_location() {
+        // Range info must round-trip — the LSP relies on label location
+        // for goto-definition and similar features. Rewrite mutates
+        // `label.value` in place without touching `label.location`.
+        let src = ":: title :: T\n\nBody.\n";
+        let doc = parse(src);
+        let first = doc
+            .annotations
+            .first()
+            .or_else(|| {
+                doc.root.children.iter().find_map(|item| match item {
+                    ContentItem::Annotation(a) => Some(a),
+                    _ => None,
+                })
+            })
+            .expect("annotation parsed");
+        let loc = &first.data.label.location;
+        assert_ne!(
+            loc.start, loc.end,
+            "rewrite must preserve the label's source location, not zero it"
+        );
+    }
+
+    #[test]
+    fn rewrite_recurses_into_annotation_children() {
+        // The walker must reach annotations nested inside another
+        // annotation's content body — `rewrite_annotation` calls
+        // `rewrite_in_item` on each child, which in turn handles inline
+        // `ContentItem::Annotation` labels.
+        let src = ":: outer ::\n    :: author :: Alice\n";
+        let doc = parse(src);
+        let outer = doc.annotations.first().expect("outer annotation parsed");
+        // Find the inner annotation in outer's children.
+        let inner_label = outer.children.iter().find_map(|item| match item {
+            ContentItem::Annotation(a) => Some(a.data.label.value.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            inner_label.as_deref(),
+            Some("lex.metadata.author"),
+            "nested annotation inside outer must be rewritten"
+        );
+    }
+}

--- a/crates/lex-core/src/lex/builtins/media.rs
+++ b/crates/lex-core/src/lex/builtins/media.rs
@@ -2,8 +2,8 @@
 //!
 //! The members — `lex.media.image`, `lex.media.video`, `lex.media.audio` —
 //! are the registry-shaped replacements for the legacy `doc.image`,
-//! `doc.video`, and `doc.audio` handlers in
-//! [`crate::common::verbatim::media`](../../../../lex-babel/src/common/verbatim/media.rs).
+//! `doc.video`, and `doc.audio` handlers in `lex-babel`
+//! (`crates/lex-babel/src/common/verbatim/media.rs`).
 //! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
 //! multi-phase migration.
 //!

--- a/crates/lex-core/src/lex/builtins/media.rs
+++ b/crates/lex-core/src/lex/builtins/media.rs
@@ -1,0 +1,225 @@
+//! Schemas for the `lex.media.*` family of verbatim labels.
+//!
+//! The members — `lex.media.image`, `lex.media.video`, `lex.media.audio` —
+//! are the registry-shaped replacements for the legacy `doc.image`,
+//! `doc.video`, and `doc.audio` handlers in
+//! [`crate::common::verbatim::media`](../../../../lex-babel/src/common/verbatim/media.rs).
+//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
+//! multi-phase migration.
+//!
+//! # Phase 1 status
+//!
+//! Schemas only — no `on_resolve` bodies yet. The legacy
+//! `VerbatimRegistry` still converts verbatim params into typed
+//! `DocNode::Image` / `Video` / `Audio` nodes. Phase 2's parse-time
+//! auto-rewrite retargets `:: doc.image ::` &c. at these labels;
+//! Phase 3 deletes the legacy lookup and Phase 4 wires `on_format` so
+//! they round-trip back to Lex source through the registry.
+
+use lex_extension::schema::{
+    BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+};
+use std::collections::BTreeMap;
+
+pub const LEX_MEDIA_IMAGE: &str = "lex.media.image";
+pub const LEX_MEDIA_VIDEO: &str = "lex.media.video";
+pub const LEX_MEDIA_AUDIO: &str = "lex.media.audio";
+
+fn string_param(required: bool, description: &'static str) -> ParamSpec {
+    ParamSpec {
+        ty: ParamType::String,
+        required,
+        default: None,
+        description: Some(description.into()),
+        pattern: None,
+        values: Vec::new(),
+    }
+}
+
+/// Common shape for media labels: verbatim attachment, optional text
+/// body (image uses it as an alt-text fallback; video/audio ignore it),
+/// no hooks until Phase 3.
+fn media_schema(
+    label: &'static str,
+    description: &'static str,
+    params: BTreeMap<String, ParamSpec>,
+    body_description: &'static str,
+) -> Schema {
+    Schema {
+        schema_version: 1,
+        label: label.into(),
+        description: Some(description.into()),
+        params,
+        attaches_to: vec!["verbatim".into()],
+        body: BodyShape {
+            kind: BodyKind::Text,
+            presence: BodyPresence::Optional,
+            description: Some(body_description.into()),
+        },
+        verbatim_label: true,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+pub fn lex_media_image_schema() -> Schema {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "src".into(),
+        string_param(true, "Source URL or path of the image."),
+    );
+    params.insert(
+        "alt".into(),
+        string_param(
+            false,
+            "Alternative text. Falls back to the verbatim body's first non-empty line when omitted.",
+        ),
+    );
+    params.insert(
+        "title".into(),
+        string_param(false, "Tooltip / accessible title for the image."),
+    );
+    media_schema(
+        LEX_MEDIA_IMAGE,
+        "Image media block. The verbatim body, when present, is treated as the \
+         alt-text fallback if no `alt=` parameter is supplied.",
+        params,
+        "Optional alt-text fallback; ignored when an explicit `alt=` parameter is present.",
+    )
+}
+
+pub fn lex_media_video_schema() -> Schema {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "src".into(),
+        string_param(true, "Source URL or path of the video."),
+    );
+    params.insert(
+        "title".into(),
+        string_param(false, "Accessible title for the video."),
+    );
+    params.insert(
+        "poster".into(),
+        string_param(false, "Poster image shown before playback begins."),
+    );
+    media_schema(
+        LEX_MEDIA_VIDEO,
+        "Video media block.",
+        params,
+        "Reserved for renderer-specific extensions; ignored by the built-in renderers.",
+    )
+}
+
+pub fn lex_media_audio_schema() -> Schema {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "src".into(),
+        string_param(true, "Source URL or path of the audio file."),
+    );
+    params.insert(
+        "title".into(),
+        string_param(false, "Accessible title for the audio clip."),
+    );
+    media_schema(
+        LEX_MEDIA_AUDIO,
+        "Audio media block.",
+        params,
+        "Reserved for renderer-specific extensions; ignored by the built-in renderers.",
+    )
+}
+
+/// All `lex.media.*` schemas, in declaration order.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![
+        lex_media_image_schema(),
+        lex_media_video_schema(),
+        lex_media_audio_schema(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_media_schema_is_a_verbatim_label() {
+        for schema in all_schemas() {
+            assert!(
+                schema.verbatim_label,
+                "{} must be a verbatim label",
+                schema.label
+            );
+            assert_eq!(
+                schema.attaches_to,
+                vec!["verbatim".to_string()],
+                "{} attaches to verbatim",
+                schema.label
+            );
+            assert!(
+                schema
+                    .params
+                    .get("src")
+                    .map(|p| p.required)
+                    .unwrap_or(false),
+                "{} must declare `src` as a required parameter",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn image_schema_carries_optional_alt_and_title() {
+        let schema = lex_media_image_schema();
+        let alt = schema.params.get("alt").expect("alt declared");
+        let title = schema.params.get("title").expect("title declared");
+        assert!(!alt.required);
+        assert!(!title.required);
+    }
+
+    #[test]
+    fn video_schema_carries_optional_poster() {
+        let schema = lex_media_video_schema();
+        let poster = schema.params.get("poster").expect("poster declared");
+        assert!(!poster.required);
+    }
+
+    #[test]
+    fn audio_schema_has_no_poster() {
+        let schema = lex_media_audio_schema();
+        assert!(
+            !schema.params.contains_key("poster"),
+            "audio schemas have no poster parameter"
+        );
+    }
+
+    #[test]
+    fn media_schemas_declare_no_hooks_in_phase_1() {
+        for schema in all_schemas() {
+            assert!(
+                !schema.hooks.resolve,
+                "{} resolve must stay off",
+                schema.label
+            );
+            assert!(
+                !schema.hooks.validate,
+                "{} validate must stay off",
+                schema.label
+            );
+            assert!(
+                schema.hooks.render.is_empty(),
+                "{} render must stay off",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn media_schemas_round_trip_through_json() {
+        for schema in all_schemas() {
+            let json = serde_json::to_string(&schema).expect("serialize");
+            let back: Schema = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back, schema, "round trip for {}", schema.label);
+        }
+    }
+}

--- a/crates/lex-core/src/lex/builtins/metadata.rs
+++ b/crates/lex-core/src/lex/builtins/metadata.rs
@@ -1,0 +1,209 @@
+//! Schemas for the `lex.metadata.*` family of document-level labels.
+//!
+//! These are the registry-shaped replacements for the hardcoded
+//! frontmatter-promotion whitelist in
+//! [`crate::ir::from_lex`](../../../../lex-babel/src/ir/from_lex.rs)
+//! (`author`, `title`, `date`, `tags`, `category`, `template`,
+//! `publishing-date`, `front-matter`). Issue
+//! [#570](https://github.com/lex-fmt/lex/issues/570) tracks the multi-phase
+//! migration.
+//!
+//! # Phase 1 status
+//!
+//! Schemas only — no hooks are declared yet. The legacy frontmatter
+//! promotion in `lex-babel` continues to own the IR work. The schemas
+//! exist as registration targets for the Phase 2 parse-time auto-rewrite
+//! (`:: title ::` → `:: lex.metadata.title ::`); Phase 3 retires the
+//! legacy IR path; Phase 4 wires `on_render`/`on_format` so these
+//! labels emit `<title>` / `<meta>` in HTML.
+//!
+//! Every schema in this module shares the same shape — only the
+//! fully-qualified label string differs — so [`metadata_schema`] does
+//! the heavy lifting and each public function is a one-liner.
+
+use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use std::collections::BTreeMap;
+
+/// The eight metadata labels, in the order they appear in the legacy
+/// whitelist (`crates/lex-babel/src/ir/from_lex.rs`). Exposed so the
+/// Phase 2 auto-rewrite can iterate the canonical set without
+/// re-declaring it.
+pub const METADATA_LABELS: &[&str] = &[
+    "lex.metadata.title",
+    "lex.metadata.author",
+    "lex.metadata.date",
+    "lex.metadata.tags",
+    "lex.metadata.category",
+    "lex.metadata.template",
+    "lex.metadata.publishing-date",
+    "lex.metadata.front-matter",
+];
+
+/// Build a metadata schema. Every `lex.metadata.*` label attaches to a
+/// document, carries its value either as the annotation body (text) or
+/// as untyped parameters (the legacy whitelist accepted both), and
+/// declares no privileged capabilities. Hooks are deliberately empty in
+/// Phase 1 — they fill in across Phases 3 + 4.
+fn metadata_schema(label: &'static str, description: &'static str) -> Schema {
+    Schema {
+        schema_version: 1,
+        label: label.into(),
+        description: Some(description.into()),
+        params: BTreeMap::new(),
+        attaches_to: vec!["document".into()],
+        body: BodyShape {
+            kind: BodyKind::Text,
+            presence: BodyPresence::Optional,
+            description: Some(
+                "Annotation body (single-line text) carries the metadata value when no \
+                 explicit parameter is supplied."
+                    .into(),
+            ),
+        },
+        verbatim_label: false,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+pub fn lex_metadata_title_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.title",
+        "Document title. Renders as `<title>` and `<meta name=\"title\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_author_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.author",
+        "Document author. Renders as `<meta name=\"author\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_date_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.date",
+        "Document date. Renders as `<meta name=\"date\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_tags_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.tags",
+        "Document tags (comma-separated). Renders as `<meta name=\"keywords\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_category_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.category",
+        "Document category. Renders as `<meta name=\"category\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_template_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.template",
+        "Template hint for renderers that select a layout per document.",
+    )
+}
+
+pub fn lex_metadata_publishing_date_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.publishing-date",
+        "Publishing date (distinct from authoring `date`). Renders as \
+         `<meta name=\"publishing-date\">` in HTML output.",
+    )
+}
+
+pub fn lex_metadata_front_matter_schema() -> Schema {
+    metadata_schema(
+        "lex.metadata.front-matter",
+        "Catch-all front-matter container for renderer-specific extensions.",
+    )
+}
+
+/// All `lex.metadata.*` schemas, in declaration order.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![
+        lex_metadata_title_schema(),
+        lex_metadata_author_schema(),
+        lex_metadata_date_schema(),
+        lex_metadata_tags_schema(),
+        lex_metadata_category_schema(),
+        lex_metadata_template_schema(),
+        lex_metadata_publishing_date_schema(),
+        lex_metadata_front_matter_schema(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_labels_match_schema_outputs() {
+        let labels: Vec<String> = all_schemas().into_iter().map(|s| s.label).collect();
+        let expected: Vec<String> = METADATA_LABELS.iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(
+            labels, expected,
+            "all_schemas() ordering must mirror METADATA_LABELS so the Phase 2 \
+             auto-rewrite has a single source of truth for the label set"
+        );
+    }
+
+    #[test]
+    fn every_metadata_schema_attaches_to_document() {
+        for schema in all_schemas() {
+            assert_eq!(
+                schema.attaches_to,
+                vec!["document".to_string()],
+                "{} must declare document-scope attachment",
+                schema.label
+            );
+            assert!(
+                !schema.verbatim_label,
+                "{} is an annotation label, not a verbatim label",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_schemas_declare_no_hooks_in_phase_1() {
+        // Phase 1's contract: schemas register but don't intercept. Hook
+        // activation comes in Phases 3 + 4. If a hook flag flips on
+        // unexpectedly, that's a signal a later-phase change leaked
+        // back into the metadata family.
+        for schema in all_schemas() {
+            assert!(
+                !schema.hooks.resolve,
+                "{} resolve hook must stay off in Phase 1",
+                schema.label
+            );
+            assert!(
+                !schema.hooks.validate,
+                "{} validate hook must stay off in Phase 1",
+                schema.label
+            );
+            assert!(
+                schema.hooks.render.is_empty(),
+                "{} render hook must stay off in Phase 1",
+                schema.label
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_schemas_round_trip_through_json() {
+        // Schema is serde-derived; making sure each label survives the
+        // round trip guards against accidental non-serializable
+        // additions to the shape (`Capabilities`, `HookSet`, etc.).
+        for schema in all_schemas() {
+            let json = serde_json::to_string(&schema).expect("serialize");
+            let back: Schema = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back, schema, "round trip for {}", schema.label);
+        }
+    }
+}

--- a/crates/lex-core/src/lex/builtins/metadata.rs
+++ b/crates/lex-core/src/lex/builtins/metadata.rs
@@ -1,12 +1,11 @@
 //! Schemas for the `lex.metadata.*` family of document-level labels.
 //!
 //! These are the registry-shaped replacements for the hardcoded
-//! frontmatter-promotion whitelist in
-//! [`crate::ir::from_lex`](../../../../lex-babel/src/ir/from_lex.rs)
-//! (`author`, `title`, `date`, `tags`, `category`, `template`,
-//! `publishing-date`, `front-matter`). Issue
-//! [#570](https://github.com/lex-fmt/lex/issues/570) tracks the multi-phase
-//! migration.
+//! frontmatter-promotion whitelist in `lex-babel`
+//! (`crates/lex-babel/src/ir/from_lex.rs`): `author`, `title`, `date`,
+//! `tags`, `category`, `template`, `publishing-date`, `front-matter`.
+//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
+//! multi-phase migration.
 //!
 //! # Phase 1 status
 //!
@@ -18,8 +17,8 @@
 //! labels emit `<title>` / `<meta>` in HTML.
 //!
 //! Every schema in this module shares the same shape — only the
-//! fully-qualified label string differs — so [`metadata_schema`] does
-//! the heavy lifting and each public function is a one-liner.
+//! fully-qualified label string differs — so a private `metadata_schema`
+//! helper does the heavy lifting and each public function is a one-liner.
 
 use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
 use std::collections::BTreeMap;

--- a/crates/lex-core/src/lex/builtins/metadata.rs
+++ b/crates/lex-core/src/lex/builtins/metadata.rs
@@ -69,35 +69,41 @@ fn metadata_schema(label: &'static str, description: &'static str) -> Schema {
 pub fn lex_metadata_title_schema() -> Schema {
     metadata_schema(
         "lex.metadata.title",
-        "Document title. Renders as `<title>` and `<meta name=\"title\">` in HTML output.",
+        "Document title. Phase 4 of #570 wires the render hook so HTML output emits \
+         `<title>` and `<meta name=\"title\">`; until then the legacy frontmatter \
+         promotion in lex-babel handles it.",
     )
 }
 
 pub fn lex_metadata_author_schema() -> Schema {
     metadata_schema(
         "lex.metadata.author",
-        "Document author. Renders as `<meta name=\"author\">` in HTML output.",
+        "Document author. Render hook (Phase 4 of #570) will emit `<meta name=\"author\">` \
+         in HTML output.",
     )
 }
 
 pub fn lex_metadata_date_schema() -> Schema {
     metadata_schema(
         "lex.metadata.date",
-        "Document date. Renders as `<meta name=\"date\">` in HTML output.",
+        "Document date. Render hook (Phase 4 of #570) will emit `<meta name=\"date\">` \
+         in HTML output.",
     )
 }
 
 pub fn lex_metadata_tags_schema() -> Schema {
     metadata_schema(
         "lex.metadata.tags",
-        "Document tags (comma-separated). Renders as `<meta name=\"keywords\">` in HTML output.",
+        "Document tags (comma-separated). Render hook (Phase 4 of #570) will emit \
+         `<meta name=\"keywords\">` in HTML output.",
     )
 }
 
 pub fn lex_metadata_category_schema() -> Schema {
     metadata_schema(
         "lex.metadata.category",
-        "Document category. Renders as `<meta name=\"category\">` in HTML output.",
+        "Document category. Render hook (Phase 4 of #570) will emit \
+         `<meta name=\"category\">` in HTML output.",
     )
 }
 
@@ -111,8 +117,8 @@ pub fn lex_metadata_template_schema() -> Schema {
 pub fn lex_metadata_publishing_date_schema() -> Schema {
     metadata_schema(
         "lex.metadata.publishing-date",
-        "Publishing date (distinct from authoring `date`). Renders as \
-         `<meta name=\"publishing-date\">` in HTML output.",
+        "Publishing date (distinct from authoring `date`). Render hook (Phase 4 of #570) \
+         will emit `<meta name=\"publishing-date\">` in HTML output.",
     )
 }
 

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -26,7 +26,7 @@
 //!
 //! The single `lex` namespace is shared by every built-in label; the
 //! composite [`LexBuiltinsHandler`] routes each dispatch by
-//! [`LabelCtx::label`](lex_extension::wire::LabelCtx) to the right
+//! [`LabelCtx::label`](lex_extension::wire::LabelCtx::label) to the right
 //! sub-handler.
 
 use std::sync::Arc;

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -36,7 +36,7 @@ use lex_extension::{
     schema::{
         BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
     },
-    wire::{LabelCtx, WireNode},
+    wire::{FormatCtx, LabelCtx, LexAnnotationOut, WireNode},
 };
 use lex_extension_host::registry::{Registry, RegistryError};
 
@@ -87,6 +87,53 @@ impl LexHandler for LexBuiltinsHandler {
             _ => Ok(None),
         }
     }
+
+    /// Phase 4b of #570: emit the canonical Lex-source shape for the
+    /// built-in `lex.tabular.*` and `lex.media.*` labels.
+    ///
+    /// The verbatim labels round-trip as `:: lex.<family>.<kind> ::`
+    /// closers with the body text and parameters carried verbatim from
+    /// the supplied `WireNode::Verbatim`. Anything else (e.g.
+    /// `lex.include`, metadata labels, unrecognised labels) returns
+    /// `Ok(None)` so the host falls back to its built-in formatter.
+    fn on_format(&self, ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, HandlerError> {
+        match ctx.label.as_str() {
+            "lex.tabular.table" | "lex.media.image" | "lex.media.video" | "lex.media.audio" => {
+                verbatim_label_on_format(ctx)
+            }
+            // `lex.include` is the resolve-only direction — it splices
+            // content in via on_resolve; no IR→Lex emission path. The
+            // metadata labels (`lex.metadata.*`) and any unrecognised
+            // label fall back to the host's default formatter.
+            _ => Ok(None),
+        }
+    }
+}
+
+/// Shared `on_format` body for the four built-in verbatim labels
+/// (`lex.tabular.table`, `lex.media.{image,video,audio}`). Each one
+/// has the same wire shape: a `WireNode::Verbatim` whose `body_text`
+/// carries the verbatim source (pipe-table syntax, alt-text fallback,
+/// etc.) and whose `params` mirror what `FormatCtx::params` already
+/// holds. We accept either the verbatim's own params or the explicit
+/// `ctx.params` — the latter wins when both are present, mirroring the
+/// `FormatCtx::params` documentation that those are the originating
+/// label parameters the host wants preserved.
+fn verbatim_label_on_format(ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, HandlerError> {
+    let body = match &ctx.node {
+        WireNode::Verbatim { body_text, .. } => body_text.clone(),
+        // For non-verbatim wire nodes (e.g. a typed Table kind that a
+        // future wire-spec revision adds), the built-in handler
+        // doesn't have a serializer yet — return None so the host
+        // falls back. Phase 4b ships the verbatim path only.
+        _ => return Ok(None),
+    };
+    Ok(Some(LexAnnotationOut {
+        label: ctx.label.clone(),
+        params: ctx.params.clone(),
+        body,
+        verbatim_label: true,
+    }))
 }
 
 /// Register every built-in `lex.*` schema and handler into `registry`.
@@ -390,5 +437,146 @@ mod tests {
                 "expected label {label} to be registered"
             );
         }
+    }
+
+    /// Build a `FormatCtx` whose `node` is a `WireNode::Verbatim`
+    /// carrying the supplied body text and params. The four built-in
+    /// verbatim labels share this shape; this helper keeps each test
+    /// to a single line of meaningful setup.
+    fn format_ctx_verbatim(
+        label: &str,
+        params: Vec<(&str, &str)>,
+        body_text: &str,
+    ) -> lex_extension::wire::FormatCtx {
+        use lex_extension::wire::{FormatCtx, WireNode};
+        let owned_params: Vec<(String, String)> = params
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        FormatCtx {
+            label: label.into(),
+            params: owned_params.clone(),
+            node: WireNode::Verbatim {
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+                label: label.into(),
+                params: serde_json::Value::Object(
+                    owned_params
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect(),
+                ),
+                body_text: body_text.into(),
+                subject: String::new(),
+                mode: "inflow".into(),
+            },
+            format_options: None,
+        }
+    }
+
+    #[test]
+    fn dispatch_format_for_lex_tabular_table_returns_verbatim_annotation() {
+        // Phase 4b of #570: the built-in `lex.tabular.table` handler
+        // takes a WireNode::Verbatim whose body_text carries the
+        // pipe-table source and emits a LexAnnotationOut that the
+        // caller (`to_lex` etc.) can splice as `:: lex.tabular.table ::`.
+        let registry = fresh_registry();
+        let body = "| a | b |\n|---|---|\n| 1 | 2 |";
+        let ctx = format_ctx_verbatim("lex.tabular.table", vec![("header", "1")], body);
+        let out = registry
+            .dispatch_format(&ctx)
+            .expect("dispatch_format ok")
+            .expect("handler returned Some");
+        assert_eq!(out.label, "lex.tabular.table");
+        assert_eq!(out.params, vec![("header".into(), "1".into())]);
+        assert_eq!(out.body, body);
+        assert!(out.verbatim_label);
+    }
+
+    #[test]
+    fn dispatch_format_for_lex_media_image_returns_verbatim_annotation() {
+        let registry = fresh_registry();
+        let ctx = format_ctx_verbatim(
+            "lex.media.image",
+            vec![("src", "chart.png"), ("alt", "Q4 chart")],
+            "",
+        );
+        let out = registry
+            .dispatch_format(&ctx)
+            .expect("dispatch_format ok")
+            .expect("handler returned Some");
+        assert_eq!(out.label, "lex.media.image");
+        let src = out
+            .params
+            .iter()
+            .find(|(k, _)| k == "src")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(src, Some("chart.png"));
+        assert!(out.verbatim_label);
+    }
+
+    #[test]
+    fn dispatch_format_for_lex_media_video_and_audio_return_verbatim_annotation() {
+        let registry = fresh_registry();
+        for label in ["lex.media.video", "lex.media.audio"] {
+            let ctx = format_ctx_verbatim(label, vec![("src", "media.mp4")], "");
+            let out = registry
+                .dispatch_format(&ctx)
+                .expect("dispatch_format ok")
+                .unwrap_or_else(|| panic!("handler must return Some for {label}"));
+            assert_eq!(out.label, label);
+            assert!(out.verbatim_label);
+        }
+    }
+
+    #[test]
+    fn dispatch_format_for_lex_include_returns_none() {
+        // `lex.include` is the resolve-only direction; on_format is
+        // not implemented for it.
+        let registry = fresh_registry();
+        let ctx = format_ctx_verbatim("lex.include", vec![("src", "other.lex")], "");
+        let out = registry.dispatch_format(&ctx).expect("dispatch_format ok");
+        assert!(out.is_none(), "lex.include has no on_format path");
+    }
+
+    #[test]
+    fn dispatch_format_for_lex_metadata_returns_none() {
+        // Metadata labels fall back to the host's built-in formatter
+        // in Phase 4b — they're not verbatim and the wire shape isn't
+        // a Verbatim node, so the shared verbatim-label helper bails.
+        let registry = fresh_registry();
+        let ctx = format_ctx_verbatim("lex.metadata.title", vec![], "My Doc");
+        let out = registry.dispatch_format(&ctx).expect("dispatch_format ok");
+        assert!(out.is_none(), "metadata labels fall back to host default");
+    }
+
+    #[test]
+    fn dispatch_format_with_non_verbatim_node_returns_none() {
+        // Even for a built-in verbatim label, if the host passes a
+        // non-verbatim WireNode (e.g. a Paragraph), the handler bails
+        // rather than emit a malformed annotation.
+        use lex_extension::wire::{FormatCtx, WireNode};
+        let registry = fresh_registry();
+        let ctx = FormatCtx {
+            label: "lex.tabular.table".into(),
+            params: vec![],
+            node: WireNode::Paragraph {
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+                inlines: vec![],
+            },
+            format_options: None,
+        };
+        let out = registry.dispatch_format(&ctx).expect("dispatch_format ok");
+        assert!(
+            out.is_none(),
+            "non-verbatim wire node must fall back to host default"
+        );
     }
 }

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -8,59 +8,112 @@
 //!
 //! # What ships today
 //!
-//! | Label         | Handler              | Status                            |
-//! |---------------|----------------------|-----------------------------------|
-//! | `lex.include` | [`LexIncludeHandler`] | Registrable; resolve pass still   |
-//! |               |                      | runs through the legacy inline    |
-//! |               |                      | path until PR 3d (#533).          |
+//! | Label family            | Handler                | Status                                |
+//! |-------------------------|------------------------|---------------------------------------|
+//! | `lex.include`           | [`LexIncludeHandler`]  | Registrable; resolve pass still runs  |
+//! |                         |                        | through the legacy inline path until  |
+//! |                         |                        | PR 3d (#533).                         |
+//! | `lex.metadata.*` (×8)   | [`LexBuiltinsHandler`] | Phase 1 of #570 — schemas only.       |
+//! |                         |                        | Legacy frontmatter promotion in       |
+//! |                         |                        | `lex-babel/src/ir/from_lex.rs` still  |
+//! |                         |                        | owns the IR work.                     |
+//! | `lex.tabular.table`     | [`LexBuiltinsHandler`] | Phase 1 of #570 — schema only.        |
+//! |                         |                        | Legacy `VerbatimRegistry::TableHandler` |
+//! |                         |                        | still parses pipe-tables.             |
+//! | `lex.media.{image,…}`   | [`LexBuiltinsHandler`] | Phase 1 of #570 — schemas only.       |
+//! |                         |                        | Legacy `VerbatimRegistry::Image/…`    |
+//! |                         |                        | handlers still build the IR nodes.    |
 //!
-//! Future built-ins (`lex.toc`, …) follow the same shape: one handler
-//! impl per label, registered through [`register_into`].
+//! The single `lex` namespace is shared by every built-in label; the
+//! composite [`LexBuiltinsHandler`] routes each dispatch by
+//! [`LabelCtx::label`](lex_extension::wire::LabelCtx) to the right
+//! sub-handler.
 
 use std::sync::Arc;
 
-use lex_extension::schema::{
-    BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+use lex_extension::{
+    handler::{HandlerError, LexHandler},
+    schema::{
+        BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+    },
+    wire::{LabelCtx, WireNode},
 };
 use lex_extension_host::registry::{Registry, RegistryError};
 
 use crate::lex::includes::{Loader, ResolveConfig};
 
 pub mod include;
+pub mod media;
+pub mod metadata;
+pub mod tabular;
 
 pub use include::LexIncludeHandler;
 
 /// The reserved namespace owned by the lex core. Its prefix is
 /// `lex.` (with the trailing dot), so registered labels look like
-/// `lex.include`, `lex.toc`, etc.
+/// `lex.include`, `lex.metadata.title`, `lex.tabular.table`, etc.
 pub const NAMESPACE: &str = "lex";
+
+/// Composite handler for the `lex.*` namespace.
+///
+/// `Registry::register_namespace` accepts one handler per namespace; the
+/// composite shape lets every `lex.*` built-in live under a single
+/// namespace registration while keeping per-label logic isolated.
+///
+/// Today the only sub-handler with a non-stub implementation is
+/// [`LexIncludeHandler`]; the `lex.metadata.*`, `lex.tabular.*`, and
+/// `lex.media.*` labels register their schemas but their hooks return
+/// the trait's default `Ok(None)` until Phase 3 of #570 moves the
+/// legacy IR transformations into the registry path.
+pub struct LexBuiltinsHandler {
+    include: LexIncludeHandler,
+}
+
+impl LexBuiltinsHandler {
+    pub fn new(loader: Arc<dyn Loader + Send + Sync>, config: ResolveConfig) -> Self {
+        Self {
+            include: LexIncludeHandler::new(loader, config),
+        }
+    }
+}
+
+impl LexHandler for LexBuiltinsHandler {
+    fn on_resolve(&self, ctx: &LabelCtx) -> Result<Option<WireNode>, HandlerError> {
+        match ctx.label.as_str() {
+            "lex.include" => self.include.on_resolve(ctx),
+            // Phase 1 of #570: schemas register but don't intercept.
+            // The legacy IR paths in lex-babel still own the work for
+            // every other `lex.*` label. Phase 3 fills these arms in.
+            _ => Ok(None),
+        }
+    }
+}
 
 /// Register every built-in `lex.*` schema and handler into `registry`.
 ///
-/// The current set is `{ lex.include }`; future built-ins land here as
-/// they're added. The single registration call covers the whole
-/// namespace because [`Registry::register_namespace`] wants every
-/// label for a namespace handed in atomically.
-///
-/// `loader` and `config` flow into [`LexIncludeHandler`] verbatim: the
-/// handler holds them by `Arc` so the registry can be cheaply cloned
-/// and shared across threads. `config.root` should already be
-/// canonicalised by the caller — see
-/// [`ResolveConfig::with_root`](crate::lex::includes::ResolveConfig::with_root).
+/// `loader` and `config` are forwarded verbatim to the composite
+/// handler; today they're consumed only by [`LexIncludeHandler`] but
+/// future built-ins may need filesystem access too (e.g. an asset
+/// resolver for `lex.media.*`).
 pub fn register_into(
     registry: &Registry,
     loader: Arc<dyn Loader + Send + Sync>,
     config: ResolveConfig,
 ) -> Result<(), RegistryError> {
-    let schemas = vec![lex_include_schema()];
-    let handler = Box::new(LexIncludeHandler::new(loader, config));
+    let mut schemas = Vec::with_capacity(13);
+    schemas.push(lex_include_schema());
+    schemas.extend(metadata::all_schemas());
+    schemas.extend(tabular::all_schemas());
+    schemas.extend(media::all_schemas());
+
+    let handler = Box::new(LexBuiltinsHandler::new(loader, config));
     registry.register_namespace(NAMESPACE, schemas, handler)
 }
 
 /// Schema for the `lex.include` label. Inlined here because v1 has
-/// exactly one built-in label; once the YAML schema loader lands in
-/// PR 4 (#520), built-ins will share the same load path as third
-/// parties (a baked-in `lex.yaml` shipped with the crate).
+/// exactly one built-in label of its kind; once the YAML schema loader
+/// lands in PR 4 (#520), built-ins will share the same load path as
+/// third parties (a baked-in `lex.yaml` shipped with the crate).
 pub fn lex_include_schema() -> Schema {
     let mut params = std::collections::BTreeMap::new();
     params.insert(
@@ -118,10 +171,13 @@ mod tests {
     use lex_extension::wire::{AnnotationBody, LabelCtx, NodeRef, Position, Range};
     use std::path::PathBuf;
 
-    fn make_ctx(src: &str, host_origin: Option<&str>) -> LabelCtx {
+    fn make_ctx(label: &str, src: Option<&str>, host_origin: Option<&str>) -> LabelCtx {
         LabelCtx {
-            label: "lex.include".into(),
-            params: serde_json::json!({ "src": src }),
+            label: label.into(),
+            params: match src {
+                Some(s) => serde_json::json!({ "src": s }),
+                None => serde_json::json!({}),
+            },
             body: AnnotationBody::None,
             node: NodeRef {
                 kind: "annotation".into(),
@@ -134,8 +190,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn register_into_attaches_namespace_and_schema() {
+    fn fresh_registry() -> Registry {
         let mut loader = MemoryLoader::new();
         loader.insert(PathBuf::from("/root/inner.lex"), "Hello.\n");
         let registry = Registry::new();
@@ -145,7 +200,12 @@ mod tests {
             ResolveConfig::with_root(PathBuf::from("/root")),
         )
         .expect("registration ok");
+        registry
+    }
 
+    #[test]
+    fn register_into_attaches_namespace_and_schema() {
+        let registry = fresh_registry();
         assert_eq!(registry.namespace_count(), 1);
         assert!(registry.is_namespace_healthy(NAMESPACE));
         let schema = registry
@@ -163,17 +223,8 @@ mod tests {
     fn dispatch_resolve_round_trip_via_registry() {
         // End-to-end through the registry: register handler, dispatch
         // a resolve via dispatch_resolve, get back Some(WireNode).
-        let mut loader = MemoryLoader::new();
-        loader.insert(PathBuf::from("/root/inner.lex"), "Spliced paragraph.\n");
-        let registry = Registry::new();
-        register_into(
-            &registry,
-            Arc::new(loader),
-            ResolveConfig::with_root(PathBuf::from("/root")),
-        )
-        .expect("registration ok");
-
-        let ctx = make_ctx("inner.lex", Some("/root/host.lex"));
+        let registry = fresh_registry();
+        let ctx = make_ctx("lex.include", Some("inner.lex"), Some("/root/host.lex"));
         let wire = registry
             .dispatch_resolve(&ctx)
             .expect("dispatch_resolve ok")
@@ -191,21 +242,18 @@ mod tests {
 
     #[test]
     fn dispatch_resolve_load_error_surfaces_diagnostic() {
-        let loader = MemoryLoader::new();
         let registry = Registry::new();
         register_into(
             &registry,
-            Arc::new(loader),
+            Arc::new(MemoryLoader::new()),
             ResolveConfig::with_root(PathBuf::from("/root")),
         )
         .expect("registration ok");
 
-        let ctx = make_ctx("missing.lex", Some("/root/host.lex"));
+        let ctx = make_ctx("lex.include", Some("missing.lex"), Some("/root/host.lex"));
         let err = registry
             .dispatch_resolve(&ctx)
             .expect_err("registry must surface the load error");
-        // The diagnostic uses `handler.custom` for our `Custom`-coded
-        // errors — see Registry::dispatch's error mapping.
         assert_eq!(err.code.as_deref(), Some("handler.custom"));
         assert!(
             err.message.contains("not found"),
@@ -234,5 +282,113 @@ mod tests {
             ),
             "second register_into must error: {second:?}"
         );
+    }
+
+    #[test]
+    fn metadata_schemas_are_registered() {
+        let registry = fresh_registry();
+        for label in metadata::METADATA_LABELS {
+            let schema = registry
+                .schema_for(label)
+                .unwrap_or_else(|| panic!("schema_for({label}) must be Some"));
+            assert_eq!(schema.label, *label);
+            assert_eq!(schema.attaches_to, vec!["document".to_string()]);
+            assert!(!schema.verbatim_label);
+        }
+    }
+
+    #[test]
+    fn tabular_table_schema_is_registered() {
+        let registry = fresh_registry();
+        let schema = registry
+            .schema_for(tabular::LEX_TABULAR_TABLE)
+            .expect("lex.tabular.table schema must be registered");
+        assert!(schema.verbatim_label);
+        assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+    }
+
+    #[test]
+    fn media_schemas_are_registered() {
+        let registry = fresh_registry();
+        for label in [
+            media::LEX_MEDIA_IMAGE,
+            media::LEX_MEDIA_VIDEO,
+            media::LEX_MEDIA_AUDIO,
+        ] {
+            let schema = registry
+                .schema_for(label)
+                .unwrap_or_else(|| panic!("schema_for({label}) must be Some"));
+            assert!(schema.verbatim_label);
+            assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+            assert!(
+                schema
+                    .params
+                    .get("src")
+                    .map(|p| p.required)
+                    .unwrap_or(false),
+                "{label} must require src"
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_resolve_for_new_schemas_returns_none_in_phase_1() {
+        // Phase 1 contract: schemas register but don't intercept.
+        // Dispatch must succeed (no panic, no error) and return None
+        // so the legacy IR paths continue to own the work until
+        // Phase 3 retires them.
+        let registry = fresh_registry();
+        let labels: Vec<&str> = metadata::METADATA_LABELS
+            .iter()
+            .copied()
+            .chain(std::iter::once(tabular::LEX_TABULAR_TABLE))
+            .chain([
+                media::LEX_MEDIA_IMAGE,
+                media::LEX_MEDIA_VIDEO,
+                media::LEX_MEDIA_AUDIO,
+            ])
+            .collect();
+        for label in labels {
+            let ctx = make_ctx(label, None, None);
+            let result = registry
+                .dispatch_resolve(&ctx)
+                .unwrap_or_else(|e| panic!("dispatch_resolve({label}) errored: {e:?}"));
+            assert!(
+                result.is_none(),
+                "dispatch_resolve({label}) must return None in Phase 1; got Some(...)"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_count_is_one_namespace_with_thirteen_labels() {
+        let registry = fresh_registry();
+        assert_eq!(
+            registry.namespace_count(),
+            1,
+            "all built-ins share the single `lex` namespace"
+        );
+        // 1 include + 8 metadata + 1 tabular + 3 media = 13.
+        let expected_labels = [
+            "lex.include",
+            "lex.metadata.title",
+            "lex.metadata.author",
+            "lex.metadata.date",
+            "lex.metadata.tags",
+            "lex.metadata.category",
+            "lex.metadata.template",
+            "lex.metadata.publishing-date",
+            "lex.metadata.front-matter",
+            "lex.tabular.table",
+            "lex.media.image",
+            "lex.media.video",
+            "lex.media.audio",
+        ];
+        for label in expected_labels {
+            assert!(
+                registry.schema_for(label).is_some(),
+                "expected label {label} to be registered"
+            );
+        }
     }
 }

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -10,18 +10,24 @@
 //!
 //! | Label family            | Handler                | Status                                |
 //! |-------------------------|------------------------|---------------------------------------|
-//! | `lex.include`           | [`LexIncludeHandler`]  | Registrable; resolve pass still runs  |
+//! | `lex.include`           | [`LexIncludeHandler`]  | Registrable; resolve pass runs        |
 //! |                         |                        | through the legacy inline path until  |
 //! |                         |                        | PR 3d (#533).                         |
-//! | `lex.metadata.*` (×8)   | [`LexBuiltinsHandler`] | Phase 1 of #570 — schemas only.       |
+//! | `lex.metadata.*` (×8)   | [`LexBuiltinsHandler`] | Schemas registered (#570 Phase 1).    |
 //! |                         |                        | Legacy frontmatter promotion in       |
 //! |                         |                        | `lex-babel/src/ir/from_lex.rs` still  |
-//! |                         |                        | owns the IR work.                     |
-//! | `lex.tabular.table`     | [`LexBuiltinsHandler`] | Phase 1 of #570 — schema only.        |
-//! |                         |                        | Legacy `VerbatimRegistry::TableHandler` |
-//! |                         |                        | still parses pipe-tables.             |
-//! | `lex.media.{image,…}`   | [`LexBuiltinsHandler`] | Phase 1 of #570 — schemas only.       |
-//! |                         |                        | Legacy `VerbatimRegistry::Image/…`    |
+//! |                         |                        | owns the IR work; on_format returns   |
+//! |                         |                        | None for this family in Phase 4b.     |
+//! | `lex.tabular.table`     | [`LexBuiltinsHandler`] | Schema registered (#570 Phase 1) +    |
+//! |                         |                        | `on_format` implemented (#570 Phase   |
+//! |                         |                        | 4b). The legacy `VerbatimRegistry::`  |
+//! |                         |                        | `TableHandler` still parses pipe-     |
+//! |                         |                        | tables on the from_lex direction; the |
+//! |                         |                        | to_lex production wiring lands in a   |
+//! |                         |                        | Phase 4b follow-up.                   |
+//! | `lex.media.{image,…}`   | [`LexBuiltinsHandler`] | Same shape as `lex.tabular.table`:    |
+//! |                         |                        | schemas + on_format implemented;      |
+//! |                         |                        | legacy `VerbatimRegistry::Image/…`    |
 //! |                         |                        | handlers still build the IR nodes.    |
 //!
 //! The single `lex` namespace is shared by every built-in label; the
@@ -60,11 +66,16 @@ pub const NAMESPACE: &str = "lex";
 /// composite shape lets every `lex.*` built-in live under a single
 /// namespace registration while keeping per-label logic isolated.
 ///
-/// Today the only sub-handler with a non-stub implementation is
-/// [`LexIncludeHandler`]; the `lex.metadata.*`, `lex.tabular.*`, and
-/// `lex.media.*` labels register their schemas but their hooks return
-/// the trait's default `Ok(None)` until Phase 3 of #570 moves the
-/// legacy IR transformations into the registry path.
+/// Implementations across hooks:
+///
+/// - `on_resolve`: only [`LexIncludeHandler`] (#532) — the
+///   `lex.tabular.*` / `lex.media.*` / `lex.metadata.*` labels return
+///   the default `Ok(None)` because the legacy `from_lex` direction
+///   in `lex-babel` already hydrates the AST.
+/// - `on_format`: implemented for `lex.tabular.table` and
+///   `lex.media.{image,video,audio}` (#570 Phase 4b). `lex.include` is
+///   resolve-only and falls back; `lex.metadata.*` flows through the
+///   render hook + legacy frontmatter promotion.
 pub struct LexBuiltinsHandler {
     include: LexIncludeHandler,
 }
@@ -114,11 +125,14 @@ impl LexHandler for LexBuiltinsHandler {
 /// (`lex.tabular.table`, `lex.media.{image,video,audio}`). Each one
 /// has the same wire shape: a `WireNode::Verbatim` whose `body_text`
 /// carries the verbatim source (pipe-table syntax, alt-text fallback,
-/// etc.) and whose `params` mirror what `FormatCtx::params` already
-/// holds. We accept either the verbatim's own params or the explicit
-/// `ctx.params` — the latter wins when both are present, mirroring the
-/// `FormatCtx::params` documentation that those are the originating
-/// label parameters the host wants preserved.
+/// etc.).
+///
+/// The handler uses `ctx.params` directly — the wire spec
+/// (`lex-extension-wire.lex` §4.8) treats `FormatCtx::params` as the
+/// authoritative originating parameters, with `WireNode::Verbatim.params`
+/// being a wire-internal copy of the same data. A well-formed host
+/// fills both with the same `(key, value)` pairs; in the
+/// hypothetical case where they diverge, `ctx.params` wins.
 fn verbatim_label_on_format(ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, HandlerError> {
     let body = match &ctx.node {
         WireNode::Verbatim { body_text, .. } => body_text.clone(),

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -2,7 +2,7 @@
 //!
 //! Today the family has a single member: `lex.tabular.table`, the
 //! registry-shaped replacement for the legacy `doc.table` handler in
-//! [`crate::common::verbatim::table`](../../../../lex-babel/src/common/verbatim/table.rs).
+//! `lex-babel` (`crates/lex-babel/src/common/verbatim/table.rs`).
 //! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
 //! multi-phase migration.
 //!

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -26,8 +26,9 @@ pub fn lex_tabular_table_schema() -> Schema {
         label: LEX_TABULAR_TABLE.into(),
         description: Some(
             "Pipe-table verbatim. The verbatim body uses markdown-style pipe-table syntax \
-             (`| col1 | col2 |\\n|------|------|\\n| ... |`) which the resolve hook \
-             parses into a typed table AST node."
+             (`| col1 | col2 |\\n|------|------|\\n| ... |`); the legacy lex-babel path \
+             parses it into a typed table AST node today, and Phase 3b of #570 moves that \
+             work into the schema's `on_resolve` hook."
                 .into(),
         ),
         params: BTreeMap::new(),
@@ -36,9 +37,7 @@ pub fn lex_tabular_table_schema() -> Schema {
             kind: BodyKind::Text,
             presence: BodyPresence::Required,
             description: Some(
-                "Pipe-table source: header row, alignment row, then one row per body \
-                 line. Empty body is rejected at resolve time."
-                    .into(),
+                "Pipe-table source: header row, alignment row, then one row per body line.".into(),
             ),
         },
         verbatim_label: true,

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -1,0 +1,88 @@
+//! Schema for the `lex.tabular.*` family of verbatim labels.
+//!
+//! Today the family has a single member: `lex.tabular.table`, the
+//! registry-shaped replacement for the legacy `doc.table` handler in
+//! [`crate::common::verbatim::table`](../../../../lex-babel/src/common/verbatim/table.rs).
+//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
+//! multi-phase migration.
+//!
+//! # Phase 1 status
+//!
+//! Schema only — no `on_resolve` body yet. The legacy `VerbatimRegistry`
+//! still parses pipe-table content into a typed `DocNode::Table`.
+//! Phase 2's parse-time auto-rewrite retargets `:: doc.table ::` at
+//! this label; Phase 3 deletes the legacy lookup and moves the
+//! parsing logic into the handler's `on_resolve`.
+
+use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use std::collections::BTreeMap;
+
+/// Fully-qualified label for the canonical tabular table.
+pub const LEX_TABULAR_TABLE: &str = "lex.tabular.table";
+
+pub fn lex_tabular_table_schema() -> Schema {
+    Schema {
+        schema_version: 1,
+        label: LEX_TABULAR_TABLE.into(),
+        description: Some(
+            "Pipe-table verbatim. The verbatim body uses markdown-style pipe-table syntax \
+             (`| col1 | col2 |\\n|------|------|\\n| ... |`) which the resolve hook \
+             parses into a typed table AST node."
+                .into(),
+        ),
+        params: BTreeMap::new(),
+        attaches_to: vec!["verbatim".into()],
+        body: BodyShape {
+            kind: BodyKind::Text,
+            presence: BodyPresence::Required,
+            description: Some(
+                "Pipe-table source: header row, alignment row, then one row per body \
+                 line. Empty body is rejected at resolve time."
+                    .into(),
+            ),
+        },
+        verbatim_label: true,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+/// All `lex.tabular.*` schemas, in declaration order.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![lex_tabular_table_schema()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tabular_table_is_a_verbatim_label() {
+        let schema = lex_tabular_table_schema();
+        assert_eq!(schema.label, LEX_TABULAR_TABLE);
+        assert!(
+            schema.verbatim_label,
+            "tabular.table must be a verbatim label"
+        );
+        assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+        assert_eq!(schema.body.kind, BodyKind::Text);
+        assert_eq!(schema.body.presence, BodyPresence::Required);
+    }
+
+    #[test]
+    fn tabular_schema_declares_no_hooks_in_phase_1() {
+        let schema = lex_tabular_table_schema();
+        assert!(!schema.hooks.resolve);
+        assert!(!schema.hooks.validate);
+        assert!(schema.hooks.render.is_empty());
+    }
+
+    #[test]
+    fn tabular_schema_round_trips_through_json() {
+        let schema = lex_tabular_table_schema();
+        let json = serde_json::to_string(&schema).expect("serialize");
+        let back: Schema = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, schema);
+    }
+}

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -135,15 +135,13 @@ pub static STRING_TO_AST: Lazy<AstTransform> = Lazy::new(|| {
         // Attach annotations as metadata
         doc = AttachAnnotations::new().run(doc)?;
 
-        // Note: `NormalizeLabels` (the #570 Phase 2 label-rewrite stage)
-        // is intentionally NOT inserted here yet. The stage is shipped
-        // as a module so the codec, tests, and a future Phase 3 wiring
-        // can use it; the legacy whitelist in
-        // `lex-babel/src/ir/from_lex.rs` and the `VerbatimRegistry` in
-        // `lex-babel/src/common/verbatim` still match on the bare label
-        // forms (`title`, `doc.table`, …), so activating the rewrite
-        // here would break the legacy IR path. Phase 3a flips the
-        // legacy paths to canonical names atomically with this wire-up.
+        // Normalize legacy labels to their canonical `lex.*` form
+        // (#570 Phase 3b). The legacy whitelists in
+        // `lex-babel/src/ir/from_lex.rs` and the `VerbatimRegistry`
+        // in `lex-babel/src/common/verbatim` have been updated to
+        // match the canonical names, so this rewrite is now safe to
+        // activate.
+        doc = crate::lex::assembling::stages::NormalizeLabels::new().run(doc)?;
 
         // Apply table config from :: table :: annotations (header, align)
         doc = crate::lex::assembling::stages::ApplyTableConfig::new().run(doc)?;

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -135,6 +135,16 @@ pub static STRING_TO_AST: Lazy<AstTransform> = Lazy::new(|| {
         // Attach annotations as metadata
         doc = AttachAnnotations::new().run(doc)?;
 
+        // Note: `NormalizeLabels` (the #570 Phase 2 label-rewrite stage)
+        // is intentionally NOT inserted here yet. The stage is shipped
+        // as a module so the codec, tests, and a future Phase 3 wiring
+        // can use it; the legacy whitelist in
+        // `lex-babel/src/ir/from_lex.rs` and the `VerbatimRegistry` in
+        // `lex-babel/src/common/verbatim` still match on the bare label
+        // forms (`title`, `doc.table`, …), so activating the rewrite
+        // here would break the legacy IR path. Phase 3a flips the
+        // legacy paths to canonical names atomically with this wire-up.
+
         // Apply table config from :: table :: annotations (header, align)
         doc = crate::lex::assembling::stages::ApplyTableConfig::new().run(doc)?;
 

--- a/crates/lex-extension-host/src/registry.rs
+++ b/crates/lex-extension-host/src/registry.rs
@@ -21,8 +21,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::RwLock;
 
 use lex_extension::{
-    CodeAction, Completion, Diagnostic, DiagnosticSeverity, Format, HandlerError, Hover, LabelCtx,
-    LexHandler, Range, RenderOut, Schema, WireNode,
+    CodeAction, Completion, Diagnostic, DiagnosticSeverity, Format, FormatCtx, HandlerError, Hover,
+    LabelCtx, LexAnnotationOut, LexHandler, Range, RenderOut, Schema, WireNode,
 };
 
 /// The namespace registry.
@@ -287,6 +287,43 @@ impl Registry {
             Ok(Some(items)) => items,
             Ok(None) => Vec::new(),
             Err(_) => Vec::new(),
+        }
+    }
+
+    /// Dispatch [`LexHandler::on_format`] — the reverse hook
+    /// introduced by #570 Phase 4 (see
+    /// `comms/specs/proposals/lex-extension-wire.lex` §4.8).
+    ///
+    /// Returns `Ok(Some(LexAnnotationOut))` when a handler produced
+    /// structured output, `Ok(None)` when no handler is registered for
+    /// the label / the handler returned its default fallback / the
+    /// namespace is unhealthy, and `Err(diag)` when the handler errored
+    /// or panicked. The caller decides whether to retry through a
+    /// built-in formatter when `Ok(None)` comes back — that's the
+    /// "host falls back" path documented in the spec.
+    pub fn dispatch_format(&self, ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, Diagnostic> {
+        // The shared `dispatch` helper expects a `LabelCtx`; the
+        // format hook uses `FormatCtx`. The only fields `dispatch`
+        // reads off `LabelCtx` are `.label` (to route to the right
+        // namespace) and `.node.range` (for diagnostic attribution
+        // when something errors). Synthesise a minimal `LabelCtx` from
+        // the `FormatCtx` so this path can reuse the panic-isolation
+        // and namespace-health bookkeeping the other hooks already
+        // share.
+        let synthetic = LabelCtx {
+            label: ctx.label.clone(),
+            params: serde_json::Value::Null,
+            body: lex_extension::AnnotationBody::None,
+            node: lex_extension::NodeRef {
+                kind: "format".into(),
+                range: ctx.node.range(),
+                origin: None,
+            },
+        };
+        match self.dispatch(&synthetic, |h| h.on_format(ctx)) {
+            Ok(Some(out)) => Ok(out),
+            Ok(None) => Ok(None),
+            Err(diag) => Err(diag),
         }
     }
 
@@ -731,6 +768,109 @@ mod tests {
         assert!(
             panicking_threads >= 1,
             "at least one thread should have observed the panic before namespace was disabled"
+        );
+    }
+
+    #[test]
+    fn dispatch_format_routes_to_handler_and_returns_annotation() {
+        // #570 Phase 4a: a handler that implements `on_format` for a
+        // registered label produces structured output via
+        // `Registry::dispatch_format`.
+        use lex_extension::wire::{FormatCtx, LexAnnotationOut};
+
+        struct FormatHandler;
+        impl LexHandler for FormatHandler {
+            fn on_format(&self, ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, HandlerError> {
+                Ok(Some(LexAnnotationOut {
+                    label: ctx.label.clone(),
+                    params: ctx.params.clone(),
+                    body: "formatted body".into(),
+                    verbatim_label: true,
+                }))
+            }
+        }
+
+        let r = Registry::new();
+        r.register_namespace("acme", vec![schema("acme.thing")], Box::new(FormatHandler))
+            .expect("register ok");
+
+        let fctx = FormatCtx {
+            label: "acme.thing".into(),
+            params: vec![("size".into(), "large".into())],
+            node: WireNode::Paragraph {
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+                inlines: vec![],
+            },
+            format_options: None,
+        };
+
+        let out = r
+            .dispatch_format(&fctx)
+            .expect("dispatch_format ok")
+            .expect("handler returned Some");
+        assert_eq!(out.label, "acme.thing");
+        assert_eq!(out.params, vec![("size".into(), "large".into())]);
+        assert_eq!(out.body, "formatted body");
+        assert!(out.verbatim_label);
+    }
+
+    #[test]
+    fn dispatch_format_returns_none_for_unregistered_label() {
+        // Unrouted labels yield `Ok(None)` — same fallback signal as
+        // every other dispatch path, no error.
+        use lex_extension::wire::FormatCtx;
+
+        let r = Registry::new();
+        let fctx = FormatCtx {
+            label: "nobody.knows".into(),
+            params: vec![],
+            node: WireNode::Paragraph {
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+                inlines: vec![],
+            },
+            format_options: None,
+        };
+        let out = r.dispatch_format(&fctx).expect("dispatch_format ok");
+        assert!(out.is_none(), "unrouted label must fall back");
+    }
+
+    #[test]
+    fn dispatch_format_returns_none_when_handler_falls_back() {
+        // A handler that returns `Ok(None)` from `on_format` (the
+        // default impl, or an explicit decision) makes
+        // `dispatch_format` surface `Ok(None)` so the caller can fall
+        // back to the host's built-in formatter.
+        use lex_extension::wire::FormatCtx;
+
+        let r = Registry::new();
+        r.register_namespace("acme", vec![schema("acme.silent")], Box::new(NoOp))
+            .expect("register ok");
+
+        let fctx = FormatCtx {
+            label: "acme.silent".into(),
+            params: vec![],
+            node: WireNode::Paragraph {
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+                inlines: vec![],
+            },
+            format_options: None,
+        };
+        let out = r.dispatch_format(&fctx).expect("dispatch_format ok");
+        assert!(
+            out.is_none(),
+            "NoOp handler must let `dispatch_format` surface None"
         );
     }
 }

--- a/crates/lex-extension/src/handler.rs
+++ b/crates/lex-extension/src/handler.rs
@@ -70,8 +70,17 @@ pub trait LexHandler: Send + Sync {
     /// owned by this handler's namespace — the inverse of
     /// [`on_resolve`](Self::on_resolve), and the reverse-direction
     /// sibling of [`on_render`](Self::on_render) for the Lex target
-    /// format. Fires during `lexd format`, `to_lex`, and any
-    /// library-driven IR→Lex pass.
+    /// format.
+    ///
+    /// Phase 4a of #570 ships this trait method, the `FormatCtx` /
+    /// `LexAnnotationOut` wire types, and the
+    /// [`Registry::dispatch_format`](`lex_extension_host::registry::Registry::dispatch_format`)
+    /// entry point. Production call sites in `to_lex.rs` and `lexd
+    /// format` get wired in Phase 4b — until that lands, the hook is
+    /// invocable through the registry (tests + library embedders use
+    /// it) but no built-in pass dispatches through it yet, so a
+    /// handler implementing `on_format` will be exercised by direct
+    /// `Registry::dispatch_format` callers only.
     ///
     /// `Ok(None)` lets the host fall back to its built-in formatter
     /// for the underlying node kind — there is no separate

--- a/crates/lex-extension/src/handler.rs
+++ b/crates/lex-extension/src/handler.rs
@@ -12,7 +12,8 @@
 //! [`LexHandler::on_label`] returns `()` because it is a notification.
 
 use crate::wire::{
-    CodeAction, Completion, Diagnostic, Format, Hover, LabelCtx, RenderOut, WireNode,
+    CodeAction, Completion, Diagnostic, Format, FormatCtx, Hover, LabelCtx, LexAnnotationOut,
+    RenderOut, WireNode,
 };
 
 /// The hook-event interface a Lex extension implements.
@@ -63,6 +64,21 @@ pub trait LexHandler: Send + Sync {
     /// `textDocument/codeAction`.
     fn on_code_action(&self, _ctx: &LabelCtx) -> Result<Vec<CodeAction>, HandlerError> {
         Ok(Vec::new())
+    }
+
+    /// Returns the Lex-source representation of a typed AST subtree
+    /// owned by this handler's namespace — the inverse of
+    /// [`on_resolve`](Self::on_resolve), and the reverse-direction
+    /// sibling of [`on_render`](Self::on_render) for the Lex target
+    /// format. Fires during `lexd format`, `to_lex`, and any
+    /// library-driven IR→Lex pass.
+    ///
+    /// `Ok(None)` lets the host fall back to its built-in formatter
+    /// for the underlying node kind — there is no separate
+    /// "not handled" error code. See `comms/specs/proposals/lex-extension-wire.lex`
+    /// §4.8 for the full wire contract.
+    fn on_format(&self, _ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, HandlerError> {
+        Ok(None)
     }
 }
 
@@ -164,6 +180,21 @@ mod tests {
         assert!(h.on_hover(&c).unwrap().is_none());
         assert!(h.on_completion(&c).unwrap().is_empty());
         assert!(h.on_code_action(&c).unwrap().is_empty());
+        // on_format added in #570 Phase 4a — same Ok(None) default.
+        let format_ctx = crate::wire::FormatCtx {
+            label: "test.label".into(),
+            params: vec![],
+            node: WireNode::Paragraph {
+                range: Range {
+                    start: Position(0, 0),
+                    end: Position(0, 0),
+                },
+                origin: None,
+                inlines: vec![],
+            },
+            format_options: None,
+        };
+        assert!(h.on_format(&format_ctx).unwrap().is_none());
     }
 
     #[test]

--- a/crates/lex-extension/src/handler.rs
+++ b/crates/lex-extension/src/handler.rs
@@ -75,11 +75,13 @@ pub trait LexHandler: Send + Sync {
     /// Phase 4a of #570 ships this trait method, the `FormatCtx` /
     /// `LexAnnotationOut` wire types, and the
     /// [`Registry::dispatch_format`](`lex_extension_host::registry::Registry::dispatch_format`)
-    /// entry point. Production call sites in `to_lex.rs` and `lexd
-    /// format` get wired in Phase 4b — until that lands, the hook is
-    /// invocable through the registry (tests + library embedders use
-    /// it) but no built-in pass dispatches through it yet, so a
-    /// handler implementing `on_format` will be exercised by direct
+    /// entry point. Phase 4b implements `on_format` in the built-in
+    /// `lex.tabular.*` / `lex.media.*` handlers. Production call
+    /// sites in `to_lex.rs` and `lexd format` get wired in a Phase 4b
+    /// follow-up — until that lands, the hook is invocable through
+    /// the registry (tests + library embedders use it) but no
+    /// built-in pass dispatches through it yet, so a handler
+    /// implementing `on_format` will be exercised by direct
     /// `Registry::dispatch_format` callers only.
     ///
     /// `Ok(None)` lets the host fall back to its built-in formatter

--- a/crates/lex-extension/src/lib.rs
+++ b/crates/lex-extension/src/lib.rs
@@ -59,9 +59,9 @@ pub mod wire;
 pub use handler::{HandlerError, LexHandler};
 pub use wire::{
     AnnotationBody, CodeAction, CodeActionKind, Completion, CompletionKind, Diagnostic,
-    DiagnosticSeverity, Format, HostNodeKind, Hover, HoverFormat, LabelCtx, NodeRef, Position,
-    Range, RefKind, RelatedDiagnostic, RenderOut, TextEdit, WireFootnote, WireInline, WireListItem,
-    WireNode, WireRow, WireTableCell,
+    DiagnosticSeverity, Format, FormatCtx, HostNodeKind, Hover, HoverFormat, LabelCtx,
+    LexAnnotationOut, NodeRef, Position, Range, RefKind, RelatedDiagnostic, RenderOut, TextEdit,
+    WireFootnote, WireInline, WireListItem, WireNode, WireRow, WireTableCell,
 };
 
 pub use schema::{

--- a/crates/lex-extension/src/wire/ast.rs
+++ b/crates/lex-extension/src/wire/ast.rs
@@ -120,6 +120,26 @@ pub enum WireNode {
     },
 }
 
+impl WireNode {
+    /// The byte range this node spans in its origin source. Useful for
+    /// diagnostic attribution when the host only has the wire node
+    /// (e.g., the `on_format` dispatch path doesn't carry a separate
+    /// `NodeRef`).
+    pub fn range(&self) -> Range {
+        match self {
+            Self::Document { range, .. }
+            | Self::Session { range, .. }
+            | Self::Definition { range, .. }
+            | Self::Paragraph { range, .. }
+            | Self::List { range, .. }
+            | Self::Verbatim { range, .. }
+            | Self::Table { range, .. }
+            | Self::Annotation { range, .. }
+            | Self::Blank { range, .. } => *range,
+        }
+    }
+}
+
 /// One item inside a [`WireNode::List`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WireListItem {

--- a/crates/lex-extension/src/wire/format_out.rs
+++ b/crates/lex-extension/src/wire/format_out.rs
@@ -68,8 +68,10 @@ pub struct LexAnnotationOut {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub body: String,
     /// `true` for verbatim closing form, `false` for inline annotation
-    /// form. Defaults to `false` on the wire.
-    #[serde(default)]
+    /// form. Defaults to `false` on the wire — omitted entirely from
+    /// the serialized JSON when `false` so marker-form annotations get
+    /// the compact `{ "label": "..." }` shape.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub verbatim_label: bool,
 }
 
@@ -136,8 +138,8 @@ mod tests {
     #[test]
     fn lex_annotation_out_minimal_form_omits_defaults() {
         // Marker-form annotation: empty params, empty body, not verbatim.
-        // The serialized form should skip those fields per the
-        // `skip_serializing_if` attributes.
+        // The serialized form must skip every default field so the
+        // wire shape collapses to `{ "label": "..." }`.
         let a = LexAnnotationOut {
             label: "lex.metadata.author".into(),
             params: vec![],
@@ -145,10 +147,12 @@ mod tests {
             verbatim_label: false,
         };
         let s = serde_json::to_string(&a).unwrap();
-        assert!(!s.contains("params"));
-        assert!(!s.contains("body"));
-        // verbatim_label is bool, not Option, so #[serde(default)] alone
-        // doesn't skip — but the default-false case still round-trips.
+        assert!(!s.contains("params"), "params must be omitted: {s}");
+        assert!(!s.contains("body"), "body must be omitted: {s}");
+        assert!(
+            !s.contains("verbatim_label"),
+            "verbatim_label must be omitted when false: {s}"
+        );
         let back: LexAnnotationOut = serde_json::from_str(&s).unwrap();
         assert_eq!(back, a);
     }

--- a/crates/lex-extension/src/wire/format_out.rs
+++ b/crates/lex-extension/src/wire/format_out.rs
@@ -1,0 +1,167 @@
+//! Wire types for the `on_format` reverse hook (#570 Phase 4).
+//!
+//! See the spec at
+//! `comms/specs/proposals/lex-extension-wire.lex` §4.8 (`on_format`)
+//! for the full contract. The hook is the inverse of `on_resolve`:
+//! given a typed AST subtree previously produced by `on_resolve`, the
+//! handler returns the Lex-source representation as a [`LexAnnotationOut`].
+//!
+//! Two types live here:
+//!
+//! - [`FormatCtx`] — the request payload. Mirrors [`LabelCtx`] but
+//!   carries the *typed* `WireNode` the handler must serialize back,
+//!   along with the originating label/params so a namespace with
+//!   several labels driving the same node kind can route on the label.
+//! - [`LexAnnotationOut`] — the structured response. Describes the
+//!   label, parameters, body, and verbatim-flag the host needs to
+//!   emit Lex source. Returning `None` (i.e. result `{ "annotation":
+//!   null }`) lets the host fall back to its built-in formatter.
+//!
+//! [`LabelCtx`]: super::LabelCtx
+
+use serde::{Deserialize, Serialize};
+
+use super::ast::WireNode;
+
+/// Request payload for [`LexHandler::on_format`](crate::handler::LexHandler::on_format).
+///
+/// The handler receives the originating `label` and `params` (lifted
+/// from the AST node that the prior `on_resolve` pass produced this
+/// typed `node` from), the typed `WireNode` to serialize, and an
+/// optional `format_options` object whose shape is namespace-defined.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FormatCtx {
+    /// Fully-qualified label of the schema that owns this format pass,
+    /// e.g. `"lex.tabular.table"`.
+    pub label: String,
+    /// Originating parameters, in the (key, value) order the host
+    /// deserialized them. Quoting and escaping decisions are left to
+    /// the host on emission.
+    pub params: Vec<(String, String)>,
+    /// The typed wire subtree to serialize back as Lex source.
+    pub node: WireNode,
+    /// Optional, namespace-defined options object. Hosts pass `None`
+    /// when no options are configured; the wire form is
+    /// `"format_options": null` (omitted from the JSON when absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format_options: Option<serde_json::Value>,
+}
+
+/// Response payload from [`LexHandler::on_format`](crate::handler::LexHandler::on_format).
+///
+/// Returned wrapped in `Option`: `Some(LexAnnotationOut)` carries the
+/// structured serialization; `None` lets the host fall back to its
+/// built-in formatter for the underlying node kind.
+///
+/// `verbatim_label: true` selects the verbatim closing form
+/// (subject-line content + `:: label ::` closer); `false` selects the
+/// inline annotation form (`:: label :: text` or `:: label ::` plus
+/// indented content).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LexAnnotationOut {
+    /// Canonical fully-qualified label, e.g. `"lex.tabular.table"`.
+    pub label: String,
+    /// `(key, value)` pairs emitted in `key=value` order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub params: Vec<(String, String)>,
+    /// Verbatim or inline text body. Empty for marker-form annotations.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub body: String,
+    /// `true` for verbatim closing form, `false` for inline annotation
+    /// form. Defaults to `false` on the wire.
+    #[serde(default)]
+    pub verbatim_label: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::range::{Position, Range};
+
+    fn r(s_l: u32, s_c: u32, e_l: u32, e_c: u32) -> Range {
+        Range::new(Position::new(s_l, s_c), Position::new(e_l, e_c))
+    }
+
+    fn sample_node() -> WireNode {
+        WireNode::Paragraph {
+            range: r(0, 0, 0, 5),
+            origin: None,
+            inlines: vec![],
+        }
+    }
+
+    #[test]
+    fn format_ctx_round_trips_through_json() {
+        let c = FormatCtx {
+            label: "lex.tabular.table".into(),
+            params: vec![("align".into(), "lcr".into())],
+            node: sample_node(),
+            format_options: Some(serde_json::json!({ "max_width": 80 })),
+        };
+        let s = serde_json::to_string(&c).unwrap();
+        let back: FormatCtx = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn format_ctx_omits_options_when_none() {
+        let c = FormatCtx {
+            label: "lex.media.image".into(),
+            params: vec![("src".into(), "x.png".into())],
+            node: sample_node(),
+            format_options: None,
+        };
+        let s = serde_json::to_string(&c).unwrap();
+        assert!(
+            !s.contains("format_options"),
+            "format_options must be omitted when None, got: {s}"
+        );
+        let back: FormatCtx = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn lex_annotation_out_round_trips_through_json() {
+        let a = LexAnnotationOut {
+            label: "lex.tabular.table".into(),
+            params: vec![("header".into(), "1".into())],
+            body: "| a | b |\n|---|---|\n| 1 | 2 |".into(),
+            verbatim_label: true,
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        let back: LexAnnotationOut = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn lex_annotation_out_minimal_form_omits_defaults() {
+        // Marker-form annotation: empty params, empty body, not verbatim.
+        // The serialized form should skip those fields per the
+        // `skip_serializing_if` attributes.
+        let a = LexAnnotationOut {
+            label: "lex.metadata.author".into(),
+            params: vec![],
+            body: String::new(),
+            verbatim_label: false,
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        assert!(!s.contains("params"));
+        assert!(!s.contains("body"));
+        // verbatim_label is bool, not Option, so #[serde(default)] alone
+        // doesn't skip — but the default-false case still round-trips.
+        let back: LexAnnotationOut = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn lex_annotation_out_deserializes_with_omitted_defaults() {
+        // A handler that returns only `{ "label": "..." }` must be
+        // accepted on the wire as a marker-form annotation.
+        let json = r#"{"label":"lex.metadata.date"}"#;
+        let a: LexAnnotationOut = serde_json::from_str(json).unwrap();
+        assert_eq!(a.label, "lex.metadata.date");
+        assert!(a.params.is_empty());
+        assert!(a.body.is_empty());
+        assert!(!a.verbatim_label);
+    }
+}

--- a/crates/lex-extension/src/wire/mod.rs
+++ b/crates/lex-extension/src/wire/mod.rs
@@ -9,6 +9,7 @@
 mod ast;
 mod ctx;
 mod format;
+mod format_out;
 mod host_node_kind;
 mod inline;
 mod payload;
@@ -17,6 +18,7 @@ mod range;
 pub use ast::{WireFootnote, WireListItem, WireNode, WireRow, WireTableCell};
 pub use ctx::{AnnotationBody, LabelCtx, NodeRef};
 pub use format::Format;
+pub use format_out::{FormatCtx, LexAnnotationOut};
 pub use host_node_kind::HostNodeKind;
 pub use inline::{RefKind, WireInline};
 pub use payload::{


### PR DESCRIPTION
## Summary

Phase 4b of the label-semantics refactor tracked in #570. Adds production `on_format` implementations to the built-in `LexBuiltinsHandler` for the four canonical verbatim labels.

Pairs with PR #579's `on_format` trait surface + `Registry::dispatch_format` infrastructure: third-party extensions can now copy this pattern to round-trip their own structural transformations.

## What lands

`LexBuiltinsHandler::on_format` matches on `ctx.label`:

| Label | Output |
|---|---|
| `lex.tabular.table` | `LexAnnotationOut { label, params, body: <pipe-table source>, verbatim_label: true }` |
| `lex.media.image` | `LexAnnotationOut { label, params: src/alt/title pairs, body: "", verbatim_label: true }` |
| `lex.media.video` | same shape |
| `lex.media.audio` | same shape |
| `lex.include` | `Ok(None)` — resolve-only direction |
| `lex.metadata.*` | `Ok(None)` — handled by render hook + legacy frontmatter promotion |
| everything else | `Ok(None)` |

A shared `verbatim_label_on_format` helper does the unwrap: receives the `WireNode::Verbatim` (the natural wire shape for these labels after #570 Phase 3b), lifts `body_text` and `ctx.params` into a `LexAnnotationOut`. Non-verbatim wire nodes (e.g. a future typed `Table` kind, or a caller passing a `Paragraph` by mistake) return `Ok(None)` so the host falls back to its default formatter.

## Tests (6 new + 33 existing in `lex::builtins::tests`)

- `dispatch_format_for_lex_tabular_table_returns_verbatim_annotation`
- `dispatch_format_for_lex_media_image_returns_verbatim_annotation`
- `dispatch_format_for_lex_media_video_and_audio_return_verbatim_annotation`
- `dispatch_format_for_lex_include_returns_none`
- `dispatch_format_for_lex_metadata_returns_none`
- `dispatch_format_with_non_verbatim_node_returns_none`

Plus a `format_ctx_verbatim` test helper that keeps each test to a single line of meaningful setup.

## Deliberately deferred to a Phase 4b follow-up

Wiring `Registry::dispatch_format` into `to_lex.rs`'s production paths (`to_lex_table`, `to_lex_media`). Today those still construct a local `VerbatimRegistry::default_with_standard()` and pattern-match on `DocNode` variants. The flip requires plumbing an `lex_extension_host::Registry` through `to_lex_document`'s caller chain — a structural change that benefits from being its own PR.

This PR ships the **handler implementations** as the first half of Phase 4b; the second half retires the local `VerbatimRegistry` construction in favour of a registry passed in from the boot path. Anyone today can call `dispatch_format` and get correct output; the next PR makes the default `to_lex` pass use it.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo nextest run --workspace` — **2074/2074 pass**
- [x] Pre-commit hook passes end-to-end

## Stacking

Branches from `feat/refac-label/phase4a-on-format-hook` (PR #579). Targets `refac/label`.

## Roadmap

- ~~Phase 1 (#575)~~, ~~Phase 2 (#576)~~, ~~Phase 3a (#577)~~, ~~Phase 3b (#578)~~, ~~comms wire-spec (lex-fmt/comms#40)~~, ~~Phase 4a (#579)~~
- **Phase 4b (this PR)** — built-in handlers implement on_format.
- Phase 5 — hard-deprecate bare labels + `lexd migrate-labels` migration tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)