### PR TITLE
test(sandbox): skip Linux landlock tests when LSM is unavailable

### DIFF
--- a/crates/lex-extension-host/tests/sandbox_enforcement.rs
+++ b/crates/lex-extension-host/tests/sandbox_enforcement.rs
@@ -77,7 +77,8 @@ fn net_probe_succeeds_under_null_sandbox() {
 
 #[cfg(target_os = "linux")]
 fn landlock_available() -> bool {
-    use landlock::{AccessFs, Ruleset, RulesetAttr, ABI};
+    // `Access` trait must be in scope for `AccessFs::from_all`.
+    use landlock::{Access, AccessFs, Ruleset, RulesetAttr, ABI};
     // Probe by creating an unbound ruleset. Doesn't call
     // `restrict_self` so the test process is unaffected. Failure here
     // means the kernel doesn't support landlock.

--- a/crates/lex-extension-host/tests/sandbox_enforcement.rs
+++ b/crates/lex-extension-host/tests/sandbox_enforcement.rs
@@ -65,10 +65,36 @@ fn net_probe_succeeds_under_null_sandbox() {
 }
 
 // -- Linux: LinuxSandbox enforcement.
+//
+// Both Linux tests are conditionally skipped when the running kernel
+// doesn't expose landlock (no `CONFIG_SECURITY_LANDLOCK` or the LSM is
+// disabled). Some container/CI environments — including the Claude
+// Code on the web sandbox — fall into this bucket. Skipping there
+// keeps the suite committable in those envs without weakening
+// coverage on properly-equipped runners (GitHub Actions, dev
+// workstations), where the tests still exercise the real enforcement
+// path.
+
+#[cfg(target_os = "linux")]
+fn landlock_available() -> bool {
+    use landlock::{AccessFs, Ruleset, RulesetAttr, ABI};
+    // Probe by creating an unbound ruleset. Doesn't call
+    // `restrict_self` so the test process is unaffected. Failure here
+    // means the kernel doesn't support landlock.
+    let abi = ABI::V1;
+    Ruleset::default()
+        .handle_access(AccessFs::from_all(abi))
+        .and_then(|r| r.create())
+        .is_ok()
+}
 
 #[cfg(target_os = "linux")]
 #[test]
 fn fs_probe_is_blocked_under_linux_sandbox() {
+    if !landlock_available() {
+        eprintln!("skipping: landlock LSM not available on this kernel");
+        return;
+    }
     // /etc/passwd is outside the landlock allowlist → EACCES → exit 42.
     assert_eq!(run_with(&LinuxSandbox, FS_PROBE, &[]), 42);
 }
@@ -76,6 +102,10 @@ fn fs_probe_is_blocked_under_linux_sandbox() {
 #[cfg(target_os = "linux")]
 #[test]
 fn net_probe_is_blocked_under_linux_sandbox() {
+    if !landlock_available() {
+        eprintln!("skipping: landlock LSM not available on this kernel");
+        return;
+    }
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind localhost");
     let addr = listener.local_addr().expect("addr");
     // socket() syscall returns EPERM → TcpStream::connect_timeout


### PR DESCRIPTION
## Summary

`crates/lex-extension-host/tests/sandbox_enforcement.rs` has two Linux-gated tests that panic on kernels without `CONFIG_SECURITY_LANDLOCK`:

- `fs_probe_is_blocked_under_linux_sandbox`
- `net_probe_is_blocked_under_linux_sandbox`

The tests are compile-gated on `target_os = "linux"` but not runtime-gated on the LSM actually being enforceable. That hits us in any container that doesn't enable landlock — notably the Claude Code on the web sandbox, where every commit ends up forced through `--no-verify` because the lefthook pre-commit runs `cargo test --workspace`. Reported during the cloud-session migration of lex-fmt/lex (see [PR #623](https://github.com/lex-fmt/lex/pull/623) context).

## Fix

Add a `landlock_available()` probe that tries to create an unbound landlock ruleset (doesn't call `restrict_self`, so the test process is unaffected). The two Linux enforcement tests skip with a diagnostic when the probe fails; properly-equipped runners (GitHub Actions, dev workstations) still exercise the real path.

NullSandbox negative controls and the macOS counterparts are unchanged.

## Verified

- `cargo check -p lex-extension-host --tests` — passes
- `cargo test -p lex-extension-host --test sandbox_enforcement` on macOS — 4/4 pass (Linux tests are cfg-gated)
- `cargo fmt --check` — clean

The Linux runtime behavior will be validated on CI (which has landlock available) — both tests should run and pass exactly as before.

## Test plan

- [ ] CI green
- [ ] After merge, commit on a Claude Code on the web cloud session against this repo without `--no-verify` and confirm lefthook passes