### PR TITLE
refactor: retire legacy IR paths post-#570 (registry dispatch + frontmatter retirement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [Unreleased]
 
+### Refactored — label semantics ([#570](https://github.com/lex-fmt/lex/issues/570))
+
+Multi-phase refactor moving label-semantic decisions out of the IR layer and through the extension registry. Eight PRs (#575–#581) landed via the `refac/label` integration branch, followed by a legacy-code cleanup pass.
+
+**New built-in `lex.*` schemas** registered alongside `lex.include`:
+
+- `lex.metadata.{title, author, date, tags, category, template, publishing-date, front-matter}`
+- `lex.tabular.table`
+- `lex.media.{image, video, audio}`
+
+**New parse-time pass** (`NormalizeLabels`) rewrites bare labels to their canonical `lex.*` form during `STRING_TO_AST`. Source `:: title ::` becomes `:: lex.metadata.title ::` in the AST; source `:: doc.table ::` (verbatim) becomes `:: lex.tabular.table ::`.
+
+**New `on_format` reverse hook** in the extension wire spec (`lex-extension-wire.lex` §4.8) and the `LexHandler` trait. Given a typed AST subtree, a handler returns a `LexAnnotationOut` describing the label, parameters, body, and verbatim flag the host emits as Lex source. `Registry::dispatch_format` is the entry point. The four built-in verbatim handlers implement it.
+
+**`to_lex.rs` now dispatches through `Registry::dispatch_format`** for `lex.tabular.table` and `lex.media.{image,video,audio}` instead of pattern-matching on `DocNode` variants through the local `VerbatimRegistry`. Output now carries canonical labels (`:: lex.tabular.table ::`, not `:: doc.table ::`).
+
+**`document_annotations` field on `DocNode::Document`** is the source of truth for document-scope metadata. `nested_to_flat` synthesizes the `frontmatter` event from it at emission time — the IR no longer carries a synthetic `frontmatter` annotation in children.
+
+**New `lexd migrate-labels <path>` subcommand** for source-level migration. Default mode prints the rewritten source to stdout; `--in-place` overwrites; `--check` exits non-zero if any migrations are pending.
+
+#### Breaking changes (pre-release, documented)
+
+- **Bare labels in source are silently rewritten at parse time.** This is observable in `lexd format` output: a file containing `:: title :: My Doc` will format to `:: lex.metadata.title :: My Doc`. Use `lexd migrate-labels` for explicit batch migration.
+- **`doc.table`, `doc.image`, `doc.video`, `doc.audio` verbatim labels in `to_lex` output are now canonical:** `lex.tabular.table` / `lex.media.{image,video,audio}`.
+- **The `VerbatimRegistry::default_with_standard()` registry no longer carries `doc.*` legacy aliases.** Embedders hand-building IR `Verbatim` nodes with the legacy labels and feeding them through `from_lex_verbatim` will hit a `None` lookup. Use the canonical names.
+- **The `VerbatimHandler` trait shrunk:** `to_ir` and `convert_from_ir` methods removed. `label()` and `format_content()` remain. The IR-construction path now goes through `from_lex_verbatim` calling free helpers directly (`table::parse_pipe_table`, `media::image_from_params`, etc.); the IR→Lex path goes through `Registry::dispatch_format`.
+- **Inline `:: lex.metadata.title :: ...` in the document body is no longer promoted to document metadata.** Inline annotations stay inline. Document-scope metadata must be attached at the document level (the lex-core `Document.annotations` slot, i.e. annotations at the very top of the source before any content). This was a behavioural quirk of the legacy whitelist.
+- **`lex-babel::ir::nodes::Document` gained a `document_annotations: Vec<Annotation>` field.** Code constructing `Document` via struct-literal syntax must add `document_annotations: vec![]` (or populate as needed).
+- **`lex-babel::common::nested_to_flat`'s legacy bare-label metadata whitelist (`["author", "note", "title", ...]`) is gone.** It synthesized `lex-metadata:<label>` verbatim events; after the refactor, document metadata flows through the `frontmatter` annotation event synthesized at the document boundary instead.
+- **`lex-extension` trait `LexHandler` gained a default-impl `on_format` method.** Existing impls compile unchanged; new method is non-breaking per the wire-spec versioning policy.
+
 ## [0.12.0] - 2026-05-12
 
 

--- a/crates/lex-babel/src/common/flat_to_nested.rs
+++ b/crates/lex-babel/src/common/flat_to_nested.rs
@@ -1304,17 +1304,12 @@ mod tests {
     }
 
     #[test]
-    fn document_annotations_event_stream_is_one_way_in_phase_3a() {
-        // Phase 3a of #570 is *additive*. `tree_to_events` deliberately
-        // does not emit `document_annotations`, and `events_to_tree`
-        // initializes the slot empty. This locks the contract:
-        // anything in `document_annotations` on the IR side is lost
-        // when the document travels through the event stream, and
-        // every annotation in the event stream lands in `children` as
-        // it always has. Phase 3b adds the scope marker that lets the
-        // events stream distinguish the two — atomically with the
-        // legacy-path retirement so downstream serializers see exactly
-        // one copy.
+    fn document_annotations_synthesize_frontmatter_event() {
+        // Post-refac/label cleanup: `tree_to_events` synthesizes a
+        // single `frontmatter` annotation event from
+        // `document_annotations`. The synthesis is what downstream
+        // HTML/Markdown serializers consume; the IR no longer carries
+        // a redundant `frontmatter` annotation in children.
         use crate::ir::nodes::Annotation;
         use crate::ir::to_events::tree_to_events;
 
@@ -1326,23 +1321,29 @@ mod tests {
             })],
             document_annotations: vec![Annotation {
                 label: "lex.metadata.author".to_string(),
-                parameters: vec![("name".to_string(), "Alice".to_string())],
-                content: vec![],
+                parameters: vec![],
+                content: vec![DocNode::Paragraph(Paragraph {
+                    content: vec![InlineContent::Text("Alice".to_string())],
+                })],
             }],
         };
 
         let events = tree_to_events(&DocNode::Document(original.clone()));
-        let doc = events_to_tree(&events).expect("events round-trip");
 
-        // The annotation was dropped on the way to events.
-        assert!(
-            doc.document_annotations.is_empty(),
-            "Phase 3a: events stream loses document_annotations (by design)"
-        );
-        // Body paragraph survives — only the document-scope slot was
-        // not encoded.
-        assert_eq!(doc.children.len(), 1);
-        assert!(matches!(doc.children[0], DocNode::Paragraph(_)));
+        // The frontmatter event must be present and carry the
+        // prefix-stripped `author` key with the body text as value.
+        let frontmatter = events.iter().find_map(|e| match e {
+            Event::StartAnnotation { label, parameters } if label == "frontmatter" => {
+                Some(parameters.clone())
+            }
+            _ => None,
+        });
+        let parameters = frontmatter.expect("frontmatter event must be synthesized");
+        let author = parameters
+            .iter()
+            .find(|(k, _)| k == "author")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(author, Some("Alice"));
     }
 
     #[test]

--- a/crates/lex-babel/src/common/nested_to_flat.rs
+++ b/crates/lex-babel/src/common/nested_to_flat.rs
@@ -252,13 +252,18 @@ fn emit_frontmatter_event(document_annotations: &[Annotation], events: &mut Vec<
             for (k, v) in &ann.parameters {
                 parameters.push((format!("{key}.{k}"), v.clone()));
             }
-        } else {
-            // Marker-form annotation with neither body nor params:
-            // emit the key with an empty value so its presence is
-            // surfaced (matches the legacy promotion behaviour for
-            // such cases).
-            parameters.push((key, String::new()));
         }
+        // Marker-form annotation (no body, no params): contribute
+        // nothing — matches the legacy `from_lex_document` promotion
+        // behaviour, which only pushed entries for annotations that
+        // carried a value or structured params.
+    }
+    // Don't emit the frontmatter event at all if every document
+    // annotation was a marker-form. Matches legacy behaviour: a
+    // synthesized `frontmatter` annotation was only inserted when
+    // `parameters` was non-empty.
+    if parameters.is_empty() {
+        return;
     }
     events.push(Event::StartAnnotation {
         label: "frontmatter".to_string(),

--- a/crates/lex-babel/src/common/nested_to_flat.rs
+++ b/crates/lex-babel/src/common/nested_to_flat.rs
@@ -46,17 +46,21 @@ pub fn tree_to_events(root_node: &DocNode) -> Vec<Event> {
 
 fn walk_node(node: &DocNode, events: &mut Vec<Event>) {
     match node {
-        DocNode::Document(Document { children, .. }) => {
-            // Phase 3a of #570: `document_annotations` is intentionally
-            // NOT emitted into the event stream by this pass. The
-            // event stream doesn't yet have a way to distinguish
-            // document-scope annotations from inline ones — Phase 3b
-            // adds the scope marker (or position contract) atomically
-            // with the source-of-truth flip. Until then, IR Documents
-            // carrying `document_annotations` lose them when they
-            // travel through events; this is documented on the IR
-            // `Document` struct.
+        DocNode::Document(Document {
+            children,
+            document_annotations,
+            ..
+        }) => {
             events.push(Event::StartDocument);
+            // Post-refac/label cleanup: synthesize the `frontmatter`
+            // annotation event from `document_annotations` here, at
+            // the events-emission layer. The IR Document no longer
+            // carries a synthetic `frontmatter` annotation in
+            // `children` (that was the legacy `from_lex_document`
+            // promotion). Downstream HTML/Markdown serializers still
+            // match on `Event::StartAnnotation { label: "frontmatter", .. }`
+            // unchanged — the event shape is preserved.
+            emit_frontmatter_event(document_annotations, events);
             for child in children {
                 walk_node(child, events);
             }
@@ -138,49 +142,18 @@ fn walk_node(node: &DocNode, events: &mut Vec<Event>) {
             parameters,
             content,
         }) => {
-            // Check if this is a metadata annotation that should be serialized as a single HTML block
-            let metadata_labels = [
-                "author", "note", "title", "date", "tags", "category", "template",
-            ];
-            if metadata_labels.contains(&label.as_str()) {
-                // Serialize content to text
-                // This is a simplification: we assume content is mostly text paragraphs
-                let mut text_content = String::new();
-                for child in content {
-                    if let DocNode::Paragraph(p) = child {
-                        for inline in &p.content {
-                            if let InlineContent::Text(t) = inline {
-                                text_content.push_str(t);
-                            } else if let InlineContent::Reference(r) = inline {
-                                text_content.push_str(r);
-                            } else if let InlineContent::Link { text, .. } = inline {
-                                text_content.push_str(text);
-                            }
-                            // Ignore other inline types for now or implement full serialization
-                        }
-                        text_content.push('\n');
-                    }
-                }
-
-                // Let's construct the full comment string here.
-                let mut comment_body = String::new();
-                for (key, value) in parameters {
-                    comment_body.push_str(&format!(" {key}={value}"));
-                }
-                if !text_content.is_empty() {
-                    comment_body.push('\n');
-                    comment_body.push_str(&text_content);
-                }
-
-                events.push(Event::StartVerbatim {
-                    language: Some(format!("lex-metadata:{label}")),
-                    subject: None,
-                });
-                events.push(Event::Inline(InlineContent::Text(comment_body)));
-                events.push(Event::EndVerbatim);
-                return;
-            }
-
+            // Post-refac/label cleanup: the bare-label metadata
+            // whitelist (`author`, `title`, …) that used to live here
+            // and synthesize `lex-metadata:<label>` verbatim events is
+            // gone. After #570 Phase 3b activated `NormalizeLabels`,
+            // no production path produces IR annotations with those
+            // bare labels — they're either rewritten to canonical
+            // `lex.metadata.*` and promoted into the `frontmatter`
+            // annotation by `from_lex_document`, or they come from
+            // markdown imports as a single packed `frontmatter`
+            // annotation. The HTML/Markdown serializers handle the
+            // `frontmatter` label directly in their `StartAnnotation`
+            // arms.
             events.push(Event::StartAnnotation {
                 label: label.clone(),
                 parameters: parameters.clone(),
@@ -252,6 +225,67 @@ fn walk_table_cell(cell: &TableCell, events: &mut Vec<Event>) {
         events.push(Event::EndContent);
     }
     events.push(Event::EndTableCell);
+}
+
+/// Synthesize the `frontmatter` annotation event from a document's
+/// `document_annotations` slot. Each annotation's `lex.metadata.<key>`
+/// label is stripped to the short form (`key`); annotations with text
+/// body become `(key, body_text)` params; annotations with structured
+/// parameters become `(key.subkey, value)` params. The legacy
+/// `from_lex_document` promotion produced the same flat-params shape
+/// the downstream serializers expect.
+fn emit_frontmatter_event(document_annotations: &[Annotation], events: &mut Vec<Event>) {
+    if document_annotations.is_empty() {
+        return;
+    }
+    let mut parameters: Vec<(String, String)> = Vec::new();
+    for ann in document_annotations {
+        let key = ann
+            .label
+            .strip_prefix("lex.metadata.")
+            .unwrap_or(ann.label.as_str())
+            .to_string();
+        let body_text = flatten_paragraph_text(&ann.content);
+        if !body_text.is_empty() {
+            parameters.push((key, body_text));
+        } else if !ann.parameters.is_empty() {
+            for (k, v) in &ann.parameters {
+                parameters.push((format!("{key}.{k}"), v.clone()));
+            }
+        } else {
+            // Marker-form annotation with neither body nor params:
+            // emit the key with an empty value so its presence is
+            // surfaced (matches the legacy promotion behaviour for
+            // such cases).
+            parameters.push((key, String::new()));
+        }
+    }
+    events.push(Event::StartAnnotation {
+        label: "frontmatter".to_string(),
+        parameters,
+    });
+    events.push(Event::EndAnnotation {
+        label: "frontmatter".to_string(),
+    });
+}
+
+/// Flatten the text content of an annotation's paragraph children into
+/// a single string. Used by `emit_frontmatter_event` to derive the
+/// metadata value when the annotation has a body but no structured
+/// parameters. Mirrors what `from_lex_document` used to do in its
+/// children-scan promotion logic.
+fn flatten_paragraph_text(content: &[DocNode]) -> String {
+    let mut text = String::new();
+    for child in content {
+        if let DocNode::Paragraph(p) = child {
+            for inline in &p.content {
+                if let InlineContent::Text(t) = inline {
+                    text.push_str(t);
+                }
+            }
+        }
+    }
+    text
 }
 
 fn walk_list_item(item: &ListItem, events: &mut Vec<Event>) {
@@ -365,12 +399,22 @@ mod tests {
             Event::EndContent,
             Event::EndDefinitionDescription,
             Event::EndDefinition,
-            Event::StartVerbatim {
-                language: Some("lex-metadata:note".to_string()),
-                subject: None,
+            // Post-refac/label cleanup: the bare-label metadata
+            // path that used to emit a `lex-metadata:note` verbatim
+            // is gone. The `:: note ::` annotation now flows through
+            // the normal annotation events.
+            Event::StartAnnotation {
+                label: "note".to_string(),
+                parameters: vec![("key".to_string(), "value".to_string())],
             },
-            Event::Inline(InlineContent::Text(" key=value\nBody\n".to_string())),
-            Event::EndVerbatim,
+            Event::StartContent,
+            Event::StartParagraph,
+            Event::Inline(InlineContent::Text("Body".to_string())),
+            Event::EndParagraph,
+            Event::EndContent,
+            Event::EndAnnotation {
+                label: "note".to_string(),
+            },
             Event::EndDocument,
         ];
 

--- a/crates/lex-babel/src/common/verbatim/media.rs
+++ b/crates/lex-babel/src/common/verbatim/media.rs
@@ -2,112 +2,61 @@ use super::VerbatimHandler;
 use crate::ir::nodes::{Audio, DocNode, Image, Video};
 use std::collections::HashMap;
 
+/// Build an IR `Image` node from a verbatim's body text + params.
+/// Used by `from_lex_verbatim` to hydrate `lex.media.image` verbatim
+/// blocks. Caller passes the verbatim's content (alt-text fallback)
+/// and the `src` / `alt` / `title` parameter map.
+pub(crate) fn image_from_params(content: &str, params: &HashMap<String, String>) -> DocNode {
+    let src = params.get("src").cloned().unwrap_or_default();
+    let alt = params
+        .get("alt")
+        .cloned()
+        .unwrap_or_else(|| content.trim().to_string());
+    let title = params.get("title").cloned();
+    DocNode::Image(Image { src, alt, title })
+}
+
+/// Build an IR `Video` node from a verbatim's params. The verbatim
+/// body is ignored — `lex.media.video` takes `src` / `title` /
+/// `poster` parameters only.
+pub(crate) fn video_from_params(params: &HashMap<String, String>) -> DocNode {
+    let src = params.get("src").cloned().unwrap_or_default();
+    let title = params.get("title").cloned();
+    let poster = params.get("poster").cloned();
+    DocNode::Video(Video { src, title, poster })
+}
+
+/// Build an IR `Audio` node from a verbatim's params.
+/// `lex.media.audio` takes `src` / `title` parameters only.
+pub(crate) fn audio_from_params(params: &HashMap<String, String>) -> DocNode {
+    let src = params.get("src").cloned().unwrap_or_default();
+    let title = params.get("title").cloned();
+    DocNode::Audio(Audio { src, title })
+}
+
 /// Handler for `doc.image` verbatim blocks.
 pub struct ImageHandler;
 
 impl VerbatimHandler for ImageHandler {
     fn label(&self) -> &str {
-        // #570 Phase 3b: canonical label. Legacy `doc.image` is still
-        // registered as an alias in `VerbatimRegistry::default_with_standard`
-        // so legacy-shaped IR continues to route to this handler.
         "lex.media.image"
-    }
-
-    fn to_ir(&self, content: &str, params: &HashMap<String, String>) -> Option<DocNode> {
-        // Content is usually empty for doc.image, params hold the data
-        // Or content could be the alt text?
-        // Let's assume params: src, alt, title.
-        // If content is present, maybe treat it as alt text if alt param is missing?
-
-        let src = params.get("src").cloned().unwrap_or_default();
-        let alt = params
-            .get("alt")
-            .cloned()
-            .unwrap_or_else(|| content.trim().to_string());
-        let title = params.get("title").cloned();
-
-        Some(DocNode::Image(Image { src, alt, title }))
-    }
-
-    fn convert_from_ir(&self, node: &DocNode) -> Option<(String, HashMap<String, String>)> {
-        if let DocNode::Image(image) = node {
-            let mut params = HashMap::new();
-            params.insert("src".to_string(), image.src.clone());
-            if !image.alt.is_empty() {
-                params.insert("alt".to_string(), image.alt.clone());
-            }
-            if let Some(title) = &image.title {
-                params.insert("title".to_string(), title.clone());
-            }
-            Some((String::new(), params))
-        } else {
-            None
-        }
     }
 }
 
-/// Handler for `doc.video` verbatim blocks.
+/// Handler for `lex.media.video` verbatim blocks.
 pub struct VideoHandler;
 
 impl VerbatimHandler for VideoHandler {
     fn label(&self) -> &str {
-        // #570 Phase 3b: canonical label. Legacy alias `doc.video`
-        // registered in `VerbatimRegistry::default_with_standard`.
         "lex.media.video"
-    }
-
-    fn to_ir(&self, _content: &str, params: &HashMap<String, String>) -> Option<DocNode> {
-        let src = params.get("src").cloned().unwrap_or_default();
-        let title = params.get("title").cloned();
-        let poster = params.get("poster").cloned();
-
-        Some(DocNode::Video(Video { src, title, poster }))
-    }
-
-    fn convert_from_ir(&self, node: &DocNode) -> Option<(String, HashMap<String, String>)> {
-        if let DocNode::Video(video) = node {
-            let mut params = HashMap::new();
-            params.insert("src".to_string(), video.src.clone());
-            if let Some(title) = &video.title {
-                params.insert("title".to_string(), title.clone());
-            }
-            if let Some(poster) = &video.poster {
-                params.insert("poster".to_string(), poster.clone());
-            }
-            Some((String::new(), params))
-        } else {
-            None
-        }
     }
 }
 
-/// Handler for `doc.audio` verbatim blocks.
+/// Handler for `lex.media.audio` verbatim blocks.
 pub struct AudioHandler;
 
 impl VerbatimHandler for AudioHandler {
     fn label(&self) -> &str {
-        // #570 Phase 3b: canonical label. Legacy alias `doc.audio`
-        // registered in `VerbatimRegistry::default_with_standard`.
         "lex.media.audio"
-    }
-
-    fn to_ir(&self, _content: &str, params: &HashMap<String, String>) -> Option<DocNode> {
-        let src = params.get("src").cloned().unwrap_or_default();
-        let title = params.get("title").cloned();
-
-        Some(DocNode::Audio(Audio { src, title }))
-    }
-
-    fn convert_from_ir(&self, node: &DocNode) -> Option<(String, HashMap<String, String>)> {
-        if let DocNode::Audio(audio) = node {
-            let mut params = HashMap::new();
-            params.insert("src".to_string(), audio.src.clone());
-            if let Some(title) = &audio.title {
-                params.insert("title".to_string(), title.clone());
-            }
-            Some((String::new(), params))
-        } else {
-            None
-        }
     }
 }

--- a/crates/lex-babel/src/common/verbatim/mod.rs
+++ b/crates/lex-babel/src/common/verbatim/mod.rs
@@ -63,7 +63,6 @@
 //! ```
 
 use crate::error::FormatError;
-use crate::ir::nodes::DocNode;
 use lex_core::lex::ast::Verbatim;
 use std::collections::HashMap;
 
@@ -71,23 +70,21 @@ pub mod media;
 pub mod table;
 
 /// A handler for a specific verbatim block type.
+///
+/// Post-refac/label cleanup: the `to_ir` and `convert_from_ir` trait
+/// methods are retired. `from_lex_verbatim` now calls free hydration
+/// helpers (`table::parse_pipe_table`, `media::image_from_params`,
+/// etc.) directly, and `to_lex_table` / `to_lex_media` route through
+/// `Registry::dispatch_format` (the `lex.tabular.*` / `lex.media.*`
+/// built-in handlers in lex-core own the IR→Lex contract). The trait
+/// shrinks to `label()` + `format_content()` — the latter is still
+/// consumed by the Lex serializer for reformat-during-format.
 pub trait VerbatimHandler: Send + Sync {
-    /// Returns the label this handler supports (e.g., "doc.table").
+    /// Returns the canonical label this handler supports
+    /// (e.g., `"lex.tabular.table"`).
     fn label(&self) -> &str;
 
-    /// Converts a Lex verbatim block to an IR node.
-    ///
-    /// # Arguments
-    /// * `content` - The raw text content of the verbatim block.
-    /// * `params` - The parameters specified in the closing marker.
-    fn to_ir(&self, content: &str, params: &HashMap<String, String>) -> Option<DocNode>;
-
-    /// Converts an IR node back to a Lex verbatim block.
-    ///
-    /// Returns `Some((content, params))` if this handler can represent the given node.
-    fn convert_from_ir(&self, node: &DocNode) -> Option<(String, HashMap<String, String>)>;
-
-    /// Formats the content of a verbatim block.
+    /// Formats the content of a verbatim block during `lexd format`.
     ///
     /// Returns `Ok(Some(formatted_content))` if the handler supports formatting,
     /// `Ok(None)` if it doesn't, or `Err` if formatting failed.
@@ -110,32 +107,23 @@ impl VerbatimRegistry {
         }
     }
 
-    /// Creates a registry with standard handlers (e.g. doc.table) pre-registered.
+    /// Creates a registry with standard handlers pre-registered under
+    /// their canonical `lex.*` labels.
     ///
-    /// #570 Phase 3b activated the [`NormalizeLabels`] pass that
-    /// rewrites bare `doc.table` / `doc.image` / `doc.video` /
-    /// `doc.audio` to their canonical `lex.tabular.*` / `lex.media.*`
-    /// forms before this lookup runs. The canonical labels are the
-    /// keys we register today. The legacy bare labels stay registered
-    /// alongside so any IR built outside `STRING_TO_AST` (e.g. an
-    /// embedder hand-building a Verbatim with the legacy label, or a
-    /// non-Lex format adapter feeding the same registry) continues
-    /// to work. Both paths point at the same handler.
-    ///
-    /// [`NormalizeLabels`]: lex_core::lex::assembling::stages::NormalizeLabels
+    /// `STRING_TO_AST` runs `NormalizeLabels` (#570 Phase 3b) before
+    /// this lookup ever sees a label, so the AST always carries
+    /// canonical names by the time `from_lex_verbatim` calls
+    /// `registry.get(...)`. The legacy `doc.*` aliases that were kept
+    /// alongside in Phase 3b are removed in the post-refac/label
+    /// cleanup — embedders that hand-build IR Verbatim nodes with the
+    /// legacy form will now hit a `None` lookup, which is the
+    /// documented breaking-change behaviour.
     pub fn default_with_standard() -> Self {
         let mut registry = Self::new();
-        // Canonical (#570 Phase 3b) — what `STRING_TO_AST` produces.
         registry.register("lex.tabular.table", Box::new(table::TableHandler));
         registry.register("lex.media.image", Box::new(media::ImageHandler));
         registry.register("lex.media.video", Box::new(media::VideoHandler));
         registry.register("lex.media.audio", Box::new(media::AudioHandler));
-        // Legacy aliases — accept inputs that didn't go through
-        // `NormalizeLabels` (embedder-built IR, alternate format adapters).
-        registry.register("doc.table", Box::new(table::TableHandler));
-        registry.register("doc.image", Box::new(media::ImageHandler));
-        registry.register("doc.video", Box::new(media::VideoHandler));
-        registry.register("doc.audio", Box::new(media::AudioHandler));
         registry
     }
 

--- a/crates/lex-babel/src/common/verbatim/table.rs
+++ b/crates/lex-babel/src/common/verbatim/table.rs
@@ -3,7 +3,6 @@ use crate::ir::nodes::{
     DocNode, InlineContent, Paragraph, Table, TableCell, TableCellAlignment, TableRow,
 };
 use lex_core::lex::ast::Verbatim;
-use std::collections::HashMap;
 
 /// Handler for `doc.table` verbatim blocks.
 ///
@@ -12,21 +11,7 @@ pub struct TableHandler;
 
 impl VerbatimHandler for TableHandler {
     fn label(&self) -> &str {
-        // #570 Phase 3b: canonical label. Legacy alias `doc.table`
-        // registered in `VerbatimRegistry::default_with_standard`.
         "lex.tabular.table"
-    }
-
-    fn to_ir(&self, content: &str, _params: &HashMap<String, String>) -> Option<DocNode> {
-        Some(parse_pipe_table(content))
-    }
-
-    fn convert_from_ir(&self, node: &DocNode) -> Option<(String, HashMap<String, String>)> {
-        if let DocNode::Table(table) = node {
-            Some((serialize_pipe_table(table), HashMap::new()))
-        } else {
-            None
-        }
     }
 
     fn format_content(
@@ -95,7 +80,7 @@ impl VerbatimHandler for TableHandler {
     }
 }
 
-fn parse_pipe_table(content: &str) -> DocNode {
+pub(crate) fn parse_pipe_table(content: &str) -> DocNode {
     let mut header = Vec::new();
     let mut rows = Vec::new();
     let mut alignments = Vec::new();
@@ -204,7 +189,7 @@ fn parse_table_row(line: &str) -> Vec<String> {
     line.split('|').map(|s| s.trim().to_string()).collect()
 }
 
-fn serialize_pipe_table(table: &Table) -> String {
+pub(crate) fn serialize_pipe_table(table: &Table) -> String {
     let mut output = String::new();
 
     // 1. Calculate column widths

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -26,6 +26,22 @@ use super::nodes::{
 };
 
 /// Converts a lex document to the IR.
+///
+/// Post-refac/label cleanup: the legacy frontmatter promotion (which
+/// scanned `children` for `lex.metadata.*` annotations and synthesized
+/// a single `frontmatter` IR Annotation into `children[0]`) is retired.
+/// Document-scope metadata now lives exclusively in
+/// `Document::document_annotations`, populated from the lex-core
+/// `doc.annotations` slot. `nested_to_flat` emits the
+/// `Event::StartAnnotation { label: "frontmatter", ... }` events
+/// downstream serializers consume — synthesized at the events layer,
+/// not in the IR tree.
+///
+/// **Behavioural break** (documented in CHANGELOG): an inline
+/// `:: lex.metadata.title :: ...` in the document body is no longer
+/// promoted to document metadata. Inline annotations stay inline;
+/// document-scope metadata must be attached at the document level
+/// (lex-core's `doc.annotations` slot).
 pub fn from_lex_document(doc: &LexDocument) -> Document {
     // Extract document title and subtitle
     let title = doc
@@ -38,142 +54,8 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
         .and_then(|t| t.subtitle.as_ref())
         .map(convert_inline_content);
 
-    let mut children = convert_children(&doc.root.children, 2);
+    let children = convert_children(&doc.root.children, 2);
 
-    let mut parameters = Vec::new();
-
-    // 1. Process document-level annotations.
-    //
-    // Strip the `lex.metadata.` prefix (#570 Phase 3b) when building
-    // the parameter key so document-level annotations rewritten by
-    // `NormalizeLabels` still produce the short-form keys downstream
-    // HTML serializers consume (`<meta name="title">`, not
-    // `<meta name="lex.metadata.title">`).
-    for ann in &doc.annotations {
-        let key = ann
-            .data
-            .label
-            .value
-            .strip_prefix("lex.metadata.")
-            .unwrap_or(ann.data.label.value.as_str())
-            .to_string();
-        let value = if !ann.children.is_empty() {
-            let mut text = String::new();
-            for child in &ann.children {
-                if let LexContentItem::Paragraph(p) = child {
-                    text.push_str(&p.text());
-                }
-            }
-            text
-        } else {
-            String::new()
-        };
-
-        if !value.is_empty() {
-            parameters.push((key, value));
-        } else {
-            for param in &ann.data.parameters {
-                parameters.push((format!("{}.{}", key, param.key), param.value.clone()));
-            }
-        }
-    }
-
-    // 2. Scan children for metadata annotations (e.g. attached to first element)
-    let mut indices_to_remove = Vec::new();
-
-    // Whitelist of labels to treat as frontmatter. #570 Phase 3b
-    // activated `NormalizeLabels` (lex-core) which rewrites bare
-    // labels to their canonical `lex.metadata.*` form before this
-    // pass runs, so the canonical names are what we match against.
-    // The legacy bare names stay in the list as aliases so IR built
-    // outside `STRING_TO_AST` (markdown imports, hand-built AST,
-    // alternate format adapters) continues to work.
-    let metadata_labels = [
-        // Canonical (#570 Phase 3b).
-        "lex.metadata.author",
-        "lex.metadata.publishing-date",
-        "lex.metadata.title",
-        "lex.metadata.date",
-        "lex.metadata.tags",
-        "lex.metadata.category",
-        "lex.metadata.template",
-        "lex.metadata.front-matter",
-        // Legacy aliases.
-        "author",
-        "publishing-date",
-        "title",
-        "date",
-        "tags",
-        "category",
-        "template",
-        "front-matter",
-    ];
-
-    for (i, child) in children.iter().enumerate() {
-        if let DocNode::Annotation(ann) = child {
-            if metadata_labels.contains(&ann.label.as_str()) {
-                // It's metadata! Strip the `lex.metadata.` prefix when
-                // building the key so the frontmatter annotation's
-                // parameter keys stay in the legacy short form
-                // (`title`, `author`, …) — that preserves the HTML
-                // comment shape (`<meta name="title">`) downstream
-                // serializers emit.
-                let key = ann
-                    .label
-                    .strip_prefix("lex.metadata.")
-                    .unwrap_or(ann.label.as_str())
-                    .to_string();
-                // Extract value (content or params)
-                let value = if !ann.content.is_empty() {
-                    // Flatten content
-                    let mut text = String::new();
-                    for c in &ann.content {
-                        if let DocNode::Paragraph(p) = c {
-                            for ic in &p.content {
-                                if let InlineContent::Text(t) = ic {
-                                    text.push_str(t);
-                                }
-                            }
-                        }
-                    }
-                    text
-                } else {
-                    String::new()
-                };
-
-                if !value.is_empty() {
-                    parameters.push((key, value));
-                } else {
-                    for (k, v) in &ann.parameters {
-                        parameters.push((format!("{key}.{k}"), v.clone()));
-                    }
-                }
-
-                indices_to_remove.push(i);
-            }
-        }
-    }
-
-    // Remove promoted annotations (in reverse order to keep indices valid)
-    for i in indices_to_remove.iter().rev() {
-        children.remove(*i);
-    }
-
-    if !parameters.is_empty() {
-        let frontmatter = DocNode::Annotation(Annotation {
-            label: "frontmatter".to_string(),
-            parameters,
-            content: vec![],
-        });
-        children.insert(0, frontmatter);
-    }
-
-    // Phase 3a of #570: populate the first-class `document_annotations`
-    // slot in parallel with the legacy frontmatter promotion above.
-    // This is additive — downstream serializers continue to read the
-    // synthetic `frontmatter` annotation from `children`. Phase 3b
-    // makes `document_annotations` the source of truth and deletes the
-    // promotion.
     let document_annotations = doc.annotations.iter().map(ir_annotation_from_lex).collect();
 
     Document {
@@ -409,18 +291,32 @@ fn from_lex_verbatim(verbatim: &LexVerbatim) -> DocNode {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let registry = crate::common::verbatim::VerbatimRegistry::default_with_standard();
+    // Post-refac/label cleanup: the legacy
+    // `VerbatimRegistry::get(...).to_ir(...)` indirection is gone.
+    // Dispatch on the canonical label directly to the free hydration
+    // helpers — same logic, no trait-object overhead.
+    let label = verbatim.closing_data.label.value.as_str();
+    let params: std::collections::HashMap<String, String> = verbatim
+        .closing_data
+        .parameters
+        .iter()
+        .map(|p| (p.key.clone(), p.value.clone()))
+        .collect();
 
-    if let Some(handler) = registry.get(&verbatim.closing_data.label.value) {
-        let params = verbatim
-            .closing_data
-            .parameters
-            .iter()
-            .map(|p| (p.key.clone(), p.value.clone()))
-            .collect();
-        if let Some(node) = handler.to_ir(&content, &params) {
-            return node;
+    match label {
+        "lex.tabular.table" => {
+            return crate::common::verbatim::table::parse_pipe_table(&content);
         }
+        "lex.media.image" => {
+            return crate::common::verbatim::media::image_from_params(&content, &params);
+        }
+        "lex.media.video" => {
+            return crate::common::verbatim::media::video_from_params(&params);
+        }
+        "lex.media.audio" => {
+            return crate::common::verbatim::media::audio_from_params(&params);
+        }
+        _ => {}
     }
 
     DocNode::Verbatim(Verbatim {
@@ -753,16 +649,14 @@ mod tests {
 
     #[test]
     fn normalize_labels_pipeline_writes_canonical_labels_into_ast() {
-        // #570 Phase 3b regression: confirm the activated
-        // `NormalizeLabels` pass produces a Document whose annotations
-        // carry canonical `lex.metadata.*` labels by the time
-        // `from_lex_document` sees them.
+        // Confirm the activated `NormalizeLabels` pass produces a
+        // Document whose annotations carry canonical `lex.metadata.*`
+        // labels by the time `from_lex_document` sees them.
         use lex_core::lex::transforms::standard::STRING_TO_AST;
 
         let lex_doc = STRING_TO_AST
             .run(":: title :: My Doc\n\nBody.\n".to_string())
             .expect("parse ok");
-        // After NormalizeLabels, the title annotation is canonical.
         let title_in_ast = lex_doc
             .annotations
             .first()
@@ -773,62 +667,44 @@ mod tests {
                 })
             })
             .expect("title annotation parsed");
-        assert_eq!(
-            title_in_ast.data.label.value, "lex.metadata.title",
-            "NormalizeLabels is wired into STRING_TO_AST"
-        );
-        // And `from_lex_document` still promotes it into the
-        // frontmatter (legacy whitelist accepts the canonical form).
+        assert_eq!(title_in_ast.data.label.value, "lex.metadata.title");
+
+        // Post-refac/label cleanup: `from_lex_document` no longer
+        // synthesizes a `frontmatter` annotation in children. The
+        // canonical-labelled annotation lands in
+        // `document_annotations` instead; the `frontmatter` event is
+        // synthesized at the events-emission layer.
         let ir = from_lex_document(&lex_doc);
-        let frontmatter = ir.children.iter().find_map(|c| match c {
-            DocNode::Annotation(a) if a.label == "frontmatter" => Some(a),
-            _ => None,
-        });
-        let frontmatter = frontmatter.expect("frontmatter still synthesized in Phase 3b");
-        // The key is the *short* form so the HTML comment output stays
-        // backwards-compatible. The prefix-strip in `from_lex_document`
-        // handles this.
-        let has_title_key = frontmatter
-            .parameters
+        let frontmatter_in_children = ir
+            .children
             .iter()
-            .any(|(k, _)| k == "title" || k == "frontmatter.title");
+            .any(|c| matches!(c, DocNode::Annotation(a) if a.label == "frontmatter"));
         assert!(
-            has_title_key,
-            "frontmatter param key must be the short form (`title`), got {:?}",
-            frontmatter.parameters
+            !frontmatter_in_children,
+            "frontmatter must no longer be synthesized in children"
         );
     }
 
     #[test]
-    fn legacy_frontmatter_promotion_still_runs_alongside_document_annotations() {
-        // Phase 3a is additive — the synthetic `frontmatter` annotation
-        // that the legacy promotion inserts must still appear in
-        // `children` so downstream serializers keep their existing
-        // shape. Phase 3b retires this duplication.
+    fn document_annotations_is_source_of_truth_for_doc_metadata() {
+        // Post-refac/label cleanup: document-scope metadata flows
+        // through `document_annotations` only — the legacy
+        // `frontmatter` synthesis in children is gone.
         let doc = doc_with_one_annotation("author", "Alice");
         let ir_doc = from_lex_document(&doc);
 
-        // New slot populated with the raw annotation.
+        // The new slot carries the annotation.
         assert_eq!(ir_doc.document_annotations.len(), 1);
         assert_eq!(ir_doc.document_annotations[0].label, "author");
 
-        // Legacy frontmatter promotion still synthesizes the
-        // `frontmatter` annotation in children, with the value
-        // collected into a parameter under the bare key.
-        let frontmatter = ir_doc.children.iter().find_map(|c| match c {
-            DocNode::Annotation(a) if a.label == "frontmatter" => Some(a),
-            _ => None,
-        });
-        let frontmatter = frontmatter.expect("legacy frontmatter promotion still runs in Phase 3a");
-        let author_value = frontmatter
-            .parameters
+        // Children no longer carry a synthetic frontmatter annotation.
+        let frontmatter_in_children = ir_doc
+            .children
             .iter()
-            .find(|(k, _)| k == "author")
-            .map(|(_, v)| v.as_str());
-        assert_eq!(
-            author_value,
-            Some("Alice"),
-            "legacy frontmatter param must still carry the annotation body under the bare label"
+            .any(|c| matches!(c, DocNode::Annotation(a) if a.label == "frontmatter"));
+        assert!(
+            !frontmatter_in_children,
+            "synthetic frontmatter must not appear in children after cleanup"
         );
     }
 }

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -11,11 +11,104 @@ use lex_core::lex::ast::elements::{
 };
 use lex_core::lex::ast::range::Position;
 use lex_core::lex::ast::{Data, Document as LexDocument, Parameter, Range, TextContent};
+use lex_core::lex::includes::{LoadError, LoadedFile, Loader, ResolveConfig};
+use lex_extension::wire::{FormatCtx, LexAnnotationOut, WireNode};
+use lex_extension::wire::{Position as WirePosition, Range as WireRange};
+use lex_extension_host::registry::Registry;
+use std::path::Path;
+use std::sync::Arc;
 
 use super::nodes::{
     Annotation, Definition, DocNode, Document, Heading, InlineContent, List, ListItem, Paragraph,
     Table, TableCell, TableRow, Verbatim,
 };
+
+/// A loader that always reports NotFound. The to_lex direction never
+/// resolves includes — it only emits source — so we never actually
+/// touch the loader. It exists because
+/// `lex_core::lex::builtins::register_into` requires one.
+struct NoopLoader;
+impl Loader for NoopLoader {
+    fn load(&self, path: &Path) -> Result<LoadedFile, LoadError> {
+        Err(LoadError::NotFound {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+/// Build a `lex_extension_host::Registry` with the built-in `lex.*`
+/// schemas registered, suitable for the to_lex direction (no
+/// filesystem access needed). Constructed lazily per call to
+/// `to_lex_document` — cheap enough that callers don't need to pass
+/// one in.
+fn build_to_lex_registry() -> Registry {
+    let registry = Registry::new();
+    let _ = lex_core::lex::builtins::register_into(
+        &registry,
+        Arc::new(NoopLoader),
+        ResolveConfig::with_root(std::path::PathBuf::from("/")),
+    );
+    registry
+}
+
+fn default_wire_range() -> WireRange {
+    WireRange {
+        start: WirePosition(0, 0),
+        end: WirePosition(0, 0),
+    }
+}
+
+/// Build a `WireNode::Verbatim` carrying `body` + `params` under the
+/// given canonical label. Used to feed `dispatch_format` for the
+/// built-in `lex.tabular.*` and `lex.media.*` handlers.
+fn wire_verbatim(label: &str, body: String, params: Vec<(String, String)>) -> WireNode {
+    let params_json = serde_json::Value::Object(
+        params
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect(),
+    );
+    WireNode::Verbatim {
+        range: default_wire_range(),
+        origin: None,
+        label: label.to_string(),
+        params: params_json,
+        body_text: body,
+        subject: String::new(),
+        mode: "inflow".to_string(),
+    }
+}
+
+/// Build a `LexContentItem::VerbatimBlock` from a `LexAnnotationOut`
+/// produced by `Registry::dispatch_format`.
+fn lex_verbatim_from_annotation_out(out: LexAnnotationOut) -> LexContentItem {
+    let label = Label::new(out.label.clone());
+    let parameters: Vec<Parameter> = out
+        .params
+        .into_iter()
+        .map(|(k, v)| Parameter {
+            key: k,
+            value: v,
+            location: default_range(),
+        })
+        .collect();
+
+    let subject = TextContent::from_string(String::new(), None);
+    let lines: Vec<VerbatimContent> = out
+        .body
+        .lines()
+        .map(|l| VerbatimContent::VerbatimLine(LexVerbatimLine::new(l.to_string())))
+        .collect();
+
+    let closing_data = Data::new(label, parameters);
+
+    LexContentItem::VerbatimBlock(Box::new(LexVerbatim::new(
+        subject,
+        lines,
+        closing_data,
+        VerbatimBlockMode::Inflow,
+    )))
+}
 
 /// Converts an IR document to a Lex document.
 ///
@@ -136,39 +229,28 @@ fn to_lex_session(heading: &Heading, level: usize) -> LexContentItem {
 /// Converts an IR Table to a Lex VerbatimBlock via the verbatim registry,
 /// falling back to a nested Annotation structure if the registry has no handler.
 fn to_lex_table(table: &Table, level: usize) -> LexContentItem {
-    let registry = crate::common::verbatim::VerbatimRegistry::default_with_standard();
-    let node = DocNode::Table(table.clone());
-
-    if let Some(handler) = registry.get("doc.table") {
-        if let Some((content, params)) = handler.convert_from_ir(&node) {
-            let label = Label::new("doc.table".to_string());
-            let parameters = params
-                .into_iter()
-                .map(|(k, v)| Parameter {
-                    key: k,
-                    value: v,
-                    location: default_range(),
-                })
-                .collect();
-
-            let subject = TextContent::from_string("".to_string(), None);
-            let lines = content
-                .lines()
-                .map(|l| VerbatimContent::VerbatimLine(LexVerbatimLine::new(l.to_string())))
-                .collect();
-
-            let closing_data = Data::new(label, parameters);
-
-            return LexContentItem::VerbatimBlock(Box::new(LexVerbatim::new(
-                subject,
-                lines,
-                closing_data,
-                VerbatimBlockMode::Inflow,
-            )));
-        }
+    // Serialize the typed IR Table into pipe-table source. The
+    // serialization logic still lives in
+    // `crate::common::verbatim::table::serialize_pipe_table`, but
+    // we now feed the result through `Registry::dispatch_format` so
+    // the built-in `lex.tabular.table` handler (#570 Phase 4b) owns
+    // the IR→Lex contract.
+    let body = crate::common::verbatim::table::serialize_pipe_table(table);
+    let registry = build_to_lex_registry();
+    let ctx = FormatCtx {
+        label: "lex.tabular.table".to_string(),
+        params: Vec::new(),
+        node: wire_verbatim("lex.tabular.table", body, Vec::new()),
+        format_options: None,
+    };
+    if let Ok(Some(out)) = registry.dispatch_format(&ctx) {
+        return lex_verbatim_from_annotation_out(out);
     }
 
-    // Fallback to annotation if registry fails (though TableHandler should handle it)
+    // Fallback to annotation if dispatch_format somehow fails (the
+    // built-in handler must always return Some for the canonical
+    // verbatim labels, so this path should be unreachable in
+    // production — kept defensive against future handler changes).
     let label = Label::new("table".to_string());
     let parameters = Vec::new(); // Could add caption here if needed
 
@@ -482,42 +564,54 @@ fn default_range() -> Range {
 }
 
 fn to_lex_media(node: &DocNode) -> LexContentItem {
-    let registry = crate::common::verbatim::VerbatimRegistry::default_with_standard();
-
-    let label = match node {
-        DocNode::Image(_) => "doc.image",
-        DocNode::Video(_) => "doc.video",
-        DocNode::Audio(_) => "doc.audio",
+    // Each media node serializes to a verbatim with the (src, alt|title|
+    // poster, …) params canonical to its kind. Extract the params from
+    // the typed IR node, then dispatch through the registry to let the
+    // built-in `lex.media.*` handler (#570 Phase 4b) produce the
+    // LexAnnotationOut.
+    let (label, params) = match node {
+        DocNode::Image(image) => {
+            let mut params = Vec::new();
+            params.push(("src".to_string(), image.src.clone()));
+            if !image.alt.is_empty() {
+                params.push(("alt".to_string(), image.alt.clone()));
+            }
+            if let Some(title) = &image.title {
+                params.push(("title".to_string(), title.clone()));
+            }
+            ("lex.media.image", params)
+        }
+        DocNode::Video(video) => {
+            let mut params = Vec::new();
+            params.push(("src".to_string(), video.src.clone()));
+            if let Some(title) = &video.title {
+                params.push(("title".to_string(), title.clone()));
+            }
+            if let Some(poster) = &video.poster {
+                params.push(("poster".to_string(), poster.clone()));
+            }
+            ("lex.media.video", params)
+        }
+        DocNode::Audio(audio) => {
+            let mut params = Vec::new();
+            params.push(("src".to_string(), audio.src.clone()));
+            if let Some(title) = &audio.title {
+                params.push(("title".to_string(), title.clone()));
+            }
+            ("lex.media.audio", params)
+        }
         _ => return LexContentItem::Paragraph(LexParagraph::new(vec![])),
     };
 
-    if let Some(handler) = registry.get(label) {
-        if let Some((content, params)) = handler.convert_from_ir(node) {
-            let label = Label::new(label.to_string());
-            let parameters = params
-                .into_iter()
-                .map(|(k, v)| Parameter {
-                    key: k,
-                    value: v,
-                    location: default_range(),
-                })
-                .collect();
-
-            let subject = TextContent::from_string("".to_string(), None);
-            let lines = content
-                .lines()
-                .map(|l| VerbatimContent::VerbatimLine(LexVerbatimLine::new(l.to_string())))
-                .collect();
-
-            let closing_data = Data::new(label, parameters);
-
-            return LexContentItem::VerbatimBlock(Box::new(LexVerbatim::new(
-                subject,
-                lines,
-                closing_data,
-                VerbatimBlockMode::Inflow,
-            )));
-        }
+    let registry = build_to_lex_registry();
+    let ctx = FormatCtx {
+        label: label.to_string(),
+        params: params.clone(),
+        node: wire_verbatim(label, String::new(), params),
+        format_options: None,
+    };
+    if let Ok(Some(out)) = registry.dispatch_format(&ctx) {
+        return lex_verbatim_from_annotation_out(out);
     }
 
     LexContentItem::Paragraph(LexParagraph::new(vec![]))

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -36,19 +36,27 @@ impl Loader for NoopLoader {
     }
 }
 
-/// Build a `lex_extension_host::Registry` with the built-in `lex.*`
-/// schemas registered, suitable for the to_lex direction (no
-/// filesystem access needed). Constructed lazily per call to
-/// `to_lex_document` — cheap enough that callers don't need to pass
-/// one in.
-fn build_to_lex_registry() -> Registry {
-    let registry = Registry::new();
-    let _ = lex_core::lex::builtins::register_into(
-        &registry,
-        Arc::new(NoopLoader),
-        ResolveConfig::with_root(std::path::PathBuf::from("/")),
-    );
-    registry
+/// Cached process-wide registry for the to_lex direction. The
+/// registry's contents are invariant (always the same built-in
+/// `lex.*` schemas), so constructing it once and reusing across
+/// every call to `to_lex_document` avoids re-registering for every
+/// table/media node in a document.
+///
+/// `Registry` uses interior `RwLock`s for its state, so sharing
+/// `&'static Registry` across threads is safe.
+fn to_lex_registry() -> &'static Registry {
+    use std::sync::OnceLock;
+    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        let registry = Registry::new();
+        lex_core::lex::builtins::register_into(
+            &registry,
+            Arc::new(NoopLoader),
+            ResolveConfig::with_root(std::path::PathBuf::from("/")),
+        )
+        .expect("registering built-in lex.* handlers must succeed for a fresh registry");
+        registry
+    })
 }
 
 fn default_wire_range() -> WireRange {
@@ -236,15 +244,31 @@ fn to_lex_table(table: &Table, level: usize) -> LexContentItem {
     // the built-in `lex.tabular.table` handler (#570 Phase 4b) owns
     // the IR→Lex contract.
     let body = crate::common::verbatim::table::serialize_pipe_table(table);
-    let registry = build_to_lex_registry();
     let ctx = FormatCtx {
         label: "lex.tabular.table".to_string(),
         params: Vec::new(),
         node: wire_verbatim("lex.tabular.table", body, Vec::new()),
         format_options: None,
     };
-    if let Ok(Some(out)) = registry.dispatch_format(&ctx) {
-        return lex_verbatim_from_annotation_out(out);
+    match to_lex_registry().dispatch_format(&ctx) {
+        Ok(Some(out)) => return lex_verbatim_from_annotation_out(out),
+        Ok(None) => {
+            // The built-in `lex.tabular.table` handler is registered
+            // by `to_lex_registry()` and always returns Some for this
+            // canonical label. None here means the registry was
+            // mutated unexpectedly — fall through to the nested-
+            // annotation fallback below so the table content isn't
+            // dropped, but log so the divergence is visible.
+            eprintln!(
+                "to_lex_table: dispatch_format returned None for `lex.tabular.table`; \
+                 falling back to nested-annotation form"
+            );
+        }
+        Err(diag) => {
+            eprintln!(
+                "to_lex_table: dispatch_format errored: {diag:?}; falling back to nested-annotation form"
+            );
+        }
     }
 
     // Fallback to annotation if dispatch_format somehow fails (the
@@ -603,18 +627,38 @@ fn to_lex_media(node: &DocNode) -> LexContentItem {
         _ => return LexContentItem::Paragraph(LexParagraph::new(vec![])),
     };
 
-    let registry = build_to_lex_registry();
     let ctx = FormatCtx {
         label: label.to_string(),
         params: params.clone(),
-        node: wire_verbatim(label, String::new(), params),
+        node: wire_verbatim(label, String::new(), params.clone()),
         format_options: None,
     };
-    if let Ok(Some(out)) = registry.dispatch_format(&ctx) {
-        return lex_verbatim_from_annotation_out(out);
+    match to_lex_registry().dispatch_format(&ctx) {
+        Ok(Some(out)) => return lex_verbatim_from_annotation_out(out),
+        Ok(None) => {
+            eprintln!(
+                "to_lex_media: dispatch_format returned None for `{label}`; \
+                 falling back to a labelled verbatim that preserves params"
+            );
+        }
+        Err(diag) => {
+            eprintln!(
+                "to_lex_media: dispatch_format errored for `{label}`: {diag:?}; \
+                 falling back to a labelled verbatim that preserves params"
+            );
+        }
     }
 
-    LexContentItem::Paragraph(LexParagraph::new(vec![]))
+    // Fallback: emit the verbatim directly with the canonical label
+    // and the same params we tried to dispatch. Preserves `src`/
+    // `alt`/`title`/`poster` rather than silently dropping the node's
+    // contents on the unreachable-in-production failure path.
+    lex_verbatim_from_annotation_out(LexAnnotationOut {
+        label: label.to_string(),
+        params,
+        body: String::new(),
+        verbatim_label: true,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up cleanup pass on top of the 8-PR `refac/label` series. Removes the legacy IR shims that were intentionally kept around during the multi-phase landing.

Addresses both items from the original #570 issue that were marked "deferred to follow-up":
- ✅ **Wire `Registry::dispatch_format` into `to_lex.rs`'s production paths.** No more local `VerbatimRegistry::convert_from_ir` indirection; the canonical `lex.*` handlers own the IR→Lex contract.
- ✅ **Retire the legacy frontmatter promotion + `VerbatimRegistry::to_ir`.** Document-scope metadata flows through `Document::document_annotations`; the `frontmatter` event is synthesized at the events-emission layer in `nested_to_flat`.

## What lands

### `to_lex.rs` dispatches through `Registry::dispatch_format`

`to_lex_table` and `to_lex_media` now build a `FormatCtx` (with a `WireNode::Verbatim` carrying serialized body + canonical params), call `Registry::dispatch_format`, and emit the resulting `LexAnnotationOut` as a `LexContentItem::VerbatimBlock`. A `NoopLoader` + lazy registry construction lives in `to_lex.rs` — the to_lex direction never resolves includes, so the loader is never touched.

Output now carries canonical labels: `:: lex.tabular.table ::`, `:: lex.media.image ::`, etc.

### `VerbatimHandler` trait shrunk

Removed `to_ir` and `convert_from_ir` methods. The trait is down to `label()` + `format_content()`, both still consumed by the Lex serializer.

The IR-construction path (`from_lex_verbatim`) now calls free helpers directly:
- `table::parse_pipe_table(content)` for `lex.tabular.table`
- `media::image_from_params(content, params)` / `video_from_params(params)` / `audio_from_params(params)` for `lex.media.*`

### `VerbatimRegistry` legacy aliases dropped

`default_with_standard()` registers only canonical labels. Legacy `doc.table` / `doc.image` / `doc.video` / `doc.audio` aliases removed.

### Frontmatter promotion retired

`from_lex_document` no longer scans children for metadata annotations or synthesizes a `frontmatter` IR annotation. The synthesis moves to `nested_to_flat::emit_frontmatter_event`, called from the `DocNode::Document` arm of `walk_node`. Downstream HTML/Markdown serializers are unchanged — they still consume `Event::StartAnnotation { label: "frontmatter", ... }`.

### Legacy whitelist cleanup

- `from_lex.rs`: legacy bare-label entries (`title`, `author`, …) removed from the metadata whitelist; only canonical `lex.metadata.*` names.
- `nested_to_flat.rs`: legacy bare-label metadata whitelist (`["author", "note", "title", …]`) deleted entirely — dead code after `NormalizeLabels` activation.

## Breaking changes (all documented in `CHANGELOG.md` under Unreleased)

- Bare labels in source rewritten at parse time (observable in `lexd format` output). Migration tool: `lexd migrate-labels`.
- `to_lex` output uses canonical labels (`lex.tabular.table`, not `doc.table`).
- `VerbatimRegistry::default_with_standard()` no longer carries `doc.*` aliases.
- `VerbatimHandler` trait shrunk — `to_ir` / `convert_from_ir` removed.
- Inline `:: lex.metadata.title :: ...` in body no longer promoted to document metadata.
- `lex-babel::ir::nodes::Document` gained `document_annotations` field (already in refac/label).
- `nested_to_flat`'s legacy bare-label metadata whitelist removed.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo nextest run --workspace` — **2085/2085 pass**
- [x] Updated Phase 3a/3b regression tests that locked the now-retired behaviour to reflect the new contracts:
  - `from_lex::tests::normalize_labels_pipeline_writes_canonical_labels_into_ast` (asserts frontmatter is NOT in children)
  - `from_lex::tests::document_annotations_is_source_of_truth_for_doc_metadata` (renamed from `legacy_frontmatter_promotion_still_runs_alongside_document_annotations`)
  - `flat_to_nested::tests::document_annotations_synthesize_frontmatter_event` (renamed from `document_annotations_event_stream_is_one_way_in_phase_3a`)
- [x] `nested_to_flat::tests::flattens_nested_document` updated to reflect the new annotation event flow (was matching the legacy `lex-metadata:note` verbatim path)

## Stacking

Branches from `refac/label`. Merging this into `refac/label` rolls it into the integration branch alongside the 8 phase PRs; then `refac/label` → `main` as the user planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)