### PR TITLE
feat(lex-core): LabelForm enum + form field on Label [#584 PR 1/5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added — `LabelForm` infrastructure ([#584](https://github.com/lex-fmt/lex/issues/584) PR 1 of 5)
+
+First of five PRs implementing the bare-as-blessed label namespace model spelled out in `comms/specs/general.lex` §4. This PR is the lex-core foundation: it adds the `LabelForm` enum (`Canonical | Stripped | Shortcut | Community`) and a `form: LabelForm` field on `Label`. `NormalizeLabels` now tags every rewrite with the matching form so downstream formatters can preserve the user's choice of spelling on roundtrip. No emission behavior changes yet — formatters still emit `label.value` verbatim; PR 3 wires `form` through.
+
+- New `comms` submodule pin: includes `specs/general.lex` §4 (Label Namespaces) and the bare-form flip in `specs/elements/lex.include.lex`.
+- `LEGACY_TO_CANONICAL` table grew a third tuple element: `(legacy, canonical, form)`. The four new-shortcut entries (`title`, `author`, `date`, `tags`) tag as `Shortcut`; the four non-shortcut metadata entries (`category`, `template`, `publishing-date`, `front-matter`) and the four `doc.*` entries tag as `Stripped`. Today these classifications are forward-looking; PR 2 of #584 hard-rejects `doc.*` and bare non-shortcut names, and PR 3 wires the form into the formatter.
+
 ### Refactored — label semantics ([#570](https://github.com/lex-fmt/lex/issues/570))
 
 Multi-phase refactor moving label-semantic decisions out of the IR layer and through the extension registry. Eight PRs (#575–#581) landed via the `refac/label` integration branch, followed by a legacy-code cleanup pass.

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -42,39 +42,57 @@
 
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::content_item::ContentItem;
+use crate::lex::ast::elements::label::LabelForm;
 use crate::lex::ast::elements::verbatim::Verbatim;
 use crate::lex::ast::Document;
 use crate::lex::transforms::{Runnable, TransformError};
 
-/// Pairings of legacy bare label → canonical `lex.*` form.
+/// Pairings of legacy bare label → canonical `lex.*` form, paired with
+/// the [`LabelForm`] each rewrite represents.
 ///
-/// Ordering mirrors the legacy whitelist in
-/// `crates/lex-babel/src/ir/from_lex.rs` (metadata first), followed by
-/// the four verbatim labels owned by the legacy
-/// `lex-babel::common::verbatim::VerbatimRegistry`. Anything not in
-/// this table is left untouched — third-party and user-defined labels
-/// are out of scope.
-pub const LEGACY_TO_CANONICAL: &[(&str, &str)] = &[
-    ("title", "lex.metadata.title"),
-    ("author", "lex.metadata.author"),
-    ("date", "lex.metadata.date"),
-    ("tags", "lex.metadata.tags"),
-    ("category", "lex.metadata.category"),
-    ("template", "lex.metadata.template"),
-    ("publishing-date", "lex.metadata.publishing-date"),
-    ("front-matter", "lex.metadata.front-matter"),
-    ("doc.table", "lex.tabular.table"),
-    ("doc.image", "lex.media.image"),
-    ("doc.video", "lex.media.video"),
-    ("doc.audio", "lex.media.audio"),
+/// The form classification is the parser-side record of which input
+/// spelling the user wrote, so downstream formatters can emit the same
+/// spelling back. See `comms/specs/general.lex` §4.2 for the normative
+/// resolution rules and §4.3 for the form-preservation contract.
+///
+/// Today the table still includes a few labels that fall outside the
+/// new bare-as-blessed namespace model (`category`, `template`,
+/// `publishing-date`, `front-matter` are tagged as `Stripped` because
+/// their bare form is scheduled for removal in PR 2 of #584; the four
+/// `doc.*` entries are tagged as `Stripped` because the prefix is
+/// reserved-forbidden and will become a parse error in PR 2). PR 1
+/// preserves current parsing behavior — every input that parses today
+/// continues to parse — and only adds the `form` classification.
+pub const LEGACY_TO_CANONICAL: &[(&str, &str, LabelForm)] = &[
+    ("title", "lex.metadata.title", LabelForm::Shortcut),
+    ("author", "lex.metadata.author", LabelForm::Shortcut),
+    ("date", "lex.metadata.date", LabelForm::Shortcut),
+    ("tags", "lex.metadata.tags", LabelForm::Shortcut),
+    ("category", "lex.metadata.category", LabelForm::Stripped),
+    ("template", "lex.metadata.template", LabelForm::Stripped),
+    (
+        "publishing-date",
+        "lex.metadata.publishing-date",
+        LabelForm::Stripped,
+    ),
+    (
+        "front-matter",
+        "lex.metadata.front-matter",
+        LabelForm::Stripped,
+    ),
+    ("doc.table", "lex.tabular.table", LabelForm::Stripped),
+    ("doc.image", "lex.media.image", LabelForm::Stripped),
+    ("doc.video", "lex.media.video", LabelForm::Stripped),
+    ("doc.audio", "lex.media.audio", LabelForm::Stripped),
 ];
 
-/// Lookup the canonical form for a legacy label, if any.
-pub fn canonical_for(label: &str) -> Option<&'static str> {
+/// Lookup the canonical form and matching [`LabelForm`] for a legacy
+/// label, if any.
+pub fn canonical_for(label: &str) -> Option<(&'static str, LabelForm)> {
     LEGACY_TO_CANONICAL
         .iter()
-        .find(|(legacy, _)| *legacy == label)
-        .map(|(_, canonical)| *canonical)
+        .find(|(legacy, _, _)| *legacy == label)
+        .map(|(_, canonical, form)| (*canonical, *form))
 }
 
 /// Post-parse pass that rewrites legacy labels to their canonical form.
@@ -110,8 +128,9 @@ impl Runnable<Document, Document> for NormalizeLabels {
 fn rewrite_in_item(item: &mut ContentItem) {
     match item {
         ContentItem::Annotation(a) => {
-            if let Some(canonical) = canonical_for(&a.data.label.value) {
+            if let Some((canonical, form)) = canonical_for(&a.data.label.value) {
                 a.data.label.value = canonical.to_string();
+                a.data.label.form = form;
             }
         }
         ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
@@ -162,8 +181,9 @@ fn rewrite_in_table(table: &mut crate::lex::ast::Table) {
 }
 
 fn rewrite_annotation(annotation: &mut Annotation) {
-    if let Some(canonical) = canonical_for(&annotation.data.label.value) {
+    if let Some((canonical, form)) = canonical_for(&annotation.data.label.value) {
         annotation.data.label.value = canonical.to_string();
+        annotation.data.label.form = form;
     }
     for child in annotation.children.as_mut_vec().iter_mut() {
         rewrite_in_item(child);
@@ -171,8 +191,9 @@ fn rewrite_annotation(annotation: &mut Annotation) {
 }
 
 fn rewrite_verbatim_label(verbatim: &mut Verbatim) {
-    if let Some(canonical) = canonical_for(&verbatim.closing_data.label.value) {
+    if let Some((canonical, form)) = canonical_for(&verbatim.closing_data.label.value) {
         verbatim.closing_data.label.value = canonical.to_string();
+        verbatim.closing_data.label.form = form;
     }
 }
 
@@ -241,10 +262,10 @@ mod tests {
 
     #[test]
     fn canonical_for_recognizes_every_legacy_label() {
-        for (legacy, canonical) in LEGACY_TO_CANONICAL {
+        for (legacy, canonical, form) in LEGACY_TO_CANONICAL {
             assert_eq!(
                 canonical_for(legacy),
-                Some(*canonical),
+                Some((*canonical, *form)),
                 "lookup must round-trip for {legacy}"
             );
         }
@@ -265,19 +286,63 @@ mod tests {
         assert_eq!(LEGACY_TO_CANONICAL.len(), 12);
         let metadata_count = LEGACY_TO_CANONICAL
             .iter()
-            .filter(|(_, c)| c.starts_with("lex.metadata."))
+            .filter(|(_, c, _)| c.starts_with("lex.metadata."))
             .count();
         let tabular_count = LEGACY_TO_CANONICAL
             .iter()
-            .filter(|(_, c)| c.starts_with("lex.tabular."))
+            .filter(|(_, c, _)| c.starts_with("lex.tabular."))
             .count();
         let media_count = LEGACY_TO_CANONICAL
             .iter()
-            .filter(|(_, c)| c.starts_with("lex.media."))
+            .filter(|(_, c, _)| c.starts_with("lex.media."))
             .count();
         assert_eq!(metadata_count, 8);
         assert_eq!(tabular_count, 1);
         assert_eq!(media_count, 3);
+    }
+
+    #[test]
+    fn shortcut_labels_tag_form_as_shortcut() {
+        // The four labels in the new normative shortcut table that today
+        // are also accepted as legacy bare names must tag form=Shortcut
+        // when rewritten (forward-looking; formatters consume this in
+        // PR 3 of #584).
+        for shortcut in ["title", "author", "date", "tags"] {
+            let (_, form) =
+                canonical_for(shortcut).unwrap_or_else(|| panic!("expected entry for {shortcut}"));
+            assert_eq!(form, LabelForm::Shortcut, "{shortcut} must tag as Shortcut");
+        }
+    }
+
+    #[test]
+    fn non_shortcut_metadata_labels_tag_form_as_stripped() {
+        // The four metadata labels with no shortcut alias in §4.2
+        // (category, template, publishing-date, front-matter) tag as
+        // Stripped today. PR 2 of #584 makes the bare form a parse
+        // error, leaving only `metadata.<name>` (Stripped) and
+        // `lex.metadata.<name>` (Canonical) accepted.
+        for stripped in ["category", "template", "publishing-date", "front-matter"] {
+            let (_, form) =
+                canonical_for(stripped).unwrap_or_else(|| panic!("expected entry for {stripped}"));
+            assert_eq!(form, LabelForm::Stripped, "{stripped} must tag as Stripped");
+        }
+    }
+
+    #[test]
+    fn doc_prefix_labels_tag_form_as_stripped() {
+        // PR 2 of #584 turns `doc.*` into a parse error; today these
+        // four still rewrite to canonical and tag as Stripped so the
+        // formatter can emit `tabular.table` / `media.image` / etc.
+        // rather than continuing to emit `doc.table` / `doc.image`.
+        for doc_label in ["doc.table", "doc.image", "doc.video", "doc.audio"] {
+            let (_, form) = canonical_for(doc_label)
+                .unwrap_or_else(|| panic!("expected entry for {doc_label}"));
+            assert_eq!(
+                form,
+                LabelForm::Stripped,
+                "{doc_label} must tag as Stripped"
+            );
+        }
     }
 
     #[test]
@@ -293,9 +358,9 @@ mod tests {
 
     #[test]
     fn every_metadata_label_rewrites() {
-        for (legacy, canonical) in LEGACY_TO_CANONICAL
+        for (legacy, canonical, _form) in LEGACY_TO_CANONICAL
             .iter()
-            .filter(|(_, c)| c.starts_with("lex.metadata."))
+            .filter(|(_, c, _)| c.starts_with("lex.metadata."))
         {
             let src = format!(":: {legacy} :: value\n\nBody.\n");
             let doc = parse(&src);

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -42,7 +42,7 @@
 
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::content_item::ContentItem;
-use crate::lex::ast::elements::label::LabelForm;
+use crate::lex::ast::elements::label::{Label, LabelForm};
 use crate::lex::ast::elements::verbatim::Verbatim;
 use crate::lex::ast::Document;
 use crate::lex::transforms::{Runnable, TransformError};
@@ -95,6 +95,16 @@ pub fn canonical_for(label: &str) -> Option<(&'static str, LabelForm)> {
         .map(|(_, canonical, form)| (*canonical, *form))
 }
 
+/// Rewrite `label` in place if its current value matches the legacy
+/// table. Shared by every label-bearing AST node the walker reaches
+/// (annotations, verbatim closers, table-cell-nested annotations).
+fn normalize_label(label: &mut Label) {
+    if let Some((canonical, form)) = canonical_for(&label.value) {
+        label.value = canonical.to_string();
+        label.form = form;
+    }
+}
+
 /// Post-parse pass that rewrites legacy labels to their canonical form.
 pub struct NormalizeLabels;
 
@@ -127,12 +137,7 @@ impl Runnable<Document, Document> for NormalizeLabels {
 
 fn rewrite_in_item(item: &mut ContentItem) {
     match item {
-        ContentItem::Annotation(a) => {
-            if let Some((canonical, form)) = canonical_for(&a.data.label.value) {
-                a.data.label.value = canonical.to_string();
-                a.data.label.form = form;
-            }
-        }
+        ContentItem::Annotation(a) => normalize_label(&mut a.data.label),
         ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
         ContentItem::Table(t) => rewrite_in_table(t),
         _ => {}
@@ -181,20 +186,14 @@ fn rewrite_in_table(table: &mut crate::lex::ast::Table) {
 }
 
 fn rewrite_annotation(annotation: &mut Annotation) {
-    if let Some((canonical, form)) = canonical_for(&annotation.data.label.value) {
-        annotation.data.label.value = canonical.to_string();
-        annotation.data.label.form = form;
-    }
+    normalize_label(&mut annotation.data.label);
     for child in annotation.children.as_mut_vec().iter_mut() {
         rewrite_in_item(child);
     }
 }
 
 fn rewrite_verbatim_label(verbatim: &mut Verbatim) {
-    if let Some((canonical, form)) = canonical_for(&verbatim.closing_data.label.value) {
-        verbatim.closing_data.label.value = canonical.to_string();
-        verbatim.closing_data.label.form = form;
-    }
+    normalize_label(&mut verbatim.closing_data.label);
 }
 
 fn attached_annotations_mut(item: &mut ContentItem) -> Option<&mut Vec<Annotation>> {
@@ -331,9 +330,12 @@ mod tests {
     #[test]
     fn doc_prefix_labels_tag_form_as_stripped() {
         // PR 2 of #584 turns `doc.*` into a parse error; today these
-        // four still rewrite to canonical and tag as Stripped so the
-        // formatter can emit `tabular.table` / `media.image` / etc.
-        // rather than continuing to emit `doc.table` / `doc.image`.
+        // four still rewrite to canonical. They tag as Stripped (rather
+        // than Shortcut) so that once PR 3 wires `Label.form` through
+        // the formatter, the emitted spelling will be the prefix-
+        // stripped canonical (`tabular.table` etc.) instead of the
+        // deprecated `doc.*` form. This PR records the tag only — no
+        // formatter consults it yet.
         for doc_label in ["doc.table", "doc.image", "doc.video", "doc.audio"] {
             let (_, form) = canonical_for(doc_label)
                 .unwrap_or_else(|| panic!("expected entry for {doc_label}"));

--- a/crates/lex-core/src/lex/ast/elements/label.rs
+++ b/crates/lex-core/src/lex/ast/elements/label.rs
@@ -29,12 +29,21 @@ use std::fmt;
 
 /// How the user spelled a label site, relative to the resolved canonical.
 ///
+/// Forward-looking infrastructure for the label namespace model
+/// described in `comms/specs/general.lex` §4. The eventual contract:
 /// Lex accepts up to three spellings of any `lex.*` label and one
 /// spelling of any community label, and round-trips the user's choice
-/// so `lexd format` does not silently rewrite the source. The full
-/// namespace model and shortcut table are normative in
-/// `comms/specs/general.lex` §4; this enum is the parser-side
-/// representation of that classification.
+/// so `lexd format` does not silently rewrite the source.
+///
+/// **Status in this PR (#584 PR 1/5):** the enum and the `form` field
+/// on [`Label`] exist; the parse-time `NormalizeLabels` stage tags
+/// labels that match its legacy-rewrite table, defaulting to
+/// `Canonical` for every other site. No formatter consults `form` yet
+/// — `lexd format` still emits `label.value` verbatim. PR 2 expands
+/// `NormalizeLabels` into the full resolution rules (universal
+/// prefix-strip, `Community` classification, hard-error for `doc.*`
+/// and unrecognized bare); PR 3 wires `form` through the formatter
+/// so the roundtrip promise lands end-to-end.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LabelForm {
     /// User wrote the canonical form verbatim (`lex.metadata.author`).
@@ -68,11 +77,11 @@ pub struct Label {
     /// the user wrote (community labels carry only one accepted form).
     pub value: String,
     pub location: Range,
-    /// Which input form the user wrote. Consumed by formatters to
-    /// emit the same spelling back, so `lexd format` does not rewrite
-    /// the user's source. Defaults to [`LabelForm::Canonical`] when a
-    /// Label is built programmatically; the parse-time
-    /// `NormalizeLabels` stage tags this based on the original input.
+    /// Which input form the user wrote. Defaults to
+    /// [`LabelForm::Canonical`] when a Label is built programmatically;
+    /// the parse-time `NormalizeLabels` stage tags this for the labels
+    /// it rewrites. See [`LabelForm`]'s docs for the PR-by-PR status —
+    /// in this PR the field is recorded but no formatter consults it.
     pub form: LabelForm,
 }
 

--- a/crates/lex-core/src/lex/ast/elements/label.rs
+++ b/crates/lex-core/src/lex/ast/elements/label.rs
@@ -27,11 +27,53 @@
 use super::super::range::{Position, Range};
 use std::fmt;
 
+/// How the user spelled a label site, relative to the resolved canonical.
+///
+/// Lex accepts up to three spellings of any `lex.*` label and one
+/// spelling of any community label, and round-trips the user's choice
+/// so `lexd format` does not silently rewrite the source. The full
+/// namespace model and shortcut table are normative in
+/// `comms/specs/general.lex` §4; this enum is the parser-side
+/// representation of that classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LabelForm {
+    /// User wrote the canonical form verbatim (`lex.metadata.author`).
+    /// This is also the default when a Label is constructed
+    /// programmatically without a specific source form (e.g. from the
+    /// wire codec, where the wire always carries the canonical).
+    Canonical,
+    /// User wrote the prefix-stripped form (`metadata.author`).
+    /// Resolves to canonical by prepending `lex.`.
+    Stripped,
+    /// User wrote the one-segment shortcut (`author`). Resolves to
+    /// canonical via the normative shortcut table.
+    Shortcut,
+    /// User wrote a community label (`acme.task`). Carries a single
+    /// accepted spelling and round-trips unchanged. Registry validation
+    /// is deferred to the analysis stage.
+    Community,
+}
+
+impl Default for LabelForm {
+    fn default() -> Self {
+        Self::Canonical
+    }
+}
+
 /// A label represents a named identifier in lex documents
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Label {
+    /// The resolved canonical spelling. For `lex.*` labels this is the
+    /// full `lex.X.Y.Z` form. For community labels it is the spelling
+    /// the user wrote (community labels carry only one accepted form).
     pub value: String,
     pub location: Range,
+    /// Which input form the user wrote. Consumed by formatters to
+    /// emit the same spelling back, so `lexd format` does not rewrite
+    /// the user's source. Defaults to [`LabelForm::Canonical`] when a
+    /// Label is built programmatically; the parse-time
+    /// `NormalizeLabels` stage tags this based on the original input.
+    pub form: LabelForm,
 }
 
 impl Label {
@@ -42,18 +84,26 @@ impl Label {
         Self {
             value,
             location: Self::default_location(),
+            form: LabelForm::Canonical,
         }
     }
     pub fn from_string(value: &str) -> Self {
         Self {
             value: value.to_string(),
             location: Self::default_location(),
+            form: LabelForm::Canonical,
         }
     }
 
     /// Preferred builder: `at(location)`
     pub fn at(mut self, location: Range) -> Self {
         self.location = location;
+        self
+    }
+
+    /// Builder: tag the input form the user wrote.
+    pub fn with_form(mut self, form: LabelForm) -> Self {
+        self.form = form;
         self
     }
 }
@@ -77,5 +127,23 @@ mod tests {
         );
         let label = Label::new("test".to_string()).at(location.clone());
         assert_eq!(label.location, location);
+    }
+
+    #[test]
+    fn label_defaults_form_to_canonical() {
+        assert_eq!(Label::new("x".into()).form, LabelForm::Canonical);
+        assert_eq!(Label::from_string("y").form, LabelForm::Canonical);
+    }
+
+    #[test]
+    fn with_form_tags_label() {
+        let l = Label::from_string("author").with_form(LabelForm::Shortcut);
+        assert_eq!(l.form, LabelForm::Shortcut);
+        assert_eq!(l.value, "author");
+    }
+
+    #[test]
+    fn label_form_default_is_canonical() {
+        assert_eq!(LabelForm::default(), LabelForm::Canonical);
     }
 }

--- a/crates/lex-core/src/lex/migrate.rs
+++ b/crates/lex-core/src/lex/migrate.rs
@@ -229,7 +229,7 @@ fn check_label(label: &Label, src: &str, sites: &mut Vec<LabelMigration>) {
         return;
     }
     let slice = &src[trim_start..trim_end];
-    if let Some(canonical) = canonical_for(slice) {
+    if let Some((canonical, _form)) = canonical_for(slice) {
         // Sanity check: the AST value should be the canonical form
         // NormalizeLabels rewrote it to.
         debug_assert_eq!(
@@ -239,8 +239,8 @@ fn check_label(label: &Label, src: &str, sites: &mut Vec<LabelMigration>) {
         );
         let from = LEGACY_TO_CANONICAL
             .iter()
-            .find(|(l, _)| *l == slice)
-            .map(|(l, _)| *l)
+            .find(|(l, _, _)| *l == slice)
+            .map(|(l, _, _)| *l)
             .expect("canonical_for matched but legacy table lookup didn't");
         sites.push(LabelMigration {
             byte_range: trim_start..trim_end,
@@ -303,9 +303,9 @@ mod tests {
     fn every_legacy_label_round_trips_through_migration() {
         // Each legacy label, when used in source, produces exactly one
         // migration entry with the right canonical replacement.
-        for (legacy, canonical) in LEGACY_TO_CANONICAL
+        for (legacy, canonical, _form) in LEGACY_TO_CANONICAL
             .iter()
-            .filter(|(_, c)| c.starts_with("lex.metadata."))
+            .filter(|(_, c, _)| c.starts_with("lex.metadata."))
         {
             let src = format!(":: {legacy} :: value\n\nBody.\n");
             let out = migrate_labels_in_source(&src).unwrap_or_else(|e| {
@@ -429,6 +429,7 @@ mod tests {
         let label = Label {
             value: "lex.metadata.title".to_string(),
             location: AstRange::new(label_span, Position::new(0, 3), Position::new(0, 8)),
+            form: crate::lex::ast::elements::label::LabelForm::Canonical,
         };
         let inner_annotation = Annotation::from_data(Data::new(label, Vec::new()), Vec::new());
 

--- a/crates/lex-core/src/lex/migrate.rs
+++ b/crates/lex-core/src/lex/migrate.rs
@@ -28,7 +28,7 @@
 //! and rewrite the source in reverse byte order. No re-parsing, no
 //! regex heuristics, no ambiguity.
 
-use crate::lex::assembling::stages::normalize_labels::{canonical_for, LEGACY_TO_CANONICAL};
+use crate::lex::assembling::stages::normalize_labels::LEGACY_TO_CANONICAL;
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::content_item::ContentItem;
 use crate::lex::ast::elements::label::Label;
@@ -229,19 +229,20 @@ fn check_label(label: &Label, src: &str, sites: &mut Vec<LabelMigration>) {
         return;
     }
     let slice = &src[trim_start..trim_end];
-    if let Some((canonical, _form)) = canonical_for(slice) {
+    // Single pass through the table — keep the `'static` legacy slice
+    // for the migration record alongside the canonical and (unused
+    // here) form classification, so we don't pay for a second lookup.
+    if let Some((from, canonical, _form)) = LEGACY_TO_CANONICAL
+        .iter()
+        .find(|(legacy, _, _)| *legacy == slice)
+    {
         // Sanity check: the AST value should be the canonical form
         // NormalizeLabels rewrote it to.
         debug_assert_eq!(
-            label.value, canonical,
+            label.value, *canonical,
             "NormalizeLabels should have rewritten {slice} to {canonical}, got {} in AST",
             label.value
         );
-        let from = LEGACY_TO_CANONICAL
-            .iter()
-            .find(|(l, _, _)| *l == slice)
-            .map(|(l, _, _)| *l)
-            .expect("canonical_for matched but legacy table lookup didn't");
         sites.push(LabelMigration {
             byte_range: trim_start..trim_end,
             from,


### PR DESCRIPTION
## Summary

First of five PRs implementing the bare-as-blessed label namespace model from `comms/specs/general.lex` §4. This PR is the lex-core foundation: it adds the form-tagging infrastructure that later PRs consume, with no current behavior change.

## What lands

- **`LabelForm` enum** (`Canonical | Stripped | Shortcut | Community`) in `crates/lex-core/src/lex/ast/elements/label.rs`. Default is `Canonical` so existing AST construction (wire codec, programmatic builders, tests) gets a sensible value with no source changes.
- **`form: LabelForm` field on `Label`**. The two constructors (`Label::new`, `Label::from_string`) initialise it to the default; a new `with_form(...)` builder lets callers override. One non-test direct-struct-literal site in `crates/lex-core/src/lex/migrate.rs:429` got the field added explicitly.
- **`LEGACY_TO_CANONICAL` grew a third tuple element**. The eight metadata legacy bare labels split by their post-#584 fate:
  - `title`, `author`, `date`, `tags` → `Shortcut` (they remain in §4.2's curated shortcut table)
  - `category`, `template`, `publishing-date`, `front-matter` → `Stripped` (their bare form becomes a parse error in PR 2)
  - `doc.table`, `doc.image`, `doc.video`, `doc.audio` → `Stripped` (the prefix becomes a parse error in PR 2; the tag describes how the formatter in PR 3 will emit the resulting canonical)
- **`canonical_for`** now returns `Option<(&'static str, LabelForm)>`. The one external consumer (`lex-core::migrate`) was updated.
- **`comms` submodule bumped** from `v0.16.0` (`5fc5810`) to current main (`3e99a63`) to pick up `specs/general.lex` §4 (Label Namespaces) and the bare-form flip in `specs/elements/lex.include.lex`.

## What does NOT land here

- Emission still uses `label.value` verbatim; the form field is recorded but no formatter reads it yet. **Form-preserving roundtrip lands in PR 3 of #584.**
- No new parse errors. `doc.*` and unrecognized bare names still parse exactly as they do at v0.12.0. **Hard-error lands in PR 2.**
- No universal prefix-strip rule or `Community`-form classification at parse time. **PR 2 introduces both.**

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean
- [x] `cargo test --workspace --exclude lex-wasm` — clean (pre-commit ran 2091 tests, 0 failures)
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New tests added: 3 in `label.rs` (default form, with_form builder, LabelForm::default) + 3 in `normalize_labels.rs` (shortcut-form tagging, stripped-form tagging for non-shortcut metadata, stripped-form tagging for `doc.*`)

## Sequencing

This PR targets `refac/label` since the #570 phases haven't landed on `main` yet. PRs 2–5 of #584 stack on top:

1. **This PR** — LabelForm infrastructure, no behavior change.
2. NormalizeLabels rewrite (new resolution rules: shortcut → input-as-is → prefix-strip → reject; `doc.*` hard error; bare-non-shortcut hard error; Community-form tagging).
3. Form-preserving emit in lex-babel (formatter consults `Label.form`).
4. Analysis surface (hover shows alias info, diagnostics for forbidden/unknown, completion ranks bare first).
5. CLI — `lexd migrate-labels` rework to handle the new strict mode.

Tracks: #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)