### PR TITLE
fix(lex-analysis): address PR 589 review comments [#584 follow-up]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed — PR 589 review fixups ([#584](https://github.com/lex-fmt/lex/issues/584) follow-up)
+
+Five issues caught in review of [#589](https://github.com/lex-fmt/lex/pull/589) — fixes shipped as a follow-up since PR 589 merged before the fixups landed.
+
+- **Hover form-classification was a no-op.** `label_form_hover_line` re-classified `annotation.data.label.value`, but `NormalizeLabels` had already rewritten it to canonical — `classify_label` always returned `Canonical` form. As a result, the "Shortcut for `lex.metadata.author`" / "Prefix-stripped form" / "Community label" hover lines PR 4 advertised never actually fired. Fixed to consult `Label.form` directly (the parser-recorded source classification) and pair it with `label.value` as the canonical.
+- **Walker double-walked attached annotations + child content.** `check_labels` had per-type walkers (`walk_annotation`/`walk_verbatim`/`walk_table`) that descended into a node's children, then `walk_item` *also* descended via `attached_annotations` + `item.children()` on the same node — duplicate diagnostics for any forbidden label nested inside another label-bearing site. Restructured into a single `walk_item` dispatcher that emits type-specific labels and defers to a uniform attached/children walk. New regression test `check_labels_emits_each_offending_site_exactly_once`.
+- **`process_full_permissive` duplicated the standard pipeline.** Hand-rolled lexing → parsing → assembling so any future stage addition / reordering would have to be mirrored. Introduced `lex_core::lex::transforms::standard::run_string_to_ast(s, mode)` so strict (`STRING_TO_AST`) and permissive (`process_full_permissive`) share a single pipeline definition.
+- **`doc.*` quickfix only fired for the 4 curated mappings.** `doc.foo` / `doc.random` produced a `forbidden-label-prefix` diagnostic with no code action. Added a generic "strip `doc.` prefix" fallback so every diagnostic has an attached quickfix.
+- **Diagnostic message text duplicated `RejectReason::message()`.** Strict-mode parser errors and permissive-mode analysis diagnostics carried near-identical wording in two places that had to stay in sync. `check_labels` now delegates message construction to `RejectReason::message()` so the wording is literally identical across both surfaces.
+
 ### Added — label-policy diagnostics, hover info, quickfix ([#584](https://github.com/lex-fmt/lex/issues/584) PR 4 of 5)
 
 Fourth of five PRs for the bare-as-blessed label namespace model. PRs 1–3 added the form-tagging infrastructure, strict resolution, and form-preserving emit. This PR wires the **user-facing surface** so editors can show what's going wrong and fix it.

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -112,7 +112,9 @@ pub fn analyze_with_registry(document: &Document, registry: &Registry) -> Vec<An
 /// AST building so these surface as in-place diagnostics rather than
 /// as a wholesale parse failure.
 fn check_labels(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-    use lex_core::lex::assembling::stages::normalize_labels::{classify_label, Resolution};
+    use lex_core::lex::assembling::stages::normalize_labels::{
+        classify_label, RejectReason, Resolution,
+    };
     use lex_core::lex::ast::Label;
 
     fn emit(label: &Label, diagnostics: &mut Vec<AnalysisDiagnostic>) {
@@ -123,12 +125,8 @@ fn check_labels(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) 
             // of wording drift between the two surfaces.
             let message = reason.message();
             let kind = match reason {
-                lex_core::lex::assembling::stages::normalize_labels::RejectReason::Forbidden {
-                    ..
-                } => DiagnosticKind::ForbiddenLabelPrefix,
-                lex_core::lex::assembling::stages::normalize_labels::RejectReason::UnknownCanonical {
-                    ..
-                } => DiagnosticKind::UnknownLexCanonical,
+                RejectReason::Forbidden { .. } => DiagnosticKind::ForbiddenLabelPrefix,
+                RejectReason::UnknownCanonical { .. } => DiagnosticKind::UnknownLexCanonical,
             };
             diagnostics.push(AnalysisDiagnostic {
                 range: label.location.clone(),

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -112,25 +112,23 @@ pub fn analyze_with_registry(document: &Document, registry: &Registry) -> Vec<An
 /// AST building so these surface as in-place diagnostics rather than
 /// as a wholesale parse failure.
 fn check_labels(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-    use lex_core::lex::assembling::stages::normalize_labels::{
-        classify_label, RejectReason, Resolution,
-    };
-    use lex_core::lex::ast::{Label, Verbatim};
+    use lex_core::lex::assembling::stages::normalize_labels::{classify_label, Resolution};
+    use lex_core::lex::ast::Label;
 
     fn emit(label: &Label, diagnostics: &mut Vec<AnalysisDiagnostic>) {
         if let Resolution::Rejected(reason) = classify_label(&label.value) {
-            let (kind, message) = match reason {
-                RejectReason::Forbidden { input } => (
-                    DiagnosticKind::ForbiddenLabelPrefix,
-                    format!(
-                        "label `{input}` uses the reserved `doc.*` prefix (forbidden under \
-                         namespace policy; see general.lex §4.1)"
-                    ),
-                ),
-                RejectReason::UnknownCanonical { input } => (
-                    DiagnosticKind::UnknownLexCanonical,
-                    format!("label `{input}` is not a registered `lex.*` canonical"),
-                ),
+            // Reuse the normative wording from `RejectReason::message()`
+            // so the strict-mode parser error and the permissive-mode
+            // analysis diagnostic stay literally identical — no chance
+            // of wording drift between the two surfaces.
+            let message = reason.message();
+            let kind = match reason {
+                lex_core::lex::assembling::stages::normalize_labels::RejectReason::Forbidden {
+                    ..
+                } => DiagnosticKind::ForbiddenLabelPrefix,
+                lex_core::lex::assembling::stages::normalize_labels::RejectReason::UnknownCanonical {
+                    ..
+                } => DiagnosticKind::UnknownLexCanonical,
             };
             diagnostics.push(AnalysisDiagnostic {
                 range: label.location.clone(),
@@ -141,58 +139,58 @@ fn check_labels(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) 
         }
     }
 
-    fn walk_annotation(annotation: &Annotation, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-        emit(&annotation.data.label, diagnostics);
-        for child in annotation.children.iter() {
-            walk_item(child, diagnostics);
-        }
-    }
-
-    fn walk_verbatim(verbatim: &Verbatim, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-        emit(&verbatim.closing_data.label, diagnostics);
-        for annotation in verbatim.annotations() {
-            walk_annotation(annotation, diagnostics);
-        }
-    }
-
-    fn walk_table(table: &Table, diagnostics: &mut Vec<AnalysisDiagnostic>) {
-        for annotation in table.annotations() {
-            walk_annotation(annotation, diagnostics);
-        }
-        for row in table.header_rows.iter().chain(table.body_rows.iter()) {
-            for cell in &row.cells {
-                for child in cell.children.iter() {
-                    walk_item(child, diagnostics);
-                }
-            }
-        }
-        if let Some(footnotes) = table.footnotes.as_ref() {
-            for annotation in footnotes.annotations() {
-                walk_annotation(annotation, diagnostics);
-            }
-            for item in footnotes.items.iter() {
-                walk_item(item, diagnostics);
-            }
-        }
-    }
-
+    // Unified dispatch: every ContentItem flows through `walk_item`,
+    // which emits the type-specific label sites (annotation label,
+    // verbatim closer label, table cells/footnotes) exactly once and
+    // then defers to `attached_annotations` + `item.children()` for
+    // the uniform recursion. The earlier shape had type-specific
+    // walkers (`walk_annotation`, `walk_verbatim`, `walk_table`) that
+    // descended on their own and then `walk_item` descended again —
+    // duplicate-walk regression caught by Copilot's review on PR 589.
     fn walk_item(item: &ContentItem, diagnostics: &mut Vec<AnalysisDiagnostic>) {
         match item {
-            ContentItem::Annotation(a) => walk_annotation(a, diagnostics),
-            ContentItem::VerbatimBlock(v) => walk_verbatim(v, diagnostics),
-            ContentItem::Table(t) => walk_table(t, diagnostics),
+            ContentItem::Annotation(a) => emit(&a.data.label, diagnostics),
+            ContentItem::VerbatimBlock(v) => emit(&v.closing_data.label, diagnostics),
+            ContentItem::Table(t) => {
+                for row in t.header_rows.iter().chain(t.body_rows.iter()) {
+                    for cell in &row.cells {
+                        for child in cell.children.iter() {
+                            walk_item(child, diagnostics);
+                        }
+                    }
+                }
+                if let Some(footnotes) = t.footnotes.as_ref() {
+                    for ann in footnotes.annotations() {
+                        walk_annotation(ann, diagnostics);
+                    }
+                    for fn_item in footnotes.items.iter() {
+                        walk_item(fn_item, diagnostics);
+                    }
+                }
+            }
             _ => {}
         }
-        // Walk attached annotations (sessions, paragraphs, lists, etc.).
+        // Attached annotations (sessions, paragraphs, lists, list
+        // items, verbatim blocks, tables — see `attached_annotations`).
         if let Some(attached) = attached_annotations(item) {
             for annotation in attached {
                 walk_annotation(annotation, diagnostics);
             }
         }
+        // Generic child descent. For ContentItem::Annotation,
+        // `item.children()` returns the annotation's body children, so
+        // type-specific walking of nested annotations is not needed.
         if let Some(children) = item.children() {
             for child in children {
                 walk_item(child, diagnostics);
             }
+        }
+    }
+
+    fn walk_annotation(annotation: &Annotation, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+        emit(&annotation.data.label, diagnostics);
+        for child in annotation.children.iter() {
+            walk_item(child, diagnostics);
         }
     }
 
@@ -584,6 +582,27 @@ mod tests {
             label_diags("Table:\n    | a | b |\n    |---|---|\n    | 1 | 2 |\n:: doc.table ::\n");
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].kind, DiagnosticKind::ForbiddenLabelPrefix);
+    }
+
+    #[test]
+    fn check_labels_emits_each_offending_site_exactly_once() {
+        // Regression for Copilot's PR 589 callout: the earlier
+        // walker shape descended into a node's children twice (once
+        // via the type-specific helper, once via the generic
+        // `walk_item` fallback), which produced duplicate
+        // diagnostics for any forbidden label nested inside another
+        // label-bearing site. Three nested + adjacent forbidden
+        // labels should produce exactly three diagnostics, not six.
+        let src = ":: doc.outer ::\n    :: doc.inner :: nested body\n\n:: doc.sibling :: x\n";
+        let diags = label_diags(src);
+        assert_eq!(
+            diags.len(),
+            3,
+            "exactly one diagnostic per offending site: {diags:?}"
+        );
+        for d in &diags {
+            assert_eq!(d.kind, DiagnosticKind::ForbiddenLabelPrefix);
+        }
     }
 
     #[test]

--- a/crates/lex-analysis/src/hover.rs
+++ b/crates/lex-analysis/src/hover.rs
@@ -135,7 +135,7 @@ fn annotation_hover(document: &Document, position: Position) -> Option<HoverResu
 
 fn annotation_hover_result(annotation: &Annotation) -> HoverResult {
     let mut parts = Vec::new();
-    if let Some(form_line) = label_form_hover_line(&annotation.data.label.value) {
+    if let Some(form_line) = label_form_hover_line(&annotation.data.label) {
         parts.push(form_line);
     }
     if !annotation.data.parameters.is_empty() {
@@ -164,23 +164,22 @@ fn annotation_hover_result(annotation: &Annotation) -> HoverResult {
     }
 }
 
-/// Build a one-liner explaining what alias form `input` resolves to,
-/// for hover content. Re-classifies the source spelling (the AST may
-/// carry an already-normalized canonical when strict parse ran, or
-/// the original spelling when the LSP's permissive parse ran). For
-/// `Canonical` form there's nothing extra to say. PR 4 of #584.
-fn label_form_hover_line(input: &str) -> Option<String> {
-    use lex_core::lex::assembling::stages::normalize_labels::{classify_label, Resolution};
+/// Build a one-liner explaining what alias form a label was authored
+/// in, for hover content. Consults the parser-recorded
+/// [`Label.form`](lex_core::lex::ast::elements::label::Label) field
+/// directly — by the time hover runs, `NormalizeLabels` has already
+/// rewritten `label.value` to the canonical for accepted labels, so
+/// re-classifying the value would always return `Canonical`. The
+/// `form` field is the source of truth for what the user wrote;
+/// `label.value` is the resolved canonical to pair it with. PR 4 of
+/// #584.
+fn label_form_hover_line(label: &lex_core::lex::ast::Label) -> Option<String> {
     use lex_core::lex::ast::elements::label::LabelForm;
-    match classify_label(input) {
-        Resolution::Resolved(canonical, LabelForm::Shortcut) => {
-            Some(format!("Shortcut for `{canonical}`"))
-        }
-        Resolution::Resolved(canonical, LabelForm::Stripped) => {
-            Some(format!("Prefix-stripped form of `{canonical}`"))
-        }
-        Resolution::Resolved(_, LabelForm::Community) => Some("Community label".to_string()),
-        Resolution::Resolved(_, LabelForm::Canonical) | Resolution::Rejected(_) => None,
+    match label.form {
+        LabelForm::Shortcut => Some(format!("Shortcut for `{}`", label.value)),
+        LabelForm::Stripped => Some(format!("Prefix-stripped form of `{}`", label.value)),
+        LabelForm::Community => Some("Community label".to_string()),
+        LabelForm::Canonical => None,
     }
 }
 

--- a/crates/lex-core/src/lex/parsing.rs
+++ b/crates/lex-core/src/lex/parsing.rs
@@ -127,45 +127,15 @@ pub fn process_full(source: &str) -> ProcessResult {
 /// tokens, hover, completion, etc. Re-classify with
 /// [`crate::lex::assembling::stages::normalize_labels::classify_label`]
 /// to determine which sites would have errored in strict mode.
+///
+/// Routes through [`crate::lex::transforms::standard::run_string_to_ast`]
+/// with `Mode::Permissive` so strict + permissive parses share a
+/// single pipeline definition — no risk of the LSP parsing
+/// differently from `lexd format` when the pipeline grows new stages.
 pub fn process_full_permissive(source: &str) -> ProcessResult {
-    use crate::lex::assembling::stages::{
-        ApplyTableConfig, AttachAnnotations, AttachRoot, NormalizeLabels,
-    };
-    use crate::lex::transforms::stages::ParseInlines;
-    use crate::lex::transforms::standard::LEXING;
-    use crate::lex::transforms::Runnable;
-
-    let normalized = if !source.is_empty() && !source.ends_with('\n') {
-        format!("{source}\n")
-    } else {
-        source.to_string()
-    };
-
-    let tokens = LEXING.run(normalized.clone()).map_err(|e| e.to_string())?;
-    let mut output = crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &normalized)
-        .map_err(|e| {
-            format!(
-                "Stage 'Parser' failed: {}",
-                e.to_string().replace('\n', " ")
-            )
-        })?;
-    output.root = ParseInlines::new()
-        .run(output.root)
-        .map_err(|e| e.to_string())?;
-    if let Some(ref mut title) = output.title {
-        title.content.ensure_inline_parsed();
-    }
-    let mut doc = AttachRoot::new().run(output).map_err(|e| e.to_string())?;
-    doc = AttachAnnotations::new()
-        .run(doc)
-        .map_err(|e| e.to_string())?;
-    doc = NormalizeLabels::permissive()
-        .run(doc)
-        .map_err(|e| e.to_string())?;
-    doc = ApplyTableConfig::new()
-        .run(doc)
-        .map_err(|e| e.to_string())?;
-    Ok(doc)
+    use crate::lex::assembling::stages::normalize_labels::Mode;
+    use crate::lex::transforms::standard::run_string_to_ast;
+    run_string_to_ast(source.to_string(), Mode::Permissive).map_err(|e| e.to_string())
 }
 
 /// Alias for `process_full` to maintain backward compatibility.

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -104,51 +104,75 @@ pub static TO_IR: Lazy<IrTransform> = Lazy::new(|| Transform::from_fn(Ok).then(P
 /// ```
 pub static STRING_TO_AST: Lazy<AstTransform> = Lazy::new(|| {
     Transform::from_fn(|s: String| {
-        // Ensure source ends with newline (required for parsing)
-        let source = if !s.is_empty() && !s.ends_with('\n') {
-            format!("{s}\n")
-        } else {
-            s
-        };
-
-        // Run lexing
-        let tokens = LEXING.run(source.clone())?;
-
-        // Parse to AST
-        let mut output = crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source)
-            .map_err(|e| crate::lex::transforms::TransformError::StageFailed {
-                stage: "Parser".to_string(),
-                message: e.to_string(),
-            })?;
-
-        // Parse inline elements in root session before assembly
-        output.root = ParseInlines::new().run(output.root)?;
-
-        // Parse inlines in document title if present
-        if let Some(ref mut title) = output.title {
-            title.content.ensure_inline_parsed();
-        }
-
-        // Attach root session and title to a document
-        let mut doc = AttachRoot::new().run(output)?;
-
-        // Attach annotations as metadata
-        doc = AttachAnnotations::new().run(doc)?;
-
-        // Normalize legacy labels to their canonical `lex.*` form
-        // (#570 Phase 3b). The legacy whitelists in
-        // `lex-babel/src/ir/from_lex.rs` and the `VerbatimRegistry`
-        // in `lex-babel/src/common/verbatim` have been updated to
-        // match the canonical names, so this rewrite is now safe to
-        // activate.
-        doc = crate::lex::assembling::stages::NormalizeLabels::new().run(doc)?;
-
-        // Apply table config from :: table :: annotations (header, align)
-        doc = crate::lex::assembling::stages::ApplyTableConfig::new().run(doc)?;
-
-        Ok(doc)
+        run_string_to_ast(
+            s,
+            crate::lex::assembling::stages::normalize_labels::Mode::Strict,
+        )
     })
 });
+
+/// Run the full source→AST pipeline with a chosen
+/// [`NormalizeLabels`](crate::lex::assembling::stages::NormalizeLabels)
+/// mode. The standard pipeline ([`STRING_TO_AST`]) is the strict-mode
+/// instantiation of this; the LSP's permissive parse path
+/// ([`crate::lex::parsing::process_full_permissive`]) is the
+/// permissive-mode instantiation.
+///
+/// Keeping both modes routed through a single pipeline function
+/// avoids the maintenance hazard of forking the lexing / parsing /
+/// assembling sequence — adding a new stage or reordering existing
+/// ones only needs to happen here.
+pub fn run_string_to_ast(
+    s: String,
+    label_mode: crate::lex::assembling::stages::normalize_labels::Mode,
+) -> Result<crate::lex::ast::Document, crate::lex::transforms::TransformError> {
+    use crate::lex::assembling::stages::normalize_labels::Mode;
+
+    // Ensure source ends with newline (required for parsing)
+    let source = if !s.is_empty() && !s.ends_with('\n') {
+        format!("{s}\n")
+    } else {
+        s
+    };
+
+    // Run lexing
+    let tokens = LEXING.run(source.clone())?;
+
+    // Parse to AST
+    let mut output =
+        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).map_err(|e| {
+            crate::lex::transforms::TransformError::StageFailed {
+                stage: "Parser".to_string(),
+                message: e.to_string(),
+            }
+        })?;
+
+    // Parse inline elements in root session before assembly
+    output.root = ParseInlines::new().run(output.root)?;
+
+    // Parse inlines in document title if present
+    if let Some(ref mut title) = output.title {
+        title.content.ensure_inline_parsed();
+    }
+
+    // Attach root session and title to a document
+    let mut doc = AttachRoot::new().run(output)?;
+
+    // Attach annotations as metadata
+    doc = AttachAnnotations::new().run(doc)?;
+
+    // Normalize labels under the requested mode.
+    let normalize = match label_mode {
+        Mode::Strict => crate::lex::assembling::stages::NormalizeLabels::new(),
+        Mode::Permissive => crate::lex::assembling::stages::NormalizeLabels::permissive(),
+    };
+    doc = normalize.run(doc)?;
+
+    // Apply table config from :: table :: annotations (header, align)
+    doc = crate::lex::assembling::stages::ApplyTableConfig::new().run(doc)?;
+
+    Ok(doc)
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/lex-lsp-core/src/available_actions.rs
+++ b/crates/lex-lsp-core/src/available_actions.rs
@@ -89,7 +89,16 @@ pub fn compute_actions(
         if code.as_str() != "forbidden-label-prefix" {
             continue;
         }
-        let Some(label) = label_text_at_range(source, &diagnostic.range) else {
+        // The parser-emitted label location bounding-box can include
+        // trailing whitespace (the separator between the label and the
+        // first param). Read the raw slice, split off any leading +
+        // trailing whitespace, then reconstruct `new_text` with the
+        // same whitespace around the rewritten label — otherwise the
+        // edit would produce e.g. `:: tableheader=1 ::` (no space
+        // between label and param) which is malformed.
+        let Some((leading_ws, label, trailing_ws)) =
+            label_slice_at_range(source, &diagnostic.range)
+        else {
             continue;
         };
         let blessed: String = if let Some(curated) = blessed_for_legacy(&label) {
@@ -114,7 +123,7 @@ pub fn compute_actions(
                     params.text_document.uri.clone(),
                     vec![TextEdit {
                         range: diagnostic.range,
-                        new_text: blessed,
+                        new_text: format!("{leading_ws}{blessed}{trailing_ws}"),
                     }],
                 )])),
                 ..Default::default()
@@ -180,14 +189,18 @@ pub fn compute_actions(
     actions
 }
 
-/// Reads the source text spanned by the diagnostic range and returns
-/// it with whitespace trimmed. Used by the `forbidden-label-prefix`
-/// quickfix: the diagnostic range covers the label token, which the
-/// parser-emitted location may pad with surrounding whitespace; we
-/// want the bare label string to feed into
-/// `blessed_for_legacy(...)`. Same multi-byte safety constraints as
-/// `label_from_diagnostic_range`.
-fn label_text_at_range(source: &str, range: &Range) -> Option<String> {
+/// Reads the source text spanned by the diagnostic range and splits
+/// it into `(leading_ws, trimmed_label, trailing_ws)`. The
+/// `forbidden-label-prefix` quickfix uses the trimmed label for the
+/// `blessed_for_legacy(...)` lookup and re-applies the leading +
+/// trailing whitespace to the replacement text so the separator
+/// between the label and any following parameters is preserved —
+/// the parser-emitted label location bounding-box includes that
+/// trailing space.
+///
+/// Returns `None` for cross-line ranges, ranges that fall on non-
+/// UTF-8 byte boundaries, or ranges where the trimmed slice is empty.
+fn label_slice_at_range(source: &str, range: &Range) -> Option<(String, String, String)> {
     if range.start.line != range.end.line {
         return None;
     }
@@ -197,10 +210,18 @@ fn label_text_at_range(source: &str, range: &Range) -> Option<String> {
     let slice = line.get(start_byte..end_byte)?;
     let trimmed = slice.trim();
     if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
+        return None;
     }
+    // `trim` returns a sub-slice; compute the byte offsets of the
+    // trimmed view inside the original slice so the leading / trailing
+    // bookends are exact byte slices (not assumed to be ASCII spaces).
+    let trim_start = trimmed.as_ptr() as usize - slice.as_ptr() as usize;
+    let trim_end = trim_start + trimmed.len();
+    Some((
+        slice[..trim_start].to_string(),
+        trimmed.to_string(),
+        slice[trim_end..].to_string(),
+    ))
 }
 
 /// Reads the source text spanned by the diagnostic range and extracts the
@@ -800,5 +821,86 @@ mod tests {
         assert_eq!(action.is_preferred, Some(true));
         // Diagnostic is attached so clients can resolve which diag the fix addresses.
         assert_eq!(action.diagnostics.as_ref().map(|v| v.len()), Some(1));
+    }
+
+    // --- forbidden-label-prefix quickfix ---
+
+    fn forbidden_label_diag(line: u32, start_col: u32, end_col: u32, label: &str) -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line,
+                    character: start_col,
+                },
+                end: Position {
+                    line,
+                    character: end_col,
+                },
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(NumberOrString::String("forbidden-label-prefix".to_string())),
+            code_description: None,
+            source: Some("lex".to_string()),
+            message: format!(
+                "label `{label}` uses the reserved `doc.*` prefix (forbidden under namespace \
+                 policy; see general.lex §4.1)"
+            ),
+            related_information: None,
+            tags: None,
+            data: None,
+        }
+    }
+
+    fn parse_permissive(source: &str) -> Document {
+        lex_core::lex::parsing::process_full_permissive(source).expect("permissive parse")
+    }
+
+    #[test]
+    fn forbidden_label_quickfix_preserves_trailing_whitespace_before_params() {
+        // Regression for Copilot's PR 590 callout. The parser-emitted
+        // label location can include the separator whitespace between
+        // the label and the next param. Replacing the full diagnostic
+        // range with just `blessed` would produce malformed
+        // `:: tableheader=1 ::`; the fix preserves the trailing space.
+        // Permissive parse so the `doc.*` label flows through to the
+        // AST instead of failing the parse.
+        let src = ":: doc.table header=1 :: My Table\n";
+        let doc = parse_permissive(src);
+        // Label spans `doc.table ` (10 cols: 3 → 13, including trailing space).
+        let diag = forbidden_label_diag(0, 3, 13, "doc.table");
+        let params = make_params(src, vec![diag]);
+        let actions = compute_actions(&doc, src, &params);
+        let action = actions
+            .iter()
+            .find(|a| a.title.starts_with("Rewrite `doc.table`"))
+            .expect("forbidden-label quickfix should be present");
+        let edit = quickfix_edit(action);
+        // After the edit, the header must still separate label from param.
+        let after = apply_edit(src, edit);
+        assert!(
+            after.starts_with(":: table header=1 ::"),
+            "edit should preserve the space between label and param; got: {after:?}"
+        );
+    }
+
+    #[test]
+    fn forbidden_label_quickfix_falls_back_to_strip_doc_prefix_for_unknown_legacy() {
+        // `doc.random` isn't in the LEGACY_TO_BLESSED curated table;
+        // the generic "strip `doc.` prefix" fallback should still
+        // produce a quickfix.
+        let src = ":: doc.random ::\nBody.\n";
+        let doc = parse_permissive(src);
+        let diag = forbidden_label_diag(0, 3, 13, "doc.random");
+        let params = make_params(src, vec![diag]);
+        let actions = compute_actions(&doc, src, &params);
+        let action = actions
+            .iter()
+            .find(|a| a.title.starts_with("Rewrite `doc.random`"))
+            .expect("fallback quickfix should be present");
+        assert!(
+            action.title.contains("`random`"),
+            "title should name the stripped form; got: {}",
+            action.title
+        );
     }
 }

--- a/crates/lex-lsp-core/src/available_actions.rs
+++ b/crates/lex-lsp-core/src/available_actions.rs
@@ -68,11 +68,20 @@ pub fn compute_actions(
     // 1b. `forbidden-label-prefix` quickfix.
     //
     // Each `:: doc.X ::` diagnostic gets its own QuickFix that
-    // replaces the label text with the blessed shortcut/stripped
-    // form via `lex_core::lex::migrate::blessed_for_legacy`. The
-    // diagnostic range points at the label token; the replacement
-    // operates on that exact slice so surrounding `::` markers and
-    // parameters survive unchanged. PR 4 of #584.
+    // rewrites the label. First try the curated legacy table —
+    // `doc.table` → `table` (blessed shortcut), `doc.image` →
+    // `image`, etc. via `lex_core::lex::migrate::blessed_for_legacy`.
+    // If that lookup misses (the user wrote `doc.foo` /
+    // `doc.unknown-thing` / etc.), fall back to a generic "strip
+    // `doc.` prefix" rewrite so every `forbidden-label-prefix`
+    // diagnostic has a quickfix attached. The fallback produces a
+    // bare-name label that the parser then re-classifies via the
+    // namespace policy (shortcut → Shortcut, registered Canonical →
+    // resolved, etc., or Community if nothing matches).
+    //
+    // The diagnostic range points at the label token; the
+    // replacement operates on that exact slice so surrounding `::`
+    // markers and parameters survive unchanged. PR 4 of #584.
     for diagnostic in &params.context.diagnostics {
         let Some(lsp_types::NumberOrString::String(code)) = &diagnostic.code else {
             continue;
@@ -83,7 +92,17 @@ pub fn compute_actions(
         let Some(label) = label_text_at_range(source, &diagnostic.range) else {
             continue;
         };
-        let Some(blessed) = blessed_for_legacy(&label) else {
+        let blessed: String = if let Some(curated) = blessed_for_legacy(&label) {
+            curated.to_string()
+        } else if let Some(stripped) = label.strip_prefix("doc.") {
+            // Generic fallback. Empty-after-strip (`doc.`) shouldn't
+            // appear in practice (the parser rejects empty labels
+            // earlier) but guard against it anyway.
+            if stripped.is_empty() {
+                continue;
+            }
+            stripped.to_string()
+        } else {
             continue;
         };
         actions.push(CodeAction {
@@ -95,7 +114,7 @@ pub fn compute_actions(
                     params.text_document.uri.clone(),
                     vec![TextEdit {
                         range: diagnostic.range,
-                        new_text: blessed.to_string(),
+                        new_text: blessed,
                     }],
                 )])),
                 ..Default::default()


### PR DESCRIPTION
## Summary

Five issues caught in review of [#589](https://github.com/lex-fmt/lex/pull/589) — shipped as a focused follow-up since #589 merged before the fixups landed.

| # | Reviewer | Problem | Fix |
|---|---|---|---|
| 4 | Copilot | Hover form-classification was a no-op | Consult `Label.form` directly instead of re-classifying `label.value` |
| 5 | Copilot | Walker double-walked attached annotations + child content | Single `walk_item` dispatcher + regression test |
| 6/3 | Copilot/Gemini | `process_full_permissive` duplicated the standard pipeline | New `run_string_to_ast(s, mode)` shared by strict + permissive |
| 7 | Copilot | `doc.*` quickfix only fired for the 4 curated mappings | Generic "strip `doc.` prefix" fallback |
| 8 | Copilot | Diagnostic message text duplicated `RejectReason::message()` | Delegate to `RejectReason::message()` |

## Detail

### Hover form-classification was a no-op (Copilot #4)

`label_form_hover_line` re-classified `annotation.data.label.value`, but `NormalizeLabels` has already rewritten `label.value` to the canonical form for accepted labels (in both strict and permissive modes — `apply_resolution` sets `label.value = canonical` regardless of mode). So when a user wrote `:: author ::`, the AST stored `value = "lex.metadata.author"` and `form = Shortcut`; `classify_label("lex.metadata.author")` then returned `Resolved(_, Canonical)` and the function always returned `None`. The hover lines PR 4 advertised never fired in practice.

Fix: consult `Label.form` directly (the parser-recorded source classification) and pair it with `label.value` as the canonical.

### Walker double-walked (Copilot #5 + Gemini #2)

`check_labels` had per-type walkers (`walk_annotation`/`walk_verbatim`/`walk_table`) that descended into a node's children, then `walk_item` also descended via `attached_annotations(item)` + `item.children()` on the same node. Any forbidden label nested inside another label-bearing site produced duplicate diagnostics.

Fix: restructured into a single `walk_item` dispatcher that emits the type-specific label sites and defers to a uniform attached/children walk. New regression test `check_labels_emits_each_offending_site_exactly_once` covers nested + adjacent forbidden labels (3 sites should produce exactly 3 diagnostics).

### Parsing pipeline duplication (Copilot #6 + Gemini #3)

`process_full_permissive` hand-rolled lexing → parsing → assembling. Any future stage addition / reordering would have to be mirrored, with no compiler help to catch drift.

Fix: introduced `lex_core::lex::transforms::standard::run_string_to_ast(s, mode)` so strict (`STRING_TO_AST`) and permissive (`process_full_permissive`) share one pipeline definition. `process_full_permissive` is now a one-liner delegating to it.

### Quickfix fallback (Copilot #7)

The `forbidden-label-prefix` quickfix only fired for entries in `LEGACY_TO_BLESSED` (the 4 curated `doc.*` mappings). User-typed `doc.foo` produced a diagnostic with no code action.

Fix: when the curated table misses, fall back to a generic "strip `doc.` prefix" rewrite. Every `forbidden-label-prefix` diagnostic now has an attached quickfix.

### Message delegation (Copilot #8)

Strict-mode parser errors (via `TransformError`) and permissive-mode analysis diagnostics (via `AnalysisDiagnostic`) carried near-identical wording in two places.

Fix: `check_labels` now calls `RejectReason::message()` directly. Wording is literally identical across both surfaces; can't drift.

## Note on Gemini #1

Gemini's first comment suggested adding a `verbatim.data.label` check alongside the closing label. There is no such field — `Verbatim` has `subject: TextContent` (the lead-in line, not a label) and `closing_data: Data` (where the label lives). Confirmed by reading `crates/lex-core/src/lex/ast/elements/verbatim.rs:148-152`. The second half of Gemini #1 (redundant `verbatim.annotations()` loop) is subsumed by the Copilot #5 walker refactor.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean
- [x] `cargo test --workspace --exclude lex-wasm` — 33 targets pass, 0 failures
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New regression test `check_labels_emits_each_offending_site_exactly_once`

## Sequencing

This PR targets `refac/label`. After it lands, PR 5 of #584 (CLI label-check subcommand) is next — `lexd migrate-labels` rework is dropped per user direction; only the label-check pre-flight validator survives.

Tracks: #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)