### PR TITLE
feat(lex-core): strict NormalizeLabels + structural-Table emit [#584 PR 2/5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 ## [Unreleased]
 
+### Changed — strict `NormalizeLabels` + structural-Table emit ([#584](https://github.com/lex-fmt/lex/issues/584) PR 2 of 5)
+
+Second of five PRs for the bare-as-blessed label namespace model. PR 1 added the form-tagging infrastructure; this PR replaces `NormalizeLabels`'s legacy whitelist with the resolution rules from `comms/specs/general.lex` §4.2 and rejects forbidden forms at parse time.
+
+**Resolution rules:**
+
+- Shortcut table → `LabelForm::Shortcut`. The 10 normative shortcuts are `table`, `image`, `video`, `audio`, `author`, `title`, `tags`, `date`, `include`, `notes`.
+- `lex.*` literal (registered canonical) → `LabelForm::Canonical`.
+- Prefix-strip (`metadata.author` → `lex.metadata.author`) when `lex.<input>` exists in the canonical set → `LabelForm::Stripped`.
+- Dotted non-reserved (`acme.task`) → `LabelForm::Community`; registry validation deferred to analysis.
+- Bare unknown (`foobar`, `42`, `^name`, `spec2025`) → `LabelForm::Community`; PR 4 of #584 adds a typo-prevention lint in analysis. The parser is deliberately permissive here so document-scoped reference identifiers (footnote IDs, citation keys, language hints on verbatim closers) parse without each needing a carve-out.
+
+**Hard rejections (TransformError at parse time):**
+
+- `doc.*` — reserved-forbidden under §4.1.
+- `lex.*` literals that aren't in the registered canonical set.
+
+**New strict / permissive modes** — `NormalizeLabels::new()` is strict (used by `STRING_TO_AST`); `NormalizeLabels::permissive()` skips rejection (used by `lexd migrate-labels`'s `parse_permissive` so legacy `doc.*` source can be parsed and rewritten).
+
+**New canonical: `lex.notes`** — registered alongside `lex.include` / `lex.metadata.*` / `lex.tabular.*` / `lex.media.*`. The label is the canonical footnote-definition-list marker. Promotion to a core canonical (rather than `metadata.notes` via prefix-strip) lets the source-level form stay `:: notes ::` and aligns with the spec's blessed-shortcut tier.
+
+**New `CANONICAL_LABELS` slice in `crates/lex-core/src/lex/builtins/mod.rs`** — single source of truth for which `lex.*` labels exist. `register_into` and `NormalizeLabels`'s `classify_label` both consume it; a parity test in `builtins::tests` enforces that the slice stays in sync with `register_into`'s schema set.
+
+**Structural-Table emit in `LexSerializer`** — `visit_table` / `leave_table` now emit a markdown-style pipe table with per-column alignment, padded for width. Previously `LexSerializer` had no Table visitor and tables resulting from the bare `:: table ::` closer serialized to an empty `:: lex.tabular.table ::` block.
+
+**Migration tool refactor** — `lex-core::migrate` now uses `parse_permissive` instead of `STRING_TO_AST` so legacy `doc.*` source can still be parsed for rewriting. The legacy-label table moved into `migrate.rs` (now scoped to migration use only; `NormalizeLabels` doesn't carry a "legacy" concept). `doc.table` → `table`, `doc.image` → `image`, `category` → `metadata.category`, etc.
+
+**Production callers flipped off legacy forms:**
+
+- `crates/lex-babel/src/templates/asset.rs` — `AssetKind::label()` emits `image`/`video`/`audio` (blessed shortcuts); `Data` falls back to `asset.data` (community-shape; no canonical for generic data assets today).
+- `crates/lex-analysis/src/completion.rs` — `STANDARD_VERBATIM_LABELS` list shrunk to blessed shortcuts only.
+- `crates/lex-analysis/src/utils.rs::is_notes_list` — accepts both `notes` (shortcut) and `lex.notes` (canonical) since callers may hand-build ASTs.
+- `crates/lex-core/src/lex/assembling/stages/apply_table_config.rs` — the `:: table ::` config annotation lookup accepts both spellings.
+
+**Test fixture migrations:**
+
+- Bare `note` / `info` / `warning` (test-only stand-ins) replaced with `test.note` / `test.info` / `test.warning` (community-shape) in ~20 files where the test was exercising parser/LSP plumbing, not label semantics.
+- `doc.note` / `doc.data` in test fixtures replaced with `test.note` / `test.data`.
+- Tests asserting specific label spellings (`closing_label("image")`) updated to expect the canonical (`closing_label("lex.media.image")`) since `NormalizeLabels` resolves at parse time.
+- The `verbatim_03_table_formatting` and `verbatim_04_user_repro` tests in `formats/lex/serializer.rs` now exercise the structural-Table emit path (no longer the legacy verbatim-with-markdown reformatter).
+- Snapshot fixtures (kitchensink markdown + html, detokenizer outputs) regenerated to match the new output.
+
+**Comms-side sibling**: `lex-fmt/comms` PR 43 adds `notes` to §4.2's normative shortcut table and flips three benchmark fixtures off `doc.*`.
+
+### Deferred follow-up
+
+The legacy verbatim-markdown reformatter code (`common/verbatim/table.rs::TableHandler` + `parse_pipe_table`, `VerbatimRegistry`'s `format_content` path, `LexSerializer::verbatim_registry` field) remains in the tree but is unreachable from user input now that:
+
+1. `doc.table` is hard-rejected, so no source-level path triggers the reformatter through NormalizeLabels.
+2. `:: table ::` parses as a structural Table and is serialized by `visit_table`.
+3. `lex.tabular.table` and `tabular.table` source also parse as Verbatim today, but no tests exercise that path; PR 3 of #584 retires it.
+
+A tidy-up PR after PR 3 can delete the dead modules and the `verbatim_registry` field on `LexSerializer`.
+
 ### Added — `LabelForm` infrastructure ([#584](https://github.com/lex-fmt/lex/issues/584) PR 1 of 5)
 
 First of five PRs implementing the bare-as-blessed label namespace model spelled out in `comms/specs/general.lex` §4. This PR is the lex-core foundation: it adds the `LabelForm` enum (`Canonical | Stripped | Shortcut | Community`) and a `form: LabelForm` field on `Label`. `NormalizeLabels` now tags every rewrite with the matching form so downstream formatters can preserve the user's choice of spelling on roundtrip. No emission behavior changes yet — formatters still emit `label.value` verbatim; PR 3 wires `form` through.

--- a/crates/lex-analysis/src/annotations.rs
+++ b/crates/lex-analysis/src/annotations.rs
@@ -232,7 +232,7 @@ mod tests {
     use lex_core::lex::ast::SourceLocation;
     use lex_core::lex::parsing;
 
-    const SAMPLE: &str = r#":: note ::
+    const SAMPLE: &str = r#":: test.note ::
     Doc note.
 
 Intro:
@@ -242,7 +242,7 @@ Intro:
 
 Paragraph text.
 
-:: info ::
+:: test.info ::
     Extra details.
 "#;
 
@@ -264,38 +264,42 @@ Paragraph text.
 
         let within_second = position_of("Paragraph");
         let second = next_annotation(&document, within_second).expect("next");
-        assert_eq!(second.label, "info");
+        assert_eq!(second.label, "test.info");
 
         let after_last = position_of("Extra details");
         let wrap = next_annotation(&document, after_last).expect("wrap");
-        assert_eq!(wrap.label, "note");
+        assert_eq!(wrap.label, "test.note");
     }
 
     #[test]
     fn navigates_backward_including_wrap() {
         let document = parse();
-        let start = position_of(":: info");
+        let start = position_of(":: test.info");
         let prev = previous_annotation(&document, start).expect("previous");
         assert_eq!(prev.label, "todo");
 
-        let wrap = previous_annotation(&document, position_of(":: note")).expect("wrap");
-        assert_eq!(wrap.label, "info");
+        let wrap = previous_annotation(&document, position_of(":: test.note")).expect("wrap");
+        assert_eq!(wrap.label, "test.info");
     }
 
     #[test]
     fn adds_status_parameter_when_resolving() {
-        let source = ":: note ::\n";
+        let source = ":: test.note ::\n";
         let document = parsing::parse_document(source).unwrap();
         let position = SourceLocation::new(source).byte_to_position(source.find("note").unwrap());
         let edit = toggle_annotation_resolution(&document, position, true).expect("edit");
-        assert_eq!(edit.new_text, ":: note status=resolved ::");
+        assert_eq!(edit.new_text, ":: test.note status=resolved ::");
     }
 
     #[test]
     fn removes_status_parameter_when_unresolving() {
+        // Programmatic AST construction — doesn't go through
+        // NormalizeLabels, so the label.value flows through to
+        // resolution_edit verbatim. Use a bare community-shape label
+        // so the assertion mirrors the input.
         use lex_core::lex::ast::{Data, Label};
         let data = Data::new(
-            Label::new("note".to_string()),
+            Label::new("test.note".to_string()),
             vec![
                 Parameter::new("priority".to_string(), "high".to_string()),
                 Parameter::new("status".to_string(), "resolved".to_string()),
@@ -307,15 +311,15 @@ Paragraph text.
             Position::new(0, 0),
         ));
         let edit = resolution_edit(&annotation, false).expect("edit");
-        assert_eq!(edit.new_text, ":: note priority=high ::");
+        assert_eq!(edit.new_text, ":: test.note priority=high ::");
     }
 
     #[test]
     fn resolves_when_cursor_at_line_start() {
-        let source = ":: note ::\n";
+        let source = ":: test.note ::\n";
         let document = parsing::parse_document(source).unwrap();
         let edit =
             toggle_annotation_resolution(&document, Position::new(0, 0), true).expect("edit");
-        assert_eq!(edit.new_text, ":: note status=resolved ::");
+        assert_eq!(edit.new_text, ":: test.note status=resolved ::");
     }
 }

--- a/crates/lex-analysis/src/completion.rs
+++ b/crates/lex-analysis/src/completion.rs
@@ -139,10 +139,10 @@ fn macro_completions(_document: &Document) -> Vec<CompletionCandidate> {
     vec![
         CompletionCandidate::new("@table", CompletionItemKind::SNIPPET)
             .with_detail("Insert table snippet")
-            .with_insert_text(":: doc.table ::\n| Header 1 | Header 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |\n::\n"),
+            .with_insert_text(":: table ::\n| Header 1 | Header 2 |\n| -------- | -------- |\n| Cell 1   | Cell 2   |\n::\n"),
         CompletionCandidate::new("@image", CompletionItemKind::SNIPPET)
             .with_detail("Insert image snippet")
-            .with_insert_text(":: doc.image src=\"$1\" ::\n"),
+            .with_insert_text(":: image src=\"$1\" ::\n"),
         CompletionCandidate::new("@note", CompletionItemKind::SNIPPET)
             .with_detail("Insert annotation reference")
             .with_insert_text("[::$1]"),
@@ -545,15 +545,10 @@ fn is_inside_verbatim_src_parameter(document: &Document, position: Position) -> 
     })
 }
 
-const STANDARD_VERBATIM_LABELS: &[&str] = &[
-    "doc.code",
-    "doc.data",
-    "doc.image",
-    "doc.table",
-    "doc.video",
-    "doc.audio",
-    "doc.note",
-];
+/// Verbatim labels offered as completion suggestions. Mirrors the
+/// blessed shortcut set in `comms/specs/general.lex` §4.2 — completions
+/// suggest the shortest accepted form per the documentation-voice rule.
+const STANDARD_VERBATIM_LABELS: &[&str] = &["table", "image", "video", "audio", "include"];
 
 const COMMON_CODE_LANGUAGES: &[&str] = &[
     "bash",
@@ -589,7 +584,7 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    const SAMPLE_DOC: &str = r#":: note ::
+    const SAMPLE_DOC: &str = r#":: test.note ::
     Document level note.
 
 Cache:
@@ -602,7 +597,7 @@ Cache:
 Image placeholder:
 
     diagram placeholder
-:: doc.image src=./images/chart.png title="Usage" ::
+:: image src=./images/chart.png title="Usage" ::
 
 Code sample:
 
@@ -636,7 +631,7 @@ Code sample:
         let completions = completion_items(&document, position_at(cursor), None, None, None);
         let labels: BTreeSet<_> = completions.iter().map(|c| c.label.as_str()).collect();
         assert!(labels.contains("Cache"));
-        assert!(labels.contains("note"));
+        assert!(labels.contains("test.note"));
         assert!(labels.contains("1"));
         assert!(labels.contains("./images/chart.png"));
     }
@@ -648,16 +643,15 @@ Code sample:
         let mut pos = verbatim.closing_data.label.location.start;
         pos.column += 1; // inside the label text
         let completions = completion_items(&document, pos, None, None, None);
-        assert!(completions.iter().any(|c| c.label == "doc.image"));
+        assert!(completions.iter().any(|c| c.label == "image"));
         assert!(completions.iter().any(|c| c.label == "rust"));
     }
 
     #[test]
     fn verbatim_src_completion_offers_known_paths() {
-        // #570 Phase 3b activated `NormalizeLabels`, so `:: doc.image ::`
-        // in `SAMPLE_DOC` is rewritten to its canonical form before
-        // this test sees the parsed AST. Look up the verbatim under
-        // the canonical name.
+        // NormalizeLabels rewrites the source-level `:: image ::`
+        // shortcut to its canonical `lex.media.image` form before
+        // this test sees the parsed AST.
         let document = parse_sample();
         let verbatim = find_verbatim(&document, "lex.media.image");
         let param = verbatim
@@ -792,7 +786,11 @@ Code sample:
         // Pass "::" as current line content
         let completions = completion_items(&document, pos, Some("::"), None, Some(":"));
 
-        assert!(completions.iter().any(|c| c.label == "doc.code"));
+        // STANDARD_VERBATIM_LABELS now ships the blessed shortcuts;
+        // `table` is the most stable check (it's the verbatim closer
+        // for tables). Language hints like `rust` come from
+        // COMMON_CODE_LANGUAGES regardless.
+        assert!(completions.iter().any(|c| c.label == "table"));
         assert!(completions.iter().any(|c| c.label == "rust"));
     }
 

--- a/crates/lex-analysis/src/document_symbols.rs
+++ b/crates/lex-analysis/src/document_symbols.rs
@@ -299,7 +299,7 @@ mod tests {
     fn builds_session_tree() {
         let document = sample_document();
         let symbols = collect_document_symbols(&document);
-        assert!(symbols.iter().any(|s| s.name == ":: doc.note ::"));
+        assert!(symbols.iter().any(|s| s.name == ":: test.note ::"));
         let session = find_symbol(&symbols, "1. Intro");
         let child_names: Vec<_> = session
             .children
@@ -425,7 +425,9 @@ mod tests {
     fn includes_document_level_annotations() {
         let document = sample_document();
         let symbols = collect_document_symbols(&document);
-        assert!(symbols.iter().any(|symbol| symbol.name == ":: doc.note ::"));
+        assert!(symbols
+            .iter()
+            .any(|symbol| symbol.name == ":: test.note ::"));
         // callout is consumed as the footer of the Cache verbatim block
     }
 }

--- a/crates/lex-analysis/src/references.rs
+++ b/crates/lex-analysis/src/references.rs
@@ -177,7 +177,7 @@ mod tests {
     use lex_core::lex::parsing;
 
     fn fixture() -> (Document, String) {
-        let source = r#":: note ::
+        let source = r#":: test.note ::
     Something.
 
 Cache:

--- a/crates/lex-analysis/src/semantic_tokens.rs
+++ b/crates/lex-analysis/src/semantic_tokens.rs
@@ -610,7 +610,7 @@ mod tests {
         let annotation_labels = snippets(&tokens, LexSemanticTokenKind::AnnotationLabel, source);
         assert!(annotation_labels
             .iter()
-            .any(|snippet| snippet.contains("doc.note")));
+            .any(|snippet| snippet.contains("test.note")));
         let parameters = snippets(&tokens, LexSemanticTokenKind::AnnotationParameter, source);
         assert!(parameters
             .iter()
@@ -687,7 +687,7 @@ mod tests {
         let tokens = collect_semantic_tokens(&document);
         let source = sample_source();
 
-        // The fixture starts with `:: doc.note severity=info :: Document preface.`
+        // The fixture starts with `:: test.note severity=info :: Document preface.`
         // "Document preface." is inline annotation content — plain text inside annotation context.
         let annotation_content = snippets(&tokens, LexSemanticTokenKind::AnnotationContent, source);
         assert!(
@@ -702,7 +702,7 @@ mod tests {
     fn annotation_content_excludes_formatted_text() {
         // Inline formatting within annotation context should get its own token type,
         // not AnnotationContent — only Plain nodes emit AnnotationContent.
-        let source = ":: note :: Some *bold* text.\n";
+        let source = ":: test.note :: Some *bold* text.\n";
         let document = lex_core::lex::parsing::parse_document(source).expect("failed to parse");
         let tokens = collect_semantic_tokens(&document);
 

--- a/crates/lex-analysis/src/utils.rs
+++ b/crates/lex-analysis/src/utils.rs
@@ -739,20 +739,24 @@ fn extract_session_identifier(title: &str) -> Option<String> {
     }
 }
 
-/// Checks whether a list is annotated with `:: notes ::`.
+/// Checks whether a list is annotated with `:: notes ::`. The
+/// parser's `NormalizeLabels` stage resolves the shortcut to its
+/// canonical (`lex.notes`); both forms are accepted here in case a
+/// caller hands an un-normalized AST.
 fn is_notes_list(list: &lex_core::lex::ast::List) -> bool {
-    list.annotations()
-        .iter()
-        .any(|a| a.data.label.value.trim().eq_ignore_ascii_case("notes"))
+    list.annotations().iter().any(label_is_notes)
 }
 
 /// Checks whether a container has a `:: notes ::` annotation (which may
 /// attach to the container itself rather than to the list, depending on
 /// blank line distance).
 fn has_notes_annotation(annotations: &[Annotation]) -> bool {
-    annotations
-        .iter()
-        .any(|a| a.data.label.value.trim().eq_ignore_ascii_case("notes"))
+    annotations.iter().any(label_is_notes)
+}
+
+fn label_is_notes(a: &Annotation) -> bool {
+    let v = a.data.label.value.trim();
+    v.eq_ignore_ascii_case("lex.notes") || v.eq_ignore_ascii_case("notes")
 }
 
 /// Collects all footnote definitions from a document.

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -5,7 +5,8 @@ use lex_core::lex::ast::{
         verbatim::VerbatimGroupItemRef, VerbatimLine,
     },
     traits::{AstNode, Visitor},
-    Annotation, Definition, Document, List, ListItem, Paragraph, Session, Verbatim,
+    Annotation, Definition, Document, List, ListItem, Paragraph, Session, Table,
+    TableCellAlignment, TableRow, Verbatim,
 };
 
 use lex_core::lex::ast::elements::sequence_marker::DecorationStyle;
@@ -420,6 +421,211 @@ impl Visitor for LexSerializer {
         footer.push_str(" ::");
         self.write_line(&footer);
     }
+
+    fn visit_table(&mut self, table: &Table) {
+        // Tables share the outer verbatim shape: leading blank line,
+        // subject line ending in `:`, indented body of pipe rows,
+        // dedented `:: table ::` closer.
+        if !self.last_emission_ended_with_container_opener_colon() {
+            self.ensure_blank_lines(1);
+        }
+
+        let subject = table.subject.as_string();
+        if !subject.is_empty() {
+            self.write_line(&format!("{subject}:"));
+        }
+
+        self.indent_level += 1;
+        emit_pipe_table(self, table);
+        self.indent_level -= 1;
+
+        // The closing `:: lex.tabular.table ::` annotation is part of
+        // `table.annotations` — emitted by the standard annotation
+        // walk after `leave_table` returns. Until form-preserving
+        // emit lands (PR 3 of #584), the annotation walker emits
+        // `label.value` verbatim; that's the canonical for now.
+    }
+
+    fn leave_table(&mut self, _table: &Table) {
+        // No-op; annotations carry the closer.
+    }
+}
+
+/// Emit a structural Table as a markdown-style pipe table, padded for
+/// column alignment. The column count is the max-width row; shorter
+/// rows pad with empty cells. Alignment follows the per-cell `align`
+/// attribute, which the parser sets from the markdown alignment row
+/// (`:---`, `:---:`, `---:`).
+fn emit_pipe_table(serializer: &mut LexSerializer, table: &Table) {
+    let all_rows: Vec<&TableRow> = table
+        .header_rows
+        .iter()
+        .chain(table.body_rows.iter())
+        .collect();
+    if all_rows.is_empty() {
+        return;
+    }
+
+    // Determine column count from the widest row.
+    let col_count = all_rows
+        .iter()
+        .map(|r| r.cells.iter().map(|c| c.colspan).sum::<usize>())
+        .max()
+        .unwrap_or(0);
+    if col_count == 0 {
+        return;
+    }
+
+    // Compute per-column alignment: first non-`None` cell wins.
+    let aligns = compute_column_aligns(&all_rows, col_count);
+
+    // Compute per-column widths from cell text content. The
+    // separator-row cells use `---` (or longer to match content
+    // width), so include their natural width in the calc too.
+    let widths = compute_column_widths(&all_rows, col_count, &aligns);
+
+    // Emit header rows.
+    for row in &table.header_rows {
+        serializer.write_line(&format_pipe_row(row, &widths, col_count));
+    }
+    // Emit separator row (between header and body).
+    if !table.header_rows.is_empty() {
+        serializer.write_line(&format_separator_row(&widths, &aligns));
+    }
+    // Emit body rows.
+    for row in &table.body_rows {
+        serializer.write_line(&format_pipe_row(row, &widths, col_count));
+    }
+}
+
+fn compute_column_aligns(rows: &[&TableRow], col_count: usize) -> Vec<TableCellAlignment> {
+    let mut aligns = vec![TableCellAlignment::None; col_count];
+    for row in rows {
+        let mut col = 0;
+        for cell in &row.cells {
+            if col >= col_count {
+                break;
+            }
+            if aligns[col] == TableCellAlignment::None && cell.align != TableCellAlignment::None {
+                aligns[col] = cell.align;
+            }
+            col += cell.colspan.max(1);
+        }
+    }
+    aligns
+}
+
+fn compute_column_widths(
+    rows: &[&TableRow],
+    col_count: usize,
+    aligns: &[TableCellAlignment],
+) -> Vec<usize> {
+    let mut widths = vec![0usize; col_count];
+    for row in rows {
+        let mut col = 0;
+        for cell in &row.cells {
+            if col >= col_count {
+                break;
+            }
+            let text_len = cell.content.as_string().trim().chars().count();
+            widths[col] = widths[col].max(text_len);
+            col += cell.colspan.max(1);
+        }
+    }
+    // Separator widths need a minimum of 3 (`---`) plus 1 for each
+    // colon a `:left`/`right:`/`:center:` marker adds. Round up so the
+    // separator row's `---` segment is at least as wide as the content.
+    for (col, w) in widths.iter_mut().enumerate() {
+        let min = match aligns.get(col).copied().unwrap_or(TableCellAlignment::None) {
+            TableCellAlignment::Center => 5,                           // `:---:`
+            TableCellAlignment::Left | TableCellAlignment::Right => 4, // `:---` / `---:`
+            TableCellAlignment::None => 3,
+        };
+        if *w < min {
+            *w = min;
+        }
+    }
+    widths
+}
+
+fn format_pipe_row(row: &TableRow, widths: &[usize], col_count: usize) -> String {
+    let mut out = String::from("|");
+    let mut col = 0;
+    for cell in &row.cells {
+        if col >= col_count {
+            break;
+        }
+        let span = cell.colspan.max(1);
+        let span_width: usize = widths[col..(col + span).min(widths.len())]
+            .iter()
+            .sum::<usize>()
+            + (span.saturating_sub(1)) * 3; // `| ` + ` ` between cells
+        let text = cell.content.as_string().trim();
+        out.push(' ');
+        // Padding to the spanned width (1 cell uses widths[col]).
+        let pad_target = if span == 1 {
+            widths.get(col).copied().unwrap_or(0)
+        } else {
+            span_width
+        };
+        let visible_len = text.chars().count();
+        out.push_str(text);
+        for _ in visible_len..pad_target {
+            out.push(' ');
+        }
+        out.push(' ');
+        out.push('|');
+        col += span;
+    }
+    // Pad trailing empty cells.
+    while col < col_count {
+        out.push(' ');
+        let w = widths.get(col).copied().unwrap_or(0);
+        for _ in 0..w {
+            out.push(' ');
+        }
+        out.push(' ');
+        out.push('|');
+        col += 1;
+    }
+    out
+}
+
+fn format_separator_row(widths: &[usize], aligns: &[TableCellAlignment]) -> String {
+    let mut out = String::from("|");
+    for (i, &w) in widths.iter().enumerate() {
+        out.push(' ');
+        let align = aligns.get(i).copied().unwrap_or(TableCellAlignment::None);
+        match align {
+            TableCellAlignment::Left => {
+                out.push(':');
+                for _ in 1..w {
+                    out.push('-');
+                }
+            }
+            TableCellAlignment::Right => {
+                for _ in 0..w.saturating_sub(1) {
+                    out.push('-');
+                }
+                out.push(':');
+            }
+            TableCellAlignment::Center => {
+                out.push(':');
+                for _ in 0..w.saturating_sub(2) {
+                    out.push('-');
+                }
+                out.push(':');
+            }
+            TableCellAlignment::None => {
+                for _ in 0..w {
+                    out.push('-');
+                }
+            }
+        }
+        out.push(' ');
+        out.push('|');
+    }
+    out
 }
 
 #[cfg(test)]
@@ -751,21 +957,23 @@ mod tests {
 
     #[test]
     fn test_verbatim_03_table_formatting() {
-        // Use standard verbatim syntax: Subject + indented content + closing marker (dedented)
-        let source =
-            "Table Example:\n    | A | B |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
-        // The serializer should format this table
+        // PR 2 of #584 retired the legacy verbatim-with-markdown-body
+        // path: `:: doc.table ::` is forbidden, and `:: lex.tabular.table ::`
+        // / `:: tabular.table ::` source no longer round-trips through
+        // a markdown reformatter. The only surviving path is the
+        // structural Table element triggered by the bare `:: table ::`
+        // closer — `LexSerializer::visit_table` emits the pipe table
+        // directly with column alignment.
+        let source = "Table Example:\n    | A | B |\n    |---|---|\n    | 1 | 2 |\n:: table ::\n";
         let formatted = format_source(source);
 
-        // Check that it's formatted (aligned)
-        // Note: The exact spacing depends on the markdown serializer, but it should be consistent
-        // Markdown serializer adds padding for alignment
+        // Column-aligned pipe-table output from visit_table.
         assert!(formatted.contains("| A   | B   |"));
         assert!(formatted.contains("| --- | --- |"));
         assert!(formatted.contains("| 1   | 2   |"));
 
-        // Also test with unformatted input
-        let unformatted = "Table Example:\n    |A|B|\n    |-|-|\n    |1|2|\n:: doc.table ::\n";
+        // Also test with unformatted input — visit_table normalises.
+        let unformatted = "Table Example:\n    |A|B|\n    |-|-|\n    |1|2|\n:: table ::\n";
         let formatted_2 = format_source(unformatted);
 
         // Should be formatted nicely
@@ -799,23 +1007,16 @@ mod tests {
 
     #[test]
     fn test_verbatim_04_user_repro() {
-        // NOTE: The user's original input had dedented marker "::  doc.table ::".
-        // This caused it to be parsed as Definition + Document Annotation.
-        // The fix is to indent the marker to match the subject.
-        //
-        // #570 Phase 3b activated `NormalizeLabels`, so the document
-        // annotation's label `doc.table` is rewritten to its canonical
-        // form `lex.tabular.table` before serialization. The footer
-        // assertion looks for the canonical form. Phase 5 ships
-        // `lexd migrate-labels` for source-level migration; this is
-        // the parser-side equivalent for files that already flow
-        // through `format`.
-        let source = "  The Table:\n    | Markup Language | Great |\n    |--------------------|--------|\n    | Markdown | No |\n    | Lex | Yes |\n  ::  doc.table ::\n";
+        // The original user input had dedented marker "::  doc.table ::"
+        // which caused parse-as-Definition + Document Annotation. The
+        // fix is to indent the marker to match the subject. Updated
+        // for PR 2 of #584: source uses the blessed `table` closer
+        // which triggers structural-Table parsing; the legacy verbatim
+        // path with markdown reformat is gone.
+        let source = "  The Table:\n    | Markup Language | Great |\n    |--------------------|--------|\n    | Markdown | No |\n    | Lex | Yes |\n  ::  table ::\n";
 
         let formatted = format_source(source);
 
-        // Check for formatting
-        // Markdown serializer adds padding for alignment
         let table_start = formatted
             .find("| Markup Language | Great |")
             .expect("Table start not found");

--- a/crates/lex-babel/src/templates/asset.rs
+++ b/crates/lex-babel/src/templates/asset.rs
@@ -29,11 +29,17 @@ impl AssetKind {
     }
 
     pub fn label(self) -> &'static str {
+        // Emit the blessed shortcut for the three media canonicals (per
+        // comms/specs/general.lex §4.2). `Data` falls back to a
+        // community-shaped placeholder because there is no canonical
+        // for generic data assets today (the legacy `doc.data` label
+        // was non-canonical under any version of the spec — it never
+        // had a registered schema).
         match self {
-            AssetKind::Image => "doc.image",
-            AssetKind::Video => "doc.video",
-            AssetKind::Audio => "doc.audio",
-            AssetKind::Data => "doc.data",
+            AssetKind::Image => "image",
+            AssetKind::Video => "video",
+            AssetKind::Audio => "audio",
+            AssetKind::Data => "asset.data",
         }
     }
 }
@@ -110,7 +116,7 @@ mod tests {
         let request = AssetSnippetRequest::new(path.as_path(), &rules);
         let snippet = build_asset_snippet(&request);
         assert_eq!(snippet.kind, AssetKind::Image);
-        assert!(snippet.text.contains(":: doc.image"));
+        assert!(snippet.text.contains(":: image"));
     }
 
     #[test]
@@ -153,6 +159,6 @@ mod tests {
         let request = AssetSnippetRequest::new(path, &rules);
         let snippet = build_asset_snippet(&request);
         assert_eq!(snippet.kind, AssetKind::Data);
-        assert!(snippet.text.contains(":: doc.data"));
+        assert!(snippet.text.contains(":: asset.data"));
     }
 }

--- a/crates/lex-babel/src/templates/verbatim.rs
+++ b/crates/lex-babel/src/templates/verbatim.rs
@@ -239,7 +239,7 @@ mod tests {
         let rules = FormattingRules::default();
         let request = VerbatimSnippetRequest::new(file.as_path(), &rules);
         let snippet = build_verbatim_snippet(&request).unwrap();
-        assert_eq!(snippet.language, "doc.image");
-        assert!(snippet.text.contains(":: doc.image"));
+        assert_eq!(snippet.language, "image");
+        assert!(snippet.text.contains(":: image"));
     }
 }

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
@@ -32,7 +32,7 @@ function example() {
     return "lex";
 }</code></pre></div></section><section class="lex-session lex-session-2"><h2>2. Second Root Session {{session}}</h2><div class="lex-content"><p class="lex-paragraph">This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}</p><!-- lex:todo status="open" assignee="team" --><div class="lex-content"><p class="lex-paragraph">This is a block annotation. {{paragraph}}</p><p class="lex-paragraph">It contains a paragraph and a list. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Task 1 to complete. {{list-item}}
 </li><li class="lex-list-item">Task 2 to complete. {{list-item}}
-</li></ul></div><!-- /lex:todo --><div class="lex-verbatim-subject">Image Reference (Marker Verbatim Block)</div><pre class="lex-verbatim" data-language="image"><code class="language-image"></code></pre></div></section><p class="lex-paragraph">Final paragraph at the end of the document. {{paragraph}}</p>
+</li></ul></div><!-- /lex:todo --><figure class="lex-image"><img src="&quot;logo.png&quot;" alt="&quot;Lex Logo&quot;"><figcaption>"Lex Logo"</figcaption></figure></div></section><p class="lex-paragraph">Final paragraph at the end of the document. {{paragraph}}</p>
 </div>
 </body>
 </html>

--- a/crates/lex-babel/tests/markdown/import.rs
+++ b/crates/lex-babel/tests/markdown/import.rs
@@ -414,7 +414,10 @@ fn test_kitchensink_round_trip() {
     // Import back to Lex
     let lex_doc2 = md_to_lex(&md);
 
-    // Count element types recursively
+    // Count element types recursively. Walks every container that
+    // can carry children — Session, List, ListItem, Definition,
+    // Annotation — so deeply-nested verbatims (e.g. a code fence
+    // inside a list item inside a session) are counted too.
     fn count_elements(elements: &[ContentItem]) -> (usize, usize, usize, usize) {
         let mut counts = (0usize, 0usize, 0usize, 0usize); // paragraphs, sessions, lists, verbatims
         for el in elements {
@@ -428,7 +431,32 @@ fn test_kitchensink_round_trip() {
                     counts.2 += inner.2;
                     counts.3 += inner.3;
                 }
-                ContentItem::List(_) => counts.2 += 1,
+                ContentItem::List(l) => {
+                    counts.2 += 1;
+                    for item in l.items.iter() {
+                        if let ContentItem::ListItem(li) = item {
+                            let inner = count_elements(&li.children);
+                            counts.0 += inner.0;
+                            counts.1 += inner.1;
+                            counts.2 += inner.2;
+                            counts.3 += inner.3;
+                        }
+                    }
+                }
+                ContentItem::Definition(d) => {
+                    let inner = count_elements(&d.children);
+                    counts.0 += inner.0;
+                    counts.1 += inner.1;
+                    counts.2 += inner.2;
+                    counts.3 += inner.3;
+                }
+                ContentItem::Annotation(a) => {
+                    let inner = count_elements(&a.children);
+                    counts.0 += inner.0;
+                    counts.1 += inner.1;
+                    counts.2 += inner.2;
+                    counts.3 += inner.3;
+                }
                 ContentItem::VerbatimBlock(_) => counts.3 += 1,
                 _ => {}
             }

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__export__kitchensink_markdown.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__export__kitchensink_markdown.snap
@@ -75,9 +75,6 @@ It contains a paragraph and a list. {{paragraph}}
 
 <!-- /lex:todo -->
 
-**Image Reference (Marker Verbatim Block)**
-
-``` image
-```
+!["Lex Logo"]("logo.png")
 
 Final paragraph at the end of the document. {{paragraph}}

--- a/crates/lex-core/src/lex/assembling/stages/apply_table_config.rs
+++ b/crates/lex-core/src/lex/assembling/stages/apply_table_config.rs
@@ -47,11 +47,15 @@ fn apply_config_in_children(children: &mut [ContentItem]) {
 
 /// Apply configuration from :: table :: annotations to a single table.
 fn apply_table_config(table: &mut Table) {
-    // Find the first annotation with label "table"
-    let config = table
-        .annotations
-        .iter()
-        .find(|a| a.data.label.value == "table");
+    // Find the first annotation whose label resolves to the canonical
+    // tabular-table label. `NormalizeLabels` (PR 2 of #584) rewrites
+    // the source-level `:: table ::` shortcut to `lex.tabular.table`
+    // before ApplyTableConfig runs; we accept both spellings to keep
+    // out-of-band callers that build ASTs by hand working.
+    let config = table.annotations.iter().find(|a| {
+        let v = a.data.label.value.as_str();
+        v == "lex.tabular.table" || v == "table"
+    });
 
     let config = match config {
         Some(c) => c,

--- a/crates/lex-core/src/lex/assembling/stages/attach_annotations.rs
+++ b/crates/lex-core/src/lex/assembling/stages/attach_annotations.rs
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn test_annotation_attaches_to_list() {
-        let source = "Intro paragraph.\n\n:: note ::\n- Bread\n- Milk\n";
+        let source = "Intro paragraph.\n\n:: test.note ::\n- Bread\n- Milk\n";
         let doc = parse_without_annotation_attachment(source).unwrap();
 
         let stage = AttachAnnotations::new();
@@ -716,7 +716,7 @@ mod tests {
     }
     #[test]
     fn test_benchmark_50_repro() {
-        let source = ":: doc.note severity=info :: Document preface.\n\n1. Intro\n";
+        let source = ":: test.note severity=info :: Document preface.\n\n1. Intro\n";
         let doc = parse_without_annotation_attachment(source).unwrap();
         let stage = AttachAnnotations::new();
         let result = stage.run(doc).unwrap();
@@ -726,6 +726,6 @@ mod tests {
             1,
             "Should have 1 document-level annotation"
         );
-        assert_eq!(result.annotations[0].data.label.value, "doc.note");
+        assert_eq!(result.annotations[0].data.label.value, "test.note");
     }
 }

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -1,116 +1,208 @@
-//! Normalize legacy bare labels to their canonical `lex.*` form.
+//! Resolve label input forms to their canonical `lex.*` spelling and
+//! tag each label site with the form the user wrote.
 //!
-//! Phase 2 of the label-semantics refactor tracked in
-//! [#570](https://github.com/lex-fmt/lex/issues/570). Walks a parsed
-//! [`Document`] and rewrites annotation labels matching the
-//! pre-extension whitelist (`title`, `author`, `date`, `tags`,
-//! `category`, `template`, `publishing-date`, `front-matter`) plus the
-//! four verbatim labels (`doc.table`, `doc.image`, `doc.video`,
-//! `doc.audio`) to their canonical `lex.metadata.*` / `lex.tabular.*` /
-//! `lex.media.*` equivalents.
+//! This stage implements the namespace-policy rules normatively
+//! defined in `comms/specs/general.lex` §4 — see [PR 1 of
+//! #584](https://github.com/lex-fmt/lex/pull/586) for the foundation
+//! (`LabelForm` enum + `form` field on [`Label`]) and PR 2 (this
+//! revision) for the resolution logic + rejection.
 //!
-//! # Activation lifecycle
+//! # Resolution order
 //!
-//! Phase 2 of #570 shipped this stage as a module without wiring it
-//! into the default
-//! [`STRING_TO_AST`](crate::lex::transforms::standard::STRING_TO_AST)
-//! pipeline. **Phase 3b wired it up**: the rewrite now runs between
-//! `AttachAnnotations` and `ApplyTableConfig`, so every Document
-//! emitted by `STRING_TO_AST` carries canonical labels. The legacy
-//! whitelists in `lex-babel` (`ir/from_lex.rs`'s frontmatter
-//! promotion and `common/verbatim/VerbatimRegistry`'s handler
-//! registrations) were updated in the same PR to recognize the
-//! canonical names — both halves of the bare-label flip landed
-//! together so no intermediate state was broken. A follow-up phase
-//! retires the legacy paths altogether once render hooks (#570
-//! Phase 4) are live.
+//! For each label-bearing AST node, the parser-time pipeline runs the
+//! resolution order from §4.2:
 //!
-//! # Why warnings are silent
+//! 1. **Shortcut.** If the input is a key in [`SHORTCUT_TABLE`],
+//!    resolve to its canonical and tag [`LabelForm::Shortcut`].
+//! 2. **Input as-is.** Otherwise, if the input names a registered
+//!    [`builtins::CANONICAL_LABELS`] entry verbatim, keep it and tag
+//!    [`LabelForm::Canonical`]; if the input has the community shape
+//!    (one or more dots, not in a reserved prefix) and no `lex.<input>`
+//!    canonical exists, tag [`LabelForm::Community`] — registry
+//!    validation is deferred to the analysis stage.
+//! 3. **Prefix strip.** Otherwise, if `lex.<input>` names a registered
+//!    canonical, resolve to that canonical and tag [`LabelForm::Stripped`].
+//! 4. **Reject.** Otherwise, the stage in [`Strict`] mode returns a
+//!    [`TransformError`] with the offending input; in [`Permissive`]
+//!    mode the label is left unchanged (used by the migration tool,
+//!    which needs to walk legacy source bytes).
 //!
-//! The issue's Phase 2 spec calls for a "parse-time deprecation
-//! warning" alongside the rewrite. Lex-core has no production
-//! diagnostic-collection vehicle today
-//! ([`Document::diagnostics`](crate::lex::ast::Document::diagnostics) is
-//! pull-based and not wired through the LSP / CLI; the LSP uses
-//! `lex-analysis::diagnostics`). Surfacing a warning therefore either
-//! requires adding storage on the AST (invasive, breaks
-//! `PartialEq`-based test fixtures) or a side channel that the LSP must
-//! opt into. Phase 5 ships the user-facing surface naturally: a
-//! `lexd migrate-labels` subcommand walks raw source, lists every legacy
-//! site by line/column, and offers an in-place rewrite. The rewrite
-//! itself stays silent here.
+//! Step 2's community branch deliberately preempts step 3's
+//! prefix-strip when the input has registered community semantics;
+//! the parser cannot know which dotted inputs have community handlers
+//! today, so it tags Community whenever no `lex.<input>` canonical
+//! exists. Core promises not to ship `lex.<owner>.<repo>`-shaped
+//! canonicals whose stripped form would shadow a third-party label;
+//! see the §4.2 closing paragraph.
+//!
+//! # Strict vs Permissive
+//!
+//! The standard parse pipeline ([`STRING_TO_AST`](crate::lex::transforms::standard::STRING_TO_AST))
+//! uses strict mode: `doc.*` (reserved-forbidden) and unrecognized
+//! bare labels surface as `TransformError`s, which propagate out as
+//! parse errors. The migration tool ([`crate::lex::migrate`]) uses
+//! permissive mode so it can parse legacy `doc.*` source and rewrite
+//! it before the source reaches a strict-mode parse.
 
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::content_item::ContentItem;
 use crate::lex::ast::elements::label::{Label, LabelForm};
 use crate::lex::ast::elements::verbatim::Verbatim;
 use crate::lex::ast::Document;
+use crate::lex::builtins;
 use crate::lex::transforms::{Runnable, TransformError};
 
-/// Pairings of legacy bare label → canonical `lex.*` form, paired with
-/// the [`LabelForm`] each rewrite represents.
+/// Curated one-segment shortcuts for high-traffic `lex.*` canonicals.
 ///
-/// The form classification is the parser-side record of which input
-/// spelling the user wrote, so downstream formatters can emit the same
-/// spelling back. See `comms/specs/general.lex` §4.2 for the normative
-/// resolution rules and §4.3 for the form-preservation contract.
-///
-/// Today the table still includes a few labels that fall outside the
-/// new bare-as-blessed namespace model (`category`, `template`,
-/// `publishing-date`, `front-matter` are tagged as `Stripped` because
-/// their bare form is scheduled for removal in PR 2 of #584; the four
-/// `doc.*` entries are tagged as `Stripped` because the prefix is
-/// reserved-forbidden and will become a parse error in PR 2). PR 1
-/// preserves current parsing behavior — every input that parses today
-/// continues to parse — and only adds the `form` classification.
-pub const LEGACY_TO_CANONICAL: &[(&str, &str, LabelForm)] = &[
-    ("title", "lex.metadata.title", LabelForm::Shortcut),
-    ("author", "lex.metadata.author", LabelForm::Shortcut),
-    ("date", "lex.metadata.date", LabelForm::Shortcut),
-    ("tags", "lex.metadata.tags", LabelForm::Shortcut),
-    ("category", "lex.metadata.category", LabelForm::Stripped),
-    ("template", "lex.metadata.template", LabelForm::Stripped),
-    (
-        "publishing-date",
-        "lex.metadata.publishing-date",
-        LabelForm::Stripped,
-    ),
-    (
-        "front-matter",
-        "lex.metadata.front-matter",
-        LabelForm::Stripped,
-    ),
-    ("doc.table", "lex.tabular.table", LabelForm::Stripped),
-    ("doc.image", "lex.media.image", LabelForm::Stripped),
-    ("doc.video", "lex.media.video", LabelForm::Stripped),
-    ("doc.audio", "lex.media.audio", LabelForm::Stripped),
+/// Normative; the same table appears verbatim in
+/// `comms/specs/general.lex` §4.2. Adding a new entry is a minor
+/// version bump; removing one is breaking and should not happen.
+pub const SHORTCUT_TABLE: &[(&str, &str)] = &[
+    ("table", "lex.tabular.table"),
+    ("image", "lex.media.image"),
+    ("video", "lex.media.video"),
+    ("audio", "lex.media.audio"),
+    ("author", "lex.metadata.author"),
+    ("title", "lex.metadata.title"),
+    ("tags", "lex.metadata.tags"),
+    ("date", "lex.metadata.date"),
+    ("include", "lex.include"),
+    ("notes", "lex.notes"),
 ];
 
-/// Lookup the canonical form and matching [`LabelForm`] for a legacy
-/// label, if any.
-pub fn canonical_for(label: &str) -> Option<(&'static str, LabelForm)> {
-    LEGACY_TO_CANONICAL
-        .iter()
-        .find(|(legacy, _, _)| *legacy == label)
-        .map(|(_, canonical, form)| (*canonical, *form))
+/// Reserved prefix the namespace policy forbids third parties (and
+/// users) from authoring. Authoring any `doc.<anything>` label is a
+/// parse error under [`Mode::Strict`].
+const FORBIDDEN_PREFIX: &str = "doc.";
+
+/// Reserved prefix for the core namespace. Inputs starting with this
+/// prefix follow the "canonical" branch of the resolution order: the
+/// label must name a registered [`builtins::CANONICAL_LABELS`] entry.
+const LEX_PREFIX: &str = "lex.";
+
+/// The resolved spelling + form classification for a label input, or a
+/// structured reason the input cannot be accepted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// Accept; carry forward `(canonical, form)` to the AST.
+    Resolved(String, LabelForm),
+    /// Reject; the input cannot be authored. Strict mode propagates
+    /// this as a parse error.
+    Rejected(RejectReason),
 }
 
-/// Rewrite `label` in place if its current value matches the legacy
-/// table. Shared by every label-bearing AST node the walker reaches
-/// (annotations, verbatim closers, table-cell-nested annotations).
-fn normalize_label(label: &mut Label) {
-    if let Some((canonical, form)) = canonical_for(&label.value) {
-        label.value = canonical.to_string();
-        label.form = form;
+/// Why a label input was rejected. Surfaces in the strict-mode
+/// [`TransformError`] message and (in PR 4 of #584) in the analysis
+/// stage's diagnostics with a quickfix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectReason {
+    /// Input started with `doc.`. The prefix is reserved-forbidden.
+    Forbidden { input: String },
+    /// Input starts with `lex.` but does not name a registered canonical.
+    UnknownCanonical { input: String },
+}
+
+impl RejectReason {
+    /// Render the reason as a user-facing message. Used by both the
+    /// strict-mode `TransformError` and PR 4's analysis-time
+    /// diagnostic.
+    pub fn message(&self) -> String {
+        match self {
+            Self::Forbidden { input } => format!(
+                "label `{input}` uses the reserved `doc.*` prefix \
+                 (forbidden under namespace policy; see general.lex §4.1)"
+            ),
+            Self::UnknownCanonical { input } => {
+                format!("label `{input}` is not a registered `lex.*` canonical")
+            }
+        }
     }
 }
 
-/// Post-parse pass that rewrites legacy labels to their canonical form.
-pub struct NormalizeLabels;
+/// Resolution mode. See module-level docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Standard parse pipeline behavior — rejected inputs surface as
+    /// `TransformError`. Used by [`STRING_TO_AST`].
+    Strict,
+    /// Migration-tool behavior — rejected inputs leave the label
+    /// unchanged, value and form untouched, so the walker can still
+    /// reach legacy spellings to rewrite them.
+    Permissive,
+}
+
+/// Classify a single label string against the namespace policy.
+/// Pure function over the input string; exposed for unit tests + the
+/// CLI's pre-format validation (PR 5).
+pub fn classify_label(input: &str) -> Resolution {
+    // 1. Shortcut table.
+    if let Some((_, canonical)) = SHORTCUT_TABLE.iter().find(|(s, _)| *s == input) {
+        return Resolution::Resolved((*canonical).to_string(), LabelForm::Shortcut);
+    }
+
+    // doc.* is reserved-forbidden — reject before any other branch.
+    if input.starts_with(FORBIDDEN_PREFIX) {
+        return Resolution::Rejected(RejectReason::Forbidden {
+            input: input.to_string(),
+        });
+    }
+
+    // 2a. `lex.*` literal — must be a registered canonical.
+    if input.starts_with(LEX_PREFIX) {
+        if builtins::is_canonical_label(input) {
+            return Resolution::Resolved(input.to_string(), LabelForm::Canonical);
+        }
+        return Resolution::Rejected(RejectReason::UnknownCanonical {
+            input: input.to_string(),
+        });
+    }
+
+    // 3. Prefix-strip: `lex.<input>` would be a registered canonical?
+    let candidate = format!("{LEX_PREFIX}{input}");
+    if builtins::is_canonical_label(&candidate) {
+        return Resolution::Resolved(candidate, LabelForm::Stripped);
+    }
+
+    // 2b. Community shape — at least one dot, no registered canonical
+    //     under the prefix-strip rule. Defer registry validation to
+    //     the analysis stage.
+    if input.contains('.') {
+        return Resolution::Resolved(input.to_string(), LabelForm::Community);
+    }
+
+    // 4. Bare input with no shortcut and no `lex.<input>` canonical:
+    //    accept as Community. The parser is deliberately permissive
+    //    here so document-scoped reference identifiers (footnote
+    //    numbers, labeled-footnote `^name` markers, citation keys)
+    //    parse without each needing a dedicated carve-out. PR 4 of
+    //    #584 adds an analysis-time lint that flags suspicious bare
+    //    names (e.g. close matches to known shortcuts) so typo
+    //    prevention moves up the stack rather than into parse-time
+    //    rejection. See `comms/specs/general.lex` §4.2 step 4.
+    Resolution::Resolved(input.to_string(), LabelForm::Community)
+}
+
+/// Post-parse pass that resolves and tags label sites against the
+/// namespace policy.
+pub struct NormalizeLabels {
+    mode: Mode,
+}
 
 impl NormalizeLabels {
+    /// Strict-mode constructor used by the standard parse pipeline.
     pub fn new() -> Self {
-        Self
+        Self { mode: Mode::Strict }
+    }
+
+    /// Permissive-mode constructor used by the migration tool.
+    pub fn permissive() -> Self {
+        Self {
+            mode: Mode::Permissive,
+        }
+    }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
     }
 }
 
@@ -123,38 +215,70 @@ impl Default for NormalizeLabels {
 impl Runnable<Document, Document> for NormalizeLabels {
     fn run(&self, mut input: Document) -> Result<Document, TransformError> {
         for annotation in input.annotations.iter_mut() {
-            rewrite_annotation(annotation);
+            rewrite_annotation(annotation, self.mode)?;
         }
         for annotation in input.root.annotations.iter_mut() {
-            rewrite_annotation(annotation);
+            rewrite_annotation(annotation, self.mode)?;
         }
         for child in input.root.children.as_mut_vec().iter_mut() {
-            rewrite_in_item(child);
+            rewrite_in_item(child, self.mode)?;
         }
         Ok(input)
     }
 }
 
-fn rewrite_in_item(item: &mut ContentItem) {
+/// Resolve `label` in place against the namespace policy. Strict mode
+/// surfaces rejections as `TransformError`; permissive mode leaves
+/// rejected labels untouched (used by the migration tool).
+fn normalize_label(label: &mut Label, mode: Mode) -> Result<(), TransformError> {
+    apply_resolution(label, classify_label(&label.value), mode)
+}
+
+// (verbatim labels share the same resolution as annotations now that
+// bare unknowns tag Community; the dedicated carve-out is gone.)
+
+fn apply_resolution(
+    label: &mut Label,
+    resolution: Resolution,
+    mode: Mode,
+) -> Result<(), TransformError> {
+    match resolution {
+        Resolution::Resolved(canonical, form) => {
+            label.value = canonical;
+            label.form = form;
+            Ok(())
+        }
+        Resolution::Rejected(reason) => match mode {
+            Mode::Strict => Err(TransformError::StageFailed {
+                stage: "NormalizeLabels".to_string(),
+                message: reason.message(),
+            }),
+            Mode::Permissive => Ok(()),
+        },
+    }
+}
+
+fn rewrite_in_item(item: &mut ContentItem, mode: Mode) -> Result<(), TransformError> {
     match item {
-        ContentItem::Annotation(a) => normalize_label(&mut a.data.label),
-        ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v),
-        ContentItem::Table(t) => rewrite_in_table(t),
+        ContentItem::Annotation(a) => normalize_label(&mut a.data.label, mode)?,
+        ContentItem::VerbatimBlock(v) => rewrite_verbatim_label(v, mode)?,
+        ContentItem::Table(t) => rewrite_in_table(t, mode)?,
         _ => {}
     }
     if let Some(attached) = attached_annotations_mut(item) {
         for annotation in attached.iter_mut() {
-            rewrite_annotation(annotation);
+            rewrite_annotation(annotation, mode)?;
         }
     }
     if let Some(children) = item.children_mut() {
         for child in children.iter_mut() {
-            rewrite_in_item(child);
+            rewrite_in_item(child, mode)?;
         }
     }
+    Ok(())
 }
 
-fn rewrite_in_table(table: &mut crate::lex::ast::Table) {
+fn rewrite_in_table(table: &mut crate::lex::ast::Table, mode: Mode) -> Result<(), TransformError> {
     // `ContentItem::children_mut` returns `None` for tables (their
     // structure lives in rows/cells, not a flat children list), so an
     // explicit walk is needed to reach annotations nested inside cells
@@ -167,33 +291,35 @@ fn rewrite_in_table(table: &mut crate::lex::ast::Table) {
     {
         for cell in row.cells.iter_mut() {
             for child in cell.children.as_mut_vec().iter_mut() {
-                rewrite_in_item(child);
+                rewrite_in_item(child, mode)?;
             }
         }
     }
     if let Some(footnotes) = table.footnotes.as_mut() {
         for annotation in footnotes.annotations.iter_mut() {
-            rewrite_annotation(annotation);
+            rewrite_annotation(annotation, mode)?;
         }
         // List children are ListItems; their `children` slot reaches
         // through `children_mut`, but we still need to walk
         // `list.items` directly because List items use the typed
         // `items` collection rather than a plain children list.
         for item in footnotes.items.as_mut_vec().iter_mut() {
-            rewrite_in_item(item);
+            rewrite_in_item(item, mode)?;
         }
     }
+    Ok(())
 }
 
-fn rewrite_annotation(annotation: &mut Annotation) {
-    normalize_label(&mut annotation.data.label);
+fn rewrite_annotation(annotation: &mut Annotation, mode: Mode) -> Result<(), TransformError> {
+    normalize_label(&mut annotation.data.label, mode)?;
     for child in annotation.children.as_mut_vec().iter_mut() {
-        rewrite_in_item(child);
+        rewrite_in_item(child, mode)?;
     }
+    Ok(())
 }
 
-fn rewrite_verbatim_label(verbatim: &mut Verbatim) {
-    normalize_label(&mut verbatim.closing_data.label);
+fn rewrite_verbatim_label(verbatim: &mut Verbatim, mode: Mode) -> Result<(), TransformError> {
+    normalize_label(&mut verbatim.closing_data.label, mode)
 }
 
 fn attached_annotations_mut(item: &mut ContentItem) -> Option<&mut Vec<Annotation>> {
@@ -214,37 +340,6 @@ mod tests {
     use super::*;
     use crate::lex::transforms::standard::STRING_TO_AST;
 
-    /// Parse + invoke the normalize stage explicitly. `STRING_TO_AST`
-    /// already runs `NormalizeLabels` after Phase 3b's wire-up, so
-    /// the second call here is idempotent — kept so the tests stay
-    /// readable as direct exercises of the stage's behaviour rather
-    /// than depending on pipeline order.
-    fn parse(src: &str) -> Document {
-        let doc = STRING_TO_AST.run(src.to_string()).expect("parse ok");
-        NormalizeLabels::new().run(doc).expect("normalize ok")
-    }
-
-    fn find_first_annotation_label(doc: &Document) -> Option<String> {
-        doc.annotations
-            .first()
-            .map(|a| a.data.label.value.clone())
-            .or_else(|| find_inline_annotation_label(&doc.root.children))
-    }
-
-    fn find_inline_annotation_label(items: &[ContentItem]) -> Option<String> {
-        for item in items {
-            if let ContentItem::Annotation(a) = item {
-                return Some(a.data.label.value.clone());
-            }
-            if let Some(children) = item.children() {
-                if let Some(label) = find_inline_annotation_label(children) {
-                    return Some(label);
-                }
-            }
-        }
-        None
-    }
-
     fn find_first_verbatim_label(items: &[ContentItem]) -> Option<String> {
         for item in items {
             if let ContentItem::VerbatimBlock(v) = item {
@@ -259,179 +354,274 @@ mod tests {
         None
     }
 
+    // ── classify_label pure-function tests ──────────────────────────────
+
     #[test]
-    fn canonical_for_recognizes_every_legacy_label() {
-        for (legacy, canonical, form) in LEGACY_TO_CANONICAL {
+    fn classify_shortcut_table_entries() {
+        // Every entry in SHORTCUT_TABLE resolves to its canonical with
+        // form=Shortcut.
+        for (input, canonical) in SHORTCUT_TABLE {
             assert_eq!(
-                canonical_for(legacy),
-                Some((*canonical, *form)),
-                "lookup must round-trip for {legacy}"
+                classify_label(input),
+                Resolution::Resolved((*canonical).to_string(), LabelForm::Shortcut),
+                "shortcut {input} must resolve to {canonical}"
             );
         }
     }
 
     #[test]
-    fn canonical_for_returns_none_for_unknown_labels() {
-        assert!(canonical_for("acme.custom").is_none());
-        assert!(canonical_for("lex.include").is_none());
-        assert!(canonical_for("").is_none());
-    }
-
-    #[test]
-    fn legacy_to_canonical_table_covers_phase_1_targets() {
-        // Locks the rewrite set to the 8 metadata + 1 tabular + 3 media
-        // schemas that Phase 1 (#575) registered. If those families grow,
-        // this list grows with them.
-        assert_eq!(LEGACY_TO_CANONICAL.len(), 12);
-        let metadata_count = LEGACY_TO_CANONICAL
-            .iter()
-            .filter(|(_, c, _)| c.starts_with("lex.metadata."))
-            .count();
-        let tabular_count = LEGACY_TO_CANONICAL
-            .iter()
-            .filter(|(_, c, _)| c.starts_with("lex.tabular."))
-            .count();
-        let media_count = LEGACY_TO_CANONICAL
-            .iter()
-            .filter(|(_, c, _)| c.starts_with("lex.media."))
-            .count();
-        assert_eq!(metadata_count, 8);
-        assert_eq!(tabular_count, 1);
-        assert_eq!(media_count, 3);
-    }
-
-    #[test]
-    fn shortcut_labels_tag_form_as_shortcut() {
-        // The four labels in the new normative shortcut table that today
-        // are also accepted as legacy bare names must tag form=Shortcut
-        // when rewritten (forward-looking; formatters consume this in
-        // PR 3 of #584).
-        for shortcut in ["title", "author", "date", "tags"] {
-            let (_, form) =
-                canonical_for(shortcut).unwrap_or_else(|| panic!("expected entry for {shortcut}"));
-            assert_eq!(form, LabelForm::Shortcut, "{shortcut} must tag as Shortcut");
-        }
-    }
-
-    #[test]
-    fn non_shortcut_metadata_labels_tag_form_as_stripped() {
-        // The four metadata labels with no shortcut alias in §4.2
-        // (category, template, publishing-date, front-matter) tag as
-        // Stripped today. PR 2 of #584 makes the bare form a parse
-        // error, leaving only `metadata.<name>` (Stripped) and
-        // `lex.metadata.<name>` (Canonical) accepted.
-        for stripped in ["category", "template", "publishing-date", "front-matter"] {
-            let (_, form) =
-                canonical_for(stripped).unwrap_or_else(|| panic!("expected entry for {stripped}"));
-            assert_eq!(form, LabelForm::Stripped, "{stripped} must tag as Stripped");
-        }
-    }
-
-    #[test]
-    fn doc_prefix_labels_tag_form_as_stripped() {
-        // PR 2 of #584 turns `doc.*` into a parse error; today these
-        // four still rewrite to canonical. They tag as Stripped (rather
-        // than Shortcut) so that once PR 3 wires `Label.form` through
-        // the formatter, the emitted spelling will be the prefix-
-        // stripped canonical (`tabular.table` etc.) instead of the
-        // deprecated `doc.*` form. This PR records the tag only — no
-        // formatter consults it yet.
-        for doc_label in ["doc.table", "doc.image", "doc.video", "doc.audio"] {
-            let (_, form) = canonical_for(doc_label)
-                .unwrap_or_else(|| panic!("expected entry for {doc_label}"));
+    fn classify_lex_canonical_input_as_canonical() {
+        // `lex.*` literal authored verbatim resolves to itself,
+        // form=Canonical, when registered.
+        for canonical in ["lex.include", "lex.metadata.author", "lex.tabular.table"] {
             assert_eq!(
-                form,
-                LabelForm::Stripped,
-                "{doc_label} must tag as Stripped"
+                classify_label(canonical),
+                Resolution::Resolved(canonical.to_string(), LabelForm::Canonical),
             );
         }
     }
 
     #[test]
-    fn document_level_title_annotation_is_rewritten() {
-        // Annotation single-line form: `:: label :: inline content`.
-        let doc = parse(":: title :: My Document\n\nBody.\n");
+    fn classify_lex_unknown_canonical_rejects() {
+        // `lex.X` that isn't registered surfaces an UnknownCanonical
+        // rejection — strict mode propagates it; permissive mode
+        // leaves the label alone.
         assert_eq!(
-            find_first_annotation_label(&doc).as_deref(),
-            Some("lex.metadata.title"),
-            "document-level :: title :: must rewrite to lex.metadata.title"
+            classify_label("lex.foobar"),
+            Resolution::Rejected(RejectReason::UnknownCanonical {
+                input: "lex.foobar".to_string()
+            })
         );
     }
 
     #[test]
-    fn every_metadata_label_rewrites() {
-        for (legacy, canonical, _form) in LEGACY_TO_CANONICAL
-            .iter()
-            .filter(|(_, c, _)| c.starts_with("lex.metadata."))
-        {
-            let src = format!(":: {legacy} :: value\n\nBody.\n");
-            let doc = parse(&src);
-            assert_eq!(
-                find_first_annotation_label(&doc).as_deref(),
-                Some(*canonical),
-                ":: {legacy} :: must rewrite to {canonical}"
-            );
-        }
-    }
-
-    #[test]
-    fn doc_table_verbatim_rewrites_to_lex_tabular_table() {
-        // Lex verbatim syntax: subject line ending in `:`, indented body,
-        // then `:: label ::` as the closer.
-        let src = "Table:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
-        let doc = parse(src);
+    fn classify_stripped_form_resolves_against_canonical_set() {
+        // Multi-segment input that prepends to a known canonical
+        // resolves Stripped.
         assert_eq!(
-            find_first_verbatim_label(&doc.root.children).as_deref(),
-            Some("lex.tabular.table"),
-            ":: doc.table :: verbatim must rewrite to lex.tabular.table"
+            classify_label("metadata.author"),
+            Resolution::Resolved("lex.metadata.author".to_string(), LabelForm::Stripped),
+        );
+        assert_eq!(
+            classify_label("tabular.table"),
+            Resolution::Resolved("lex.tabular.table".to_string(), LabelForm::Stripped),
+        );
+        assert_eq!(
+            classify_label("media.image"),
+            Resolution::Resolved("lex.media.image".to_string(), LabelForm::Stripped),
         );
     }
 
     #[test]
-    fn doc_image_verbatim_rewrites_to_lex_media_image() {
-        let src = "Image:\n    alt text\n:: doc.image src=x.png ::\n";
-        let doc = parse(src);
-        assert_eq!(
-            find_first_verbatim_label(&doc.root.children).as_deref(),
-            Some("lex.media.image"),
-        );
-    }
-
-    #[test]
-    fn doc_video_and_audio_verbatims_rewrite() {
-        for (legacy, canonical) in [
-            ("doc.video", "lex.media.video"),
-            ("doc.audio", "lex.media.audio"),
+    fn classify_stripped_form_works_for_non_shortcut_metadata() {
+        // The four metadata labels without a shortcut entry must still
+        // be reachable via prefix-strip (this is the §4.2 contract:
+        // prefix-strip is universal, shortcuts are curated additions).
+        for stripped in [
+            "metadata.category",
+            "metadata.template",
+            "metadata.publishing-date",
+            "metadata.front-matter",
         ] {
-            let src = format!("Media:\n    caption\n:: {legacy} src=file ::\n");
-            let doc = parse(&src);
+            let canonical = format!("lex.{stripped}");
             assert_eq!(
-                find_first_verbatim_label(&doc.root.children).as_deref(),
-                Some(canonical),
-                ":: {legacy} :: must rewrite to {canonical}"
+                classify_label(stripped),
+                Resolution::Resolved(canonical.clone(), LabelForm::Stripped),
+                "{stripped} must resolve to {canonical}"
             );
         }
     }
 
     #[test]
-    fn non_legacy_labels_are_left_alone() {
-        let src = ":: acme.custom param=value :: body\n\nBody.\n";
-        let doc = parse(src);
-        let label = find_first_annotation_label(&doc);
+    fn classify_community_labels_tag_as_community() {
+        // Dotted non-reserved inputs without a prefix-strip match tag
+        // Community. Registry validation is deferred to analysis.
+        for community in ["acme.task", "mycompany.review", "owner.repo.subtype"] {
+            assert_eq!(
+                classify_label(community),
+                Resolution::Resolved(community.to_string(), LabelForm::Community),
+                "{community} must tag as Community"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_doc_prefix_rejects() {
+        // `doc.*` is reserved-forbidden under §4.1; every doc.X input
+        // must reject with Forbidden, including the four legacy
+        // entries (doc.table / doc.image / doc.video / doc.audio).
+        for forbidden in [
+            "doc.table",
+            "doc.image",
+            "doc.video",
+            "doc.audio",
+            "doc.random",
+        ] {
+            assert_eq!(
+                classify_label(forbidden),
+                Resolution::Rejected(RejectReason::Forbidden {
+                    input: forbidden.to_string()
+                }),
+                "{forbidden} must reject as Forbidden"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_unknown_bare_tags_as_community() {
+        // Bare inputs that aren't in SHORTCUT_TABLE and have no
+        // matching `lex.<input>` canonical are accepted as Community
+        // (per the spec's §4.2 step 4 — analysis lints typos rather
+        // than parse-time rejection). This covers footnote IDs (`42`,
+        // `^name`), citation keys (`spec2025`), and unrecognized but
+        // user-authored marker labels.
+        for community in ["42", "^name", "spec2025", "foobar"] {
+            assert_eq!(
+                classify_label(community),
+                Resolution::Resolved(community.to_string(), LabelForm::Community),
+                "{community} must tag as Community"
+            );
+        }
+    }
+
+    // ── End-to-end NormalizeLabels (strict mode) tests ──────────────────
+
+    /// Parse through the standard strict-mode pipeline. `STRING_TO_AST`
+    /// already invokes `NormalizeLabels::new()` (strict) as one of its
+    /// stages, so the resulting document is fully classified.
+    fn parse(src: &str) -> Document {
+        STRING_TO_AST.run(src.to_string()).expect("parse ok")
+    }
+
+    fn parse_strict(src: &str) -> Result<Document, TransformError> {
+        STRING_TO_AST.run(src.to_string())
+    }
+
+    #[test]
+    fn shortcut_title_resolves_to_canonical_with_shortcut_form() {
+        let doc = parse(":: title :: My Document\n\nBody.\n");
+        let ann = doc.annotations.first().expect("title annotation");
+        assert_eq!(ann.data.label.value, "lex.metadata.title");
+        assert_eq!(ann.data.label.form, LabelForm::Shortcut);
+    }
+
+    #[test]
+    fn stripped_metadata_resolves_to_canonical_with_stripped_form() {
+        let doc = parse(":: metadata.category :: tech\n\nBody.\n");
+        let ann = doc.annotations.first().expect("category annotation");
+        assert_eq!(ann.data.label.value, "lex.metadata.category");
+        assert_eq!(ann.data.label.form, LabelForm::Stripped);
+    }
+
+    #[test]
+    fn lex_canonical_input_keeps_value_and_canonical_form() {
+        let doc = parse(":: lex.include src=other.lex ::\n\nBody.\n");
+        let ann = doc.annotations.first().expect("include annotation");
+        assert_eq!(ann.data.label.value, "lex.include");
+        assert_eq!(ann.data.label.form, LabelForm::Canonical);
+    }
+
+    #[test]
+    fn community_label_keeps_value_and_community_form() {
+        let doc = parse(":: acme.custom param=value :: body\n\nBody.\n");
+        let ann = doc.annotations.first().expect("acme annotation");
+        assert_eq!(ann.data.label.value, "acme.custom");
+        assert_eq!(ann.data.label.form, LabelForm::Community);
+    }
+
+    #[test]
+    fn doc_table_verbatim_rejects_in_strict_mode() {
+        // Was accepted under PR 1; strict mode now rejects per §4.1.
+        let src = "Table:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
+        let err = parse_strict(src).expect_err("doc.table must be rejected in strict mode");
+        match err {
+            TransformError::StageFailed { stage, message } => {
+                assert_eq!(stage, "NormalizeLabels");
+                assert!(
+                    message.contains("doc.table") && message.contains("reserved"),
+                    "message should call out the forbidden prefix; got: {message}"
+                );
+            }
+            _ => panic!("expected StageFailed; got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_bare_annotation_tags_as_community_in_strict_mode() {
+        // Per §4.2 step 4, bare unknowns are accepted as Community at
+        // parse time; PR 4 of #584 wires up the typo-prevention lint
+        // in lex-analysis. This test pins the parser-side behavior so
+        // a future regression to hard-reject can't silently break
+        // existing documents.
+        let doc = parse(":: category :: foo\n\nBody.\n");
+        let ann = doc.annotations.first().expect("category annotation");
+        assert_eq!(ann.data.label.value, "category");
+        assert_eq!(ann.data.label.form, LabelForm::Community);
+    }
+
+    #[test]
+    fn unknown_lex_prefix_rejects_in_strict_mode() {
+        // `lex.foobar` looks canonical-shaped but isn't registered.
+        let err = parse_strict(":: lex.foobar ::\n\nBody.\n")
+            .expect_err("unregistered lex.* canonical must reject");
+        match err {
+            TransformError::StageFailed { message, .. } => {
+                assert!(message.contains("lex.foobar"));
+            }
+            _ => panic!("expected StageFailed; got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn permissive_mode_keeps_doc_table_unchanged() {
+        // The migration tool needs to walk legacy source; permissive
+        // mode classifies what it can and silently leaves the rest.
+        let src = "Table:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
+        // Bypass STRING_TO_AST (which always uses strict mode); run
+        // the earlier stages explicitly and finish with permissive
+        // NormalizeLabels.
+        use crate::lex::assembling::stages::{ApplyTableConfig, AttachAnnotations, AttachRoot};
+        use crate::lex::transforms::stages::ParseInlines;
+        use crate::lex::transforms::standard::LEXING;
+        let source = format!("{src}\n");
+        let tokens = LEXING.run(source.clone()).expect("tokens");
+        let mut output =
+            crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).expect("parse");
+        output.root = ParseInlines::new().run(output.root).expect("inlines");
+        let mut doc = AttachRoot::new().run(output).expect("attach root");
+        doc = AttachAnnotations::new().run(doc).expect("attach anns");
+        let doc = NormalizeLabels::permissive()
+            .run(doc)
+            .expect("permissive must not error");
+        // ApplyTableConfig runs after normalize in the standard pipeline,
+        // but isn't needed for this assertion.
+        let _ = ApplyTableConfig::new();
+
+        let verbatim_label = find_first_verbatim_label(&doc.root.children);
         assert_eq!(
-            label.as_deref(),
-            Some("acme.custom"),
-            "third-party labels must be preserved verbatim"
+            verbatim_label.as_deref(),
+            Some("doc.table"),
+            "permissive mode must leave doc.* untouched so the migration tool can rewrite it"
         );
     }
 
     #[test]
-    fn lex_include_label_is_left_alone() {
-        // Already-canonical lex.* labels must not be rewritten.
-        let src = ":: lex.include src=other.lex ::\n\nBody.\n";
-        let doc = parse(src);
-        let label = find_first_annotation_label(&doc);
-        assert_eq!(label.as_deref(), Some("lex.include"));
+    fn shortcut_table_covers_normative_entries() {
+        // Lock the table to exactly the 10 shortcuts §4.2 names.
+        // Adding a label requires updating both this test and the
+        // comms spec — the constraint is intentional.
+        assert_eq!(SHORTCUT_TABLE.len(), 10);
+        let names: Vec<&str> = SHORTCUT_TABLE.iter().map(|(s, _)| *s).collect();
+        assert!(names.contains(&"table"));
+        assert!(names.contains(&"image"));
+        assert!(names.contains(&"video"));
+        assert!(names.contains(&"audio"));
+        assert!(names.contains(&"author"));
+        assert!(names.contains(&"title"));
+        assert!(names.contains(&"tags"));
+        assert!(names.contains(&"date"));
+        assert!(names.contains(&"include"));
+        assert!(names.contains(&"notes"));
     }
 
     #[test]
@@ -462,9 +652,6 @@ mod tests {
 
     #[test]
     fn rewrite_preserves_label_location() {
-        // Range info must round-trip — the LSP relies on label location
-        // for goto-definition and similar features. Rewrite mutates
-        // `label.value` in place without touching `label.location`.
         let src = ":: title :: T\n\nBody.\n";
         let doc = parse(src);
         let first = doc
@@ -486,15 +673,10 @@ mod tests {
 
     #[test]
     fn rewrite_recurses_into_table_cell_block_children() {
-        // Regression for Copilot's PR 576 callout: `ContentItem::Table`
-        // returns `None` from `children_mut()` (its structure lives in
-        // rows/cells), so the generic walker won't reach legacy labels
-        // nested inside a cell's block content. Today's parser does
-        // not emit block children in cells — cell annotations land in
-        // the inline `content: TextContent` — but the AST surface
-        // allows it via `TableCell::with_children`, and Phase 3's
-        // wire-up may begin using that slot. Test the contract
-        // directly by building the AST programmatically.
+        // Same regression as PR 576's Copilot callout — walker must
+        // reach annotations nested inside a cell's block content
+        // (TableCell::with_children path) since
+        // ContentItem::children_mut returns None for Tables.
         use crate::lex::ast::elements::annotation::Annotation;
         use crate::lex::ast::elements::label::Label;
         use crate::lex::ast::elements::table::{Table, TableCell, TableRow};
@@ -521,8 +703,6 @@ mod tests {
 
         let doc = NormalizeLabels::new().run(doc).expect("normalize ok");
 
-        // Reach into the table and confirm the nested annotation got
-        // rewritten.
         let table = doc
             .root
             .children
@@ -533,38 +713,39 @@ mod tests {
             })
             .expect("table present");
         let cell = &table.body_rows[0].cells[0];
-        let nested_label = cell
+        let nested = cell
             .children
             .iter()
             .find_map(|item| match item {
-                ContentItem::Annotation(a) => Some(a.data.label.value.as_str()),
+                ContentItem::Annotation(a) => Some(&a.data.label),
                 _ => None,
             })
             .expect("nested annotation in cell.children");
-        assert_eq!(
-            nested_label, "lex.metadata.title",
-            "legacy label inside a table cell's block children must be rewritten"
-        );
+        assert_eq!(nested.value, "lex.metadata.title");
+        assert_eq!(nested.form, LabelForm::Shortcut);
     }
 
     #[test]
     fn rewrite_recurses_into_annotation_children() {
-        // The walker must reach annotations nested inside another
-        // annotation's content body — `rewrite_annotation` calls
-        // `rewrite_in_item` on each child, which in turn handles inline
-        // `ContentItem::Annotation` labels.
-        let src = ":: outer ::\n    :: author :: Alice\n";
+        // The walker reaches annotations nested inside another
+        // annotation's body content. The outer label must itself be
+        // an accepted form — `frontmatter` was an ad-hoc legacy name
+        // and is rejected today, so use `metadata.front-matter`
+        // (Stripped) as the outer to verify nested resolution.
+        let src = ":: metadata.front-matter ::\n    :: author :: Alice\n";
         let doc = parse(src);
         let outer = doc.annotations.first().expect("outer annotation parsed");
-        // Find the inner annotation in outer's children.
-        let inner_label = outer.children.iter().find_map(|item| match item {
-            ContentItem::Annotation(a) => Some(a.data.label.value.clone()),
-            _ => None,
-        });
-        assert_eq!(
-            inner_label.as_deref(),
-            Some("lex.metadata.author"),
-            "nested annotation inside outer must be rewritten"
-        );
+        assert_eq!(outer.data.label.value, "lex.metadata.front-matter");
+        assert_eq!(outer.data.label.form, LabelForm::Stripped);
+        let inner = outer
+            .children
+            .iter()
+            .find_map(|item| match item {
+                ContentItem::Annotation(a) => Some(&a.data.label),
+                _ => None,
+            })
+            .expect("nested annotation");
+        assert_eq!(inner.value, "lex.metadata.author");
+        assert_eq!(inner.form, LabelForm::Shortcut);
     }
 }

--- a/crates/lex-core/src/lex/ast/diagnostics.rs
+++ b/crates/lex-core/src/lex/ast/diagnostics.rs
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_valid_structure_no_warnings() {
-        let source = ":: note :: A valid annotation.\n\n";
+        let source = ":: test.note :: A valid annotation.\n\n";
         let doc = parse_document(source).unwrap();
 
         let diagnostics = validate_structure(&doc);

--- a/crates/lex-core/src/lex/ast/elements/annotation.rs
+++ b/crates/lex-core/src/lex/ast/elements/annotation.rs
@@ -33,7 +33,7 @@
 //!      Label only:
 //!         :: image ::  
 //!      Label and parameters:
-//!         :: note severity=high :: Check this carefully
+//!         :: test.note severity=high :: Check this carefully
 //!      Marker form (no content):
 //!         :: debug ::
 //!      Parameters augmenting the label:

--- a/crates/lex-core/src/lex/ast/elements/data.rs
+++ b/crates/lex-core/src/lex/ast/elements/data.rs
@@ -15,7 +15,7 @@
 //!
 //!     Examples:
 //!         :: note
-//!         :: note severity=high
+//!         :: test.note severity=high
 //!         :: syntax
 //!
 //!     Data nodes always appear at the start of a line (after whitespace), so they are

--- a/crates/lex-core/src/lex/building/ast_nodes.rs
+++ b/crates/lex-core/src/lex/building/ast_nodes.rs
@@ -747,7 +747,7 @@ mod tests {
     fn test_annotation_allows_non_session_children() {
         use crate::lex::ast::elements::Paragraph;
 
-        let source = ":: note ::\n    Some content\n";
+        let source = ":: test.note ::\n    Some content\n";
         let source_location = SourceLocation::new(source);
         let para = Paragraph::from_line("Some content".to_string());
         let content = vec![ContentElement::Paragraph(para)];

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -51,6 +51,7 @@ use crate::lex::includes::{Loader, ResolveConfig};
 pub mod include;
 pub mod media;
 pub mod metadata;
+pub mod notes;
 pub mod tabular;
 
 pub use include::LexIncludeHandler;
@@ -59,6 +60,45 @@ pub use include::LexIncludeHandler;
 /// `lex.` (with the trailing dot), so registered labels look like
 /// `lex.include`, `lex.metadata.title`, `lex.tabular.table`, etc.
 pub const NAMESPACE: &str = "lex";
+
+/// Every canonical `lex.*` label the core ships. Aggregated from
+/// `include`, `metadata::METADATA_LABELS`, `tabular::LEX_TABULAR_TABLE`,
+/// and `media::{LEX_MEDIA_IMAGE, LEX_MEDIA_VIDEO, LEX_MEDIA_AUDIO}` so
+/// the parse-time `NormalizeLabels` stage in `assembling::stages` can
+/// resolve user-authored bare and prefix-stripped forms to the
+/// canonical registry without depending on a runtime registry handle.
+///
+/// Adding a new `lex.*` canonical requires adding it here too — the
+/// builtin-tests in each family enforce the corresponding ordering /
+/// presence checks. Order within the slice is informational only;
+/// lookups are unordered.
+pub const CANONICAL_LABELS: &[&str] = &[
+    "lex.include",
+    "lex.notes",
+    // metadata family
+    "lex.metadata.title",
+    "lex.metadata.author",
+    "lex.metadata.date",
+    "lex.metadata.tags",
+    "lex.metadata.category",
+    "lex.metadata.template",
+    "lex.metadata.publishing-date",
+    "lex.metadata.front-matter",
+    // tabular family
+    "lex.tabular.table",
+    // media family
+    "lex.media.image",
+    "lex.media.video",
+    "lex.media.audio",
+];
+
+/// Return `true` if `label` names a canonical built-in. Lookup is a
+/// linear scan of [`CANONICAL_LABELS`]; the slice is small (13 entries
+/// today) so this stays cheaper than a `HashSet` materialised at
+/// startup.
+pub fn is_canonical_label(label: &str) -> bool {
+    CANONICAL_LABELS.contains(&label)
+}
 
 /// Composite handler for the `lex.*` namespace.
 ///
@@ -161,8 +201,9 @@ pub fn register_into(
     loader: Arc<dyn Loader + Send + Sync>,
     config: ResolveConfig,
 ) -> Result<(), RegistryError> {
-    let mut schemas = Vec::with_capacity(13);
+    let mut schemas = Vec::with_capacity(14);
     schemas.push(lex_include_schema());
+    schemas.extend(notes::all_schemas());
     schemas.extend(metadata::all_schemas());
     schemas.extend(tabular::all_schemas());
     schemas.extend(media::all_schemas());
@@ -262,6 +303,45 @@ mod tests {
         )
         .expect("registration ok");
         registry
+    }
+
+    #[test]
+    fn canonical_labels_matches_registered_schemas() {
+        // CANONICAL_LABELS feeds the parse-time NormalizeLabels stage —
+        // it MUST contain exactly the same labels that register_into
+        // registers, in any order. If a new lex.* schema is added without
+        // updating CANONICAL_LABELS, NormalizeLabels will start rejecting
+        // valid documents authored using its canonical or stripped forms.
+        let mut registered: Vec<String> = Vec::new();
+        registered.push(lex_include_schema().label);
+        registered.extend(notes::all_schemas().into_iter().map(|s| s.label));
+        registered.extend(metadata::all_schemas().into_iter().map(|s| s.label));
+        registered.extend(tabular::all_schemas().into_iter().map(|s| s.label));
+        registered.extend(media::all_schemas().into_iter().map(|s| s.label));
+
+        let constant: Vec<String> = CANONICAL_LABELS.iter().map(|s| (*s).to_string()).collect();
+
+        let mut registered_sorted = registered.clone();
+        registered_sorted.sort();
+        let mut constant_sorted = constant.clone();
+        constant_sorted.sort();
+        assert_eq!(
+            registered_sorted, constant_sorted,
+            "CANONICAL_LABELS and registered schemas must match; \
+             registered={registered:?} constant={constant:?}"
+        );
+    }
+
+    #[test]
+    fn is_canonical_label_recognizes_every_constant() {
+        for label in CANONICAL_LABELS {
+            assert!(is_canonical_label(label), "{label} must be canonical");
+        }
+        assert!(!is_canonical_label(""));
+        assert!(!is_canonical_label("title"));
+        assert!(!is_canonical_label("metadata.title"));
+        assert!(!is_canonical_label("doc.table"));
+        assert!(!is_canonical_label("acme.task"));
     }
 
     #[test]

--- a/crates/lex-core/src/lex/builtins/notes.rs
+++ b/crates/lex-core/src/lex/builtins/notes.rs
@@ -1,0 +1,96 @@
+//! Schema for the `lex.notes` annotation label.
+//!
+//! `lex.notes` is a marker annotation that attaches to a list, signaling
+//! that the list's items are footnote definitions. Heavily used inside
+//! `lex-analysis` (`utils::collect_footnote_definitions`,
+//! `diagnostics::validate_references`, `hover::footnote_content`) and
+//! `lex-lsp-core` to identify footnote-definition lists.
+//!
+//! Blessed as a one-segment shortcut in `comms/specs/general.lex` §4.2
+//! — users author `:: notes ::` and the parser resolves to this
+//! canonical via `NormalizeLabels`. PR 2 of #584 added the entry.
+
+use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use std::collections::BTreeMap;
+
+/// Fully-qualified label for the `notes` marker annotation.
+pub const LEX_NOTES: &str = "lex.notes";
+
+pub fn lex_notes_schema() -> Schema {
+    Schema {
+        schema_version: 1,
+        label: LEX_NOTES.into(),
+        description: Some(
+            "Marker annotation attached to a list whose items define footnotes. Items \
+             with numeric markers (1., 2., ...) define numbered footnotes referenced by \
+             `[1]`, `[2]`; items with labeled markers (`[^name]:`) define labeled \
+             footnotes referenced by `[^name]`. `lex.notes` may attach at the document \
+             root (footnotes visible globally) or inside a session (scoped to that \
+             session)."
+                .into(),
+        ),
+        params: BTreeMap::new(),
+        attaches_to: vec!["list".into()],
+        body: BodyShape {
+            kind: BodyKind::None,
+            presence: BodyPresence::Optional,
+            description: Some(
+                "Marker annotation; no body. The list it attaches to carries the \
+                 footnote definitions."
+                    .into(),
+            ),
+        },
+        verbatim_label: false,
+        capabilities: Capabilities::default(),
+        hooks: HookSet::default(),
+        handler: None,
+    }
+}
+
+/// Single-entry helper so `register_into` can splice notes alongside
+/// the other families.
+pub fn all_schemas() -> Vec<Schema> {
+    vec![lex_notes_schema()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notes_is_an_annotation_label() {
+        let schema = lex_notes_schema();
+        assert_eq!(schema.label, LEX_NOTES);
+        assert!(
+            !schema.verbatim_label,
+            "notes is an annotation, not verbatim"
+        );
+        assert_eq!(schema.attaches_to, vec!["list".to_string()]);
+    }
+
+    #[test]
+    fn notes_takes_no_body() {
+        let schema = lex_notes_schema();
+        assert_eq!(schema.body.kind, BodyKind::None);
+        // BodyPresence::Optional is as restrictive as the schema enum
+        // goes today — semantic enforcement of "no body allowed" lives
+        // in the analysis stage's validator.
+        assert_eq!(schema.body.presence, BodyPresence::Optional);
+    }
+
+    #[test]
+    fn notes_declares_no_hooks() {
+        let schema = lex_notes_schema();
+        assert!(!schema.hooks.resolve);
+        assert!(!schema.hooks.validate);
+        assert!(schema.hooks.render.is_empty());
+    }
+
+    #[test]
+    fn notes_schema_round_trips_through_json() {
+        let schema = lex_notes_schema();
+        let json = serde_json::to_string(&schema).expect("serialize");
+        let back: Schema = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, schema);
+    }
+}

--- a/crates/lex-core/src/lex/escape.rs
+++ b/crates/lex-core/src/lex/escape.rs
@@ -939,7 +939,7 @@ mod tests {
     #[test]
     fn structural_markers_with_quoted_marker() {
         use crate::lex::token::Token;
-        // :: note foo=":: value" ::
+        // :: test.note foo=":: value" ::
         let tokens = vec![
             Token::LexMarker, // 0: structural
             Token::Whitespace(1),
@@ -961,7 +961,7 @@ mod tests {
     #[test]
     fn structural_markers_data_line_with_quoted_marker() {
         use crate::lex::token::Token;
-        // :: note foo=":: value"  (no closing ::)
+        // :: test.note foo=":: value"  (no closing ::)
         let tokens = vec![
             Token::LexMarker, // 0: structural
             Token::Whitespace(1),
@@ -979,7 +979,7 @@ mod tests {
     #[test]
     fn structural_markers_escaped_quote_does_not_toggle() {
         use crate::lex::token::Token;
-        // :: note foo="value with \" inside" ::
+        // :: test.note foo="value with \" inside" ::
         // The \" should NOT toggle quote state
         let tokens = vec![
             Token::LexMarker, // 0: structural
@@ -1002,7 +1002,7 @@ mod tests {
     #[test]
     fn structural_markers_double_backslash_before_quote_not_escaped() {
         use crate::lex::token::Token;
-        // :: note foo="val\\" ::
+        // :: test.note foo="val\\" ::
         // \\\\ (double backslash) before quote means the backslashes escape each other,
         // so the quote IS a real closing quote
         let tokens = vec![

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -921,15 +921,15 @@ fn invariant_unrelated_annotations_in_included_file_keep_their_attachment_target
         ":: lex.include src=\"chapter.lex\" ::\n",
         &[(
             "/repo/chapter.lex",
-            "1. Chapter\n\n    :: note :: Important.\n\n    The body.\n",
+            "1. Chapter\n\n    :: test.note :: Important.\n\n    The body.\n",
         )],
     )
     .unwrap();
 
     let labels = tree.all_attached_annotation_labels();
     assert!(
-        labels.iter().any(|l| l == "note"),
-        "note annotation should still be attached after splice, got {labels:?}"
+        labels.iter().any(|l| l == "test.note"),
+        "test.note annotation should still be attached after splice, got {labels:?}"
     );
 }
 

--- a/crates/lex-core/src/lex/lexing/line_classification.rs
+++ b/crates/lex-core/src/lex/lexing/line_classification.rs
@@ -121,7 +121,7 @@ fn is_blank_line(tokens: &[Token]) -> bool {
 /// Grammar: <lex-marker><space><label>(<space><parameters>)? <lex-marker> <content>?
 ///
 /// Uses quote-aware marker detection so that `::` inside quoted parameter
-/// values (e.g., `:: note msg=":: value" ::`) is not misidentified as a
+/// values (e.g., `:: test.note msg=":: value" ::`) is not misidentified as a
 /// structural delimiter.
 fn is_data_marker_line(tokens: &[Token]) -> bool {
     if tokens.is_empty() {
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_lex_marker_inside_quoted_value_is_annotation_start() {
-        // :: note foo=":: jane" ::
+        // :: test.note foo=":: jane" ::
         let tokens = vec![
             Token::LexMarker,
             Token::Whitespace(1),
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     fn test_lex_marker_inside_quoted_value_data_line() {
-        // :: note foo=":: value"  (no closing ::)
+        // :: test.note foo=":: value"  (no closing ::)
         let tokens = vec![
             Token::LexMarker,
             Token::Whitespace(1),

--- a/crates/lex-core/src/lex/migrate.rs
+++ b/crates/lex-core/src/lex/migrate.rs
@@ -28,13 +28,39 @@
 //! and rewrite the source in reverse byte order. No re-parsing, no
 //! regex heuristics, no ambiguity.
 
-use crate::lex::assembling::stages::normalize_labels::LEGACY_TO_CANONICAL;
+use crate::lex::assembling::stages::{
+    ApplyTableConfig, AttachAnnotations, AttachRoot, NormalizeLabels,
+};
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::content_item::ContentItem;
 use crate::lex::ast::elements::label::Label;
 use crate::lex::ast::elements::verbatim::Verbatim;
 use crate::lex::ast::Document;
-use crate::lex::transforms::standard::STRING_TO_AST;
+use crate::lex::transforms::stages::ParseInlines;
+use crate::lex::transforms::standard::LEXING;
+use crate::lex::transforms::Runnable;
+
+/// Mapping of legacy label inputs to the canonical they migrate to.
+/// Local to the migration tool — the parse-time `NormalizeLabels` no
+/// longer carries any "legacy" concept since PR 2 of #584: it only
+/// resolves accepted forms. Anything in this table is what the
+/// migration tool recognizes as needing a source-level rewrite.
+///
+/// `doc.*` entries map to the prefix-stripped form of the corresponding
+/// canonical (so `:: doc.table ::` rewrites to `:: table ::`, the
+/// blessed shortcut). The non-shortcut metadata labels (`category`,
+/// `template`, etc.) rewrite to their prefix-stripped form (e.g.
+/// `:: category ::` → `:: metadata.category ::`).
+const LEGACY_TO_BLESSED: &[(&str, &str)] = &[
+    ("category", "metadata.category"),
+    ("template", "metadata.template"),
+    ("publishing-date", "metadata.publishing-date"),
+    ("front-matter", "metadata.front-matter"),
+    ("doc.table", "table"),
+    ("doc.image", "image"),
+    ("doc.video", "video"),
+    ("doc.audio", "audio"),
+];
 
 /// One legacy-label rewrite site.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,11 +102,13 @@ impl MigrationOutcome {
 /// pass needs a clean parse to locate label spans. Soft diagnostics
 /// from the parser are ignored; only hard parse errors abort.
 pub fn migrate_labels_in_source(src: &str) -> Result<MigrationOutcome, MigrationError> {
-    let doc = STRING_TO_AST
-        .run(src.to_string())
-        .map_err(|e| MigrationError::ParseFailed {
-            message: e.to_string(),
-        })?;
+    // Strict-mode parse rejects legacy `doc.*` and bare non-shortcuts —
+    // exactly the inputs the migration tool needs to rewrite. Run a
+    // permissive pipeline so legacy spellings survive into the AST,
+    // then walk it to map source spans onto the rewrite table.
+    let doc = parse_permissive(src).map_err(|e| MigrationError::ParseFailed {
+        message: e.to_string(),
+    })?;
 
     let mut sites = Vec::new();
     collect_sites(&doc, src, &mut sites);
@@ -90,6 +118,35 @@ pub fn migrate_labels_in_source(src: &str) -> Result<MigrationOutcome, Migration
         rewritten,
         migrations: sites,
     })
+}
+
+/// Run the parse + assembly stages with NormalizeLabels in permissive
+/// mode so legacy label spellings (`doc.*`, bare non-shortcut metadata)
+/// flow through unchanged. Mirrors `STRING_TO_AST` exactly except for
+/// the NormalizeLabels constructor.
+fn parse_permissive(src: &str) -> Result<Document, crate::lex::transforms::TransformError> {
+    let source = if !src.is_empty() && !src.ends_with('\n') {
+        format!("{src}\n")
+    } else {
+        src.to_string()
+    };
+    let tokens = LEXING.run(source.clone())?;
+    let mut output =
+        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).map_err(|e| {
+            crate::lex::transforms::TransformError::StageFailed {
+                stage: "Parser".to_string(),
+                message: e.to_string(),
+            }
+        })?;
+    output.root = ParseInlines::new().run(output.root)?;
+    if let Some(ref mut title) = output.title {
+        title.content.ensure_inline_parsed();
+    }
+    let mut doc = AttachRoot::new().run(output)?;
+    doc = AttachAnnotations::new().run(doc)?;
+    doc = NormalizeLabels::permissive().run(doc)?;
+    doc = ApplyTableConfig::new().run(doc)?;
+    Ok(doc)
 }
 
 /// Errors surfaced by [`migrate_labels_in_source`].
@@ -229,24 +286,21 @@ fn check_label(label: &Label, src: &str, sites: &mut Vec<LabelMigration>) {
         return;
     }
     let slice = &src[trim_start..trim_end];
-    // Single pass through the table — keep the `'static` legacy slice
-    // for the migration record alongside the canonical and (unused
-    // here) form classification, so we don't pay for a second lookup.
-    if let Some((from, canonical, _form)) = LEGACY_TO_CANONICAL
+    if let Some((from, to)) = LEGACY_TO_BLESSED
         .iter()
-        .find(|(legacy, _, _)| *legacy == slice)
+        .find(|(legacy, _)| *legacy == slice)
     {
-        // Sanity check: the AST value should be the canonical form
-        // NormalizeLabels rewrote it to.
+        // Permissive parse keeps the legacy spelling on the AST too;
+        // the source slice and label.value should agree.
         debug_assert_eq!(
-            label.value, *canonical,
-            "NormalizeLabels should have rewritten {slice} to {canonical}, got {} in AST",
+            label.value, *from,
+            "permissive parse must preserve legacy spelling; got {} for source {slice}",
             label.value
         );
         sites.push(LabelMigration {
             byte_range: trim_start..trim_end,
             from,
-            to: canonical,
+            to,
         });
     }
 }
@@ -281,78 +335,73 @@ mod tests {
     }
 
     #[test]
-    fn single_legacy_metadata_label_is_rewritten() {
-        let src = ":: title :: My Document\n\nBody.\n";
-        let out = migrate_labels_in_source(src).expect("migrate ok");
-        assert!(out.is_modified());
-        assert_eq!(out.migrations.len(), 1);
-        assert_eq!(out.migrations[0].from, "title");
-        assert_eq!(out.migrations[0].to, "lex.metadata.title");
-        assert!(
-            out.rewritten.contains(":: lex.metadata.title ::"),
-            "rewritten source must contain the canonical label: {}",
-            out.rewritten
-        );
-        assert!(
-            !out.rewritten.contains(":: title ::"),
-            "legacy label must be replaced: {}",
-            out.rewritten
-        );
+    fn blessed_shortcuts_are_not_migrated() {
+        // Under #584, `:: title ::` and `:: author ::` are the blessed
+        // forms — no migration needed.
+        for shortcut in ["title", "author", "date", "tags"] {
+            let src = format!(":: {shortcut} :: value\n\nBody.\n");
+            let out = migrate_labels_in_source(&src).expect("migrate ok");
+            assert!(
+                !out.is_modified(),
+                "shortcut :: {shortcut} :: is the blessed form; must not migrate"
+            );
+            assert_eq!(out.rewritten, src);
+        }
     }
 
     #[test]
-    fn every_legacy_label_round_trips_through_migration() {
-        // Each legacy label, when used in source, produces exactly one
-        // migration entry with the right canonical replacement.
-        for (legacy, canonical, _form) in LEGACY_TO_CANONICAL
-            .iter()
-            .filter(|(_, c, _)| c.starts_with("lex.metadata."))
-        {
+    fn non_shortcut_bare_metadata_migrates_to_stripped_form() {
+        // The four metadata labels with no shortcut alias migrate to
+        // their prefix-stripped form (`metadata.<name>`), which is the
+        // shortest accepted form for them.
+        for (legacy, blessed) in [
+            ("category", "metadata.category"),
+            ("template", "metadata.template"),
+            ("publishing-date", "metadata.publishing-date"),
+            ("front-matter", "metadata.front-matter"),
+        ] {
             let src = format!(":: {legacy} :: value\n\nBody.\n");
             let out = migrate_labels_in_source(&src).unwrap_or_else(|e| {
                 panic!("migrate failed for {legacy}: {e}");
             });
+            assert!(out.is_modified(), "{legacy} must trigger migration");
+            assert_eq!(out.migrations[0].from, legacy);
+            assert_eq!(out.migrations[0].to, blessed);
             assert!(
-                out.is_modified(),
-                "migration must rewrite :: {legacy} :: ..."
-            );
-            assert_eq!(out.migrations[0].from, *legacy);
-            assert_eq!(out.migrations[0].to, *canonical);
-            assert!(
-                out.rewritten.contains(&format!(":: {canonical} ::")),
-                "rewritten source must contain :: {canonical} ::, got: {}",
+                out.rewritten.contains(&format!(":: {blessed} ::")),
+                "rewritten must contain :: {blessed} ::, got: {}",
                 out.rewritten
             );
         }
     }
 
     #[test]
-    fn verbatim_doc_table_label_is_rewritten() {
+    fn doc_table_migrates_to_blessed_table_shortcut() {
         let src = "Table:\n\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n";
         let out = migrate_labels_in_source(src).expect("migrate ok");
         assert!(out.is_modified());
         assert_eq!(out.migrations.len(), 1);
         assert_eq!(out.migrations[0].from, "doc.table");
-        assert_eq!(out.migrations[0].to, "lex.tabular.table");
-        assert!(out.rewritten.contains(":: lex.tabular.table ::"));
+        assert_eq!(out.migrations[0].to, "table");
+        assert!(out.rewritten.contains(":: table ::"));
         assert!(!out.rewritten.contains(":: doc.table ::"));
     }
 
     #[test]
-    fn verbatim_doc_image_video_audio_labels_rewrite() {
-        for (legacy, canonical) in [
-            ("doc.image", "lex.media.image"),
-            ("doc.video", "lex.media.video"),
-            ("doc.audio", "lex.media.audio"),
+    fn doc_image_video_audio_migrate_to_blessed_shortcuts() {
+        for (legacy, blessed) in [
+            ("doc.image", "image"),
+            ("doc.video", "video"),
+            ("doc.audio", "audio"),
         ] {
             let src = format!("Media:\n    caption\n:: {legacy} src=file ::\n");
             let out = migrate_labels_in_source(&src).expect("migrate ok");
             assert!(out.is_modified(), ":: {legacy} :: must trigger migration");
             assert_eq!(out.migrations[0].from, legacy);
-            assert_eq!(out.migrations[0].to, canonical);
+            assert_eq!(out.migrations[0].to, blessed);
             assert!(
-                out.rewritten.contains(&format!(":: {canonical} ")),
-                "expected canonical :: {canonical} :: in {}",
+                out.rewritten.contains(&format!(":: {blessed} ")),
+                "expected blessed :: {blessed} :: in {}",
                 out.rewritten
             );
         }
@@ -360,7 +409,7 @@ mod tests {
 
     #[test]
     fn multiple_legacy_labels_all_rewrite_with_correct_offsets() {
-        let src = ":: title :: My Doc\n:: author :: Alice\n\nBody.\n";
+        let src = ":: category :: tech\n:: template :: x\n\nBody.\n";
         let out = migrate_labels_in_source(src).expect("migrate ok");
         assert_eq!(
             out.migrations.len(),
@@ -368,10 +417,10 @@ mod tests {
             "two legacy labels must produce two migrations: {:?}",
             out.migrations
         );
-        assert!(out.rewritten.contains(":: lex.metadata.title ::"));
-        assert!(out.rewritten.contains(":: lex.metadata.author ::"));
-        assert!(!out.rewritten.contains(":: title ::"));
-        assert!(!out.rewritten.contains(":: author ::"));
+        assert!(out.rewritten.contains(":: metadata.category ::"));
+        assert!(out.rewritten.contains(":: metadata.template ::"));
+        assert!(!out.rewritten.contains(":: category ::"));
+        assert!(!out.rewritten.contains(":: template ::"));
     }
 
     #[test]
@@ -392,9 +441,9 @@ mod tests {
 
     #[test]
     fn body_text_containing_legacy_words_is_not_rewritten() {
-        // Important: "title" inside paragraph body text isn't a label
-        // and must not be touched.
-        let src = "This paragraph mentions the title and author words.\n";
+        // Important: "category" inside paragraph body text isn't a
+        // label and must not be touched.
+        let src = "This paragraph mentions the category and template words.\n";
         let out = migrate_labels_in_source(src).expect("migrate ok");
         assert!(!out.is_modified(), "body words must not be rewritten");
         assert_eq!(out.rewritten, src);
@@ -402,18 +451,16 @@ mod tests {
 
     #[test]
     fn collect_in_table_recurses_into_cell_block_children() {
-        // Regression for Copilot's PR 581 callout, mirroring the Phase 2
-        // `normalize_labels` regression: `ContentItem::Table` returns
-        // `None` from `children()`, so the generic walker doesn't reach
-        // a legacy annotation that lives in a cell's block-content
-        // `children` slot. Today's parser doesn't emit block children
-        // in cells (annotations in cells live in inline `content`),
-        // but the AST surface allows it via `TableCell::with_children`,
-        // and a future parser change must not silently lose migrations.
+        // Regression for Copilot's PR 581 callout: `ContentItem::Table`
+        // returns `None` from `children()`, so the generic walker
+        // doesn't reach a legacy annotation that lives in a cell's
+        // block-content `children` slot. Today's parser doesn't emit
+        // block children in cells, but the AST surface allows it via
+        // `TableCell::with_children`, and a future parser change must
+        // not silently lose migrations.
         //
-        // The check_label byte-range lookup requires the src string to
-        // contain the legacy label at the right offset, so we use a
-        // crafted src string and a hand-built AST with matching span.
+        // Permissive mode preserves the original spelling, so the AST
+        // label value matches the source slice (no canonical rewrite).
         use crate::lex::ast::elements::annotation::Annotation;
         use crate::lex::ast::elements::data::Data;
         use crate::lex::ast::elements::label::Label;
@@ -424,12 +471,12 @@ mod tests {
         use crate::lex::ast::text_content::TextContent;
         use crate::lex::ast::Document as LexDocument;
 
-        // The crafted src places `title` at bytes 3..8 (after `:: `).
-        let src = ":: title ::\n";
-        let label_span = std::ops::Range { start: 3, end: 8 };
+        // The crafted src places `category` at bytes 3..11 (after `:: `).
+        let src = ":: category ::\n";
+        let label_span = std::ops::Range { start: 3, end: 11 };
         let label = Label {
-            value: "lex.metadata.title".to_string(),
-            location: AstRange::new(label_span, Position::new(0, 3), Position::new(0, 8)),
+            value: "category".to_string(),
+            location: AstRange::new(label_span, Position::new(0, 3), Position::new(0, 11)),
             form: crate::lex::ast::elements::label::LabelForm::Canonical,
         };
         let inner_annotation = Annotation::from_data(Data::new(label, Vec::new()), Vec::new());
@@ -458,16 +505,16 @@ mod tests {
             1,
             "legacy annotation inside a table cell's block children must be discovered"
         );
-        assert_eq!(sites[0].from, "title");
-        assert_eq!(sites[0].to, "lex.metadata.title");
-        assert_eq!(sites[0].byte_range, 3..8);
+        assert_eq!(sites[0].from, "category");
+        assert_eq!(sites[0].to, "metadata.category");
+        assert_eq!(sites[0].byte_range, 3..11);
     }
 
     #[test]
     fn migrations_have_correct_byte_ranges() {
         // Span sanity: `from` slice from the input at the migration's
         // byte range must equal the legacy label string.
-        let src = ":: title :: My Doc\n\nBody.\n";
+        let src = ":: category :: foo\n\nBody.\n";
         let out = migrate_labels_in_source(src).expect("migrate ok");
         let m = &out.migrations[0];
         let slice = &src[m.byte_range.clone()];

--- a/crates/lex-core/src/lex/parsing/engine.rs
+++ b/crates/lex-core/src/lex/parsing/engine.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_parse_annotation() {
         // Use tokens from the lexer pipeline
-        let source = ":: note ::\n";
+        let source = ":: test.note ::\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
         let result = parse_from_flat_tokens(tokens, source);
@@ -318,13 +318,13 @@ mod tests {
         // Test annotations combined with paragraphs, lists, and sessions
         let source = r#"Document with annotations and trifecta
 
-:: info ::
+:: test.info ::
 
 Paragraph before session.
 
 1. Session with annotation inside
 
-    :: note author="system" ::
+    :: test.note author="system" ::
         This is an annotated note within a session
 
     - List item 1
@@ -332,7 +332,7 @@ Paragraph before session.
 
     Another paragraph in session.
 
-:: warning severity=high ::
+:: test.warning severity=high ::
     - Item in annotated warning
     - Important item
 
@@ -417,7 +417,7 @@ Final paragraph.
     #[test]
     fn test_parse_incomplete_annotation_block() {
         let source = r#"
-:: warning ::
+:: test.warning ::
     This is content
 
 No closing marker

--- a/crates/lex-core/src/lex/testing.rs
+++ b/crates/lex-core/src/lex/testing.rs
@@ -239,7 +239,7 @@ pub fn workspace_path(relative_path: &str) -> std::path::PathBuf {
 /// ```rust,ignore
 /// use crate::lex::testing::parse_without_annotation_attachment;
 ///
-/// let source = ":: note ::\nSome paragraph\n";
+/// let source = ":: test.note ::\nSome paragraph\n";
 /// let doc = parse_without_annotation_attachment(source).unwrap();
 ///
 /// // Annotation is still in content tree, not attached as metadata

--- a/crates/lex-core/src/lex/wire/tests.rs
+++ b/crates/lex-core/src/lex/wire/tests.rs
@@ -202,7 +202,7 @@ fn multi_line_paragraph_round_trips() {
 #[test]
 fn string_body_annotation_becomes_paragraph_child() {
     // A wire annotation with a string body (the single-line form,
-    // e.g. `:: note :: hello`) should round-trip into an Annotation
+    // e.g. `:: test.note :: hello`) should round-trip into an Annotation
     // whose children contain a single Paragraph carrying the text.
     let wire = lex_extension::wire::WireNode::Annotation {
         range: lex_extension::wire::Range::new(

--- a/crates/lex-core/tests/detokenizer/snapshots/detokenizer__lexplore_tests__detokenize_annotation_raw.snap
+++ b/crates/lex-core/tests/detokenizer/snapshots/detokenizer__lexplore_tests__detokenize_annotation_raw.snap
@@ -1,5 +1,5 @@
 ---
-source: lex-parser/tests/detokenizer/main.rs
+source: crates/lex-core/tests/detokenizer/main.rs
 expression: detokenized
 ---
 :: note ::

--- a/crates/lex-core/tests/integration/elements_annotations.rs
+++ b/crates/lex-core/tests/integration/elements_annotations.rs
@@ -24,7 +24,7 @@ fn parse_annotation_without_attachment(
 
 #[test]
 fn test_annotation_01_flat_marker_simple() {
-    // annotation-01-flat-marker-simple.lex: Simple marker annotation ":: note ::"
+    // annotation-01-flat-marker-simple.lex: Simple marker annotation ":: test.note ::"
     let doc = parse_annotation_without_attachment(1).unwrap();
 
     assert_ast(&doc).item_count(1).item(0, |item| {

--- a/crates/lex-core/tests/integration/elements_verbatim.rs
+++ b/crates/lex-core/tests/integration/elements_verbatim.rs
@@ -53,13 +53,16 @@ fn test_verbatim_03_flat_with_params() {
 
 #[test]
 fn test_verbatim_04_flat_marker_form() {
-    // verbatim-04-flat-marker-form.lex: Marker-style verbatim with descriptive content
+    // verbatim-04-flat-marker-form.lex: Marker-style verbatim with descriptive content.
+    // PR 2 of #584 added strict-mode NormalizeLabels, which rewrites
+    // the source-level `:: image ::` shortcut to its canonical
+    // `lex.media.image` before the AST reaches assertion code.
     let doc = Lexplore::verbatim(4).parse().unwrap();
 
     assert_ast(&doc).item_count(1).item(0, |item| {
         item.assert_verbatim_block()
             .subject("Sunset Photo")
-            .closing_label("image")
+            .closing_label("lex.media.image")
             .has_closing_parameter_with_value("src", "sunset.jpg")
             .content_contains("As the sun sets over the ocean.")
             .line_count(1);
@@ -626,11 +629,12 @@ fn test_verbatim_12_document_simple() {
             });
     });
 
-    // Verify image marker verbatim block
+    // Verify image marker verbatim block (source-level `:: image ::`
+    // is canonicalized to `lex.media.image` by NormalizeLabels).
     assert_ast(&doc).item(6, |item| {
         item.assert_verbatim_block()
             .subject("This is an Image Verbatim Representation")
-            .closing_label("image")
+            .closing_label("lex.media.image")
             .assert_marker_form()
             .has_closing_parameter_with_value("src", "\"image.jpg\"");
     });

--- a/crates/lex-core/tests/integration/parser_kitchensink.rs
+++ b/crates/lex-core/tests/integration/parser_kitchensink.rs
@@ -119,7 +119,7 @@ fn kitchensink_primary_session_structure() {
                 child
                     .assert_list()
                     .item_count(2)
-                    .annotation_count(1) // :: warning severity=high :: attached to list
+                    .annotation_count(1) // :: test.warning severity=high :: attached to list
                     .annotation(0, |ann| {
                         ann.label("warning")
                             .has_parameter_with_value("severity", "high")
@@ -265,7 +265,7 @@ fn kitchensink_second_session() {
                 child
                     .assert_verbatim_block()
                     .subject("Image Reference (Marker Verbatim Block)")
-                    .closing_label("image")
+                    .closing_label("lex.media.image")
                     .has_closing_parameter_with_value("src", "\"logo.png\"")
                     .has_closing_parameter_with_value("alt", "\"Lex Logo\"")
                     .annotation_count(1)

--- a/crates/lex-core/tests/integration/parser_regression.rs
+++ b/crates/lex-core/tests/integration/parser_regression.rs
@@ -128,7 +128,7 @@ fn regression_395_annotations_inside_session_not_dropped() {
 fn regression_395_annotations_with_attachment() {
     // Same as above but WITH attachment — annotations should attach to nearest element
     let source =
-        "1. Session\n\n    Some content.\n\n    :: note :: Annotation text\n\n    More content.\n";
+        "1. Session\n\n    Some content.\n\n    :: test.note :: Annotation text\n\n    More content.\n";
     let doc = parse_document(source).unwrap();
 
     assert_ast(&doc).item_count(1).item(0, |item| {

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -2433,7 +2433,7 @@ mod tests {
         };
         let result = server.execute_command(params).await.unwrap();
         let snippet: SnippetResponse = serde_json::from_value(result.unwrap()).unwrap();
-        assert!(snippet.text.contains(":: doc.image"));
+        assert!(snippet.text.contains(":: image"));
         assert!(snippet.text.contains(asset_file.to_string_lossy().as_ref()));
 
         let verbatim_file = temp_dir.path().join("example.py");


### PR DESCRIPTION
## Summary

Second of five PRs for the bare-as-blessed label namespace model from `comms/specs/general.lex` §4. PR 1 ([#586](https://github.com/lex-fmt/lex/pull/586)) added the form-tagging infrastructure; this PR replaces `NormalizeLabels`'s legacy whitelist with the resolution rules from §4.2 and rejects forbidden forms at parse time.

## Resolution rules

- **Shortcut table** → `LabelForm::Shortcut`. The 10 normative shortcuts: `table`, `image`, `video`, `audio`, `author`, `title`, `tags`, `date`, `include`, `notes`.
- **`lex.*` literal** (registered canonical) → `LabelForm::Canonical`.
- **Prefix-strip** (`metadata.author` → `lex.metadata.author`) when `lex.<input>` exists in the canonical set → `LabelForm::Stripped`.
- **Dotted non-reserved** (`acme.task`) → `LabelForm::Community`; registry validation deferred to analysis.
- **Bare unknown** (`foobar`, `42`, `^name`, `spec2025`) → `LabelForm::Community`. PR 4 of #584 adds the typo-prevention lint. The parser is deliberately permissive so footnote IDs / citation keys / verbatim language hints parse without per-shape carve-outs.

## Hard rejections (TransformError at parse time)

- `doc.*` — reserved-forbidden under §4.1.
- `lex.*` literals not in the registered canonical set.

## Highlights

- **`NormalizeLabels` strict / permissive modes** — `new()` is strict (default for `STRING_TO_AST`); `permissive()` skips rejection (used by `lexd migrate-labels` so legacy `doc.*` source still parses for rewriting).
- **New canonical `lex.notes`** + `notes` shortcut. Required because `:: notes ::` is heavily used across `lex-analysis` as the footnote-definition list marker and was previously a bare unknown.
- **New `CANONICAL_LABELS` slice** in `crates/lex-core/src/lex/builtins/mod.rs` — single source of truth for which `lex.*` labels exist. Parity test enforces it stays in sync with `register_into`.
- **Structural-Table emit** in `LexSerializer::visit_table` / `leave_table` — emits markdown-style pipe tables with per-column alignment. Pre-PR2, `LexSerializer` had no Table visitor, so bare `:: table ::` source produced an empty `:: lex.tabular.table ::` output.
- **Migration tool rewired** — `lex-core::migrate` now uses a permissive parse pipeline; the legacy-label table moved out of `NormalizeLabels` into `migrate.rs` (scoped to migration only).

## Production callers flipped off legacy forms

- `crates/lex-babel/src/templates/asset.rs::AssetKind::label()` — emits `image`/`video`/`audio` (Data falls back to `asset.data` since no canonical exists for generic data assets).
- `crates/lex-analysis/src/completion.rs::STANDARD_VERBATIM_LABELS` — shrunk to blessed shortcuts.
- `crates/lex-analysis/src/utils.rs::is_notes_list` — accepts both `notes` (shortcut) and `lex.notes` (canonical).
- `crates/lex-core/src/lex/assembling/stages/apply_table_config.rs` — the `:: table ::` config lookup accepts both spellings.

## Test migrations

- Bare `note` / `info` / `warning` (test stand-ins) → `test.note` / `test.info` / `test.warning` (community-shape) in ~20 files.
- `doc.note` / `doc.data` in test fixtures → `test.note` / `test.data`.
- Tests asserting specific label spellings (`closing_label("image")`) → expect canonical (`closing_label("lex.media.image")`) since `NormalizeLabels` resolves at parse time.
- Kitchensink snapshots (markdown + html) and detokenizer snapshots regenerated.
- `verbatim_03_table_formatting` + `verbatim_04_user_repro` now exercise the structural-Table emit path.

## Comms-side sibling

[lex-fmt/comms PR 43](https://github.com/lex-fmt/comms/pull/43) — adds `notes` to §4.2's normative shortcut table and flips three benchmark fixtures off `doc.*`. Submodule bumped to that PR's tip.

## Deferred follow-up

The legacy verbatim-markdown reformatter code remains in the tree but is now unreachable from user input:

- `crates/lex-babel/src/common/verbatim/table.rs::TableHandler` + `parse_pipe_table`
- The `VerbatimRegistry` `format_content` path
- `LexSerializer::verbatim_registry` field

`doc.table` is hard-rejected so no source-level path triggers the reformatter through `NormalizeLabels`. `:: table ::` parses as a structural Table and is serialized by `visit_table`. `lex.tabular.table` / `tabular.table` source still parses as Verbatim but no tests exercise the reformatter for those today.

A tidy-up PR after #584 PR 3 will delete the dead modules and the `verbatim_registry` field.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean
- [x] `cargo test --workspace --exclude lex-wasm` — ~2200 tests pass, 0 failures
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Reviewer cross-checks comms PR 43's `notes` schema description against `lex-core/src/lex/builtins/notes.rs::lex_notes_schema()`

## Sequencing

This PR targets `refac/label` (#570 phases haven't landed on `main` yet) and stacks on PR 1 (#586, merged). PRs 3-5 of #584 continue:

3. Form-preserving emit in lex-babel (formatter consults `Label.form`).
4. Analysis surface (hover, diagnostics, completion + typo-prevention lint for bare unknowns).
5. CLI — `lexd migrate-labels` UX rework.

Tracks: #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)