### PR TITLE
feat(lex-babel): form-preserving emit in LexSerializer [#584 PR 3/5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added — form-preserving emit ([#584](https://github.com/lex-fmt/lex/issues/584) PR 3 of 5)
+
+Third of five PRs for the bare-as-blessed label namespace model. PRs 1 + 2 added `LabelForm` and tagged every label site at parse time; this PR wires that tag through `LexSerializer` so emit preserves the user's source spelling.
+
+- New `source_spelling(&Label) -> String` and `shortcut_for_canonical(&str) -> Option<&'static str>` in `crates/lex-core/src/lex/assembling/stages/normalize_labels.rs`. Pure functions; reverse-lookup `SHORTCUT_TABLE` for Shortcut-tagged labels, strip the `lex.` prefix for Stripped-tagged labels, return `value` verbatim for Canonical / Community.
+- `LexSerializer::visit_annotation` and `LexSerializer::leave_verbatim_block` now call `source_spelling` instead of emitting `label.value` directly. Tables inherit the same behavior because the `:: table ::` closer is itself an annotation walked through `visit_annotation`.
+- Roundtrip contract from `comms/specs/general.lex` §4.3 is now live: `:: author ::` → AST canonical `lex.metadata.author` (form=Shortcut) → emit `:: author ::`. Same for `metadata.author` (Stripped), `lex.metadata.author` (Canonical), `acme.task` (Community).
+- New round-trip tests in `formats/lex/serializer.rs` for all four forms, plus a verbatim closer test (`image src=…`). `test_verbatim_04_user_repro` was updated to expect the shortcut closer (`:: table ::`) instead of the canonical (`:: lex.tabular.table ::`).
+- New unit tests in `normalize_labels.rs` covering `source_spelling` for each form variant and `shortcut_for_canonical` for both hit + miss.
+
 ### Changed — strict `NormalizeLabels` + structural-Table emit ([#584](https://github.com/lex-fmt/lex/issues/584) PR 2 of 5)
 
 Second of five PRs for the bare-as-blessed label namespace model. PR 1 added the form-tagging infrastructure; this PR replaces `NormalizeLabels`'s legacy whitelist with the resolution rules from `comms/specs/general.lex` §4.2 and rejects forbidden forms at parse time.

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -9,6 +9,7 @@ use lex_core::lex::ast::{
     TableCellAlignment, TableRow, Verbatim,
 };
 
+use lex_core::lex::assembling::stages::normalize_labels::source_spelling;
 use lex_core::lex::ast::elements::sequence_marker::DecorationStyle;
 
 struct ListContext {
@@ -315,7 +316,7 @@ impl Visitor for LexSerializer {
     }
 
     fn visit_annotation(&mut self, annotation: &Annotation) {
-        let label = &annotation.data.label.value;
+        let label = source_spelling(&annotation.data.label);
         let params = &annotation.data.parameters;
 
         let mut header = format!(":: {label}");
@@ -408,7 +409,7 @@ impl Visitor for LexSerializer {
             }
         }
 
-        let label = &verbatim.closing_data.label.value;
+        let label = source_spelling(&verbatim.closing_data.label);
         let mut footer = format!(":: {label}");
         if !verbatim.closing_data.parameters.is_empty() {
             for param in &verbatim.closing_data.parameters {
@@ -642,6 +643,77 @@ mod tests {
         let mut serializer = LexSerializer::new(rules);
         doc.accept(&mut serializer);
         serializer.output
+    }
+
+    // ==== Form-preserving roundtrip tests (#584 PR 3) =====================
+
+    #[test]
+    fn shortcut_form_round_trips_to_shortcut_spelling() {
+        // `:: author ::` source classifies as form=Shortcut for
+        // canonical `lex.metadata.author`. The formatter must emit the
+        // shortcut back, not the canonical. (The serializer's
+        // single-line-vs-block emission is a separate concern; this
+        // test focuses on the label-spelling preservation contract.)
+        let formatted = format_source(":: author :: Alice\n\nBody.\n");
+        assert!(
+            formatted.contains(":: author"),
+            "shortcut spelling should round-trip; got: {formatted}"
+        );
+        assert!(
+            !formatted.contains("lex.metadata.author"),
+            "canonical spelling must not leak into output: {formatted}"
+        );
+    }
+
+    #[test]
+    fn stripped_form_round_trips_to_stripped_spelling() {
+        // `:: metadata.category ::` classifies as Stripped — formatter
+        // must emit `metadata.category`, not the canonical.
+        let formatted = format_source(":: metadata.category :: tech\n\nBody.\n");
+        assert!(
+            formatted.contains(":: metadata.category"),
+            "stripped spelling should round-trip; got: {formatted}"
+        );
+        assert!(
+            !formatted.contains("lex.metadata.category"),
+            "canonical spelling must not leak: {formatted}"
+        );
+    }
+
+    #[test]
+    fn canonical_form_round_trips_unchanged() {
+        // `:: lex.metadata.title ::` classifies as Canonical and
+        // formats back as itself.
+        let formatted = format_source(":: lex.metadata.title :: My Doc\n\nBody.\n");
+        assert!(
+            formatted.contains(":: lex.metadata.title"),
+            "canonical spelling should round-trip; got: {formatted}"
+        );
+    }
+
+    #[test]
+    fn community_form_round_trips_unchanged() {
+        let formatted = format_source(":: acme.task id=42 :: foo\n\nBody.\n");
+        assert!(
+            formatted.contains(":: acme.task"),
+            "community label should round-trip; got: {formatted}"
+        );
+    }
+
+    #[test]
+    fn verbatim_shortcut_closer_round_trips() {
+        // `:: image src=x.png ::` (marker form) classifies as
+        // Shortcut for `lex.media.image`. The closing label must
+        // emit as `image`, not canonical.
+        let formatted = format_source("Photo subject:\n    alt text\n:: image src=\"x.png\" ::\n");
+        assert!(
+            formatted.contains(":: image"),
+            "verbatim closer should preserve shortcut: {formatted}"
+        );
+        assert!(
+            !formatted.contains("lex.media.image"),
+            "canonical must not leak: {formatted}"
+        );
     }
 
     // ==== Paragraph Tests ====
@@ -1023,9 +1095,10 @@ mod tests {
         let separator = formatted
             .find("| --------------- | ----- |")
             .expect("Separator not found");
-        let footer_start = formatted
-            .find(":: lex.tabular.table")
-            .expect("Footer not found");
+        // PR 3 of #584 wired form-preserving emission: the `:: table ::`
+        // source classifies as Shortcut, so the emitted closer is also
+        // `:: table ::`, not the canonical `:: lex.tabular.table ::`.
+        let footer_start = formatted.find(":: table ::").expect("Footer not found");
 
         assert!(table_start < separator);
         assert!(separator < footer_start);

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -182,6 +182,44 @@ pub fn classify_label(input: &str) -> Resolution {
     Resolution::Resolved(input.to_string(), LabelForm::Community)
 }
 
+/// Reverse-lookup the [`SHORTCUT_TABLE`]: given a canonical `lex.*`
+/// label, return its blessed shortcut, if any. Used by emitters that
+/// preserve the user's source spelling on roundtrip — when a label
+/// was classified as `LabelForm::Shortcut`, this is the spelling to
+/// emit.
+pub fn shortcut_for_canonical(canonical: &str) -> Option<&'static str> {
+    SHORTCUT_TABLE
+        .iter()
+        .find(|(_, c)| *c == canonical)
+        .map(|(shortcut, _)| *shortcut)
+}
+
+/// Return the source-form spelling for `label`. Formatters call this
+/// to emit the same spelling the user wrote, honoring the
+/// form-preservation contract from `comms/specs/general.lex` §4.3.
+///
+/// - `Canonical` / `Community` → the stored `value` verbatim.
+/// - `Stripped` → `lex.` prefix stripped from the canonical.
+/// - `Shortcut` → the blessed shortcut from [`SHORTCUT_TABLE`].
+///
+/// Falls back to `value` for any malformed combination (e.g. a
+/// `Shortcut`-tagged label whose canonical isn't in the table —
+/// shouldn't happen but defensively keeps emission lossless).
+pub fn source_spelling(label: &crate::lex::ast::elements::label::Label) -> String {
+    use crate::lex::ast::elements::label::LabelForm;
+    match label.form {
+        LabelForm::Canonical | LabelForm::Community => label.value.clone(),
+        LabelForm::Stripped => label
+            .value
+            .strip_prefix(LEX_PREFIX)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| label.value.clone()),
+        LabelForm::Shortcut => shortcut_for_canonical(&label.value)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| label.value.clone()),
+    }
+}
+
 /// Post-parse pass that resolves and tags label sites against the
 /// namespace policy.
 pub struct NormalizeLabels {
@@ -352,6 +390,65 @@ mod tests {
             }
         }
         None
+    }
+
+    // ── source_spelling round-trip tests ────────────────────────────────
+
+    #[test]
+    fn source_spelling_canonical_returns_value() {
+        use crate::lex::ast::elements::label::Label;
+        let label = Label::from_string("lex.metadata.author").with_form(LabelForm::Canonical);
+        assert_eq!(source_spelling(&label), "lex.metadata.author");
+    }
+
+    #[test]
+    fn source_spelling_stripped_drops_lex_prefix() {
+        use crate::lex::ast::elements::label::Label;
+        let label = Label::from_string("lex.metadata.author").with_form(LabelForm::Stripped);
+        assert_eq!(source_spelling(&label), "metadata.author");
+    }
+
+    #[test]
+    fn source_spelling_shortcut_reverse_looks_up_table() {
+        use crate::lex::ast::elements::label::Label;
+        let label = Label::from_string("lex.metadata.author").with_form(LabelForm::Shortcut);
+        assert_eq!(source_spelling(&label), "author");
+    }
+
+    #[test]
+    fn source_spelling_community_returns_value() {
+        use crate::lex::ast::elements::label::Label;
+        let label = Label::from_string("acme.task").with_form(LabelForm::Community);
+        assert_eq!(source_spelling(&label), "acme.task");
+    }
+
+    #[test]
+    fn source_spelling_round_trips_every_shortcut_table_entry() {
+        // For each (shortcut, canonical) row, building a Shortcut-form
+        // Label with the canonical value must round-trip to the
+        // shortcut. Locks the SHORTCUT_TABLE forward + reverse maps in
+        // lockstep.
+        use crate::lex::ast::elements::label::Label;
+        for (shortcut, canonical) in SHORTCUT_TABLE {
+            let label = Label::from_string(canonical).with_form(LabelForm::Shortcut);
+            assert_eq!(
+                source_spelling(&label),
+                *shortcut,
+                "round-trip mismatch for canonical {canonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn shortcut_for_canonical_returns_none_for_unmapped_canonical() {
+        // `lex.metadata.category` has no shortcut entry (it's
+        // intentionally not in the table per §4.2 — its bare form
+        // reads ambiguously). Reverse lookup returns None; emitters
+        // fall back to the stripped form via the spelling helper's
+        // own logic.
+        assert!(shortcut_for_canonical("lex.metadata.category").is_none());
+        assert!(shortcut_for_canonical("acme.task").is_none());
+        assert!(shortcut_for_canonical("").is_none());
     }
 
     // ── classify_label pure-function tests ──────────────────────────────

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -205,18 +205,11 @@ pub fn shortcut_for_canonical(canonical: &str) -> Option<&'static str> {
 /// Falls back to `value` for any malformed combination (e.g. a
 /// `Shortcut`-tagged label whose canonical isn't in the table —
 /// shouldn't happen but defensively keeps emission lossless).
-pub fn source_spelling(label: &crate::lex::ast::elements::label::Label) -> String {
-    use crate::lex::ast::elements::label::LabelForm;
+pub fn source_spelling(label: &Label) -> &str {
     match label.form {
-        LabelForm::Canonical | LabelForm::Community => label.value.clone(),
-        LabelForm::Stripped => label
-            .value
-            .strip_prefix(LEX_PREFIX)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| label.value.clone()),
-        LabelForm::Shortcut => shortcut_for_canonical(&label.value)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| label.value.clone()),
+        LabelForm::Canonical | LabelForm::Community => &label.value,
+        LabelForm::Stripped => label.value.strip_prefix(LEX_PREFIX).unwrap_or(&label.value),
+        LabelForm::Shortcut => shortcut_for_canonical(&label.value).unwrap_or(&label.value),
     }
 }
 


### PR DESCRIPTION
## Summary

Third of five PRs for the bare-as-blessed label namespace model. PRs 1 ([#586](https://github.com/lex-fmt/lex/pull/586)) + 2 ([#587](https://github.com/lex-fmt/lex/pull/587)) added `LabelForm` tagging at parse time; this PR wires the tag through `LexSerializer` so emission preserves the user's source spelling per `comms/specs/general.lex` §4.3.

## What lands

### New `source_spelling` helper

`crates/lex-core/src/lex/assembling/stages/normalize_labels.rs` gains two pure functions:

- `source_spelling(&Label) -> String`
  - `Canonical` / `Community` → `label.value` verbatim
  - `Stripped` → `label.value` with `lex.` prefix dropped
  - `Shortcut` → reverse-lookup in `SHORTCUT_TABLE`
- `shortcut_for_canonical(&str) -> Option<&'static str>` — reverse lookup; exposed for the CLI's pre-format validation (PR 5).

Both are pure and table-driven. Falls back to `value` for any malformed combination (defensive — never observed in practice).

### LexSerializer plumbed through

- `visit_annotation` → emits `source_spelling(&annotation.data.label)`.
- `leave_verbatim_block` → emits `source_spelling(&verbatim.closing_data.label)`.
- Tables inherit form-preservation behavior because the `:: table ::` closer is itself an annotation walked through `visit_annotation`.

## §4.3 contract now live end-to-end

| Source                            | Tagged form  | Emit                              |
|-----------------------------------|--------------|-----------------------------------|
| `:: author ::`                    | Shortcut     | `:: author ::`                    |
| `:: metadata.author ::`           | Stripped     | `:: metadata.author ::`           |
| `:: lex.metadata.author ::`       | Canonical    | `:: lex.metadata.author ::`       |
| `:: acme.task ::`                 | Community    | `:: acme.task ::`                 |

Roundtrip is now lossless across every spelling that parses. `lexd format` no longer silently canonicalizes the user's source.

## Tests

- **5 new round-trip tests** in `formats/lex/serializer.rs` covering each form + a verbatim closer (`image src=…`).
- **6 new unit tests** in `normalize_labels.rs` covering `source_spelling` for each form variant, `shortcut_for_canonical` hit/miss, and a parity test that round-trips every `SHORTCUT_TABLE` entry.
- `test_verbatim_04_user_repro` updated to expect the shortcut closer (`:: table ::`) since its source uses the shortcut. The earlier expected canonical (`:: lex.tabular.table ::`) was a vestige of PR 2's pre-form-preserving emit.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean
- [x] `cargo test --workspace --exclude lex-wasm` — ~2200 tests pass, 0 failures
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Sequencing

This PR targets `refac/label` and stacks on PR 2 (#587, merged). PRs 4-5 of #584 continue:

4. Analysis surface — hover shows alias info (\"`author` resolves to `lex.metadata.author`\"); diagnostics for forbidden / unknown forms; typo-prevention lint for bare unknowns close to known shortcuts; completion ranks bare first.
5. CLI — `lexd migrate-labels` UX rework + `lexd format --check-labels` pre-flight validator.

Tracks: #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)