### PR TITLE
feat(wire): wire_version 2 + on_resolve for tabular + media (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Wire `on_resolve` for tabular + media ([#583](https://github.com/lex-fmt/lex/issues/583))
+
+Closing follow-up to #570. The `lex.tabular.table` and `lex.media.{image,video,audio}` labels now go through `Registry::dispatch_resolve` at IR construction time rather than being pattern-matched on `DocNode` variants by the legacy `VerbatimRegistry` lookup. This is the load-bearing piece of the refactor: third-party namespaces can now intercept verbatim labels through the same code path the built-ins use.
+
+**Wire format bumped to `wire_version: 2`.** Two shape changes; both are breaking for handlers that decoded the wire format directly.
+
+- `WireNode::Table` carries per-column alignment via `column_aligns: Vec<String>` (was a single `align: String` summary in v1). Mixed-alignment tables — e.g. left-aligned first column, right-aligned numeric second column — now round-trip losslessly. `column_aligns.length` equals the widest row in the table.
+- New typed `WireNode::{Image, Video, Audio}` variants for media. Resolve dispatch for `lex.media.*` produces these directly instead of a generic `Verbatim` node with reconstructed params.
+
+`lex-extension v0.12.0`'s `WIRE_VERSION` const ticks to 2. The reusable subprocess fixture handler picks up the bump automatically (it forwards `lex_extension::WIRE_VERSION`).
+
+**Registry parameter on `from_lex_document`.** `lex-babel::ir::from_lex::from_lex_document` and the recursive helpers it dispatches through (`convert_children`, `from_lex_session`, `from_lex_list`, `from_lex_definition`, `from_lex_annotation`, `from_lex_table`, `from_lex_verbatim`, …) now take `registry: &Registry`. The public `lex_babel::to_ir(doc)` still works — it delegates to the new `to_ir_with_registry(doc, registry)` using a process-wide `default_registry()` populated with the built-in `lex.*` schemas. Callers that boot a custom registry (`lex-cli`, `lex-lsp`, embedders) plumb theirs through `to_ir_with_registry`. Same `default_registry()` is reused by `to_lex_document` so verbatim labels round-trip through `Registry::dispatch_format` regardless of which direction kicks the conversion off.
+
+`Schema::hooks.resolve` is now `true` on `lex.tabular.table` and the three `lex.media.*` schemas. The legacy `parse_pipe_table` helper in `lex-babel/src/common/verbatim/table.rs` is gone — the canonical parser is `lex_core::lex::builtins::tabular::parse_pipe_table_to_wire`, which emits a typed `WireNode::Table`. The reverse path (`from_wire_node`) decodes the typed media wire kinds back into `ContentItem::Verbatim` with reconstructed params so lex-core's untyped AST shape is preserved.
+
 ### Added — form-preserving emit ([#584](https://github.com/lex-fmt/lex/issues/584) PR 3 of 5)
 
 Third of five PRs for the bare-as-blessed label namespace model. PRs 1 + 2 added `LabelForm` and tagged every label site at parse time; this PR wires that tag through `LexSerializer` so emit preserves the user's source spelling.

--- a/crates/lex-babel/src/common/verbatim/table.rs
+++ b/crates/lex-babel/src/common/verbatim/table.rs
@@ -1,7 +1,5 @@
 use super::VerbatimHandler;
-use crate::ir::nodes::{
-    DocNode, InlineContent, Paragraph, Table, TableCell, TableCellAlignment, TableRow,
-};
+use crate::ir::nodes::{DocNode, InlineContent, Table, TableCell, TableCellAlignment};
 use lex_core::lex::ast::Verbatim;
 
 /// Handler for `doc.table` verbatim blocks.
@@ -78,115 +76,6 @@ impl VerbatimHandler for TableHandler {
         }
         Ok(None)
     }
-}
-
-pub(crate) fn parse_pipe_table(content: &str) -> DocNode {
-    let mut header = Vec::new();
-    let mut rows = Vec::new();
-    let mut alignments = Vec::new();
-
-    let lines: Vec<&str> = content
-        .lines()
-        .map(|l| l.trim())
-        .filter(|l| !l.is_empty())
-        .collect();
-
-    if lines.is_empty() {
-        return DocNode::Table(Table {
-            rows,
-            header,
-            caption: None,
-            footnotes: vec![],
-            fullwidth: false,
-        });
-    }
-
-    // Parse header
-    if let Some(header_line) = lines.first() {
-        let cells = parse_table_row(header_line);
-        let mut header_row = TableRow { cells: Vec::new() };
-        for cell_content in cells {
-            header_row.cells.push(TableCell {
-                content: vec![DocNode::Paragraph(Paragraph {
-                    content: vec![InlineContent::Text(cell_content)],
-                })],
-                header: true,
-                align: TableCellAlignment::None,
-                colspan: 1,
-                rowspan: 1,
-            });
-        }
-        header.push(header_row);
-    }
-
-    // Parse separator line to determine alignments
-    if lines.len() > 1 {
-        let separator = lines[1];
-        if separator.contains(['-', '|']) {
-            let parts = parse_table_row(separator);
-            for part in parts {
-                let trimmed = part.trim();
-                if trimmed.starts_with(':') && trimmed.ends_with(':') {
-                    alignments.push(TableCellAlignment::Center);
-                } else if trimmed.ends_with(':') {
-                    alignments.push(TableCellAlignment::Right);
-                } else if trimmed.starts_with(':') {
-                    alignments.push(TableCellAlignment::Left);
-                } else {
-                    alignments.push(TableCellAlignment::None);
-                }
-            }
-        }
-    }
-
-    // Parse body rows
-    for line in lines.iter().skip(2) {
-        let cells = parse_table_row(line);
-        let mut row = TableRow { cells: Vec::new() };
-        for (i, cell_content) in cells.into_iter().enumerate() {
-            let align = if i < alignments.len() {
-                alignments[i]
-            } else {
-                TableCellAlignment::None
-            };
-
-            row.cells.push(TableCell {
-                content: vec![DocNode::Paragraph(Paragraph {
-                    content: vec![InlineContent::Text(cell_content)],
-                })],
-                header: false,
-                align,
-                colspan: 1,
-                rowspan: 1,
-            });
-        }
-        rows.push(row);
-    }
-
-    // Apply alignments to header
-    if !header.is_empty() {
-        for (i, cell) in header[0].cells.iter_mut().enumerate() {
-            if i < alignments.len() {
-                cell.align = alignments[i];
-            }
-        }
-    }
-
-    DocNode::Table(Table {
-        rows,
-        header,
-        caption: None,
-        footnotes: vec![],
-        fullwidth: false,
-    })
-}
-
-fn parse_table_row(line: &str) -> Vec<String> {
-    let line = line.trim();
-    let line = line.strip_prefix('|').unwrap_or(line);
-    let line = line.strip_suffix('|').unwrap_or(line);
-
-    line.split('|').map(|s| s.trim().to_string()).collect()
 }
 
 pub(crate) fn serialize_pipe_table(table: &Table) -> String {

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -19,6 +19,9 @@ use lex_core::lex::ast::elements::{
     Verbatim as LexVerbatim, VerbatimLine as LexVerbatimLine,
 };
 use lex_core::lex::ast::TextContent;
+use lex_core::lex::wire::from_wire_node;
+use lex_extension::wire::{AnnotationBody, LabelCtx, NodeRef, Position, Range};
+use lex_extension_host::registry::Registry;
 
 use super::nodes::{
     Annotation, Definition, DocNode, Document, Heading, InlineContent, List, ListForm, ListItem,
@@ -26,6 +29,14 @@ use super::nodes::{
 };
 
 /// Converts a lex document to the IR.
+///
+/// `registry` is the extension registry used to dispatch verbatim
+/// labels through their `on_resolve` hooks (#583 — required for
+/// `lex.tabular.table` to produce a typed `DocNode::Table` and for
+/// `lex.media.{image,video,audio}` to participate in the IR
+/// construction). Callers that only need the built-in `lex.*`
+/// namespaces can pass [`default_registry()`]; CLI / LSP callers
+/// that boot a registry with third-party namespaces pass theirs.
 ///
 /// Post-refac/label cleanup: the legacy frontmatter promotion (which
 /// scanned `children` for `lex.metadata.*` annotations and synthesized
@@ -42,7 +53,7 @@ use super::nodes::{
 /// promoted to document metadata. Inline annotations stay inline;
 /// document-scope metadata must be attached at the document level
 /// (lex-core's `doc.annotations` slot).
-pub fn from_lex_document(doc: &LexDocument) -> Document {
+pub fn from_lex_document(doc: &LexDocument, registry: &Registry) -> Document {
     // Extract document title and subtitle
     let title = doc
         .title
@@ -54,9 +65,13 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
         .and_then(|t| t.subtitle.as_ref())
         .map(convert_inline_content);
 
-    let children = convert_children(&doc.root.children, 2);
+    let children = convert_children(&doc.root.children, 2, registry);
 
-    let document_annotations = doc.annotations.iter().map(ir_annotation_from_lex).collect();
+    let document_annotations = doc
+        .annotations
+        .iter()
+        .map(|a| ir_annotation_from_lex(a, registry))
+        .collect();
 
     Document {
         title,
@@ -69,7 +84,7 @@ pub fn from_lex_document(doc: &LexDocument) -> Document {
 /// Build an IR `Annotation` directly from a lex-core annotation, without
 /// the `DocNode` enum wrapper that [`from_lex_annotation`] returns. Used
 /// by [`from_lex_document`] to populate `Document::document_annotations`.
-fn ir_annotation_from_lex(annotation: &LexAnnotation) -> Annotation {
+fn ir_annotation_from_lex(annotation: &LexAnnotation, registry: &Registry) -> Annotation {
     let label = annotation.data.label.value.clone();
     let parameters = annotation
         .data
@@ -77,7 +92,7 @@ fn ir_annotation_from_lex(annotation: &LexAnnotation) -> Annotation {
         .iter()
         .map(|p| (p.key.clone(), p.value.clone()))
         .collect();
-    let content = convert_children(&annotation.children, 2);
+    let content = convert_children(&annotation.children, 2, registry);
     Annotation {
         label,
         parameters,
@@ -87,20 +102,24 @@ fn ir_annotation_from_lex(annotation: &LexAnnotation) -> Annotation {
 
 /// Helper: Converts a list of content items, filtering out blank lines
 /// Also extracts annotations attached to each element
-fn convert_children(items: &[LexContentItem], level: usize) -> Vec<DocNode> {
+fn convert_children(items: &[LexContentItem], level: usize, registry: &Registry) -> Vec<DocNode> {
     items
         .iter()
         .filter(|item| !matches!(item, LexContentItem::BlankLineGroup(_)))
         .flat_map(|item| {
-            let mut nodes = extract_attached_annotations(item, level);
-            nodes.push(from_lex_content_item_with_level(item, level));
+            let mut nodes = extract_attached_annotations(item, level, registry);
+            nodes.push(from_lex_content_item_with_level(item, level, registry));
             nodes
         })
         .collect()
 }
 
 /// Extracts annotations attached to a content item and converts them to IR nodes
-fn extract_attached_annotations(item: &LexContentItem, level: usize) -> Vec<DocNode> {
+fn extract_attached_annotations(
+    item: &LexContentItem,
+    level: usize,
+    registry: &Registry,
+) -> Vec<DocNode> {
     let annotations = match item {
         LexContentItem::Session(session) => session.annotations(),
         LexContentItem::Paragraph(paragraph) => paragraph.annotations(),
@@ -114,7 +133,7 @@ fn extract_attached_annotations(item: &LexContentItem, level: usize) -> Vec<DocN
 
     annotations
         .iter()
-        .map(|anno| from_lex_annotation(anno, level))
+        .map(|anno| from_lex_annotation(anno, level, registry))
         .collect()
 }
 
@@ -152,16 +171,20 @@ fn convert_inline_node(node: &InlineNode) -> InlineContent {
 }
 
 /// Converts a lex content item to an IR node with a given level.
-fn from_lex_content_item_with_level(item: &LexContentItem, level: usize) -> DocNode {
+fn from_lex_content_item_with_level(
+    item: &LexContentItem,
+    level: usize,
+    registry: &Registry,
+) -> DocNode {
     match item {
-        LexContentItem::Session(session) => from_lex_session(session, level),
+        LexContentItem::Session(session) => from_lex_session(session, level, registry),
         LexContentItem::Paragraph(paragraph) => from_lex_paragraph(paragraph),
-        LexContentItem::List(list) => from_lex_list(list, level),
-        LexContentItem::ListItem(list_item) => from_lex_list_item(list_item, level),
-        LexContentItem::Definition(definition) => from_lex_definition(definition, level),
-        LexContentItem::VerbatimBlock(verbatim) => from_lex_verbatim(verbatim),
-        LexContentItem::Table(table) => from_lex_table(table),
-        LexContentItem::Annotation(annotation) => from_lex_annotation(annotation, level),
+        LexContentItem::List(list) => from_lex_list(list, level, registry),
+        LexContentItem::ListItem(list_item) => from_lex_list_item(list_item, level, registry),
+        LexContentItem::Definition(definition) => from_lex_definition(definition, level, registry),
+        LexContentItem::VerbatimBlock(verbatim) => from_lex_verbatim(verbatim, registry),
+        LexContentItem::Table(table) => from_lex_table(table, registry),
+        LexContentItem::Annotation(annotation) => from_lex_annotation(annotation, level, registry),
         LexContentItem::TextLine(text_line) => from_lex_text_line(text_line),
         LexContentItem::VerbatimLine(verbatim_line) => from_lex_verbatim_line(verbatim_line),
         LexContentItem::BlankLineGroup(_) => {
@@ -177,10 +200,10 @@ fn from_lex_content_item_with_level(item: &LexContentItem, level: usize) -> DocN
 /// title text and are preserved as regular `InlineContent::Text` — not as a
 /// separate structural variant. The full title text (including any numbering
 /// prefix) is kept in `Heading.content`.
-fn from_lex_session(session: &LexSession, level: usize) -> DocNode {
+fn from_lex_session(session: &LexSession, level: usize, registry: &Registry) -> DocNode {
     let content = convert_inline_content(&session.title);
 
-    let children = convert_children(&session.children, level + 1);
+    let children = convert_children(&session.children, level + 1, registry);
     DocNode::Heading(Heading {
         level,
         content,
@@ -205,13 +228,13 @@ fn from_lex_paragraph(paragraph: &LexParagraph) -> DocNode {
 }
 
 /// Converts a lex list to an IR list.
-fn from_lex_list(list: &LexList, level: usize) -> DocNode {
+fn from_lex_list(list: &LexList, level: usize, registry: &Registry) -> DocNode {
     let items: Vec<ListItem> = list
         .items
         .iter()
         .filter_map(|item| {
             if let LexContentItem::ListItem(li) = item {
-                Some(convert_list_item(li, level))
+                Some(convert_list_item(li, level, registry))
             } else {
                 None
             }
@@ -245,32 +268,46 @@ fn from_lex_list(list: &LexList, level: usize) -> DocNode {
 }
 
 /// Converts a lex list item to an IR list item node.
-fn from_lex_list_item(list_item: &LexListItem, level: usize) -> DocNode {
-    DocNode::ListItem(convert_list_item(list_item, level))
+fn from_lex_list_item(list_item: &LexListItem, level: usize, registry: &Registry) -> DocNode {
+    DocNode::ListItem(convert_list_item(list_item, level, registry))
 }
 
 /// Converts a lex list item to an IR list item struct.
 ///
 /// List markers are structural (captured by `List.style` and `List.form` on the
 /// parent) and are not included in the item's inline content.
-fn convert_list_item(list_item: &LexListItem, level: usize) -> ListItem {
+fn convert_list_item(list_item: &LexListItem, level: usize, registry: &Registry) -> ListItem {
     let mut content = Vec::new();
     for text_content in &list_item.text {
         content.extend(convert_inline_content(text_content));
     }
-    let children = convert_children(&list_item.children, level);
+    let children = convert_children(&list_item.children, level, registry);
     ListItem { content, children }
 }
 
 /// Converts a lex definition to an IR definition.
-fn from_lex_definition(definition: &LexDefinition, level: usize) -> DocNode {
+fn from_lex_definition(definition: &LexDefinition, level: usize, registry: &Registry) -> DocNode {
     let term = convert_inline_content(&definition.subject);
-    let description = convert_children(&definition.children, level);
+    let description = convert_children(&definition.children, level, registry);
     DocNode::Definition(Definition { term, description })
 }
 
 /// Converts a lex verbatim block to an IR verbatim block.
-fn from_lex_verbatim(verbatim: &LexVerbatim) -> DocNode {
+///
+/// #583: dispatches through the registry first. The built-in
+/// `lex.tabular.table` and `lex.media.{image,video,audio}` handlers
+/// parse the verbatim into a typed `WireNode` (`Table` / `Image` /
+/// `Video` / `Audio` per `wire_version: 2`); we decode that back to
+/// a lex-core AST node via `from_wire_node`, then run the matching
+/// `from_lex_*` converter for the final IR. Third-party namespaces
+/// that register a verbatim handler with `on_resolve` participate
+/// the same way — their registered handler's typed output flows
+/// through this path.
+///
+/// Falls back to a generic `DocNode::Verbatim` when no handler is
+/// registered for the label (third-party verbatim labels with no
+/// resolve hook, or unrecognised labels).
+fn from_lex_verbatim(verbatim: &LexVerbatim, registry: &Registry) -> DocNode {
     let subject_str = verbatim.subject.as_string();
     let subject = if subject_str.is_empty() {
         None
@@ -291,32 +328,53 @@ fn from_lex_verbatim(verbatim: &LexVerbatim) -> DocNode {
         .collect::<Vec<_>>()
         .join("\n");
 
-    // Post-refac/label cleanup: the legacy
-    // `VerbatimRegistry::get(...).to_ir(...)` indirection is gone.
-    // Dispatch on the canonical label directly to the free hydration
-    // helpers — same logic, no trait-object overhead.
-    let label = verbatim.closing_data.label.value.as_str();
-    let params: std::collections::HashMap<String, String> = verbatim
-        .closing_data
-        .parameters
-        .iter()
-        .map(|p| (p.key.clone(), p.value.clone()))
-        .collect();
-
-    match label {
-        "lex.tabular.table" => {
-            return crate::common::verbatim::table::parse_pipe_table(&content);
+    // Build a LabelCtx and dispatch through the registry. The
+    // handler-returned WireNode goes through `from_wire_node` →
+    // lex-core AST `ContentItem`, then the matching `from_lex_*`
+    // converter produces IR.
+    let label = verbatim.closing_data.label.value.clone();
+    let params_object = serde_json::Value::Object(
+        verbatim
+            .closing_data
+            .parameters
+            .iter()
+            .map(|p| (p.key.clone(), serde_json::Value::String(p.value.clone())))
+            .collect(),
+    );
+    let ctx = LabelCtx {
+        label,
+        params: params_object,
+        body: AnnotationBody::Text(content.clone()),
+        node: NodeRef {
+            kind: "verbatim".into(),
+            range: Range {
+                start: Position(0, 0),
+                end: Position(0, 0),
+            },
+            origin: None,
+        },
+    };
+    if let Ok(Some(wire_node)) = registry.dispatch_resolve(&ctx) {
+        if let Ok(items) = from_wire_node(&wire_node) {
+            if let Some(first) = items.into_iter().next() {
+                match first {
+                    LexContentItem::Table(table) => return from_lex_table(&table, registry),
+                    LexContentItem::VerbatimBlock(v) => {
+                        // Image/Video/Audio wire kinds decode to a
+                        // Verbatim with their params reconstructed
+                        // (lex-core's `ContentItem` has no typed
+                        // media variants today). Re-dispatch on the
+                        // canonical label to build the typed IR
+                        // node via the free hydration helpers.
+                        return from_lex_media_verbatim(&v, &content);
+                    }
+                    _ => {
+                        // Unrecognised wire kind for a verbatim
+                        // resolve — fall through to generic Verbatim.
+                    }
+                }
+            }
         }
-        "lex.media.image" => {
-            return crate::common::verbatim::media::image_from_params(&content, &params);
-        }
-        "lex.media.video" => {
-            return crate::common::verbatim::media::video_from_params(&params);
-        }
-        "lex.media.audio" => {
-            return crate::common::verbatim::media::audio_from_params(&params);
-        }
-        _ => {}
     }
 
     DocNode::Verbatim(Verbatim {
@@ -326,8 +384,36 @@ fn from_lex_verbatim(verbatim: &LexVerbatim) -> DocNode {
     })
 }
 
+/// Decode a media verbatim (canonical label `lex.media.{image,video,audio}`)
+/// into the matching IR `DocNode::Image` / `Video` / `Audio` by routing
+/// through the existing free helpers. The wire `Image` / `Video` /
+/// `Audio` kinds decode to a lex-core AST `Verbatim` with their
+/// params reconstructed; this helper closes the loop to a typed IR
+/// node.
+fn from_lex_media_verbatim(verbatim: &LexVerbatim, original_content: &str) -> DocNode {
+    let label = verbatim.closing_data.label.value.as_str();
+    let params: std::collections::HashMap<String, String> = verbatim
+        .closing_data
+        .parameters
+        .iter()
+        .map(|p| (p.key.clone(), p.value.clone()))
+        .collect();
+    match label {
+        "lex.media.image" => {
+            crate::common::verbatim::media::image_from_params(original_content, &params)
+        }
+        "lex.media.video" => crate::common::verbatim::media::video_from_params(&params),
+        "lex.media.audio" => crate::common::verbatim::media::audio_from_params(&params),
+        _ => DocNode::Verbatim(Verbatim {
+            subject: None,
+            language: Some(label.to_string()),
+            content: original_content.to_string(),
+        }),
+    }
+}
+
 /// Converts a lex annotation to an IR annotation.
-fn from_lex_annotation(annotation: &LexAnnotation, level: usize) -> DocNode {
+fn from_lex_annotation(annotation: &LexAnnotation, level: usize, registry: &Registry) -> DocNode {
     let label = annotation.data.label.value.clone();
     let parameters = annotation
         .data
@@ -335,7 +421,7 @@ fn from_lex_annotation(annotation: &LexAnnotation, level: usize) -> DocNode {
         .iter()
         .map(|p| (p.key.clone(), p.value.clone()))
         .collect();
-    let content = convert_children(&annotation.children, level);
+    let content = convert_children(&annotation.children, level, registry);
     DocNode::Annotation(Annotation {
         label,
         parameters,
@@ -353,7 +439,7 @@ fn from_lex_text_line(text_line: &LexTextLine) -> DocNode {
 /// Converts a VerbatimLine to an IR verbatim block.
 /// VerbatimLines are typically parts of VerbatimBlocks, but can appear standalone.
 /// Converts a native lex Table AST node to an IR Table node.
-fn from_lex_table(table: &lex_core::lex::ast::Table) -> DocNode {
+fn from_lex_table(table: &lex_core::lex::ast::Table, registry: &Registry) -> DocNode {
     use crate::ir::nodes::{
         Table as IrTable, TableCell as IrTableCell, TableCellAlignment as IrAlign,
         TableRow as IrTableRow,
@@ -375,7 +461,7 @@ fn from_lex_table(table: &lex_core::lex::ast::Table) -> DocNode {
                 .iter()
                 .map(|cell| {
                     let content = if cell.has_block_content() {
-                        convert_children(&cell.children, 2)
+                        convert_children(&cell.children, 2, registry)
                     } else {
                         vec![DocNode::Paragraph(Paragraph {
                             content: convert_inline_content(&cell.content),
@@ -404,7 +490,7 @@ fn from_lex_table(table: &lex_core::lex::ast::Table) -> DocNode {
     let footnotes = table
         .footnotes
         .as_ref()
-        .map(|list| vec![from_lex_list(list, 2)])
+        .map(|list| vec![from_lex_list(list, 2, registry)])
         .unwrap_or_default();
 
     let fullwidth = matches!(
@@ -496,6 +582,12 @@ mod tests {
     };
     use lex_core::lex::ast::{ContentItem, Document as LexDocument, TextContent};
 
+    /// Test-scope shorthand for the lex-babel default registry —
+    /// every test that calls `from_lex_document` directly needs one.
+    fn test_registry() -> &'static Registry {
+        crate::default_registry()
+    }
+
     #[test]
     fn test_simple_paragraph_conversion() {
         let lex_para = LexParagraph::from_line("Hello world".to_string());
@@ -515,7 +607,7 @@ mod tests {
     #[test]
     fn test_session_to_heading() {
         let session = LexSession::with_title("Test Section".to_string());
-        let ir_node = from_lex_session(&session, 1);
+        let ir_node = from_lex_session(&session, 1, test_registry());
 
         match ir_node {
             DocNode::Heading(heading) => {
@@ -533,7 +625,7 @@ mod tests {
         let item2 = LexListItem::new("-".to_string(), "Item 2".to_string());
         let list = LexList::new(vec![item1, item2]);
 
-        let ir_node = from_lex_list(&list, 1);
+        let ir_node = from_lex_list(&list, 1, test_registry());
 
         match ir_node {
             DocNode::List(list) => {
@@ -560,7 +652,7 @@ mod tests {
             lex_core::lex::ast::elements::verbatim::VerbatimBlockMode::Inflow,
         );
 
-        let ir_node = from_lex_verbatim(&verb);
+        let ir_node = from_lex_verbatim(&verb, test_registry());
 
         match ir_node {
             DocNode::Verbatim(verb) => {
@@ -579,7 +671,7 @@ mod tests {
             Vec::new(),
         ));
 
-        let children = convert_children(&[para, blank], 1);
+        let children = convert_children(&[para, blank], 1, test_registry());
 
         assert_eq!(children.len(), 1);
     }
@@ -590,7 +682,7 @@ mod tests {
             "Test paragraph".to_string(),
         ))]);
 
-        let ir_doc = from_lex_document(&doc);
+        let ir_doc = from_lex_document(&doc, test_registry());
 
         assert_eq!(ir_doc.children.len(), 1);
         assert!(matches!(ir_doc.children[0], DocNode::Paragraph(_)));
@@ -621,7 +713,7 @@ mod tests {
         // annotation that the legacy promotion inserts into
         // `children` is *additive* in Phase 3a — Phase 3b removes it.
         let doc = doc_with_one_annotation("acme.custom", "Body text.");
-        let ir_doc = from_lex_document(&doc);
+        let ir_doc = from_lex_document(&doc, test_registry());
 
         assert_eq!(
             ir_doc.document_annotations.len(),
@@ -640,7 +732,7 @@ mod tests {
         let doc = LexDocument::with_content(vec![ContentItem::Paragraph(LexParagraph::from_line(
             "Body only.".to_string(),
         ))]);
-        let ir_doc = from_lex_document(&doc);
+        let ir_doc = from_lex_document(&doc, test_registry());
         assert!(
             ir_doc.document_annotations.is_empty(),
             "empty input must produce empty document_annotations"
@@ -674,7 +766,7 @@ mod tests {
         // canonical-labelled annotation lands in
         // `document_annotations` instead; the `frontmatter` event is
         // synthesized at the events-emission layer.
-        let ir = from_lex_document(&lex_doc);
+        let ir = from_lex_document(&lex_doc, test_registry());
         let frontmatter_in_children = ir
             .children
             .iter()
@@ -691,7 +783,7 @@ mod tests {
         // through `document_annotations` only — the legacy
         // `frontmatter` synthesis in children is gone.
         let doc = doc_with_one_annotation("author", "Alice");
-        let ir_doc = from_lex_document(&doc);
+        let ir_doc = from_lex_document(&doc, test_registry());
 
         // The new slot carries the annotation.
         assert_eq!(ir_doc.document_annotations.len(), 1);

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -19,8 +19,8 @@ use lex_core::lex::ast::elements::{
     Verbatim as LexVerbatim, VerbatimLine as LexVerbatimLine,
 };
 use lex_core::lex::ast::TextContent;
-use lex_core::lex::wire::from_wire_node;
-use lex_extension::wire::{AnnotationBody, LabelCtx, NodeRef, Position, Range};
+use lex_core::lex::wire::{from_wire_node, origin_string, range_to_wire};
+use lex_extension::wire::{AnnotationBody, HostNodeKind, LabelCtx, NodeRef};
 use lex_extension_host::registry::Registry;
 
 use super::nodes::{
@@ -346,12 +346,9 @@ fn from_lex_verbatim(verbatim: &LexVerbatim, registry: &Registry) -> DocNode {
         params: params_object,
         body: AnnotationBody::Text(content.clone()),
         node: NodeRef {
-            kind: "verbatim".into(),
-            range: Range {
-                start: Position(0, 0),
-                end: Position(0, 0),
-            },
-            origin: None,
+            kind: HostNodeKind::Verbatim.as_str().into(),
+            range: range_to_wire(&verbatim.location),
+            origin: origin_string(&verbatim.location),
         },
     };
     if let Ok(Some(wire_node)) = registry.dispatch_resolve(&ctx) {

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -11,52 +11,18 @@ use lex_core::lex::ast::elements::{
 };
 use lex_core::lex::ast::range::Position;
 use lex_core::lex::ast::{Data, Document as LexDocument, Parameter, Range, TextContent};
-use lex_core::lex::includes::{LoadError, LoadedFile, Loader, ResolveConfig};
 use lex_extension::wire::{FormatCtx, LexAnnotationOut, WireNode};
 use lex_extension::wire::{Position as WirePosition, Range as WireRange};
-use lex_extension_host::registry::Registry;
-use std::path::Path;
-use std::sync::Arc;
 
 use super::nodes::{
     Annotation, Definition, DocNode, Document, Heading, InlineContent, List, ListItem, Paragraph,
     Table, TableCell, TableRow, Verbatim,
 };
 
-/// A loader that always reports NotFound. The to_lex direction never
-/// resolves includes — it only emits source — so we never actually
-/// touch the loader. It exists because
-/// `lex_core::lex::builtins::register_into` requires one.
-struct NoopLoader;
-impl Loader for NoopLoader {
-    fn load(&self, path: &Path) -> Result<LoadedFile, LoadError> {
-        Err(LoadError::NotFound {
-            path: path.to_path_buf(),
-        })
-    }
-}
-
-/// Cached process-wide registry for the to_lex direction. The
-/// registry's contents are invariant (always the same built-in
-/// `lex.*` schemas), so constructing it once and reusing across
-/// every call to `to_lex_document` avoids re-registering for every
-/// table/media node in a document.
-///
-/// `Registry` uses interior `RwLock`s for its state, so sharing
-/// `&'static Registry` across threads is safe.
-fn to_lex_registry() -> &'static Registry {
-    use std::sync::OnceLock;
-    static REGISTRY: OnceLock<Registry> = OnceLock::new();
-    REGISTRY.get_or_init(|| {
-        let registry = Registry::new();
-        lex_core::lex::builtins::register_into(
-            &registry,
-            Arc::new(NoopLoader),
-            ResolveConfig::with_root(std::path::PathBuf::from("/")),
-        )
-        .expect("registering built-in lex.* handlers must succeed for a fresh registry");
-        registry
-    })
+/// The to_lex direction shares the same default registry as the
+/// from_lex direction — see [`crate::default_registry`].
+fn to_lex_registry() -> &'static lex_extension_host::registry::Registry {
+    crate::default_registry()
 }
 
 fn default_wire_range() -> WireRange {

--- a/crates/lex-babel/src/lib.rs
+++ b/crates/lex-babel/src/lib.rs
@@ -139,8 +139,63 @@ pub use registry::FormatRegistry;
 /// - Comment annotations at document level
 ///
 /// For lossless Lex representation, use the AST directly.
+///
+/// Uses the shared default registry ([`default_registry()`]) for
+/// verbatim-label `on_resolve` dispatch. Callers that need to plug
+/// in third-party namespaces (lex-cli with `boot_registry`, lex-lsp,
+/// embedders) should call [`to_ir_with_registry`] directly.
 pub fn to_ir(doc: &lex_core::lex::ast::elements::Document) -> ir::nodes::Document {
-    ir::from_lex::from_lex_document(doc)
+    to_ir_with_registry(doc, default_registry())
+}
+
+/// Converts a Lex AST to its IR representation, dispatching verbatim
+/// labels through the supplied registry's `on_resolve` hooks.
+///
+/// This is the explicit-registry variant of [`to_ir`] — use it when
+/// the caller has its own registry (with third-party namespaces
+/// registered) and wants those handlers to participate in IR
+/// construction.
+pub fn to_ir_with_registry(
+    doc: &lex_core::lex::ast::elements::Document,
+    registry: &lex_extension_host::registry::Registry,
+) -> ir::nodes::Document {
+    ir::from_lex::from_lex_document(doc, registry)
+}
+
+/// Process-wide registry with the built-in `lex.*` schemas
+/// registered. Used by `to_ir` and `to_lex_document` for callers
+/// that don't supply their own. Constructed lazily on first call.
+///
+/// Filesystem access is plumbed through a no-op loader — this
+/// registry doesn't resolve `lex.include` (the to_ir/to_lex paths
+/// never invoke `on_resolve` for that label; includes are resolved
+/// elsewhere in the pipeline).
+pub fn default_registry() -> &'static lex_extension_host::registry::Registry {
+    use lex_core::lex::includes::{LoadError, LoadedFile, Loader, ResolveConfig};
+    use lex_extension_host::registry::Registry;
+    use std::path::Path;
+    use std::sync::{Arc, OnceLock};
+
+    struct NoopLoader;
+    impl Loader for NoopLoader {
+        fn load(&self, path: &Path) -> Result<LoadedFile, LoadError> {
+            Err(LoadError::NotFound {
+                path: path.to_path_buf(),
+            })
+        }
+    }
+
+    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        let registry = Registry::new();
+        lex_core::lex::builtins::register_into(
+            &registry,
+            Arc::new(NoopLoader),
+            ResolveConfig::with_root(std::path::PathBuf::from("/")),
+        )
+        .expect("registering built-in lex.* handlers must succeed for a fresh registry");
+        registry
+    })
 }
 
 /// Converts an IR document back to Lex AST.

--- a/crates/lex-core/src/lex/builtins/media.rs
+++ b/crates/lex-core/src/lex/builtins/media.rs
@@ -1,20 +1,11 @@
-//! Schemas for the `lex.media.*` family of verbatim labels.
+//! Schemas for the `lex.media.*` family of verbatim labels:
+//! `lex.media.image`, `lex.media.video`, `lex.media.audio`.
 //!
-//! The members — `lex.media.image`, `lex.media.video`, `lex.media.audio` —
-//! are the registry-shaped replacements for the legacy `doc.image`,
-//! `doc.video`, and `doc.audio` handlers in `lex-babel`
-//! (`crates/lex-babel/src/common/verbatim/media.rs`).
-//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
-//! multi-phase migration.
-//!
-//! # Phase 1 status
-//!
-//! Schemas only — no `on_resolve` bodies yet. The legacy
-//! `VerbatimRegistry` still converts verbatim params into typed
-//! `DocNode::Image` / `Video` / `Audio` nodes. Phase 2's parse-time
-//! auto-rewrite retargets `:: doc.image ::` &c. at these labels;
-//! Phase 3 deletes the legacy lookup and Phase 4 wires `on_format` so
-//! they round-trip back to Lex source through the registry.
+//! `on_resolve` is declared on all three; resolve bodies live in
+//! [`crate::lex::builtins`] (`resolve_media_image` / `_video` /
+//! `_audio`) and emit the typed [`WireNode::Image`],
+//! [`WireNode::Video`], [`WireNode::Audio`] variants introduced with
+//! `wire_version: 2`.
 
 use lex_extension::schema::{
     BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
@@ -58,7 +49,10 @@ fn media_schema(
         },
         verbatim_label: true,
         capabilities: Capabilities::default(),
-        hooks: HookSet::default(),
+        hooks: HookSet {
+            resolve: true,
+            ..HookSet::default()
+        },
         handler: None,
     }
 }
@@ -194,11 +188,15 @@ mod tests {
     }
 
     #[test]
-    fn media_schemas_declare_no_hooks_in_phase_1() {
+    fn media_schemas_declare_resolve_hook() {
+        // Phase 3 of #570 turned on `on_resolve` for the media labels
+        // so they go through the registry dispatch like
+        // `lex.tabular.table`. Validate + render stay off — those are
+        // future-phase work.
         for schema in all_schemas() {
             assert!(
-                !schema.hooks.resolve,
-                "{} resolve must stay off",
+                schema.hooks.resolve,
+                "{} resolve must be on (Phase 3+)",
                 schema.label
             );
             assert!(

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -187,7 +187,15 @@ fn resolve_tabular_table(ctx: &LabelCtx) -> WireNode {
         // well-formed inputs.)
         _ => "",
     };
-    tabular::parse_pipe_table_to_wire(body)
+    let mut table = tabular::parse_pipe_table_to_wire(body);
+    // Stamp the host's range + origin onto the wire node — the
+    // parser builds with `(0,0)` defaults since it has no source
+    // context of its own.
+    if let WireNode::Table { range, origin, .. } = &mut table {
+        *range = ctx.node.range;
+        *origin = ctx.node.origin.clone();
+    }
+    table
 }
 
 /// `on_resolve` for `lex.media.image`: read `src`/`alt`/`title` from
@@ -590,6 +598,61 @@ mod tests {
                 other => panic!("dispatch_resolve({label}) produced unexpected variant {other:?}"),
             };
             assert_eq!(actual, expect_kind, "wire variant for {label}");
+        }
+    }
+
+    #[test]
+    fn dispatch_resolve_propagates_ctx_range_and_origin() {
+        // Resolve handlers must stamp `ctx.node.range` and
+        // `ctx.node.origin` onto the WireNode they return so
+        // downstream diagnostics can attribute back to source. Hard-
+        // coded `(0,0)` and `origin: None` would silently break LSP
+        // hover / go-to-def for handler-emitted nodes.
+        let registry = fresh_registry();
+        let stamped_range = Range {
+            start: Position(12, 4),
+            end: Position(14, 10),
+        };
+        let stamped_origin = Some("/host/doc.lex".to_string());
+        let cases: &[(&str, &str)] = &[
+            (
+                tabular::LEX_TABULAR_TABLE,
+                "| a | b |\n|---|---|\n| 1 | 2 |",
+            ),
+            (media::LEX_MEDIA_IMAGE, ""),
+            (media::LEX_MEDIA_VIDEO, ""),
+            (media::LEX_MEDIA_AUDIO, ""),
+        ];
+        for (label, body) in cases {
+            let ctx = LabelCtx {
+                label: (*label).into(),
+                params: serde_json::json!({ "src": "x" }),
+                body: AnnotationBody::Text((*body).into()),
+                node: NodeRef {
+                    kind: "verbatim".into(),
+                    range: stamped_range,
+                    origin: stamped_origin.clone(),
+                },
+            };
+            let result = registry
+                .dispatch_resolve(&ctx)
+                .unwrap_or_else(|e| panic!("dispatch_resolve({label}) errored: {e:?}"))
+                .unwrap_or_else(|| panic!("dispatch_resolve({label}) must return Some"));
+            let (got_range, got_origin) = match result {
+                lex_extension::wire::WireNode::Table { range, origin, .. }
+                | lex_extension::wire::WireNode::Image { range, origin, .. }
+                | lex_extension::wire::WireNode::Video { range, origin, .. }
+                | lex_extension::wire::WireNode::Audio { range, origin, .. } => (range, origin),
+                other => panic!("dispatch_resolve({label}) produced unexpected variant {other:?}"),
+            };
+            assert_eq!(
+                got_range, stamped_range,
+                "range must propagate from LabelCtx to WireNode for {label}"
+            );
+            assert_eq!(
+                got_origin, stamped_origin,
+                "origin must propagate from LabelCtx to WireNode for {label}"
+            );
         }
     }
 

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -42,7 +42,7 @@ use lex_extension::{
     schema::{
         BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
     },
-    wire::{FormatCtx, LabelCtx, LexAnnotationOut, WireNode},
+    wire::{AnnotationBody, FormatCtx, LabelCtx, LexAnnotationOut, Position, Range, WireNode},
 };
 use lex_extension_host::registry::{Registry, RegistryError};
 
@@ -132,9 +132,10 @@ impl LexHandler for LexBuiltinsHandler {
     fn on_resolve(&self, ctx: &LabelCtx) -> Result<Option<WireNode>, HandlerError> {
         match ctx.label.as_str() {
             "lex.include" => self.include.on_resolve(ctx),
-            // Phase 1 of #570: schemas register but don't intercept.
-            // The legacy IR paths in lex-babel still own the work for
-            // every other `lex.*` label. Phase 3 fills these arms in.
+            "lex.tabular.table" => Ok(Some(resolve_tabular_table(ctx))),
+            "lex.media.image" => Ok(Some(resolve_media_image(ctx))),
+            "lex.media.video" => Ok(Some(resolve_media_video(ctx))),
+            "lex.media.audio" => Ok(Some(resolve_media_audio(ctx))),
             _ => Ok(None),
         }
     }
@@ -173,6 +174,83 @@ impl LexHandler for LexBuiltinsHandler {
 /// being a wire-internal copy of the same data. A well-formed host
 /// fills both with the same `(key, value)` pairs; in the
 /// hypothetical case where they diverge, `ctx.params` wins.
+/// `on_resolve` for `lex.tabular.table`: parse the verbatim body
+/// (pipe-table source) into a typed [`WireNode::Table`]. The wire
+/// table carries per-column alignment in `column_aligns` — no
+/// fidelity loss on mixed-alignment tables.
+fn resolve_tabular_table(ctx: &LabelCtx) -> WireNode {
+    let body = match &ctx.body {
+        AnnotationBody::Text(s) => s.as_str(),
+        // No body or a `Lex`-shaped body — fall back to an empty
+        // table. (Verbatim labels can't legitimately have a `Lex`
+        // body; schema enforcement keeps this branch unreachable in
+        // well-formed inputs.)
+        _ => "",
+    };
+    tabular::parse_pipe_table_to_wire(body)
+}
+
+/// `on_resolve` for `lex.media.image`: read `src`/`alt`/`title` from
+/// `ctx.params`. Falls back to the verbatim body for `alt` when the
+/// `alt=` param is missing — mirrors the lex-babel
+/// `image_from_params` contract.
+fn resolve_media_image(ctx: &LabelCtx) -> WireNode {
+    let src = string_param(ctx, "src").unwrap_or_default();
+    let alt = string_param(ctx, "alt").unwrap_or_else(|| match &ctx.body {
+        AnnotationBody::Text(s) => s.trim().to_string(),
+        _ => String::new(),
+    });
+    let title = string_param(ctx, "title");
+    WireNode::Image {
+        range: ctx.node.range,
+        origin: ctx.node.origin.clone(),
+        src,
+        alt,
+        title,
+    }
+}
+
+/// `on_resolve` for `lex.media.video`: read `src`/`title`/`poster`
+/// from `ctx.params`.
+fn resolve_media_video(ctx: &LabelCtx) -> WireNode {
+    WireNode::Video {
+        range: ctx.node.range,
+        origin: ctx.node.origin.clone(),
+        src: string_param(ctx, "src").unwrap_or_default(),
+        title: string_param(ctx, "title"),
+        poster: string_param(ctx, "poster"),
+    }
+}
+
+/// `on_resolve` for `lex.media.audio`: read `src`/`title` from
+/// `ctx.params`.
+fn resolve_media_audio(ctx: &LabelCtx) -> WireNode {
+    WireNode::Audio {
+        range: ctx.node.range,
+        origin: ctx.node.origin.clone(),
+        src: string_param(ctx, "src").unwrap_or_default(),
+        title: string_param(ctx, "title"),
+    }
+}
+
+/// Extract a string-typed parameter from `ctx.params`. Returns `None`
+/// when the key is missing or the value isn't a string. Used by the
+/// media resolve helpers.
+fn string_param(ctx: &LabelCtx, key: &str) -> Option<String> {
+    ctx.params
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+#[allow(dead_code)]
+fn default_resolve_range() -> Range {
+    Range {
+        start: Position(0, 0),
+        end: Position(0, 0),
+    }
+}
+
 fn verbatim_label_on_format(ctx: &FormatCtx) -> Result<Option<LexAnnotationOut>, HandlerError> {
     let body = match &ctx.node {
         WireNode::Verbatim { body_text, .. } => body_text.clone(),
@@ -473,31 +551,45 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_resolve_for_new_schemas_returns_none_in_phase_1() {
-        // Phase 1 contract: schemas register but don't intercept.
-        // Dispatch must succeed (no panic, no error) and return None
-        // so the legacy IR paths continue to own the work until
-        // Phase 3 retires them.
+    fn dispatch_resolve_metadata_returns_none() {
+        // Metadata schemas don't declare `on_resolve` (they're
+        // attached to the document, consumed by analysis). Dispatch
+        // must short-circuit to None for each one.
         let registry = fresh_registry();
-        let labels: Vec<&str> = metadata::METADATA_LABELS
-            .iter()
-            .copied()
-            .chain(std::iter::once(tabular::LEX_TABULAR_TABLE))
-            .chain([
-                media::LEX_MEDIA_IMAGE,
-                media::LEX_MEDIA_VIDEO,
-                media::LEX_MEDIA_AUDIO,
-            ])
-            .collect();
-        for label in labels {
+        for label in metadata::METADATA_LABELS {
             let ctx = make_ctx(label, None, None);
             let result = registry
                 .dispatch_resolve(&ctx)
                 .unwrap_or_else(|e| panic!("dispatch_resolve({label}) errored: {e:?}"));
             assert!(
                 result.is_none(),
-                "dispatch_resolve({label}) must return None in Phase 1; got Some(...)"
+                "dispatch_resolve({label}) must return None; got Some(...)"
             );
+        }
+    }
+
+    #[test]
+    fn dispatch_resolve_media_returns_typed_wire_kinds() {
+        // Phase 3 of #570: `lex.media.*` resolve to typed
+        // `WireNode::{Image, Video, Audio}` variants.
+        let registry = fresh_registry();
+        for (label, expect_kind) in [
+            (media::LEX_MEDIA_IMAGE, "image"),
+            (media::LEX_MEDIA_VIDEO, "video"),
+            (media::LEX_MEDIA_AUDIO, "audio"),
+        ] {
+            let ctx = make_ctx(label, Some("./asset.media"), None);
+            let result = registry
+                .dispatch_resolve(&ctx)
+                .unwrap_or_else(|e| panic!("dispatch_resolve({label}) errored: {e:?}"))
+                .unwrap_or_else(|| panic!("dispatch_resolve({label}) must return Some"));
+            let actual = match result {
+                lex_extension::wire::WireNode::Image { .. } => "image",
+                lex_extension::wire::WireNode::Video { .. } => "video",
+                lex_extension::wire::WireNode::Audio { .. } => "audio",
+                other => panic!("dispatch_resolve({label}) produced unexpected variant {other:?}"),
+            };
+            assert_eq!(actual, expect_kind, "wire variant for {label}");
         }
     }
 

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -1,24 +1,132 @@
 //! Schema for the `lex.tabular.*` family of verbatim labels.
 //!
-//! Today the family has a single member: `lex.tabular.table`, the
-//! registry-shaped replacement for the legacy `doc.table` handler in
-//! `lex-babel` (`crates/lex-babel/src/common/verbatim/table.rs`).
-//! Issue [#570](https://github.com/lex-fmt/lex/issues/570) tracks the
-//! multi-phase migration.
-//!
-//! # Phase 1 status
-//!
-//! Schema only — no `on_resolve` body yet. The legacy `VerbatimRegistry`
-//! still parses pipe-table content into a typed `DocNode::Table`.
-//! Phase 2's parse-time auto-rewrite retargets `:: doc.table ::` at
-//! this label; Phase 3 deletes the legacy lookup and moves the
-//! parsing logic into the handler's `on_resolve`.
+//! Today the family has a single member: `lex.tabular.table` — the
+//! canonical pipe-table verbatim. The `on_resolve` body lives in
+//! [`crate::lex::builtins::resolve_tabular_table`] and produces a
+//! typed [`WireNode::Table`] with per-column alignment
+//! (`column_aligns`) preserved losslessly under `wire_version: 2`.
 
 use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use lex_extension::wire::{Position, Range, WireInline, WireNode, WireRow, WireTableCell};
 use std::collections::BTreeMap;
 
 /// Fully-qualified label for the canonical tabular table.
 pub const LEX_TABULAR_TABLE: &str = "lex.tabular.table";
+
+/// Parse markdown-style pipe-table source text into a typed
+/// [`WireNode::Table`].
+///
+/// Input shape: header row, alignment row (`|---|---|` or
+/// `|:---:|---:|`), then one body row per remaining non-blank line.
+/// Cells are split on `|`; leading/trailing pipes are optional.
+///
+/// Alignment markers in the separator row map to per-column entries
+/// in `column_aligns`: `:---:` → `"center"`, `---:` → `"right"`,
+/// `:---` → `"left"`, otherwise `""`. `column_aligns.length` equals
+/// the widest row (the `wire_version: 2` invariant).
+pub fn parse_pipe_table_to_wire(content: &str) -> WireNode {
+    let lines: Vec<&str> = content
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let default_range = Range {
+        start: Position(0, 0),
+        end: Position(0, 0),
+    };
+
+    if lines.is_empty() {
+        return WireNode::Table {
+            range: default_range,
+            origin: None,
+            caption: String::new(),
+            header_rows: 0,
+            column_aligns: Vec::new(),
+            rows: Vec::new(),
+            footnotes: Vec::new(),
+        };
+    }
+
+    let mut rows: Vec<WireRow> = Vec::new();
+    let mut column_aligns: Vec<String> = Vec::new();
+
+    // Header row (first line)
+    let header_cells = parse_pipe_row(lines[0]);
+    rows.push(WireRow {
+        cells: header_cells
+            .into_iter()
+            .map(|c| WireTableCell {
+                inlines: vec![WireInline::Text { text: c }],
+                colspan: 1,
+                rowspan: 1,
+            })
+            .collect(),
+    });
+    let header_rows: u32 = 1;
+
+    // Alignment row (second line). Skipped as a data row; populates
+    // `column_aligns`.
+    let mut body_start_idx = 1;
+    if lines.len() > 1 {
+        let separator = lines[1];
+        if separator.contains(['-', '|']) {
+            for part in parse_pipe_row(separator) {
+                let trimmed = part.trim();
+                column_aligns.push(match (trimmed.starts_with(':'), trimmed.ends_with(':')) {
+                    (true, true) => "center".to_string(),
+                    (false, true) => "right".to_string(),
+                    (true, false) => "left".to_string(),
+                    (false, false) => String::new(),
+                });
+            }
+            body_start_idx = 2;
+        }
+    }
+
+    // Body rows
+    for line in lines.iter().skip(body_start_idx) {
+        let cells = parse_pipe_row(line);
+        rows.push(WireRow {
+            cells: cells
+                .into_iter()
+                .map(|c| WireTableCell {
+                    inlines: vec![WireInline::Text { text: c }],
+                    colspan: 1,
+                    rowspan: 1,
+                })
+                .collect(),
+        });
+    }
+
+    // Ensure `column_aligns.length` matches the widest row (the wire
+    // spec invariant). Pad with `""` if the separator row is shorter
+    // (or absent).
+    let widest = rows.iter().map(|r| r.cells.len()).max().unwrap_or(0);
+    while column_aligns.len() < widest {
+        column_aligns.push(String::new());
+    }
+
+    WireNode::Table {
+        range: default_range,
+        origin: None,
+        caption: String::new(),
+        header_rows,
+        column_aligns,
+        rows,
+        footnotes: Vec::new(),
+    }
+}
+
+/// Split a `|`-delimited row into per-cell strings. Leading and
+/// trailing `|` are optional and stripped; cells are individually
+/// trimmed.
+fn parse_pipe_row(line: &str) -> Vec<String> {
+    let line = line.trim();
+    let line = line.strip_prefix('|').unwrap_or(line);
+    let line = line.strip_suffix('|').unwrap_or(line);
+    line.split('|').map(|s| s.trim().to_string()).collect()
+}
 
 pub fn lex_tabular_table_schema() -> Schema {
     Schema {
@@ -42,7 +150,10 @@ pub fn lex_tabular_table_schema() -> Schema {
         },
         verbatim_label: true,
         capabilities: Capabilities::default(),
-        hooks: HookSet::default(),
+        hooks: HookSet {
+            resolve: true,
+            ..HookSet::default()
+        },
         handler: None,
     }
 }
@@ -70,9 +181,13 @@ mod tests {
     }
 
     #[test]
-    fn tabular_schema_declares_no_hooks_in_phase_1() {
+    fn tabular_schema_declares_resolve_hook() {
+        // Phase 3 of #570: `lex.tabular.table` now goes through
+        // `on_resolve` (parse-time dispatch produces the typed wire
+        // `WireNode::Table`). Validate + render are still future
+        // work.
         let schema = lex_tabular_table_schema();
-        assert!(!schema.hooks.resolve);
+        assert!(schema.hooks.resolve);
         assert!(!schema.hooks.validate);
         assert!(schema.hooks.render.is_empty());
     }

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -542,15 +542,21 @@ fn table_from_wire(
     let mut body_vec = Vec::with_capacity(rows.len().saturating_sub(header_count));
     for (i, row) in rows.iter().enumerate() {
         let is_header = i < header_count;
+        // Track a running column cursor so cells with `colspan > 1`
+        // advance past the columns they cover when picking
+        // alignments. Naively using the cell index would mis-align
+        // every cell after a spanning one.
+        let mut col_cursor: usize = 0;
         let cells = row
             .cells
             .iter()
-            .enumerate()
-            .map(|(col, c)| {
+            .map(|c| {
                 let align = column_alignment
-                    .get(col)
+                    .get(col_cursor)
                     .copied()
                     .unwrap_or(TableCellAlignment::None);
+                col_cursor =
+                    col_cursor.saturating_add(usize::try_from(c.colspan.max(1)).unwrap_or(1));
                 table_cell_from_wire(c, align, is_header)
             })
             .collect();

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -184,7 +184,7 @@ fn convert_one(
             origin,
             caption,
             header_rows,
-            align,
+            column_aligns,
             rows,
             footnotes,
             ..
@@ -195,7 +195,7 @@ fn convert_one(
                 eff,
                 caption,
                 *header_rows,
-                align,
+                column_aligns,
                 rows,
                 footnotes,
                 interner,
@@ -214,6 +214,92 @@ fn convert_one(
             let eff = effective(origin.as_deref(), inherited_origin);
             Ok(verbatim_from_wire(
                 range, eff, label, params, body_text, subject, mode, interner,
+            )?)
+        }
+        // `Image` / `Video` / `Audio` are wire_version 2 media kinds.
+        // lex-core has no typed `ContentItem` variant for them — the
+        // information lives in `ContentItem::Verbatim` with the same
+        // params lex-babel's media helpers consume. Round-trip them
+        // back to a Verbatim with the canonical label + params, so
+        // downstream `from_lex_verbatim` (or any consumer using the
+        // free `image_from_params` / `video_from_params` /
+        // `audio_from_params` helpers in lex-babel) sees the shape
+        // it expects.
+        WireNode::Image {
+            range,
+            origin,
+            src,
+            alt,
+            title,
+        } => {
+            let eff = effective(origin.as_deref(), inherited_origin);
+            let mut params = serde_json::Map::new();
+            params.insert("src".into(), Value::String(src.clone()));
+            if !alt.is_empty() {
+                params.insert("alt".into(), Value::String(alt.clone()));
+            }
+            if let Some(title) = title {
+                params.insert("title".into(), Value::String(title.clone()));
+            }
+            Ok(verbatim_from_wire(
+                range,
+                eff,
+                "lex.media.image",
+                &Value::Object(params),
+                "",
+                "",
+                "inflow",
+                interner,
+            )?)
+        }
+        WireNode::Video {
+            range,
+            origin,
+            src,
+            title,
+            poster,
+        } => {
+            let eff = effective(origin.as_deref(), inherited_origin);
+            let mut params = serde_json::Map::new();
+            params.insert("src".into(), Value::String(src.clone()));
+            if let Some(title) = title {
+                params.insert("title".into(), Value::String(title.clone()));
+            }
+            if let Some(poster) = poster {
+                params.insert("poster".into(), Value::String(poster.clone()));
+            }
+            Ok(verbatim_from_wire(
+                range,
+                eff,
+                "lex.media.video",
+                &Value::Object(params),
+                "",
+                "",
+                "inflow",
+                interner,
+            )?)
+        }
+        WireNode::Audio {
+            range,
+            origin,
+            src,
+            title,
+        } => {
+            let eff = effective(origin.as_deref(), inherited_origin);
+            let mut params = serde_json::Map::new();
+            params.insert("src".into(), Value::String(src.clone()));
+            if let Some(title) = title {
+                params.insert("title".into(), Value::String(title.clone()));
+            }
+            Ok(verbatim_from_wire(
+                range,
+                eff,
+                "lex.media.audio",
+                &Value::Object(params),
+                "",
+                "",
+                "inflow",
+                interner,
             )?)
         }
         // WireNode is `#[non_exhaustive]` — future kinds surface here.
@@ -433,17 +519,24 @@ fn table_from_wire(
     origin: Option<&str>,
     caption: &str,
     header_rows: u32,
-    align: &str,
+    column_aligns: &[String],
     rows: &[WireRow],
     footnotes: &[WireFootnote],
     interner: &mut OriginInterner,
 ) -> Result<Table, FromWireError> {
-    let alignment = match align {
-        "left" => TableCellAlignment::Left,
-        "center" => TableCellAlignment::Center,
-        "right" => TableCellAlignment::Right,
-        _ => TableCellAlignment::None,
-    };
+    // Per-column alignment in wire_version 2 — one entry per column.
+    // Applied to every cell in that column on the reverse codec; rows
+    // shorter than `column_aligns.length` get cells dropped on the
+    // wire and aren't reconstructed here.
+    let column_alignment: Vec<TableCellAlignment> = column_aligns
+        .iter()
+        .map(|s| match s.as_str() {
+            "left" => TableCellAlignment::Left,
+            "center" => TableCellAlignment::Center,
+            "right" => TableCellAlignment::Right,
+            _ => TableCellAlignment::None,
+        })
+        .collect();
     let header_count = header_rows as usize;
     let mut header_vec = Vec::with_capacity(header_count.min(rows.len()));
     let mut body_vec = Vec::with_capacity(rows.len().saturating_sub(header_count));
@@ -452,7 +545,14 @@ fn table_from_wire(
         let cells = row
             .cells
             .iter()
-            .map(|c| table_cell_from_wire(c, alignment, is_header))
+            .enumerate()
+            .map(|(col, c)| {
+                let align = column_alignment
+                    .get(col)
+                    .copied()
+                    .unwrap_or(TableCellAlignment::None);
+                table_cell_from_wire(c, align, is_header)
+            })
             .collect();
         let table_row = TableRow::new(cells);
         if is_header {
@@ -664,6 +764,9 @@ fn kind_name(node: &WireNode) -> &'static str {
         WireNode::List { .. } => "list",
         WireNode::Verbatim { .. } => "verbatim",
         WireNode::Table { .. } => "table",
+        WireNode::Image { .. } => "image",
+        WireNode::Video { .. } => "video",
+        WireNode::Audio { .. } => "audio",
         WireNode::Annotation { .. } => "annotation",
         WireNode::Blank { .. } => "blank",
         _ => "unknown",

--- a/crates/lex-core/src/lex/wire/mod.rs
+++ b/crates/lex-core/src/lex/wire/mod.rs
@@ -93,7 +93,7 @@
 mod error;
 pub mod from_wire;
 mod inline;
-mod range;
+pub mod range;
 pub mod to_wire;
 
 #[cfg(test)]
@@ -101,4 +101,5 @@ mod tests;
 
 pub use error::FromWireError;
 pub use from_wire::{from_wire_node, from_wire_subtree};
+pub use range::{origin_string, range_to_wire};
 pub use to_wire::{to_wire_document, to_wire_node};

--- a/crates/lex-core/src/lex/wire/range.rs
+++ b/crates/lex-core/src/lex/wire/range.rs
@@ -75,7 +75,7 @@ pub(crate) fn position_from_wire(p: &WirePosition) -> CorePosition {
     CorePosition::new(p.line() as usize, p.column() as usize)
 }
 
-pub(crate) fn range_to_wire(r: &CoreRange) -> WireRange {
+pub fn range_to_wire(r: &CoreRange) -> WireRange {
     WireRange::new(position_to_wire(&r.start), position_to_wire(&r.end))
 }
 
@@ -103,8 +103,7 @@ pub(crate) fn range_from_wire_with_origin(
 }
 
 /// Lift a lex-core `Range`'s `origin_path` to the wire `origin` string.
-#[allow(dead_code)] // consumed by to_wire.rs starting in the next module
-pub(crate) fn origin_string(r: &CoreRange) -> Option<String> {
+pub fn origin_string(r: &CoreRange) -> Option<String> {
     r.origin_path
         .as_ref()
         .map(|p| p.to_string_lossy().into_owned())

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -655,6 +655,82 @@ fn table_round_trips_caption_and_rows() {
 }
 
 #[test]
+fn table_colspan_preserves_per_column_alignment_round_trip() {
+    use crate::lex::ast::elements::table::{Table, TableCell, TableCellAlignment, TableRow};
+    use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+    // 4-column table whose body row contains a `colspan = 2` cell
+    // covering columns 1 and 2. The wire codec must produce a
+    // 4-entry `column_aligns` vector and the reverse codec must
+    // restore the per-column alignments without indexing by cell
+    // position (which would mis-align columns 2 and 3).
+    let header = TableRow::new(vec![
+        TableCell::new(TextContent::from_string("L".into(), None))
+            .with_header(true)
+            .with_align(TableCellAlignment::Left),
+        TableCell::new(TextContent::from_string("C".into(), None))
+            .with_header(true)
+            .with_align(TableCellAlignment::Center),
+        TableCell::new(TextContent::from_string("R".into(), None))
+            .with_header(true)
+            .with_align(TableCellAlignment::Right),
+        TableCell::new(TextContent::from_string("L".into(), None))
+            .with_header(true)
+            .with_align(TableCellAlignment::Left),
+    ]);
+    let body = vec![TableRow::new(vec![
+        TableCell::new(TextContent::from_string("a".into(), None))
+            .with_align(TableCellAlignment::Left),
+        TableCell::new(TextContent::from_string("merged".into(), None))
+            .with_span(2, 1)
+            .with_align(TableCellAlignment::Center),
+        TableCell::new(TextContent::from_string("d".into(), None))
+            .with_align(TableCellAlignment::Left),
+    ])];
+    let t = Table::new(
+        TextContent::from_string(String::new(), None),
+        vec![header],
+        body,
+        VerbatimBlockMode::Inflow,
+    );
+    let item = ContentItem::Table(Box::new(t));
+    let wire = to_wire_node(&item);
+
+    if let WireNode::Table {
+        ref column_aligns, ..
+    } = wire
+    {
+        assert_eq!(
+            column_aligns,
+            &vec![
+                "left".to_string(),
+                "center".to_string(),
+                "right".to_string(),
+                "left".to_string(),
+            ],
+            "column_aligns must be widened by colspan and stay per-column"
+        );
+    } else {
+        panic!("expected WireNode::Table");
+    }
+
+    let back = from_wire_node(&json_round_trip(&wire)).expect("ok");
+    match &back[0] {
+        ContentItem::Table(t) => {
+            // Body row: cell 0 is column 0 (Left); cell 1 is a
+            // colspan=2 covering columns 1+2 — its align comes from
+            // column_aligns[1] (Center); cell 2 advances to column 3
+            // (Left).
+            let row = &t.body_rows[0];
+            assert_eq!(row.cells[0].align, TableCellAlignment::Left);
+            assert_eq!(row.cells[1].align, TableCellAlignment::Center);
+            assert_eq!(row.cells[1].colspan, 2);
+            assert_eq!(row.cells[2].align, TableCellAlignment::Left);
+        }
+        other => panic!("expected Table, got {other:?}"),
+    }
+}
+
+#[test]
 fn document_with_session_paragraph_blank_round_trips() {
     use crate::lex::ast::elements::session::Session;
     let mut s = Session::with_title("Intro".into());

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -266,10 +266,16 @@ fn table_cell_to_wire(cell: &TableCell) -> WireTableCell {
 /// the alignment row implicitly). Columns with no alignment
 /// anywhere yield `""`.
 ///
-/// `column_aligns.length` equals the widest row in the table — this
-/// is what the wire spec uses to define the table's column count.
+/// `column_aligns.length` equals the widest row in the table (sum of
+/// each cell's `colspan`) — this is what the wire spec uses to define
+/// the table's column count. Spanning cells contribute their
+/// alignment once to the leftmost covered column; the remaining
+/// covered columns receive no signal from that cell.
 fn table_column_aligns(t: &Table) -> Vec<String> {
-    let column_count = t.all_rows().map(|row| row.cells.len()).max().unwrap_or(0);
+    let row_width = |row: &crate::lex::ast::elements::table::TableRow| -> usize {
+        row.cells.iter().map(|c| c.colspan.max(1)).sum::<usize>()
+    };
+    let column_count = t.all_rows().map(row_width).max().unwrap_or(0);
     let mut aligns: Vec<String> = vec![String::new(); column_count];
 
     let align_str = |a: TableCellAlignment| -> Option<&'static str> {
@@ -281,35 +287,28 @@ fn table_column_aligns(t: &Table) -> Vec<String> {
         }
     };
 
-    // First pass: scan body rows, fill the first non-None per column.
-    for row in &t.body_rows {
-        for (col, cell) in row.cells.iter().enumerate() {
-            if col >= aligns.len() {
-                continue;
-            }
-            if aligns[col].is_empty() {
-                if let Some(s) = align_str(cell.align) {
-                    aligns[col] = s.to_string();
+    let mut fill_pass = |rows: &[crate::lex::ast::elements::table::TableRow]| {
+        for row in rows {
+            let mut col = 0usize;
+            for cell in &row.cells {
+                if col >= aligns.len() {
+                    break;
                 }
+                if aligns[col].is_empty() {
+                    if let Some(s) = align_str(cell.align) {
+                        aligns[col] = s.to_string();
+                    }
+                }
+                col = col.saturating_add(cell.colspan.max(1));
             }
         }
-    }
+    };
 
-    // Second pass: any column still empty falls back to the header
-    // cell's alignment. This covers header-only tables and any table
-    // whose body cells all happen to be `None` for a given column.
-    for row in &t.header_rows {
-        for (col, cell) in row.cells.iter().enumerate() {
-            if col >= aligns.len() {
-                continue;
-            }
-            if aligns[col].is_empty() {
-                if let Some(s) = align_str(cell.align) {
-                    aligns[col] = s.to_string();
-                }
-            }
-        }
-    }
+    // First pass: body rows, then header rows for any column still
+    // empty (header-only tables and tables whose body cells all happen
+    // to be `None` for a given column).
+    fill_pass(&t.body_rows);
+    fill_pass(&t.header_rows);
 
     aligns
 }

--- a/crates/lex-core/src/lex/wire/to_wire.rs
+++ b/crates/lex-core/src/lex/wire/to_wire.rs
@@ -219,7 +219,7 @@ fn table_to_wire(t: &Table) -> WireNode {
     }
 
     let header_rows = u32::try_from(t.header_rows.len()).unwrap_or(u32::MAX);
-    let align = table_align_summary(t);
+    let column_aligns = table_column_aligns(t);
     let rows = t
         .all_rows()
         .map(|row| WireRow {
@@ -236,7 +236,7 @@ fn table_to_wire(t: &Table) -> WireNode {
         origin: origin_string(&t.location),
         caption: t.subject.as_string().to_string(),
         header_rows,
-        align,
+        column_aligns,
         rows,
         footnotes,
     }
@@ -257,26 +257,61 @@ fn table_cell_to_wire(cell: &TableCell) -> WireTableCell {
     }
 }
 
-/// Summarise a table's per-cell alignment into a single string. Wire
-/// tables carry one alignment per table; lex-core tracks alignment per
-/// cell. We pick the alignment of the first non-`None` *body* cell —
-/// header cells are skipped because their alignment is often a
-/// styling artefact (centered headers over left-aligned columns) and
-/// would mislead the reverse codec, which applies the chosen
-/// alignment to every cell in the table. Returns the empty string
-/// when no body alignment is set anywhere.
-fn table_align_summary(t: &Table) -> String {
+/// Produce per-column alignment strings for a table's wire form.
+///
+/// One entry per column. For each column we pick the alignment of
+/// the first non-`None` body cell, falling back to the header cell's
+/// alignment when every body cell is `None` (matters for
+/// header-only tables and for tables whose body cells inherit from
+/// the alignment row implicitly). Columns with no alignment
+/// anywhere yield `""`.
+///
+/// `column_aligns.length` equals the widest row in the table — this
+/// is what the wire spec uses to define the table's column count.
+fn table_column_aligns(t: &Table) -> Vec<String> {
+    let column_count = t.all_rows().map(|row| row.cells.len()).max().unwrap_or(0);
+    let mut aligns: Vec<String> = vec![String::new(); column_count];
+
+    let align_str = |a: TableCellAlignment| -> Option<&'static str> {
+        match a {
+            TableCellAlignment::Left => Some("left"),
+            TableCellAlignment::Center => Some("center"),
+            TableCellAlignment::Right => Some("right"),
+            TableCellAlignment::None => None,
+        }
+    };
+
+    // First pass: scan body rows, fill the first non-None per column.
     for row in &t.body_rows {
-        for cell in &row.cells {
-            match cell.align {
-                TableCellAlignment::Left => return "left".into(),
-                TableCellAlignment::Center => return "center".into(),
-                TableCellAlignment::Right => return "right".into(),
-                TableCellAlignment::None => {}
+        for (col, cell) in row.cells.iter().enumerate() {
+            if col >= aligns.len() {
+                continue;
+            }
+            if aligns[col].is_empty() {
+                if let Some(s) = align_str(cell.align) {
+                    aligns[col] = s.to_string();
+                }
             }
         }
     }
-    String::new()
+
+    // Second pass: any column still empty falls back to the header
+    // cell's alignment. This covers header-only tables and any table
+    // whose body cells all happen to be `None` for a given column.
+    for row in &t.header_rows {
+        for (col, cell) in row.cells.iter().enumerate() {
+            if col >= aligns.len() {
+                continue;
+            }
+            if aligns[col].is_empty() {
+                if let Some(s) = align_str(cell.align) {
+                    aligns[col] = s.to_string();
+                }
+            }
+        }
+    }
+
+    aligns
 }
 
 fn table_footnotes_to_wire(footnotes: &List) -> Vec<WireFootnote> {

--- a/crates/lex-core/tests/proptests/main.rs
+++ b/crates/lex-core/tests/proptests/main.rs
@@ -21,5 +21,6 @@ mod proptest_nested_lists;
 mod proptest_references;
 mod proptest_table_cells;
 mod proptest_table_config;
+mod proptest_table_wire_align;
 mod proptest_verbatim;
 mod split_respecting_escape_proptest;

--- a/crates/lex-core/tests/proptests/proptest_table_wire_align.rs
+++ b/crates/lex-core/tests/proptests/proptest_table_wire_align.rs
@@ -1,0 +1,238 @@
+//! Property tests for the wire-codec preservation of table column
+//! alignment, including the `colspan > 1` cases that motivated #585.
+//!
+//! Invariants under test:
+//!
+//! 1. `column_aligns.length` on the wire equals the table's column
+//!    count (the max sum-of-colspans across all rows).
+//!
+//! 2. Every column's alignment as seen on the wire is preserved
+//!    through `to_wire_node` → JSON → `from_wire_node`: the alignment
+//!    of a body cell starting at column `c` round-trips back to the
+//!    alignment at column `c` in the reconstructed table.
+//!
+//! Coverage that the targeted unit test alone missed: variable column
+//! counts, multiple body rows, mixed alignments per column, and
+//! spanning cells at arbitrary positions.
+
+use lex_core::lex::ast::elements::table::{Table, TableCell, TableCellAlignment, TableRow};
+use lex_core::lex::ast::elements::verbatim::VerbatimBlockMode;
+use lex_core::lex::ast::{ContentItem, TextContent};
+use lex_core::lex::wire::{from_wire_node, to_wire_node};
+use lex_extension::wire::WireNode;
+use proptest::prelude::*;
+
+/// Random alignment marker.
+fn alignment_strategy() -> impl Strategy<Value = TableCellAlignment> {
+    prop_oneof![
+        Just(TableCellAlignment::None),
+        Just(TableCellAlignment::Left),
+        Just(TableCellAlignment::Center),
+        Just(TableCellAlignment::Right),
+    ]
+}
+
+/// String representation of a wire-side alignment marker.
+fn align_to_wire_string(a: TableCellAlignment) -> &'static str {
+    match a {
+        TableCellAlignment::Left => "left",
+        TableCellAlignment::Center => "center",
+        TableCellAlignment::Right => "right",
+        TableCellAlignment::None => "",
+    }
+}
+
+/// A table laid out by **column count and per-column alignment**, with
+/// random body rows whose cells span 1–N columns chosen so the row's
+/// total `sum(colspan)` equals the column count.
+///
+/// Returns `(column_count, per_column_alignments, table)`. The table
+/// has one header row (single cells, no spans) and one or more body
+/// rows; every body cell carries the alignment of the leftmost
+/// column it covers (so the wire codec's "first non-None per column"
+/// rule produces the per-column alignment vector deterministically).
+fn table_with_colspans_strategy() -> impl Strategy<Value = (usize, Vec<TableCellAlignment>, Table)>
+{
+    (2usize..=5)
+        .prop_flat_map(|cols| {
+            let aligns = prop::collection::vec(alignment_strategy(), cols);
+            let body_rows = prop::collection::vec(row_strategy(cols), 1..=3);
+            (Just(cols), aligns, body_rows)
+        })
+        .prop_map(
+            |(cols, aligns, body_rows): (usize, Vec<_>, Vec<Vec<(usize, TableCellAlignment)>>)| {
+                // Header: one cell per column, no spans, alignment = column align.
+                let header = TableRow::new(
+                    aligns
+                        .iter()
+                        .enumerate()
+                        .map(|(i, a)| {
+                            TableCell::new(TextContent::from_string(format!("H{i}"), None))
+                                .with_header(true)
+                                .with_align(*a)
+                        })
+                        .collect(),
+                );
+
+                // Body rows: each cell's align is the leftmost-column's
+                // alignment. That mirrors what a writer would put on the
+                // source — and lets us assert tight equality after the
+                // round trip.
+                let body: Vec<TableRow> = body_rows
+                    .into_iter()
+                    .map(|row| {
+                        let mut col = 0;
+                        let cells = row
+                            .into_iter()
+                            .map(|(span, _)| {
+                                let leftmost_col = col;
+                                let cell = TableCell::new(TextContent::from_string(
+                                    format!("c{leftmost_col}s{span}"),
+                                    None,
+                                ))
+                                .with_span(span, 1)
+                                .with_align(aligns[leftmost_col]);
+                                col += span;
+                                cell
+                            })
+                            .collect();
+                        TableRow::new(cells)
+                    })
+                    .collect();
+
+                let table = Table::new(
+                    TextContent::from_string(String::new(), None),
+                    vec![header],
+                    body,
+                    VerbatimBlockMode::Inflow,
+                );
+                (cols, aligns, table)
+            },
+        )
+}
+
+/// Strategy for a single body row: pick a sequence of `colspan`
+/// values whose sum is exactly `cols`, plus dummy `TableCellAlignment`
+/// per cell (unused — the table-level mapper overrides cell alignment
+/// to match the column alignment of the leftmost covered column).
+fn row_strategy(cols: usize) -> impl Strategy<Value = Vec<(usize, TableCellAlignment)>> {
+    // Greedy random partition of `cols` into spans of 1..=cols.
+    Just(cols).prop_flat_map(move |total| {
+        partition_strategy(total).prop_map(|spans| {
+            spans
+                .into_iter()
+                .map(|s| (s, TableCellAlignment::None))
+                .collect()
+        })
+    })
+}
+
+/// Partition `n` into a `Vec<usize>` of positive parts. Each part is
+/// at least 1; the parts sum to `n`.
+fn partition_strategy(n: usize) -> impl Strategy<Value = Vec<usize>> {
+    // Generate up to `n` parts, then trim/pad to make them sum to n.
+    prop::collection::vec(1usize..=n.max(1), 1..=n.max(1)).prop_map(move |mut parts| {
+        let mut total: usize = parts.iter().sum();
+        while total > n && parts.len() > 1 {
+            // Trim the last element until we don't overshoot.
+            let last = parts.pop().unwrap();
+            total -= last;
+        }
+        if total > n {
+            // Single element overshot — clamp it.
+            parts[0] = n;
+        } else if total < n {
+            // Pad with single-column cells.
+            parts.extend(std::iter::repeat_n(1, n - total));
+        }
+        parts
+    })
+}
+
+fn json_round_trip(node: &WireNode) -> WireNode {
+    let s = serde_json::to_string(node).expect("serialize wire node");
+    serde_json::from_str(&s).expect("deserialize wire node")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// `column_aligns.length` equals the column count of the source
+    /// table, regardless of where colspan cells are placed.
+    #[test]
+    fn wire_column_aligns_width_matches_column_count(
+        (cols, _aligns, table) in table_with_colspans_strategy(),
+    ) {
+        let item = ContentItem::Table(Box::new(table));
+        let wire = to_wire_node(&item);
+        if let WireNode::Table { column_aligns, .. } = &wire {
+            prop_assert_eq!(
+                column_aligns.len(),
+                cols,
+                "column_aligns must have one entry per column (got {} for {} cols)",
+                column_aligns.len(),
+                cols
+            );
+        } else {
+            prop_assert!(false, "expected WireNode::Table");
+        }
+    }
+
+    /// Per-column alignment is preserved on the wire under arbitrary
+    /// colspan layouts: column `c` keeps its alignment regardless of
+    /// which body cell happens to cover it.
+    #[test]
+    fn wire_column_aligns_values_match_column_alignments(
+        (_cols, aligns, table) in table_with_colspans_strategy(),
+    ) {
+        let item = ContentItem::Table(Box::new(table));
+        let wire = to_wire_node(&item);
+        if let WireNode::Table { column_aligns, .. } = &wire {
+            let expected: Vec<String> = aligns
+                .iter()
+                .map(|a| align_to_wire_string(*a).to_string())
+                .collect();
+            prop_assert_eq!(
+                column_aligns,
+                &expected,
+                "column_aligns must carry the per-column alignment in order"
+            );
+        } else {
+            prop_assert!(false, "expected WireNode::Table");
+        }
+    }
+
+    /// After JSON round-trip and reverse codec, every body cell's
+    /// alignment matches the alignment of the column it starts at.
+    /// This is what would have caught the index-by-cell-position bug
+    /// in `table_from_wire`: a colspan cell shifts subsequent cells
+    /// to later columns, so the alignment lookup must track a column
+    /// cursor.
+    #[test]
+    fn round_trip_preserves_cell_alignment_after_colspans(
+        (_cols, aligns, table) in table_with_colspans_strategy(),
+    ) {
+        let item = ContentItem::Table(Box::new(table));
+        let wire = to_wire_node(&item);
+        let back = from_wire_node(&json_round_trip(&wire)).expect("from_wire ok");
+        match &back[0] {
+            ContentItem::Table(t) => {
+                for row in &t.body_rows {
+                    let mut col = 0usize;
+                    for cell in &row.cells {
+                        prop_assert_eq!(
+                            cell.align,
+                            aligns[col],
+                            "cell starting at column {} must carry column alignment {:?}, got {:?}",
+                            col,
+                            aligns[col],
+                            cell.align
+                        );
+                        col += cell.colspan.max(1);
+                    }
+                }
+            }
+            other => prop_assert!(false, "expected Table, got {:?}", other),
+        }
+    }
+}

--- a/crates/lex-extension-host/tests/fixtures/fixture_handler.rs
+++ b/crates/lex-extension-host/tests/fixtures/fixture_handler.rs
@@ -179,7 +179,7 @@ fn run(mode: Mode) -> ExitCode {
 fn initialize_result(mode: &Mode) -> Value {
     let wire_version = match mode {
         Mode::VersionMismatch { version } => *version,
-        _ => 1,
+        _ => lex_extension::WIRE_VERSION,
     };
     let implements = match mode {
         Mode::Malformed => vec!["on_validate"],

--- a/crates/lex-extension/src/lib.rs
+++ b/crates/lex-extension/src/lib.rs
@@ -75,4 +75,4 @@ pub use schema::{
 /// down to the highest version both sides support. A host that receives a
 /// lower `wire_version` than this constant refuses the handler with a startup
 /// diagnostic.
-pub const WIRE_VERSION: u32 = 1;
+pub const WIRE_VERSION: u32 = 2;

--- a/crates/lex-extension/src/wire/ast.rs
+++ b/crates/lex-extension/src/wire/ast.rs
@@ -96,10 +96,54 @@ pub enum WireNode {
         origin: Option<String>,
         caption: String,
         header_rows: u32,
-        align: String,
+        /// Per-column alignment. One entry per column; values are
+        /// `"left"`, `"center"`, `"right"`, or `""` (no alignment).
+        /// `column_aligns.length` defines the table's column count
+        /// and MUST equal the longest row in `rows`; rows MUST NOT
+        /// exceed this length. See `lex-extension-wire.lex` §2.2.
+        ///
+        /// Replaces the single whole-table `align: String` from
+        /// `wire_version: 1`. The old shape collapsed mixed-alignment
+        /// tables (e.g. a markdown pipe-table with `| :--- | :---: |`)
+        /// to a single alignment on the reverse codec.
+        column_aligns: Vec<String>,
         rows: Vec<WireRow>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         footnotes: Vec<WireFootnote>,
+    },
+    /// Image media node. Produced by `on_resolve` for
+    /// `lex.media.image`-class verbatim labels; carries the same
+    /// data the host would otherwise flatten into `verbatim.params`.
+    /// New in `wire_version: 2` — see `lex-extension-wire.lex` §2.2.
+    Image {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        src: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        alt: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+    },
+    /// Video media node. New in `wire_version: 2`.
+    Video {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        src: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        poster: Option<String>,
+    },
+    /// Audio media node. New in `wire_version: 2`.
+    Audio {
+        range: Range,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        origin: Option<String>,
+        src: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
     },
     Annotation {
         range: Range,
@@ -134,6 +178,9 @@ impl WireNode {
             | Self::List { range, .. }
             | Self::Verbatim { range, .. }
             | Self::Table { range, .. }
+            | Self::Image { range, .. }
+            | Self::Video { range, .. }
+            | Self::Audio { range, .. }
             | Self::Annotation { range, .. }
             | Self::Blank { range, .. } => *range,
         }
@@ -290,6 +337,130 @@ mod tests {
             }
             _ => panic!("expected Verbatim"),
         }
+    }
+
+    #[test]
+    fn table_round_trips_with_per_column_aligns() {
+        // Wire_version 2 (#583): `column_aligns` carries per-column
+        // alignment as a `Vec<String>` instead of the single-string
+        // whole-table summary of v1. Test the round-trip preserves
+        // mixed alignments — that was the regression that motivated
+        // the bump.
+        let t = WireNode::Table {
+            range: r(0, 0, 3, 0),
+            origin: None,
+            caption: "Demo".into(),
+            header_rows: 1,
+            column_aligns: vec!["left".into(), "center".into(), "right".into()],
+            rows: vec![
+                WireRow {
+                    cells: vec![
+                        WireTableCell {
+                            inlines: vec![WireInline::Text { text: "h1".into() }],
+                            colspan: 1,
+                            rowspan: 1,
+                        },
+                        WireTableCell {
+                            inlines: vec![WireInline::Text { text: "h2".into() }],
+                            colspan: 1,
+                            rowspan: 1,
+                        },
+                        WireTableCell {
+                            inlines: vec![WireInline::Text { text: "h3".into() }],
+                            colspan: 1,
+                            rowspan: 1,
+                        },
+                    ],
+                },
+                WireRow {
+                    cells: vec![
+                        WireTableCell {
+                            inlines: vec![WireInline::Text { text: "c1".into() }],
+                            colspan: 1,
+                            rowspan: 1,
+                        },
+                        WireTableCell {
+                            inlines: vec![WireInline::Text { text: "c2".into() }],
+                            colspan: 1,
+                            rowspan: 1,
+                        },
+                        WireTableCell {
+                            inlines: vec![WireInline::Text { text: "c3".into() }],
+                            colspan: 1,
+                            rowspan: 1,
+                        },
+                    ],
+                },
+            ],
+            footnotes: vec![],
+        };
+        let s = serde_json::to_string(&t).unwrap();
+        assert!(
+            s.contains(r#""column_aligns":["left","center","right"]"#),
+            "column_aligns must serialize as an array of per-column strings, got: {s}"
+        );
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn image_round_trips() {
+        let i = WireNode::Image {
+            range: r(2, 0, 2, 30),
+            origin: None,
+            src: "chart.png".into(),
+            alt: "Q4 chart".into(),
+            title: Some("Quarter".into()),
+        };
+        let s = serde_json::to_string(&i).unwrap();
+        assert!(s.contains(r#""kind":"image""#));
+        assert!(s.contains(r#""src":"chart.png""#));
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, i);
+    }
+
+    #[test]
+    fn image_marker_form_omits_empty_alt() {
+        let i = WireNode::Image {
+            range: r(0, 0, 0, 0),
+            origin: None,
+            src: "x.png".into(),
+            alt: String::new(),
+            title: None,
+        };
+        let s = serde_json::to_string(&i).unwrap();
+        assert!(!s.contains("alt"), "empty alt must be omitted: {s}");
+        assert!(!s.contains("title"), "None title must be omitted: {s}");
+    }
+
+    #[test]
+    fn video_round_trips_with_poster() {
+        let v = WireNode::Video {
+            range: r(0, 0, 0, 0),
+            origin: None,
+            src: "demo.mp4".into(),
+            title: Some("Demo".into()),
+            poster: Some("frame.png".into()),
+        };
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.contains(r#""kind":"video""#));
+        assert!(s.contains(r#""poster":"frame.png""#));
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn audio_round_trips() {
+        let a = WireNode::Audio {
+            range: r(0, 0, 0, 0),
+            origin: None,
+            src: "track.mp3".into(),
+            title: None,
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        assert!(s.contains(r#""kind":"audio""#));
+        let back: WireNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, a);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the #570 follow-up: `lex.tabular.table` and `lex.media.{image,video,audio}` now go through `Registry::dispatch_resolve` at IR construction time rather than legacy `VerbatimRegistry` pattern matching. Third-party namespaces can now intercept verbatim labels through the same code path the built-ins use.

The wire spec landed in comms 0a4f514 (PR #41). This is the Rust side.

## Wire format: v1 → v2 (breaking for handlers decoding the wire format)

- `WireNode::Table` carries `column_aligns: Vec<String>` (was a single `align: String` summary). Mixed-alignment tables — left-aligned first column, right-aligned numeric second column — now round-trip losslessly. `column_aligns.length` equals the widest row in the table.
- New typed `WireNode::{Image, Video, Audio}` variants. Resolve dispatch for `lex.media.*` produces these directly instead of a generic `Verbatim` node with reconstructed params.

`lex-extension::WIRE_VERSION` ticks to 2. The reusable subprocess fixture handler picks up the bump automatically (it forwards `lex_extension::WIRE_VERSION`).

## Registry threading

`from_lex_document(doc, registry: &Registry)` plus the recursive helpers (`convert_children`, `from_lex_session`, `from_lex_list`, `from_lex_definition`, `from_lex_annotation`, `from_lex_table`, `from_lex_verbatim`, …) all take `&Registry` now. The public `lex_babel::to_ir(doc)` still works — it delegates to a new `to_ir_with_registry(doc, registry)` using a process-wide `default_registry()` populated with the built-in `lex.*` schemas. Callers that boot a custom registry (`lex-cli`, `lex-lsp`, embedders) plumb theirs through `to_ir_with_registry`. The same `default_registry()` is reused by `to_lex_document` so verbatim labels round-trip through `Registry::dispatch_format` regardless of conversion direction.

## Schema + parser changes

- `Schema::hooks.resolve = true` on `lex.tabular.table` and the three `lex.media.*` schemas.
- Legacy `parse_pipe_table` helper in `lex-babel/src/common/verbatim/table.rs` retired. Canonical parser is `lex_core::lex::builtins::tabular::parse_pipe_table_to_wire`, which emits a typed `WireNode::Table` with per-column alignment.
- `from_wire_node` decodes typed media variants back into `ContentItem::Verbatim` with reconstructed params (preserves lex-core's untyped AST shape).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --exclude lex-wasm` (2091 tests pass)
- [x] `cargo clippy --workspace --all-targets --exclude lex-wasm -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `./scripts/rust-pre-commit`
- [x] Round-trip tests for new wire variants (Image/Video/Audio/Table column_aligns)
- [x] Existing phase-1 contract tests (`tabular_schema_declares_no_hooks_in_phase_1` etc.) updated to reflect the post-Phase-3 state

🤖 Generated with [Claude Code](https://claude.com/claude-code)