### PR TITLE
feat(lex-cli): `lexd check-labels` pre-flight validator [#584 PR 5/5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added — `lexd check-labels` pre-flight validator ([#584](https://github.com/lex-fmt/lex/issues/584) PR 5 of 5)
+
+Final PR of the bare-as-blessed label namespace model. PRs 1–4 added the form-tagging infrastructure, strict resolution, form-preserving emit, and the LSP-side label-policy surface. This PR ships the CLI equivalent for batch / CI use.
+
+- **New subcommand `lexd check-labels <path>`** in `crates/lex-cli/src/main.rs`. Parses the file permissively (so `doc.*` and unknown `lex.*` labels flow through into the AST), runs the analysis pass, and reports any `forbidden-label-prefix` / `unknown-lex-canonical` diagnostics with `path:line:col: error[<code>]: <message>` formatting. Exits `0` on a clean file, `1` if any violations are found, `2` on I/O or fatal parse error.
+- **Designed for CI use** — permissive parse means every violation surfaces in one invocation; you don't have to fix one and re-run to see the next.
+- **Out of scope** — the originally-planned `lexd migrate-labels` UX rework was dropped (nothing in the wild needs migrating; the existing command already covers the rare cases). Per #584's reduced PR 5 scope: just the label-check pre-flight.
+
 ### Fixed — PR 589 review fixups ([#584](https://github.com/lex-fmt/lex/issues/584) follow-up)
 
 Five issues caught in review of [#589](https://github.com/lex-fmt/lex/pull/589) — fixes shipped as a follow-up since PR 589 merged before the fixups landed.

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -565,6 +565,18 @@ fn main() {
                 std::process::exit(1);
             });
         }
+        // `check-labels` doesn't need workspace config — only the
+        // built-in `lex.*` canonical set, which the analysis pass
+        // consults through compile-in constants. Short-circuiting
+        // before `builder.load()` keeps the documented exit-code
+        // contract (0/1/2 only) — a config load failure inside this
+        // subcommand would otherwise exit with code 1 instead of 2.
+        Some(("check-labels", sub_matches)) => {
+            let exit = handle_check_labels_command(sub_matches);
+            if exit != 0 {
+                std::process::exit(exit);
+            }
+        }
         _ => {
             let config = builder.load().unwrap_or_else(|e| {
                 eprintln!("Failed to load configuration: {e}");
@@ -658,12 +670,6 @@ fn main() {
                 }
                 Some(("migrate-labels", sub_matches)) => {
                     let exit = handle_migrate_labels_command(sub_matches);
-                    if exit != 0 {
-                        std::process::exit(exit);
-                    }
-                }
-                Some(("check-labels", sub_matches)) => {
-                    let exit = handle_check_labels_command(sub_matches);
                     if exit != 0 {
                         std::process::exit(exit);
                     }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -438,6 +438,31 @@ fn build_cli() -> Command {
                 ),
         )
         .subcommand(
+            Command::new("check-labels")
+                .about("Check a .lex file for label-policy violations (CI-friendly)")
+                .long_about(
+                    "Parse a .lex file in permissive mode and report any label-policy \
+                     violations that strict-mode parsing would have rejected:\n\n  \
+                     - `forbidden-label-prefix` — labels using the reserved `doc.*` \
+                     prefix (see general.lex §4.1)\n  \
+                     - `unknown-lex-canonical` — `lex.*` literals that aren't \
+                     registered canonicals\n\n\
+                     Permissive parse means the rest of the file still produces \
+                     diagnostics — useful for batch CI runs where you want to see all \
+                     violations at once rather than failing on the first.\n\n\
+                     Exit codes:\n  \
+                     0: clean (no label-policy violations)\n  \
+                     1: at least one violation found\n  \
+                     2: I/O failure (file not found) or fatal parse error",
+                )
+                .arg(
+                    Arg::new("path")
+                        .help("Path to the .lex document")
+                        .value_hint(ValueHint::FilePath)
+                        .required(true),
+                ),
+        )
+        .subcommand(
             Command::new("migrate-labels")
                 .about("Migrate legacy bare labels in a .lex file to their canonical lex.* form")
                 .long_about(
@@ -495,6 +520,7 @@ fn main() {
                 "generate-lex-css",
                 "labels",
                 "migrate-labels",
+                "check-labels",
                 "help",
             ];
             let first_arg = args.get(1).map(String::as_str);
@@ -636,6 +662,12 @@ fn main() {
                         std::process::exit(exit);
                     }
                 }
+                Some(("check-labels", sub_matches)) => {
+                    let exit = handle_check_labels_command(sub_matches);
+                    if exit != 0 {
+                        std::process::exit(exit);
+                    }
+                }
                 _ => {
                     eprintln!("Unknown subcommand. Use --help for usage information.");
                     std::process::exit(1);
@@ -732,6 +764,90 @@ fn handle_migrate_labels_command(sub: &ArgMatches) -> i32 {
     // Default: print rewritten source to stdout.
     print!("{}", outcome.rewritten);
     0
+}
+
+/// Dispatch `lexd check-labels <path>`. Parses the file permissively
+/// so `doc.*` and unknown `lex.*` labels survive into the AST,
+/// then runs the analysis pass and filters to the label-policy
+/// diagnostics (`ForbiddenLabelPrefix` + `UnknownLexCanonical`).
+/// Reports each violation with line/column info; exits non-zero
+/// when any are found.
+///
+/// Exit codes:
+///
+/// - `0`: clean (no label-policy violations).
+/// - `1`: at least one violation found.
+/// - `2`: I/O failure (file not found) or fatal parse error.
+fn handle_check_labels_command(sub: &ArgMatches) -> i32 {
+    use lex_analysis::diagnostics::{analyze, DiagnosticKind};
+    use lex_core::lex::parsing::process_full_permissive;
+
+    let path: PathBuf = sub
+        .get_one::<String>("path")
+        .map(PathBuf::from)
+        .expect("clap enforces required");
+
+    let source = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("lexd check-labels: failed to read {}: {e}", path.display());
+            return 2;
+        }
+    };
+
+    let document = match process_full_permissive(&source) {
+        Ok(doc) => doc,
+        Err(e) => {
+            eprintln!(
+                "lexd check-labels: {} could not be parsed: {e}",
+                path.display()
+            );
+            return 2;
+        }
+    };
+
+    // Only label-policy diagnostics are in scope for this subcommand.
+    // Other analysis diagnostics (missing-footnote, table-column,
+    // schema validation) keep firing through `lexd format` /
+    // `lex-lsp`; this command is the focused pre-flight check.
+    let label_diags: Vec<_> = analyze(&document)
+        .into_iter()
+        .filter(|d| {
+            matches!(
+                d.kind,
+                DiagnosticKind::ForbiddenLabelPrefix | DiagnosticKind::UnknownLexCanonical
+            )
+        })
+        .collect();
+
+    if label_diags.is_empty() {
+        return 0;
+    }
+
+    for diag in &label_diags {
+        let code = match diag.kind {
+            DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix",
+            DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical",
+            _ => "label-policy",
+        };
+        // 1-based line/column for the human-readable report.
+        let line = diag.range.start.line + 1;
+        let col = diag.range.start.column + 1;
+        eprintln!(
+            "{}:{}:{}: error[{code}]: {}",
+            path.display(),
+            line,
+            col,
+            diag.message
+        );
+    }
+    eprintln!();
+    eprintln!(
+        "{}: {} label-policy violation(s)",
+        path.display(),
+        label_diags.len()
+    );
+    1
 }
 
 /// Dispatch `lexd labels {list,validate}`. Returns the exit code

--- a/crates/lex-cli/tests/integration/labels.rs
+++ b/crates/lex-cli/tests/integration/labels.rs
@@ -144,3 +144,83 @@ lex = "github:fake/lex-labels"
         .failure()
         .stderr(predicates::str::contains("reserved"));
 }
+
+// `lexd check-labels` — PR 5 of #584.
+
+#[test]
+fn check_labels_exits_zero_on_clean_document() {
+    let dir = TempDir::new().unwrap();
+    let doc = dir.path().join("clean.lex");
+    fs::write(&doc, ":: author :: Alice\n\n1. Intro\n\n    Body.\n").unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .args(["check-labels", doc.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn check_labels_exits_one_on_forbidden_doc_prefix() {
+    let dir = TempDir::new().unwrap();
+    let doc = dir.path().join("bad.lex");
+    fs::write(&doc, ":: doc.table ::\n\nBody.\n").unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .args(["check-labels", doc.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(
+            predicates::str::contains("doc.table")
+                .and(predicates::str::contains("forbidden-label-prefix"))
+                .and(predicates::str::contains("1 label-policy violation")),
+        );
+}
+
+#[test]
+fn check_labels_exits_one_on_unknown_lex_canonical() {
+    let dir = TempDir::new().unwrap();
+    let doc = dir.path().join("bad.lex");
+    fs::write(&doc, ":: lex.foobar :: x\n\nBody.\n").unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .args(["check-labels", doc.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(
+            predicates::str::contains("lex.foobar")
+                .and(predicates::str::contains("unknown-lex-canonical")),
+        );
+}
+
+#[test]
+fn check_labels_reports_every_violation_in_one_run() {
+    // Permissive parse means every violation surfaces in a single
+    // invocation — useful for batch CI runs.
+    let dir = TempDir::new().unwrap();
+    let doc = dir.path().join("multi.lex");
+    fs::write(
+        &doc,
+        ":: doc.table :: x\n:: doc.image :: y\n:: lex.foobar :: z\n\nBody.\n",
+    )
+    .unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .args(["check-labels", doc.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicates::str::contains("3 label-policy violation"));
+}
+
+#[test]
+fn check_labels_exits_two_on_missing_file() {
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .args(["check-labels", "/nonexistent/path/that/does/not/exist.lex"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicates::str::contains("failed to read"));
+}

--- a/crates/lex-cli/tests/integration/labels.rs
+++ b/crates/lex-cli/tests/integration/labels.rs
@@ -224,3 +224,31 @@ fn check_labels_exits_two_on_missing_file() {
         .code(2)
         .stderr(predicates::str::contains("failed to read"));
 }
+
+#[test]
+fn check_labels_short_circuits_before_config_load() {
+    // Regression for Copilot's PR 591 callout: the documented
+    // exit-code contract is 0/1/2 only. A workspace with a broken
+    // `.lex.toml` would have exited with code 1 from `builder.load()`
+    // before reaching `handle_check_labels_command` — violating the
+    // contract. `check-labels` now short-circuits before config
+    // load, so a malformed `.lex.toml` doesn't pollute the exit
+    // code: a clean doc still exits 0, a doc with violations exits 1
+    // (not 1-from-broken-config-load-conflated-with-1-from-violation).
+    let dir = TempDir::new().unwrap();
+    // Deliberately broken .lex.toml — `[labels]` block with a value
+    // that triggers a load error (reserved namespace).
+    fs::write(
+        dir.path().join(".lex.toml"),
+        "[labels]\nlex = \"github:fake/lex-labels\"\n",
+    )
+    .unwrap();
+    let doc = dir.path().join("clean.lex");
+    fs::write(&doc, ":: author :: Alice\n\n1. Intro\n\n    Body.\n").unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["check-labels", doc.to_str().unwrap()])
+        .assert()
+        .success(); // exits 0 despite the broken workspace config
+}


### PR DESCRIPTION
## Summary

Final PR of the bare-as-blessed label namespace model. PRs 1–4 added the form-tagging infrastructure ([#586](https://github.com/lex-fmt/lex/pull/586)), strict resolution ([#587](https://github.com/lex-fmt/lex/pull/587)), form-preserving emit ([#588](https://github.com/lex-fmt/lex/pull/588)), and the LSP-side label-policy surface ([#589](https://github.com/lex-fmt/lex/pull/589) + [#590](https://github.com/lex-fmt/lex/pull/590) fixup). This PR ships the CLI equivalent for batch / CI use.

Closes #584.

## What lands

### New subcommand `lexd check-labels <path>`

Parses the file permissively (so `doc.*` and unknown `lex.*` labels flow through into the AST), runs the analysis pass, and reports any `forbidden-label-prefix` / `unknown-lex-canonical` diagnostics with:

```
<path>:<line>:<col>: error[<code>]: <message>
```

Example session:

```
$ lexd check-labels /tmp/bad.lex
/tmp/bad.lex:1:4: error[forbidden-label-prefix]: label `doc.note` uses the reserved `doc.*` prefix (forbidden under namespace policy; see general.lex §4.1)
/tmp/bad.lex:3:4: error[forbidden-label-prefix]: label `doc.table` uses the reserved `doc.*` prefix (forbidden under namespace policy; see general.lex §4.1)
/tmp/bad.lex:4:4: error[unknown-lex-canonical]: label `lex.foobar` is not a registered `lex.*` canonical

/tmp/bad.lex: 3 label-policy violation(s)
$ echo $?
1
```

### Exit codes

| Code | Meaning |
|---|---|
| `0` | Clean — no label-policy violations |
| `1` | At least one violation found |
| `2` | I/O failure (file not found) or fatal parse error |

### Why permissive parse

Permissive parse means every violation surfaces in one invocation — useful for batch CI runs where you want to see all violations at once rather than failing on the first one. Strict-mode parsing would have aborted at the first `doc.*` label.

## What does NOT land

- **The originally-planned `lexd migrate-labels` UX rework** is dropped per your direction. Nothing in the wild needs migrating; the existing command already covers the rare cases. PR 5's scope reduced to just the label-check pre-flight.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean
- [x] `cargo test --workspace --exclude lex-wasm` — clean
- [x] `cargo clippy --workspace --exclude lex-wasm -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 5 new integration tests in `crates/lex-cli/tests/integration/labels.rs`:
  - `check_labels_exits_zero_on_clean_document`
  - `check_labels_exits_one_on_forbidden_doc_prefix`
  - `check_labels_exits_one_on_unknown_lex_canonical`
  - `check_labels_reports_every_violation_in_one_run`
  - `check_labels_exits_two_on_missing_file`

## Closing the issue

With this PR merged, all five PRs in #584's plan are in:

1. ✅ [#586](https://github.com/lex-fmt/lex/pull/586) — `LabelForm` enum + `form` field
2. ✅ [#587](https://github.com/lex-fmt/lex/pull/587) — strict `NormalizeLabels` + structural-Table emit
3. ✅ [#588](https://github.com/lex-fmt/lex/pull/588) — form-preserving emit in `LexSerializer`
4. ✅ [#589](https://github.com/lex-fmt/lex/pull/589) + [#590](https://github.com/lex-fmt/lex/pull/590) — analysis surface (diagnostics, hover, quickfix)
5. This PR — CLI pre-flight validator

Plus the spec-side changes that shipped through comms (PR #42 — §4 label namespace model; PR #43 — `notes` shortcut + benchmark fixture flip).

Tracks: #584 (closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)