### PR TITLE
feat(lex-analysis): label-policy diagnostics + hover + quickfix [#584 PR 4/5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added — label-policy diagnostics, hover info, quickfix ([#584](https://github.com/lex-fmt/lex/issues/584) PR 4 of 5)
+
+Fourth of five PRs for the bare-as-blessed label namespace model. PRs 1–3 added the form-tagging infrastructure, strict resolution, and form-preserving emit. This PR wires the **user-facing surface** so editors can show what's going wrong and fix it.
+
+- **New `process_full_permissive` parse entry point** in `crates/lex-core/src/lex/parsing.rs`. Mirrors `process_full` but runs `NormalizeLabels` in permissive mode so `doc.*` and unknown `lex.*` labels flow through into the AST instead of failing the parse. Intended for hosts (the LSP) that want to surface label-policy violations as in-place diagnostics rather than as wholesale parse failures.
+
+- **LSP parse switched to permissive mode** (`crates/lex-lsp/src/server.rs::DocumentStore::upsert`). A `:: doc.table ::` in a file no longer blanks out every LSP feature (semantic tokens, hover, completion, goto-def) — the rest of the file keeps working and the offending label gets a diagnostic.
+
+- **New `check_labels` analysis pass** (`crates/lex-analysis/src/diagnostics.rs`). Walks every label site (annotation, verbatim closer, table closer, nested annotation) and re-classifies via `classify_label`. Emits:
+  - `DiagnosticKind::ForbiddenLabelPrefix` (Error, code `forbidden-label-prefix`) for `doc.*` labels.
+  - `DiagnosticKind::UnknownLexCanonical` (Error, code `unknown-lex-canonical`) for `lex.*` literals not in the registered canonical set.
+
+- **Hover shows form classification** (`crates/lex-analysis/src/hover.rs::annotation_hover_result`). For `Shortcut`-form labels: "Shortcut for `lex.metadata.author`". For `Stripped`: "Prefix-stripped form of `lex.metadata.author`". For `Community`: "Community label". `Canonical` form gets no extra line (already the natural reading).
+
+- **Quickfix for `doc.*` labels** (`crates/lex-lsp-core/src/available_actions.rs`). When a `forbidden-label-prefix` diagnostic is on a known legacy spelling (`doc.table`, `doc.image`, `doc.video`, `doc.audio`), offers "Rewrite `doc.table` to `table`" as a `QUICKFIX`-kind code action. Reuses the legacy→blessed map newly exposed as `lex_core::lex::migrate::blessed_for_legacy`.
+
 ### Wire `on_resolve` for tabular + media ([#583](https://github.com/lex-fmt/lex/issues/583))
 
 Closing follow-up to #570. The `lex.tabular.table` and `lex.media.{image,video,audio}` labels now go through `Registry::dispatch_resolve` at IR construction time rather than being pattern-matched on `DocNode` variants by the legacy `VerbatimRegistry` lookup. This is the load-bearing piece of the refactor: third-party namespaces can now intercept verbatim labels through the same code path the built-ins use.

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -25,6 +25,17 @@ pub enum DiagnosticKind {
         namespace: String,
         code: Option<String>,
     },
+    /// A label uses the reserved `doc.*` prefix (forbidden under
+    /// `comms/specs/general.lex` §4.1). PR 4 of #584 emits this when
+    /// permissive-mode parse lets the label flow through; the LSP
+    /// then offers a quickfix to rewrite to the blessed shortcut
+    /// (`doc.table` → `table`, `doc.image` → `image`, etc.).
+    ForbiddenLabelPrefix,
+    /// A `lex.*` literal that doesn't match any registered canonical
+    /// in [`lex_core::lex::builtins::CANONICAL_LABELS`]. Typically a
+    /// typo (`lex.fooar`) or a label authored against a future
+    /// version of the core schemas.
+    UnknownLexCanonical,
 }
 
 /// Severity for analysis-emitted diagnostics. The analyser populates
@@ -88,8 +99,131 @@ pub fn analyze_with_registry(document: &Document, registry: &Registry) -> Vec<An
     let mut diagnostics = Vec::new();
     check_footnotes(document, &mut diagnostics);
     check_tables(document, &mut diagnostics);
+    check_labels(document, &mut diagnostics);
     crate::label_dispatch::dispatch_labels(document, registry, &mut diagnostics);
     diagnostics
+}
+
+/// Walk every label site in the document and re-classify via
+/// [`classify_label`](lex_core::lex::assembling::stages::normalize_labels::classify_label).
+/// Emits diagnostics for sites that strict-mode parsing would have
+/// rejected — `doc.*` (forbidden) and unknown `lex.*` (not a
+/// registered canonical). The LSP-side permissive parse keeps the
+/// AST building so these surface as in-place diagnostics rather than
+/// as a wholesale parse failure.
+fn check_labels(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+    use lex_core::lex::assembling::stages::normalize_labels::{
+        classify_label, RejectReason, Resolution,
+    };
+    use lex_core::lex::ast::{Label, Verbatim};
+
+    fn emit(label: &Label, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        if let Resolution::Rejected(reason) = classify_label(&label.value) {
+            let (kind, message) = match reason {
+                RejectReason::Forbidden { input } => (
+                    DiagnosticKind::ForbiddenLabelPrefix,
+                    format!(
+                        "label `{input}` uses the reserved `doc.*` prefix (forbidden under \
+                         namespace policy; see general.lex §4.1)"
+                    ),
+                ),
+                RejectReason::UnknownCanonical { input } => (
+                    DiagnosticKind::UnknownLexCanonical,
+                    format!("label `{input}` is not a registered `lex.*` canonical"),
+                ),
+            };
+            diagnostics.push(AnalysisDiagnostic {
+                range: label.location.clone(),
+                severity: DiagnosticSeverity::Error,
+                kind,
+                message,
+            });
+        }
+    }
+
+    fn walk_annotation(annotation: &Annotation, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        emit(&annotation.data.label, diagnostics);
+        for child in annotation.children.iter() {
+            walk_item(child, diagnostics);
+        }
+    }
+
+    fn walk_verbatim(verbatim: &Verbatim, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        emit(&verbatim.closing_data.label, diagnostics);
+        for annotation in verbatim.annotations() {
+            walk_annotation(annotation, diagnostics);
+        }
+    }
+
+    fn walk_table(table: &Table, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        for annotation in table.annotations() {
+            walk_annotation(annotation, diagnostics);
+        }
+        for row in table.header_rows.iter().chain(table.body_rows.iter()) {
+            for cell in &row.cells {
+                for child in cell.children.iter() {
+                    walk_item(child, diagnostics);
+                }
+            }
+        }
+        if let Some(footnotes) = table.footnotes.as_ref() {
+            for annotation in footnotes.annotations() {
+                walk_annotation(annotation, diagnostics);
+            }
+            for item in footnotes.items.iter() {
+                walk_item(item, diagnostics);
+            }
+        }
+    }
+
+    fn walk_item(item: &ContentItem, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        match item {
+            ContentItem::Annotation(a) => walk_annotation(a, diagnostics),
+            ContentItem::VerbatimBlock(v) => walk_verbatim(v, diagnostics),
+            ContentItem::Table(t) => walk_table(t, diagnostics),
+            _ => {}
+        }
+        // Walk attached annotations (sessions, paragraphs, lists, etc.).
+        if let Some(attached) = attached_annotations(item) {
+            for annotation in attached {
+                walk_annotation(annotation, diagnostics);
+            }
+        }
+        if let Some(children) = item.children() {
+            for child in children {
+                walk_item(child, diagnostics);
+            }
+        }
+    }
+
+    fn walk_session(session: &Session, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        for annotation in session.annotations() {
+            walk_annotation(annotation, diagnostics);
+        }
+        for child in &session.children {
+            walk_item(child, diagnostics);
+        }
+    }
+
+    fn attached_annotations(item: &ContentItem) -> Option<&[Annotation]> {
+        match item {
+            ContentItem::Session(s) => Some(s.annotations()),
+            ContentItem::Paragraph(p) => Some(p.annotations()),
+            ContentItem::Definition(d) => Some(d.annotations()),
+            ContentItem::List(l) => Some(l.annotations()),
+            ContentItem::ListItem(li) => Some(li.annotations()),
+            ContentItem::VerbatimBlock(v) => Some(v.annotations()),
+            ContentItem::Table(t) => Some(t.annotations()),
+            _ => None,
+        }
+    }
+
+    // Document-level annotations.
+    for annotation in document.annotations() {
+        walk_annotation(annotation, diagnostics);
+    }
+    // Root session walks.
+    walk_session(&document.root, diagnostics);
 }
 
 fn check_footnotes(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
@@ -375,6 +509,7 @@ fn compute_row_widths(rows: &[&TableRow]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lex_core::lex::parsing::process_full_permissive;
     use lex_core::lex::testing::lexplore::Lexplore;
 
     fn footnote_diags(doc: &Document) -> Vec<AnalysisDiagnostic> {
@@ -382,6 +517,73 @@ mod tests {
             .into_iter()
             .filter(|d| d.kind == DiagnosticKind::MissingFootnoteDefinition)
             .collect()
+    }
+
+    fn label_diags(source: &str) -> Vec<AnalysisDiagnostic> {
+        let doc = process_full_permissive(source).expect("permissive parse");
+        analyze(&doc)
+            .into_iter()
+            .filter(|d| {
+                matches!(
+                    d.kind,
+                    DiagnosticKind::ForbiddenLabelPrefix | DiagnosticKind::UnknownLexCanonical
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn check_labels_emits_for_doc_prefix() {
+        let diags = label_diags(":: doc.table :: x\n\nBody.\n");
+        assert_eq!(diags.len(), 1, "expected 1 forbidden-prefix diagnostic");
+        assert_eq!(diags[0].kind, DiagnosticKind::ForbiddenLabelPrefix);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+        assert!(
+            diags[0].message.contains("doc.table") && diags[0].message.contains("reserved"),
+            "message names the offending prefix; got: {}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn check_labels_emits_for_unknown_lex_canonical() {
+        let diags = label_diags(":: lex.foobar :: x\n\nBody.\n");
+        assert_eq!(diags.len(), 1, "expected 1 unknown-canonical diagnostic");
+        assert_eq!(diags[0].kind, DiagnosticKind::UnknownLexCanonical);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+        assert!(
+            diags[0].message.contains("lex.foobar"),
+            "message names the offending label; got: {}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn check_labels_silent_on_accepted_forms() {
+        // Shortcut, prefix-stripped, canonical, and community labels
+        // all accept silently — analysis only flags the two reject
+        // categories from `classify_label`.
+        let sources = [
+            ":: author :: Alice\n\nBody.\n",
+            ":: metadata.author :: Alice\n\nBody.\n",
+            ":: lex.metadata.author :: Alice\n\nBody.\n",
+            ":: acme.task :: x\n\nBody.\n",
+        ];
+        for src in sources {
+            let diags = label_diags(src);
+            assert!(
+                diags.is_empty(),
+                "no label diagnostics expected for {src:?}; got {diags:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn check_labels_finds_verbatim_closer_violations() {
+        let diags =
+            label_diags("Table:\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].kind, DiagnosticKind::ForbiddenLabelPrefix);
     }
 
     #[test]

--- a/crates/lex-analysis/src/hover.rs
+++ b/crates/lex-analysis/src/hover.rs
@@ -135,6 +135,9 @@ fn annotation_hover(document: &Document, position: Position) -> Option<HoverResu
 
 fn annotation_hover_result(annotation: &Annotation) -> HoverResult {
     let mut parts = Vec::new();
+    if let Some(form_line) = label_form_hover_line(&annotation.data.label.value) {
+        parts.push(form_line);
+    }
     if !annotation.data.parameters.is_empty() {
         let params = annotation
             .data
@@ -158,6 +161,26 @@ fn annotation_hover_result(annotation: &Annotation) -> HoverResult {
             annotation.data.label.value,
             parts.join("\n\n")
         ),
+    }
+}
+
+/// Build a one-liner explaining what alias form `input` resolves to,
+/// for hover content. Re-classifies the source spelling (the AST may
+/// carry an already-normalized canonical when strict parse ran, or
+/// the original spelling when the LSP's permissive parse ran). For
+/// `Canonical` form there's nothing extra to say. PR 4 of #584.
+fn label_form_hover_line(input: &str) -> Option<String> {
+    use lex_core::lex::assembling::stages::normalize_labels::{classify_label, Resolution};
+    use lex_core::lex::ast::elements::label::LabelForm;
+    match classify_label(input) {
+        Resolution::Resolved(canonical, LabelForm::Shortcut) => {
+            Some(format!("Shortcut for `{canonical}`"))
+        }
+        Resolution::Resolved(canonical, LabelForm::Stripped) => {
+            Some(format!("Prefix-stripped form of `{canonical}`"))
+        }
+        Resolution::Resolved(_, LabelForm::Community) => Some("Community label".to_string()),
+        Resolution::Resolved(_, LabelForm::Canonical) | Resolution::Rejected(_) => None,
     }
 }
 

--- a/crates/lex-core/src/lex/migrate.rs
+++ b/crates/lex-core/src/lex/migrate.rs
@@ -51,7 +51,7 @@ use crate::lex::transforms::Runnable;
 /// blessed shortcut). The non-shortcut metadata labels (`category`,
 /// `template`, etc.) rewrite to their prefix-stripped form (e.g.
 /// `:: category ::` → `:: metadata.category ::`).
-const LEGACY_TO_BLESSED: &[(&str, &str)] = &[
+pub const LEGACY_TO_BLESSED: &[(&str, &str)] = &[
     ("category", "metadata.category"),
     ("template", "metadata.template"),
     ("publishing-date", "metadata.publishing-date"),
@@ -61,6 +61,16 @@ const LEGACY_TO_BLESSED: &[(&str, &str)] = &[
     ("doc.video", "video"),
     ("doc.audio", "audio"),
 ];
+
+/// Lookup helper for the legacy→blessed map. Used by the LSP's
+/// `forbidden-label-prefix` quickfix in `lex-lsp-core::available_actions`
+/// — PR 4 of #584 wired up the code action surface.
+pub fn blessed_for_legacy(legacy: &str) -> Option<&'static str> {
+    LEGACY_TO_BLESSED
+        .iter()
+        .find(|(l, _)| *l == legacy)
+        .map(|(_, b)| *b)
+}
 
 /// One legacy-label rewrite site.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/lex-core/src/lex/parsing.rs
+++ b/crates/lex-core/src/lex/parsing.rs
@@ -116,6 +116,58 @@ pub fn process_full(source: &str) -> ProcessResult {
         .map_err(|e| e.to_string())
 }
 
+/// Same as [`process_full`] but runs `NormalizeLabels` in permissive
+/// mode so labels that strict mode would reject (`doc.*`,
+/// unrecognised `lex.*`) flow through into the AST instead of failing
+/// the parse. Intended for hosts that want to surface label-policy
+/// violations as in-place diagnostics rather than as a parse failure
+/// — `lex-lsp` is the primary consumer; PR 4 of #584 added the entry
+/// point so the analysis stage can emit a diagnostic on the offending
+/// label while the rest of the document keeps providing semantic
+/// tokens, hover, completion, etc. Re-classify with
+/// [`crate::lex::assembling::stages::normalize_labels::classify_label`]
+/// to determine which sites would have errored in strict mode.
+pub fn process_full_permissive(source: &str) -> ProcessResult {
+    use crate::lex::assembling::stages::{
+        ApplyTableConfig, AttachAnnotations, AttachRoot, NormalizeLabels,
+    };
+    use crate::lex::transforms::stages::ParseInlines;
+    use crate::lex::transforms::standard::LEXING;
+    use crate::lex::transforms::Runnable;
+
+    let normalized = if !source.is_empty() && !source.ends_with('\n') {
+        format!("{source}\n")
+    } else {
+        source.to_string()
+    };
+
+    let tokens = LEXING.run(normalized.clone()).map_err(|e| e.to_string())?;
+    let mut output = crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &normalized)
+        .map_err(|e| {
+            format!(
+                "Stage 'Parser' failed: {}",
+                e.to_string().replace('\n', " ")
+            )
+        })?;
+    output.root = ParseInlines::new()
+        .run(output.root)
+        .map_err(|e| e.to_string())?;
+    if let Some(ref mut title) = output.title {
+        title.content.ensure_inline_parsed();
+    }
+    let mut doc = AttachRoot::new().run(output).map_err(|e| e.to_string())?;
+    doc = AttachAnnotations::new()
+        .run(doc)
+        .map_err(|e| e.to_string())?;
+    doc = NormalizeLabels::permissive()
+        .run(doc)
+        .map_err(|e| e.to_string())?;
+    doc = ApplyTableConfig::new()
+        .run(doc)
+        .map_err(|e| e.to_string())?;
+    Ok(doc)
+}
+
 /// Alias for `process_full` to maintain backward compatibility.
 ///
 /// The term "parse" colloquially refers to the entire processing pipeline

--- a/crates/lex-lsp-core/src/available_actions.rs
+++ b/crates/lex-lsp-core/src/available_actions.rs
@@ -1,5 +1,6 @@
 use lex_analysis::utils::collect_footnote_definitions;
 use lex_core::lex::ast::Document;
+use lex_core::lex::migrate::blessed_for_legacy;
 use lsp_types::{
     CodeAction, CodeActionKind, CodeActionParams, Position, Range, TextEdit, WorkspaceEdit,
 };
@@ -64,6 +65,48 @@ pub fn compute_actions(
         });
     }
 
+    // 1b. `forbidden-label-prefix` quickfix.
+    //
+    // Each `:: doc.X ::` diagnostic gets its own QuickFix that
+    // replaces the label text with the blessed shortcut/stripped
+    // form via `lex_core::lex::migrate::blessed_for_legacy`. The
+    // diagnostic range points at the label token; the replacement
+    // operates on that exact slice so surrounding `::` markers and
+    // parameters survive unchanged. PR 4 of #584.
+    for diagnostic in &params.context.diagnostics {
+        let Some(lsp_types::NumberOrString::String(code)) = &diagnostic.code else {
+            continue;
+        };
+        if code.as_str() != "forbidden-label-prefix" {
+            continue;
+        }
+        let Some(label) = label_text_at_range(source, &diagnostic.range) else {
+            continue;
+        };
+        let Some(blessed) = blessed_for_legacy(&label) else {
+            continue;
+        };
+        actions.push(CodeAction {
+            title: format!("Rewrite `{label}` to `{blessed}`"),
+            kind: Some(CodeActionKind::QUICKFIX),
+            diagnostics: Some(vec![diagnostic.clone()]),
+            edit: Some(WorkspaceEdit {
+                changes: Some(HashMap::from([(
+                    params.text_document.uri.clone(),
+                    vec![TextEdit {
+                        range: diagnostic.range,
+                        new_text: blessed.to_string(),
+                    }],
+                )])),
+                ..Default::default()
+            }),
+            command: None,
+            is_preferred: Some(true),
+            disabled: None,
+            data: None,
+        });
+    }
+
     // 2. Global actions (Refactor)
     let requested_kind = params.context.only.as_ref().and_then(|k| k.first());
     let wants_refactor = requested_kind
@@ -116,6 +159,29 @@ pub fn compute_actions(
     }
 
     actions
+}
+
+/// Reads the source text spanned by the diagnostic range and returns
+/// it with whitespace trimmed. Used by the `forbidden-label-prefix`
+/// quickfix: the diagnostic range covers the label token, which the
+/// parser-emitted location may pad with surrounding whitespace; we
+/// want the bare label string to feed into
+/// `blessed_for_legacy(...)`. Same multi-byte safety constraints as
+/// `label_from_diagnostic_range`.
+fn label_text_at_range(source: &str, range: &Range) -> Option<String> {
+    if range.start.line != range.end.line {
+        return None;
+    }
+    let line = source.lines().nth(range.start.line as usize)?;
+    let start_byte = range.start.character as usize;
+    let end_byte = range.end.character as usize;
+    let slice = line.get(start_byte..end_byte)?;
+    let trimmed = slice.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Reads the source text spanned by the diagnostic range and extracts the

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -211,7 +211,14 @@ struct DocumentStore {
 
 impl DocumentStore {
     async fn upsert(&self, uri: Url, text: String) -> Option<DocumentEntry> {
-        let parsed = match parsing::parse_document(&text) {
+        // Permissive parse: `doc.*` and unknown `lex.*` labels — which
+        // strict-mode `NormalizeLabels` rejects as parse errors — flow
+        // through into the AST instead so the analysis stage can
+        // surface them as in-place diagnostics. PR 4 of #584 wires up
+        // the diagnostic surface; without permissive parse here, a
+        // single forbidden label would blank out every LSP feature
+        // for the document.
+        let parsed = match parsing::process_full_permissive(&text) {
             Ok(document) => Some(DocumentEntry {
                 document: Arc::new(document),
                 text: Arc::new(text),
@@ -1979,6 +1986,8 @@ fn to_lsp_diagnostic(diag: AnalysisDiagnostic) -> Diagnostic {
         DiagnosticKind::Handler { code, .. } => {
             code.clone().unwrap_or_else(|| "handler.diagnostic".into())
         }
+        DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix".into(),
+        DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical".into(),
     };
 
     let source = match &diag.kind {


### PR DESCRIPTION
## Summary

Fourth of five PRs for the bare-as-blessed label namespace model. PRs 1 ([#586](https://github.com/lex-fmt/lex/pull/586)) + 2 ([#587](https://github.com/lex-fmt/lex/pull/587)) + 3 ([#588](https://github.com/lex-fmt/lex/pull/588)) added the form-tagging infrastructure, strict resolution, and form-preserving emit. This PR wires the **user-facing surface** so editors can show what's going wrong and fix it.

## What lands

### Permissive LSP parse

- **New `process_full_permissive` parse entry point** in `crates/lex-core/src/lex/parsing.rs`. Mirrors `process_full` but runs `NormalizeLabels` in permissive mode so `doc.*` and unknown `lex.*` labels flow through into the AST instead of failing the parse.
- **LSP parse switched to permissive** (`DocumentStore::upsert` in `crates/lex-lsp/src/server.rs`). A `:: doc.table ::` in a file no longer blanks out every LSP feature — the rest of the document keeps providing semantic tokens / hover / completion / goto-def, and the offending label gets a diagnostic in place.

### `check_labels` validator

New analysis pass in `crates/lex-analysis/src/diagnostics.rs`. Walks every label site (annotation, verbatim closer, table closer, nested annotation) and re-classifies via `classify_label`. Emits:

| Diagnostic | Code | Severity | When |
|---|---|---|---|
| `ForbiddenLabelPrefix` | `forbidden-label-prefix` | Error | `:: doc.X ::` source-level label |
| `UnknownLexCanonical` | `unknown-lex-canonical` | Error | `:: lex.foobar ::` (not in `CANONICAL_LABELS`) |

Both fire only post-permissive-parse; accepted forms (Canonical/Stripped/Shortcut/Community) pass silently.

### Hover enrichment

`annotation_hover_result` now leads with a form-classification line:

| Form | Hover prefix |
|---|---|
| Shortcut (`:: author ::`) | `Shortcut for `lex.metadata.author`` |
| Stripped (`:: metadata.author ::`) | `Prefix-stripped form of `lex.metadata.author`` |
| Community (`:: acme.task ::`) | `Community label` |
| Canonical (`:: lex.metadata.author ::`) | no extra line (already the natural reading) |

### Quickfix for `doc.*`

New code action in `crates/lex-lsp-core/src/available_actions.rs`. For each `forbidden-label-prefix` diagnostic, offers "Rewrite `doc.table` to `table`" as a `QUICKFIX`-kind action with `is_preferred: true`. Reuses `lex_core::lex::migrate::blessed_for_legacy` (newly `pub` exposed) for the legacy→blessed mapping.

## What does NOT land here

- **Completion ranking tweak** — already mostly done in PR 2 (`STANDARD_VERBATIM_LABELS` shrunk to blessed shortcuts).
- **Typo-prevention lint** (Levenshtein-distance suggestion for Community-tagged bare unknowns close to known shortcuts). Out of scope for PR 4; can land as a follow-up or in PR 5.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean
- [x] `cargo test --workspace --exclude lex-wasm` — 33 targets pass, 0 failures
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 4 new tests in `lex-analysis::diagnostics`: `check_labels_emits_for_doc_prefix`, `check_labels_emits_for_unknown_lex_canonical`, `check_labels_silent_on_accepted_forms`, `check_labels_finds_verbatim_closer_violations`

## Sequencing

This PR targets `refac/label` and stacks on PRs 1–3 (all merged). PR 5 of #584 continues:

5. **CLI** — `lexd migrate-labels` UX rework + `lexd format --check-labels` pre-flight validator.

Tracks: #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)