### PR TITLE
babel: four interop fixes (#607 #608 #610 #611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed — four babel/CLI interop fixes ([#607](https://github.com/lex-fmt/lex/issues/607), [#608](https://github.com/lex-fmt/lex/issues/608), [#610](https://github.com/lex-fmt/lex/issues/610), [#611](https://github.com/lex-fmt/lex/issues/611))
+
+Four more user-visible converter fixes, continuing the interop work-stream.
+
+- **KaTeX CDN tags carry SRI hashes (#611).** The KaTeX 0.16.11 CSS, core JS, and auto-render JS tags emitted by the HTML serializer now include `integrity="sha384-…"` attributes; browsers reject any CDN payload whose hash doesn't match. Hashes were computed from the official release tarball at github.com/KaTeX/KaTeX/releases/tag/v0.16.11.
+- **`.lex-verbatim` paged-media break-rule modernized (#607).** Every other paged-media element in `@media print` already pairs the legacy `page-break-*` property with its modern `break-*` companion; `.lex-verbatim` only had the legacy form. Chromium's headless paged-media now treats `page-break-inside` as deprecated, so without the modern companion code blocks could split across PDF pages.
+- **Mojibake detection for `lexd convert` / `lexd format` (#608).** A new `lex-core::lex::mojibake::detect_mojibake` helper scans for the two-character signatures of a UTF-8 → cp1252 → UTF-8 round-trip (`Ã©`, `Ã¶`, `â€…`, etc.) and the CLI prints a one-shot stderr warning when ≥3 distinct patterns appear in the entry file or any `:: lex.include ::`-pulled file. The conversion still runs to completion — detection is informational. Suppress with the new `--no-warnings` global flag or `LEX_QUIET=1` env. Auto-correction is out of scope (re-encoding mojibake is lossy in edge cases).
+- **Redundant `<div class="lex-content">` wrapper dropped inside `<section>` (#610, option 1).** Extends the `<dd>`-specific narrow fix (#604) to its broader sibling case: the wrapper is also pure DOM bloat when the immediate parent is a `<section>` (the section IS the content area). Baseline CSS gains a direct-child `margin-left` rule on the section's content children (`p, .lex-list, .lex-verbatim, .lex-verbatim-subject, .lex-definition, .lex-table, blockquote, figure, section.lex-session`) that replaces the wrapper's old padding. `margin-left` (not padding-left) so boxed children like `.lex-verbatim` keep moving as a whole instead of just nudging their inner text. The further targets the issue lists (`<li>`, `<blockquote>` parents) are deferred for a follow-up; each needs its own CSS-compensation pass and snapshot review. Snapshots updated: kitchensink + three trifecta fixtures. No theme changes required (neither `theme-fancy-serif.css` nor `theme-modern.css` references `.lex-content` or `section.lex-session`).
+
 ### Changed — three babel interop fixes ([#604](https://github.com/lex-fmt/lex/issues/604), [#605](https://github.com/lex-fmt/lex/issues/605), [#606](https://github.com/lex-fmt/lex/issues/606))
 
 Three user-visible changes to the markdown / HTML converters, surfaced during the glossary-doc review (deferred from PR #609).

--- a/crates/lex-babel/css/baseline.css
+++ b/crates/lex-babel/css/baseline.css
@@ -98,6 +98,21 @@ section.lex-session:first-child {
   padding-left: var(--lex-indent-content);
 }
 
+/* #610 (option 1): the `<div class="lex-content">` wrapper is now
+ * suppressed when the immediate parent is a `<section>` (the section
+ * IS the semantic content area, so the wrapper was pure DOM bloat).
+ * Compensate by indenting the section's direct content children. */
+section.lex-session > p,
+section.lex-session > .lex-list,
+section.lex-session > .lex-verbatim,
+section.lex-session > .lex-definition,
+section.lex-session > .lex-table,
+section.lex-session > blockquote,
+section.lex-session > figure,
+section.lex-session > section.lex-session {
+  padding-left: var(--lex-indent-content);
+}
+
 /* Top-level sessions retain standard content padding */
 
 /* === Headings with Scaled Sizes === */

--- a/crates/lex-babel/css/baseline.css
+++ b/crates/lex-babel/css/baseline.css
@@ -101,16 +101,23 @@ section.lex-session:first-child {
 /* #610 (option 1): the `<div class="lex-content">` wrapper is now
  * suppressed when the immediate parent is a `<section>` (the section
  * IS the semantic content area, so the wrapper was pure DOM bloat).
- * Compensate by indenting the section's direct content children. */
+ * Compensate by offsetting the section's direct content children with
+ * `margin-left`. `padding-left` is wrong for elements that draw their
+ * own box (`.lex-verbatim` has a background + border) — padding would
+ * leave the box at the section edge and only push the inner text right.
+ * `margin-left` moves the entire box, matching what the wrapper used
+ * to do. The captions emitted before code blocks (`.lex-verbatim-subject`)
+ * are siblings of `.lex-verbatim` and need the same offset. */
 section.lex-session > p,
 section.lex-session > .lex-list,
 section.lex-session > .lex-verbatim,
+section.lex-session > .lex-verbatim-subject,
 section.lex-session > .lex-definition,
 section.lex-session > .lex-table,
 section.lex-session > blockquote,
 section.lex-session > figure,
 section.lex-session > section.lex-session {
-  padding-left: var(--lex-indent-content);
+  margin-left: var(--lex-indent-content);
 }
 
 /* Top-level sessions retain standard content padding */

--- a/crates/lex-babel/css/baseline.css
+++ b/crates/lex-babel/css/baseline.css
@@ -438,6 +438,7 @@ img {
 
   .lex-verbatim {
     border: var(--lex-border-thin) solid #ccc;
+    break-inside: avoid-page;
     page-break-inside: avoid;
   }
 

--- a/crates/lex-babel/src/formats/html/mod.rs
+++ b/crates/lex-babel/src/formats/html/mod.rs
@@ -308,7 +308,8 @@ mod tests {
         let verbatim_in_print = print_block
             .find(".lex-verbatim")
             .expect("@media print should style .lex-verbatim");
-        let snippet = &print_block[verbatim_in_print..(verbatim_in_print + 250).min(print_block.len())];
+        let snippet =
+            &print_block[verbatim_in_print..(verbatim_in_print + 250).min(print_block.len())];
         assert!(
             snippet.contains("break-inside: avoid"),
             "@media print .lex-verbatim should declare modern `break-inside: avoid[-page]`: {snippet}"

--- a/crates/lex-babel/src/formats/html/mod.rs
+++ b/crates/lex-babel/src/formats/html/mod.rs
@@ -288,6 +288,38 @@ mod tests {
     }
 
     #[test]
+    fn test_baseline_css_keeps_verbatim_blocks_unsplit() {
+        // Follow-up to #607: every other paged-media element pairs the
+        // legacy `page-break-*` property with its modern `break-*`
+        // companion so Chromium's headless paged-media (which now treats
+        // `page-break-inside` as deprecated) keeps honoring the rule.
+        // The `.lex-verbatim` class (emitted on every `<pre>` from a
+        // verbatim block) only had the legacy form, so code blocks could
+        // still split across pages.
+        let css = get_default_css();
+        // The paged-media `.lex-verbatim` rule lives inside the
+        // `@media print` block. Locate the print block, then assert
+        // both companion properties are present on `.lex-verbatim`
+        // within it.
+        let print_idx = css
+            .find("@media print")
+            .expect("baseline should declare an @media print block");
+        let print_block = &css[print_idx..];
+        let verbatim_in_print = print_block
+            .find(".lex-verbatim")
+            .expect("@media print should style .lex-verbatim");
+        let snippet = &print_block[verbatim_in_print..(verbatim_in_print + 250).min(print_block.len())];
+        assert!(
+            snippet.contains("break-inside: avoid"),
+            "@media print .lex-verbatim should declare modern `break-inside: avoid[-page]`: {snippet}"
+        );
+        assert!(
+            snippet.contains("page-break-inside: avoid"),
+            "@media print .lex-verbatim should retain legacy `page-break-inside: avoid`: {snippet}"
+        );
+    }
+
+    #[test]
     fn test_css_path_option_loads_file() {
         let mut temp = NamedTempFile::new().expect("failed to create temp file");
         writeln!(temp, ".from-path {{ color: blue; }}").expect("failed to write temp css");

--- a/crates/lex-babel/src/formats/html/serializer.rs
+++ b/crates/lex-babel/src/formats/html/serializer.rs
@@ -914,11 +914,14 @@ fn wrap_in_document(
     };
 
     // KaTeX is only included when the document contains math spans — saves
-    // ~290 KB on the wire for math-free documents.
+    // ~290 KB on the wire for math-free documents. SRI hashes are pinned to
+    // KaTeX 0.16.11; bumping the version requires re-computing them from the
+    // release tarball (github.com/KaTeX/KaTeX/releases) with
+    // `openssl dgst -sha384 -binary <file> | openssl base64 -A`.
     let katex_html = if has_math {
-        r#"  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous" onload="renderMathInElement(document.body, {delimiters: [{left: '$', right: '$', display: false}, {left: '$$', right: '$$', display: true}], throwOnError: false});"></script>
+        r#"  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous" onload="renderMathInElement(document.body, {delimiters: [{left: '$', right: '$', display: false}, {left: '$$', right: '$$', display: true}], throwOnError: false});"></script>
 "#
     } else {
         ""

--- a/crates/lex-babel/src/formats/html/serializer.rs
+++ b/crates/lex-babel/src/formats/html/serializer.rs
@@ -301,12 +301,23 @@ fn build_html_dom_with_splice(
 
             Event::StartContent => {
                 // Create content wrapper (mirrors AST container structure for indentation).
-                // Inside `<dd>` the wrapper is redundant — the dd is already the
-                // content container — so skip it (#604). Push the dd onto the
-                // stack so EndContent's pop is balanced and leaves current_parent
-                // pointing back at the dd.
+                //
+                // Inside a parent element that is ALREADY a semantic content
+                // area, the wrapper is pure DOM bloat — two stacked containers
+                // carrying the same "this is content" cue. Skip it for those
+                // parents and push the parent onto the stack so EndContent's
+                // pop is balanced and leaves current_parent pointing back at
+                // the same element.
+                //
+                // - `<dd>`      — #604: the dd is already the content holder
+                //                 for a definition body.
+                // - `<section>` — #610 (option 1): after a heading the section
+                //                 is the semantic content container; the
+                //                 wrapper is redundant.
                 current_heading = None;
-                if is_element_with_tag(&current_parent, "dd") {
+                let parent_is_content_area = is_element_with_tag(&current_parent, "dd")
+                    || is_element_with_tag(&current_parent, "section");
+                if parent_is_content_area {
                     parent_stack.push(current_parent.clone());
                 } else {
                     let content = create_element("div", vec![("class", "lex-content")]);

--- a/crates/lex-babel/src/formats/html/serializer.rs
+++ b/crates/lex-babel/src/formats/html/serializer.rs
@@ -946,13 +946,13 @@ fn wrap_in_document(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="lex-babel">
   <title>{escaped_head_title}</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous">
 {katex_html}  <style>
 {baseline_css}
 {theme_css}
 {custom_css}
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
   <script>hljs.highlightAll();</script>
 </head>
 <body>

--- a/crates/lex-babel/tests/html/export.rs
+++ b/crates/lex-babel/tests/html/export.rs
@@ -489,6 +489,31 @@ fn test_katex_injected_when_math_present() {
 }
 
 #[test]
+fn test_highlight_js_tags_have_sri_integrity_hashes() {
+    // Follow-up to #611 (Copilot review): every CDN-loaded third-party
+    // asset should carry an SRI hash, not just KaTeX. Hashes are for
+    // highlight.js 11.11.1 and were computed from the official cdn-release
+    // tarball at github.com/highlightjs/cdn-release/releases/tag/11.11.1.
+    let lex_src = "Plain document for the highlight.js tag check.\n";
+    let html = lex_to_html(lex_src, HtmlTheme::Modern);
+
+    // styles/github.min.css
+    assert!(
+        html.contains(
+            "integrity=\"sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L\""
+        ),
+        "highlight.js github.min.css must carry verified SRI hash: {html}"
+    );
+    // highlight.min.js
+    assert!(
+        html.contains(
+            "integrity=\"sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU\""
+        ),
+        "highlight.min.js must carry verified SRI hash: {html}"
+    );
+}
+
+#[test]
 fn test_katex_tags_have_sri_integrity_hashes() {
     // Regression test for #611: CDN-loaded KaTeX assets must carry
     // Subresource Integrity (SRI) hashes so a compromised CDN cannot

--- a/crates/lex-babel/tests/html/export.rs
+++ b/crates/lex-babel/tests/html/export.rs
@@ -599,6 +599,58 @@ fn test_non_definition_between_definitions_breaks_dl_grouping() {
 }
 
 #[test]
+fn test_section_body_emits_no_redundant_content_wrapper() {
+    // Regression test for #610 (option 1): after a heading, the
+    // semantic content area is the `<section>` element itself. Wrapping
+    // its body in a further `<div class="lex-content">` is DOM bloat —
+    // two stacked containers carrying the same "this is content" cue.
+    // The fix suppresses `StartContent` when the immediate parent is a
+    // `<section>`, mirroring the existing skip for `<dd>` (#604).
+    let lex_src = concat!(
+        "1. Primary Session\n\n",
+        "    A simple paragraph inside the session.\n",
+    );
+    let html = lex_to_html(lex_src, HtmlTheme::Modern);
+
+    assert!(
+        !html.contains("<section class=\"lex-session lex-session-2\"><h2>Primary Session</h2><div class=\"lex-content\">"),
+        "section body should not open with <div class=\"lex-content\">: {html}"
+    );
+    // The paragraph should be a direct child of the section.
+    assert!(
+        html.contains("</h2><p class=\"lex-paragraph\">A simple paragraph inside the session.</p>"),
+        "section body should emit <p> directly under the heading: {html}"
+    );
+}
+
+#[test]
+fn test_nested_sections_share_no_redundant_wrappers() {
+    // A nested-session document collapses two layers of wrappers — the
+    // outer section's body wrapper AND the inner section's body wrapper —
+    // both of which are redundant under #610.
+    let lex_src = concat!(
+        "1. Outer\n\n",
+        "    Outer paragraph.\n\n",
+        "    1.1. Inner\n\n",
+        "        Inner paragraph.\n",
+    );
+    let html = lex_to_html(lex_src, HtmlTheme::Modern);
+
+    // Zero `<div class="lex-content">` wrappers should appear in the
+    // rendered body: the body of every session is now the section
+    // element itself. We scope the match to the post-`<body>` segment
+    // so the literal CSS-comment string `<div class="lex-content">`
+    // embedded in baseline.css doesn't false-positive.
+    let body_start = html.find("<body>").expect("body tag present");
+    let body = &html[body_start..];
+    let wrapper_count = body.matches("<div class=\"lex-content\">").count();
+    assert_eq!(
+        wrapper_count, 0,
+        "expected zero .lex-content wrappers in nested sessions, got {wrapper_count}: {body}"
+    );
+}
+
+#[test]
 fn test_dd_body_emits_p_directly_without_content_wrapper() {
     // Regression test for #604: `<dd>` body used to wrap its content in
     // `<div class="lex-content"><p class="lex-paragraph">…</p></div>`. The

--- a/crates/lex-babel/tests/html/export.rs
+++ b/crates/lex-babel/tests/html/export.rs
@@ -489,6 +489,39 @@ fn test_katex_injected_when_math_present() {
 }
 
 #[test]
+fn test_katex_tags_have_sri_integrity_hashes() {
+    // Regression test for #611: CDN-loaded KaTeX assets must carry
+    // Subresource Integrity (SRI) hashes so a compromised CDN cannot
+    // substitute malicious bytes. Hashes are for KaTeX 0.16.11 and were
+    // computed from the actual release tarball at
+    // github.com/KaTeX/KaTeX/releases/tag/v0.16.11.
+    let lex_src = "1. Math\n\n    Inline: #\\log_2# present.\n";
+    let html = lex_to_html(lex_src, HtmlTheme::Modern);
+
+    // katex.min.css
+    assert!(
+        html.contains(
+            "integrity=\"sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+\""
+        ),
+        "katex.min.css must carry verified SRI hash: {html}"
+    );
+    // katex.min.js
+    assert!(
+        html.contains(
+            "integrity=\"sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg\""
+        ),
+        "katex.min.js must carry verified SRI hash: {html}"
+    );
+    // contrib/auto-render.min.js
+    assert!(
+        html.contains(
+            "integrity=\"sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk\""
+        ),
+        "auto-render.min.js must carry verified SRI hash: {html}"
+    );
+}
+
+#[test]
 fn test_katex_not_injected_when_no_math() {
     // Math-free documents shouldn't pay the KaTeX cost.
     let lex_src = "Just a paragraph with no math at all.\n";

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lex-babel/tests/html/export.rs
-assertion_line: 746
+assertion_line: 831
 expression: snapshot_without_styles(&html)
 ---
 <!DOCTYPE html>
@@ -21,20 +21,20 @@ expression: snapshot_without_styles(&html)
 <p class="lex-paragraph">This document includes <strong>all major features</strong> of the lex language to serve as a comprehensive "kitchensink" regression test for the parser, as noted in <a href="#ref-spec2025, pp. 45-46">@spec2025, pp. 45-46</a>. {{paragraph}}</p><p class="lex-paragraph">This is a two-lined paragraph.
 First, a simple <em>definition</em> at the root level. {{paragraph}}</p><dl class="lex-definition"><dt>Root Definition</dt><dd><p>This definition contains a paragraph and a <code>list</code> to test mixed content at the top level. {{definition}}</p><ul class="lex-list"><li class="lex-list-item">Item 1 in definition referencing <a href="TK-rootlist">TK-rootlist</a>. {{list-item}}
 </li><li class="lex-list-item">Item 2 in definition with note <a href="42">42</a>. {{list-item}}
-</li></ul></dd></dl><p class="lex-paragraph">This is a marker annotation at the root level, attached to the definition above.</p><section class="lex-session lex-session-2"><h2>1. Primary Session {{session}}</h2><div class="lex-content"><p class="lex-paragraph">This session acts as the main container for testing nested structures. It starts with a simple paragraph. {{paragraph}}</p><!-- lex:warning severity=high --><div class="lex-content"><p class="lex-paragraph"> This is a single-line annotation inside the session.</p></div><!-- /lex:warning --><ul class="lex-list"><li class="lex-list-item">Followed by a simple list. {{list-item}}
+</li></ul></dd></dl><p class="lex-paragraph">This is a marker annotation at the root level, attached to the definition above.</p><section class="lex-session lex-session-2"><h2>1. Primary Session {{session}}</h2><p class="lex-paragraph">This session acts as the main container for testing nested structures. It starts with a simple paragraph. {{paragraph}}</p><!-- lex:warning severity=high --><p class="lex-paragraph"> This is a single-line annotation inside the session.</p><!-- /lex:warning --><ul class="lex-list"><li class="lex-list-item">Followed by a simple list. {{list-item}}
 </li><li class="lex-list-item">This list has two items. {{list-item}}
-</li></ul><section class="lex-session lex-session-3"><h3>1.1. Nested Session (Level 2) {{session}}</h3><div class="lex-content"><p class="lex-paragraph">This is a second-level session containing a definition and a list with nested content. {{paragraph}}</p><dl class="lex-definition"><dt>Nested Definition</dt><dd><p>This definition is inside a nested session and contains a list. {{definition}}</p><ul class="lex-list"><li class="lex-list-item">List inside a nested definition. {{list-item}}
+</li></ul><section class="lex-session lex-session-3"><h3>1.1. Nested Session (Level 2) {{session}}</h3><p class="lex-paragraph">This is a second-level session containing a definition and a list with nested content. {{paragraph}}</p><dl class="lex-definition"><dt>Nested Definition</dt><dd><p>This definition is inside a nested session and contains a list. {{definition}}</p><ul class="lex-list"><li class="lex-list-item">List inside a nested definition. {{list-item}}
 </li><li class="lex-list-item">Second item. {{list-item}}
 </li></ul></dd></dl><ul class="lex-list"><li class="lex-list-item">A list item at level 2. {{list-item}}
 <div class="lex-content"><p class="lex-paragraph">This list item contains a nested paragraph. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">And a nested list (Level 3). {{list-item}}
 </li><li class="lex-list-item">With its own items. {{list-item}}
 </li></ul></div></li><li class="lex-list-item">Another list item at level 2. {{list-item}}
-</li></ul></div></section><p class="lex-paragraph">A paragraph back at the first level of nesting. {{paragraph}}</p><div class="lex-verbatim-subject">Code Example (Verbatim Block)</div><pre class="lex-verbatim" data-language="javascript"><code class="language-javascript">// This is a verbatim block with code.
+</li></ul></section><p class="lex-paragraph">A paragraph back at the first level of nesting. {{paragraph}}</p><div class="lex-verbatim-subject">Code Example (Verbatim Block)</div><pre class="lex-verbatim" data-language="javascript"><code class="language-javascript">// This is a verbatim block with code.
 function example() {
     return "lex";
-}</code></pre></div></section><section class="lex-session lex-session-2"><h2>2. Second Root Session {{session}}</h2><div class="lex-content"><p class="lex-paragraph">This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}</p><!-- lex:todo status="open" assignee="team" --><div class="lex-content"><p class="lex-paragraph">This is a block annotation. {{paragraph}}</p><p class="lex-paragraph">It contains a paragraph and a list. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Task 1 to complete. {{list-item}}
+}</code></pre></section><section class="lex-session lex-session-2"><h2>2. Second Root Session {{session}}</h2><p class="lex-paragraph">This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}</p><!-- lex:todo status="open" assignee="team" --><p class="lex-paragraph">This is a block annotation. {{paragraph}}</p><p class="lex-paragraph">It contains a paragraph and a list. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Task 1 to complete. {{list-item}}
 </li><li class="lex-list-item">Task 2 to complete. {{list-item}}
-</li></ul></div><!-- /lex:todo --><figure class="lex-image"><img src="&quot;logo.png&quot;" alt="&quot;Lex Logo&quot;" title="Image Reference (Marker Verbatim Block)"><figcaption>"Lex Logo"</figcaption></figure></div></section><p class="lex-paragraph">Final paragraph at the end of the document. {{paragraph}}</p>
+</li></ul><!-- /lex:todo --><figure class="lex-image"><img src="&quot;logo.png&quot;" alt="&quot;Lex Logo&quot;" title="Image Reference (Marker Verbatim Block)"><figcaption>"Lex Logo"</figcaption></figure></section><p class="lex-paragraph">Final paragraph at the end of the document. {{paragraph}}</p>
 </div>
 </body>
 </html>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lex-babel/tests/html/export.rs
-assertion_line: 831
+assertion_line: 856
 expression: snapshot_without_styles(&html)
 ---
 <!DOCTYPE html>
@@ -10,9 +10,9 @@ expression: snapshot_without_styles(&html)
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="lex-babel">
   <title>Kitchensink Test Document: A Comprehensive Regression Test {{paragraph}}</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous">
   <style data-lex-snapshot="removed"></style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
   <script>hljs.highlightAll();</script>
 </head>
 <body>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_010_paragraphs_sessions_flat_single.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_010_paragraphs_sessions_flat_single.snap
@@ -10,9 +10,9 @@ expression: snapshot_without_styles(&html)
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="lex-babel">
   <title>Paragraphs and Single Session Test {{paragraph}}</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous">
   <style data-lex-snapshot="removed"></style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
   <script>hljs.highlightAll();</script>
 </head>
 <body>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_010_paragraphs_sessions_flat_single.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_010_paragraphs_sessions_flat_single.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/lex-babel/tests/html/export.rs
+assertion_line: 359
 expression: snapshot_without_styles(&html)
 ---
 <!DOCTYPE html>
@@ -17,7 +18,7 @@ expression: snapshot_without_styles(&html)
 <body>
 <div class="lex-document">
 <header class="lex-doc-header"><h1 class="lex-doc-title">Paragraphs and Single Session Test {{paragraph}}</h1></header>
-<p class="lex-paragraph">This document tests the combination of paragraphs and a single session at the root level. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>1. Introduction {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">This is the content of the session. It contains a paragraph that is indented relative to the session title. {{paragraph}}</p><p class="lex-paragraph">The session can contain multiple paragraphs as long as they are properly indented. {{paragraph}}</p></div></section><p class="lex-paragraph">This paragraph comes after the session and is at the root level. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>Another Session {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">This session demonstrates that we can have multiple sessions at the same level. {{paragraph}}</p></div></section><p class="lex-paragraph">Final paragraph at the root level. {{paragraph}}</p>
+<p class="lex-paragraph">This document tests the combination of paragraphs and a single session at the root level. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>1. Introduction {{session-title}}</h2><p class="lex-paragraph">This is the content of the session. It contains a paragraph that is indented relative to the session title. {{paragraph}}</p><p class="lex-paragraph">The session can contain multiple paragraphs as long as they are properly indented. {{paragraph}}</p></section><p class="lex-paragraph">This paragraph comes after the session and is at the root level. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>Another Session {{session-title}}</h2><p class="lex-paragraph">This session demonstrates that we can have multiple sessions at the same level. {{paragraph}}</p></section><p class="lex-paragraph">Final paragraph at the root level. {{paragraph}}</p>
 </div>
 </body>
 </html>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_020_paragraphs_sessions_flat_multiple.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_020_paragraphs_sessions_flat_multiple.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/lex-babel/tests/html/export.rs
+assertion_line: 375
 expression: snapshot_without_styles(&html)
 ---
 <!DOCTYPE html>
@@ -17,7 +18,7 @@ expression: snapshot_without_styles(&html)
 <body>
 <div class="lex-document">
 <header class="lex-doc-header"><h1 class="lex-doc-title">Multiple Sessions Flat Test {{paragraph}}</h1></header>
-<p class="lex-paragraph">This document tests multiple sessions at the root level with paragraphs between them. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>1. First Session {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">This is the content of the first session. {{paragraph}}</p><p class="lex-paragraph">It can have multiple paragraphs. {{paragraph}}</p></div></section><section class="lex-session lex-session-2"><h2>2. Second Session {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">The second session also has content. {{paragraph}}</p></div></section><p class="lex-paragraph">A paragraph between sessions. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>3. Third Session {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">Sessions can have different amounts of content. {{paragraph}}</p></div></section><p class="lex-paragraph">Another paragraph. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>4. Session Without Numbering {{session-title}}</h2><div class="lex-content"><section class="lex-session lex-session-3"><h3>Session titles don't require numbering markers. {{session-title}}</h3><div class="lex-content"><p class="lex-paragraph">They just need to be followed by a blank line and indented content. {{paragraph}}</p></div></section></div></section><p class="lex-paragraph">Final paragraph at the root level. {{paragraph}}</p>
+<p class="lex-paragraph">This document tests multiple sessions at the root level with paragraphs between them. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>1. First Session {{session-title}}</h2><p class="lex-paragraph">This is the content of the first session. {{paragraph}}</p><p class="lex-paragraph">It can have multiple paragraphs. {{paragraph}}</p></section><section class="lex-session lex-session-2"><h2>2. Second Session {{session-title}}</h2><p class="lex-paragraph">The second session also has content. {{paragraph}}</p></section><p class="lex-paragraph">A paragraph between sessions. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>3. Third Session {{session-title}}</h2><p class="lex-paragraph">Sessions can have different amounts of content. {{paragraph}}</p></section><p class="lex-paragraph">Another paragraph. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>4. Session Without Numbering {{session-title}}</h2><section class="lex-session lex-session-3"><h3>Session titles don't require numbering markers. {{session-title}}</h3><p class="lex-paragraph">They just need to be followed by a blank line and indented content. {{paragraph}}</p></section></section><p class="lex-paragraph">Final paragraph at the root level. {{paragraph}}</p>
 </div>
 </body>
 </html>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_020_paragraphs_sessions_flat_multiple.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_020_paragraphs_sessions_flat_multiple.snap
@@ -10,9 +10,9 @@ expression: snapshot_without_styles(&html)
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="lex-babel">
   <title>Multiple Sessions Flat Test {{paragraph}}</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous">
   <style data-lex-snapshot="removed"></style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
   <script>hljs.highlightAll();</script>
 </head>
 <body>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_060_nesting.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_060_nesting.snap
@@ -10,9 +10,9 @@ expression: snapshot_without_styles(&html)
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="lex-babel">
   <title>Trifecta Nesting Test {{paragraph}}</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" integrity="sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L" crossorigin="anonymous">
   <style data-lex-snapshot="removed"></style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
   <script>hljs.highlightAll();</script>
 </head>
 <body>

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_060_nesting.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__trifecta_060_nesting.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/lex-babel/tests/html/export.rs
+assertion_line: 390
 expression: snapshot_without_styles(&html)
 ---
 <!DOCTYPE html>
@@ -17,25 +18,25 @@ expression: snapshot_without_styles(&html)
 <body>
 <div class="lex-document">
 <header class="lex-doc-header"><h1 class="lex-doc-title">Trifecta Nesting Test {{paragraph}}</h1></header>
-<p class="lex-paragraph">This document tests the combination of all three core elements (sessions, paragraphs, lists) with various levels of nesting. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>1. Root Session {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">This root session contains various nested elements. {{paragraph}}</p><section class="lex-session lex-session-3"><h3>1.1. Sub-session with Paragraph {{session-title}}</h3><div class="lex-content"><p class="lex-paragraph">This sub-session starts with a paragraph. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Then has a list {{list-item}}
+<p class="lex-paragraph">This document tests the combination of all three core elements (sessions, paragraphs, lists) with various levels of nesting. {{paragraph}}</p><section class="lex-session lex-session-2"><h2>1. Root Session {{session-title}}</h2><p class="lex-paragraph">This root session contains various nested elements. {{paragraph}}</p><section class="lex-session lex-session-3"><h3>1.1. Sub-session with Paragraph {{session-title}}</h3><p class="lex-paragraph">This sub-session starts with a paragraph. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Then has a list {{list-item}}
 </li><li class="lex-list-item">With multiple items {{list-item}}
-</li></ul></div></section><section class="lex-session lex-session-3"><h3>1.2. Sub-session with List {{session-title}}</h3><div class="lex-content"><ul class="lex-list"><li class="lex-list-item">Starts with a list {{list-item}}
+</li></ul></section><section class="lex-session lex-session-3"><h3>1.2. Sub-session with List {{session-title}}</h3><ul class="lex-list"><li class="lex-list-item">Starts with a list {{list-item}}
 </li><li class="lex-list-item">Has multiple items {{list-item}}
-</li></ul><p class="lex-paragraph">Then has a paragraph. {{paragraph}}</p><section class="lex-session lex-session-4"><h4>1.2.1. Deeply Nested Session {{session-title}}</h4><div class="lex-content"><p class="lex-paragraph">This is a deeply nested session. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">With its own list {{list-item}}
+</li></ul><p class="lex-paragraph">Then has a paragraph. {{paragraph}}</p><section class="lex-session lex-session-4"><h4>1.2.1. Deeply Nested Session {{session-title}}</h4><p class="lex-paragraph">This is a deeply nested session. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">With its own list {{list-item}}
 </li><li class="lex-list-item">And multiple items {{list-item}}
 </li></ul><ul class="lex-list"><li class="lex-list-item">Another list follows {{list-item}}
 </li><li class="lex-list-item">In the same session {{list-item}}
-</li></ul></div></section></div></section><p class="lex-paragraph">Back to the root session level. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Root session can also have lists {{list-item}}
+</li></ul></section></section><p class="lex-paragraph">Back to the root session level. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Root session can also have lists {{list-item}}
 </li><li class="lex-list-item">At its own level {{list-item}}
-</li></ul></div></section><section class="lex-session lex-session-2"><h2>2. Another Root Session {{session-title}}</h2><div class="lex-content"><p class="lex-paragraph">This session demonstrates different nesting patterns. {{paragraph}}</p><section class="lex-session lex-session-3"><h3>2.1. Mixed Content Sub-session {{session-title}}</h3><div class="lex-content"><ul class="lex-list"><li class="lex-list-item">Starts with list {{list-item}}
+</li></ul></section><section class="lex-session lex-session-2"><h2>2. Another Root Session {{session-title}}</h2><p class="lex-paragraph">This session demonstrates different nesting patterns. {{paragraph}}</p><section class="lex-session lex-session-3"><h3>2.1. Mixed Content Sub-session {{session-title}}</h3><ul class="lex-list"><li class="lex-list-item">Starts with list {{list-item}}
 </li><li class="lex-list-item">Multiple items {{list-item}}
 </li></ul><p class="lex-paragraph">Paragraph in the middle. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Ends with another list {{list-item}}
 </li><li class="lex-list-item">To complete the pattern {{list-item}}
-</li></ul><section class="lex-session lex-session-4"><h4>2.1.1. Even Deeper Nesting {{session-title}}</h4><div class="lex-content"><p class="lex-paragraph">The deepest level contains paragraphs and lists. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">First deep list {{list-item}}
+</li></ul><section class="lex-session lex-session-4"><h4>2.1.1. Even Deeper Nesting {{session-title}}</h4><p class="lex-paragraph">The deepest level contains paragraphs and lists. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">First deep list {{list-item}}
 </li><li class="lex-list-item">Second deep item {{list-item}}
 </li></ul><p class="lex-paragraph">Another paragraph at deep level. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Second deep list {{list-item}}
 </li><li class="lex-list-item">Completing the deep structure {{list-item}}
-</li></ul></div></section></div></section></div></section><p class="lex-paragraph">Final root level paragraph. {{paragraph}}</p>
+</li></ul></section></section></section><p class="lex-paragraph">Final root level paragraph. {{paragraph}}</p>
 </div>
 </body>
 </html>

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -35,6 +35,7 @@ use lex_config::{LexConfig, PdfPageSize, CONFIG_FILE_NAME};
 use lex_core::lex::ast::{find_node_path_at_position, Position};
 use lex_core::lex::builtins;
 use lex_core::lex::includes::{resolve_from_source, FsLoader, ResolveConfig};
+use lex_core::lex::mojibake::detect_mojibake;
 use lex_extension_host::registry::Registry;
 use std::collections::HashMap;
 use std::fs;
@@ -100,6 +101,13 @@ fn build_cli() -> Command {
                 .value_name("PATH")
                 .help("Resolution root for lex.include (default: nearest .lex.toml or entry-file directory)")
                 .value_hint(ValueHint::DirPath)
+                .global(true),
+        )
+        .arg(
+            Arg::new("no-warnings")
+                .long("no-warnings")
+                .help("Suppress non-fatal warnings on stderr (also: LEX_QUIET=1)")
+                .action(ArgAction::SetTrue)
                 .global(true),
         )
         .subcommand(
@@ -632,14 +640,16 @@ fn main() {
 
                     let output = sub_matches.get_one::<String>("output").map(|s| s.as_str());
                     let inc = IncludeOptions::for_expanding_command(&matches, &config);
-                    handle_convert_command(input, &from, to, output, &config, &inc);
+                    let warnings_on = warnings_enabled(&matches);
+                    handle_convert_command(input, &from, to, output, &config, &inc, warnings_on);
                 }
                 Some(("format", sub_matches)) => {
                     let input = sub_matches.get_one::<String>("input").map(|s| s.as_str());
                     // Format command always outputs to stdout (no -o flag) and
                     // never expands includes (per proposal §11.4).
                     let inc = IncludeOptions::for_format_command();
-                    handle_convert_command(input, "lex", "lex", None, &config, &inc);
+                    let warnings_on = warnings_enabled(&matches);
+                    handle_convert_command(input, "lex", "lex", None, &config, &inc, warnings_on);
                 }
                 Some(("element-at", sub_matches)) => {
                     let path = sub_matches
@@ -1212,6 +1222,19 @@ fn expand_includes_to_source(source: &str, entry_path: &str, inc: &IncludeOption
 }
 
 /// Handle the convert command
+/// Returns true when CLI warnings should be printed to stderr. Off when
+/// either `--no-warnings` was passed or `LEX_QUIET` is set to a
+/// non-empty, non-zero value.
+fn warnings_enabled(matches: &ArgMatches) -> bool {
+    if matches.get_flag("no-warnings") {
+        return false;
+    }
+    match std::env::var("LEX_QUIET") {
+        Ok(v) if !v.is_empty() && v != "0" => false,
+        _ => true,
+    }
+}
+
 fn handle_convert_command(
     input: Option<&str>,
     from: &str,
@@ -1219,6 +1242,7 @@ fn handle_convert_command(
     output: Option<&str>,
     config: &LexConfig,
     inc: &IncludeOptions,
+    warnings_on: bool,
 ) {
     let registry = FormatRegistry::default();
 
@@ -1233,6 +1257,17 @@ fn handle_convert_command(
     }
 
     let source = read_source(input);
+
+    if warnings_on && detect_mojibake(&source).is_some() {
+        // Detection-only — never blocks the conversion. The user fixes
+        // it at the source by re-saving from a clean UTF-8 editor.
+        let label = input.unwrap_or("<stdin>");
+        eprintln!(
+            "warning: {label} appears to be UTF-8-double-encoded.\n  \
+             em-dashes, accented letters, and curly quotes may be corrupted.\n  \
+             consider re-saving the file in UTF-8 from a clean source."
+        );
+    }
 
     // Parse — for lex input with includes enabled and a real input
     // path, route through the include resolver so the merged tree is

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -34,7 +34,9 @@ use lex_babel::{
 use lex_config::{LexConfig, PdfPageSize, CONFIG_FILE_NAME};
 use lex_core::lex::ast::{find_node_path_at_position, Position};
 use lex_core::lex::builtins;
-use lex_core::lex::includes::{resolve_from_source, FsLoader, ResolveConfig};
+use lex_core::lex::includes::{
+    resolve_from_source, FsLoader, LoadError, LoadedFile, Loader, ResolveConfig,
+};
 use lex_core::lex::mojibake::detect_mojibake;
 use lex_extension_host::registry::Registry;
 use std::collections::HashMap;
@@ -1222,6 +1224,42 @@ fn expand_includes_to_source(source: &str, entry_path: &str, inc: &IncludeOption
 }
 
 /// Handle the convert command
+/// Loader decorator that records the canonical path of any file whose
+/// source text trips the mojibake detector, then delegates to the
+/// inner loader unchanged. The CLI uses this to surface a per-file
+/// warning for content pulled in by `:: lex.include ::` — content the
+/// entry-source mojibake scan can't see on its own.
+struct MojibakeScanningLoader<L: Loader> {
+    inner: L,
+    scan_enabled: bool,
+    findings: Arc<std::sync::Mutex<Vec<PathBuf>>>,
+}
+
+impl<L: Loader> MojibakeScanningLoader<L> {
+    fn new(inner: L, scan_enabled: bool) -> Self {
+        Self {
+            inner,
+            scan_enabled,
+            findings: Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+
+    fn findings(&self) -> Arc<std::sync::Mutex<Vec<PathBuf>>> {
+        Arc::clone(&self.findings)
+    }
+}
+
+impl<L: Loader> Loader for MojibakeScanningLoader<L> {
+    fn load(&self, path: &Path) -> Result<LoadedFile, LoadError> {
+        let loaded = self.inner.load(path)?;
+        if self.scan_enabled && detect_mojibake(&loaded.source).is_some() {
+            let mut findings = self.findings.lock().expect("findings mutex");
+            findings.push(loaded.canonical_path.clone());
+        }
+        Ok(loaded)
+    }
+}
+
 /// Returns true when CLI warnings should be printed to stderr. Off when
 /// either `--no-warnings` was passed or `LEX_QUIET` is set to a
 /// non-empty, non-zero value.
@@ -1229,10 +1267,7 @@ fn warnings_enabled(matches: &ArgMatches) -> bool {
     if matches.get_flag("no-warnings") {
         return false;
     }
-    match std::env::var("LEX_QUIET") {
-        Ok(v) if !v.is_empty() && v != "0" => false,
-        _ => true,
-    }
+    !matches!(std::env::var("LEX_QUIET"), Ok(v) if !v.is_empty() && v != "0")
 }
 
 fn handle_convert_command(
@@ -1283,17 +1318,37 @@ fn handle_convert_command(
             max_depth: inc.max_depth,
             max_total_includes: inc.max_total_includes,
         };
-        let loader = FsLoader::new(root).with_max_file_size(inc.max_file_size);
+        let inner_loader = FsLoader::new(root).with_max_file_size(inc.max_file_size);
+        // Wrap the loader so each included file is scanned for mojibake
+        // too — the entry-source scan above doesn't see content pulled
+        // in by `:: lex.include ::`, so without this an included file
+        // could silently propagate corrupted bytes through the
+        // converter.
+        let scanning_loader = MojibakeScanningLoader::new(inner_loader, warnings_on);
+        let mojibake_paths = scanning_loader.findings();
         let registry = Registry::new();
-        builtins::register_into(&registry, Arc::new(loader), resolve_config.clone())
+        builtins::register_into(&registry, Arc::new(scanning_loader), resolve_config.clone())
             .unwrap_or_else(|e| {
                 eprintln!("Failed to register lex.* built-ins: {e}");
                 std::process::exit(1);
             });
-        resolve_from_source(&source, Some(entry), &resolve_config, &registry).unwrap_or_else(|e| {
-            eprintln!("Include resolution error: {e}");
-            std::process::exit(1);
-        })
+        let resolved = resolve_from_source(&source, Some(entry), &resolve_config, &registry)
+            .unwrap_or_else(|e| {
+                eprintln!("Include resolution error: {e}");
+                std::process::exit(1);
+            });
+        if warnings_on {
+            let paths = mojibake_paths.lock().expect("loader findings mutex");
+            for path in paths.iter() {
+                eprintln!(
+                    "warning: {} appears to be UTF-8-double-encoded.\n  \
+                     em-dashes, accented letters, and curly quotes may be corrupted.\n  \
+                     consider re-saving the file in UTF-8 from a clean source.",
+                    path.display()
+                );
+            }
+        }
+        resolved
     } else {
         registry.parse(&source, from).unwrap_or_else(|e| {
             eprintln!("Parse error: {e}");

--- a/crates/lex-cli/tests/integration/main.rs
+++ b/crates/lex-cli/tests/integration/main.rs
@@ -5,6 +5,7 @@ mod format_config;
 mod includes;
 mod labels;
 mod markdown_import;
+mod mojibake;
 mod nodemap;
 mod pdf;
 mod stdin_input;

--- a/crates/lex-cli/tests/integration/mojibake.rs
+++ b/crates/lex-cli/tests/integration/mojibake.rs
@@ -11,8 +11,7 @@ use predicates::prelude::*;
 
 /// A small lex paragraph with multiple cp1252 → UTF-8 mojibake glyphs,
 /// enough to clear the ≥3-distinct-pattern threshold.
-const MOJIBAKE_LEX: &str =
-    "RÃ©sumÃ© of the MÃ¶bius cafÃ©: Ã¼nique Ã±otes â€\u{201D} indeed.\n";
+const MOJIBAKE_LEX: &str = "RÃ©sumÃ© of the MÃ¶bius cafÃ©: Ã¼nique Ã±otes â€\u{201D} indeed.\n";
 
 const CLEAN_LEX: &str = "A perfectly clean paragraph with no mojibake.\n";
 
@@ -26,11 +25,9 @@ fn convert_warns_on_mojibake_input() {
         .arg("markdown")
         .write_stdin(MOJIBAKE_LEX);
 
-    cmd.assert()
-        .success()
-        .stderr(predicate::str::contains(
-            "appears to be UTF-8-double-encoded",
-        ));
+    cmd.assert().success().stderr(predicate::str::contains(
+        "appears to be UTF-8-double-encoded",
+    ));
 }
 
 #[test]
@@ -85,9 +82,7 @@ fn format_warns_on_mojibake_input() {
     let mut cmd = cargo_bin_cmd!("lexd");
     cmd.arg("format").write_stdin(MOJIBAKE_LEX);
 
-    cmd.assert()
-        .success()
-        .stderr(predicate::str::contains(
-            "appears to be UTF-8-double-encoded",
-        ));
+    cmd.assert().success().stderr(predicate::str::contains(
+        "appears to be UTF-8-double-encoded",
+    ));
 }

--- a/crates/lex-cli/tests/integration/mojibake.rs
+++ b/crates/lex-cli/tests/integration/mojibake.rs
@@ -1,0 +1,93 @@
+//! CLI integration tests for the mojibake-detection warning (#608).
+//!
+//! `lexd convert` and `lexd format` scan their input for UTF-8
+//! double-encoding signatures and print a single warning to stderr when
+//! the input looks corrupted. The warning is informational — it never
+//! blocks the conversion, and `--no-warnings` or `LEX_QUIET=1` suppresses
+//! it.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+/// A small lex paragraph with multiple cp1252 → UTF-8 mojibake glyphs,
+/// enough to clear the ≥3-distinct-pattern threshold.
+const MOJIBAKE_LEX: &str =
+    "RÃ©sumÃ© of the MÃ¶bius cafÃ©: Ã¼nique Ã±otes â€\u{201D} indeed.\n";
+
+const CLEAN_LEX: &str = "A perfectly clean paragraph with no mojibake.\n";
+
+#[test]
+fn convert_warns_on_mojibake_input() {
+    let mut cmd = cargo_bin_cmd!("lexd");
+    cmd.arg("convert")
+        .arg("--from")
+        .arg("lex")
+        .arg("--to")
+        .arg("markdown")
+        .write_stdin(MOJIBAKE_LEX);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "appears to be UTF-8-double-encoded",
+        ));
+}
+
+#[test]
+fn convert_stays_silent_on_clean_input() {
+    let mut cmd = cargo_bin_cmd!("lexd");
+    cmd.arg("convert")
+        .arg("--from")
+        .arg("lex")
+        .arg("--to")
+        .arg("markdown")
+        .write_stdin(CLEAN_LEX);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("UTF-8-double-encoded").not());
+}
+
+#[test]
+fn no_warnings_flag_suppresses_mojibake_warning() {
+    let mut cmd = cargo_bin_cmd!("lexd");
+    cmd.arg("--no-warnings")
+        .arg("convert")
+        .arg("--from")
+        .arg("lex")
+        .arg("--to")
+        .arg("markdown")
+        .write_stdin(MOJIBAKE_LEX);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("UTF-8-double-encoded").not());
+}
+
+#[test]
+fn lex_quiet_env_suppresses_mojibake_warning() {
+    let mut cmd = cargo_bin_cmd!("lexd");
+    cmd.env("LEX_QUIET", "1")
+        .arg("convert")
+        .arg("--from")
+        .arg("lex")
+        .arg("--to")
+        .arg("markdown")
+        .write_stdin(MOJIBAKE_LEX);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("UTF-8-double-encoded").not());
+}
+
+#[test]
+fn format_warns_on_mojibake_input() {
+    let mut cmd = cargo_bin_cmd!("lexd");
+    cmd.arg("format").write_stdin(MOJIBAKE_LEX);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "appears to be UTF-8-double-encoded",
+        ));
+}

--- a/crates/lex-core/src/lex.rs
+++ b/crates/lex-core/src/lex.rs
@@ -77,6 +77,7 @@ pub mod inlines;
 pub mod lexing;
 pub mod loader;
 pub mod migrate;
+pub mod mojibake;
 pub mod parsing;
 pub mod testing;
 pub mod token;

--- a/crates/lex-core/src/lex/mojibake.rs
+++ b/crates/lex-core/src/lex/mojibake.rs
@@ -34,7 +34,7 @@ const PATTERNS: &[&str] = &[
     "Ã²", "Ã³", "Ã´", "Ã¶", // o-family
     "Ã¹", "Ãº", "Ã»", "Ã¼", // u-family
     "Ã±", "Ã§", // tilde n, c-cedilla
-    "ÃŸ",  // sharp s
+    "ÃŸ", // sharp s
     // Smart-punctuation double-encodings all start with `â€`
     // (mojibake of the `\xE2\x80` Unicode-punctuation block prefix).
     // The trailing byte distinguishes em-dash / en-dash / curly quotes;
@@ -49,10 +49,7 @@ const PATTERNS: &[&str] = &[
 /// contains an isolated `â` or `Ã` (e.g. a Spanish or French word) does
 /// not trigger a warning.
 pub fn detect_mojibake(input: &str) -> Option<MojibakeReport> {
-    let distinct = PATTERNS
-        .iter()
-        .filter(|pat| input.contains(*pat))
-        .count();
+    let distinct = PATTERNS.iter().filter(|pat| input.contains(*pat)).count();
     if distinct >= 3 {
         Some(MojibakeReport {
             distinct_patterns: distinct,

--- a/crates/lex-core/src/lex/mojibake.rs
+++ b/crates/lex-core/src/lex/mojibake.rs
@@ -1,0 +1,118 @@
+//! Detect UTF-8 double-encoding (mojibake) in source text.
+//!
+//! When a UTF-8 file is misread as cp1252 (or similar) and then re-encoded
+//! back to UTF-8, characters acquire a telltale two-character signature
+//! such as `Ã©` (for `é`), `Ã¶` (for `ö`), or `â€"` (for em-dash).
+//! Converters pass these through verbatim, so the broken bytes appear in
+//! markdown / HTML / PDF outputs and surprise the author downstream.
+//!
+//! The check is intentionally cheap (substring scan) and high-signal:
+//! every pattern listed below is essentially never produced by legitimate
+//! UTF-8 text, but to keep the false-positive rate near zero on text that
+//! happens to contain `â` or `Ã` in isolation, [`detect_mojibake`] only
+//! returns `Some` when at least three distinct patterns appear in the
+//! input.
+
+/// Summary of mojibake patterns observed in a single input string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MojibakeReport {
+    /// How many distinct mojibake patterns were hit (a single pattern
+    /// can occur many times in one file; we count each pattern once).
+    pub distinct_patterns: usize,
+}
+
+/// Two-character signatures of UTF-8 → cp1252 → UTF-8 round-trips. Each
+/// is rare-to-impossible in legitimate UTF-8 prose, but trivially common
+/// in mojibaked output.
+const PATTERNS: &[&str] = &[
+    // Latin-1 letters double-encoded: original UTF-8 byte pair (e.g.
+    // `\xC3\xA9` for `é`) is read as two cp1252 chars (`Ã` + `©`) which
+    // then re-encode to a 4-byte UTF-8 sequence displaying as `Ã©`.
+    "Ã©", "Ã¨", "Ãª", "Ã«", // e-family
+    "Ã ", "Ã¡", "Ã¢", "Ã£", "Ã¤", "Ã¥", // a-family
+    "Ã¬", "Ã­", "Ã®", "Ã¯", // i-family
+    "Ã²", "Ã³", "Ã´", "Ã¶", // o-family
+    "Ã¹", "Ãº", "Ã»", "Ã¼", // u-family
+    "Ã±", "Ã§", // tilde n, c-cedilla
+    "ÃŸ",  // sharp s
+    // Smart-punctuation double-encodings all start with `â€`
+    // (mojibake of the `\xE2\x80` Unicode-punctuation block prefix).
+    // The trailing byte distinguishes em-dash / en-dash / curly quotes;
+    // any `â€` is a near-certain mojibake signal on its own.
+    "â€",
+];
+
+/// Scan `input` for mojibake patterns. Returns `Some` with a report when
+/// at least three distinct patterns are present; otherwise `None`.
+///
+/// Single-pattern hits are deliberately silent so legitimate text that
+/// contains an isolated `â` or `Ã` (e.g. a Spanish or French word) does
+/// not trigger a warning.
+pub fn detect_mojibake(input: &str) -> Option<MojibakeReport> {
+    let distinct = PATTERNS
+        .iter()
+        .filter(|pat| input.contains(*pat))
+        .count();
+    if distinct >= 3 {
+        Some(MojibakeReport {
+            distinct_patterns: distinct,
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_classic_double_encoded_paragraph() {
+        // A paragraph containing several mojibaked words. Should fire.
+        // The em-dash mojibake `â€\u{201D}` ends in a curly quote, not
+        // the ASCII string-terminator quote — explicit escape avoids
+        // confusing Rust's lexer.
+        let input = "RÃ©sumÃ© of MÃ¶bius strip: a cafÃ© favourite. â€\u{201D} indeed.";
+        let report = detect_mojibake(input).expect("clear mojibake should report");
+        assert!(
+            report.distinct_patterns >= 3,
+            "expected ≥3 distinct patterns, got {}",
+            report.distinct_patterns
+        );
+    }
+
+    #[test]
+    fn ignores_legitimate_text_with_isolated_accents() {
+        // Spanish / French prose containing real `â`, `Ã` etc. should
+        // NOT trigger. Single isolated occurrences stay below the
+        // threshold.
+        let input = "El niño visitó la ciudad. Le maître prépare le dîner.";
+        assert_eq!(detect_mojibake(input), None);
+    }
+
+    #[test]
+    fn ignores_pure_ascii() {
+        let input = "Just plain ASCII text with no special characters.\n";
+        assert_eq!(detect_mojibake(input), None);
+    }
+
+    #[test]
+    fn ignores_single_pattern_hit() {
+        // A single mojibake occurrence — could equally be an unrelated
+        // accented word — stays under the threshold.
+        let input = "An odd Ã© occurrence, nothing else.";
+        assert_eq!(detect_mojibake(input), None);
+    }
+
+    #[test]
+    fn flags_smart_quote_em_dash_storm() {
+        // Curly-quote / em-dash mojibake clusters around `â€` patterns.
+        // All cp1252-byte trailers (em-dash, right-quote, left-quote)
+        // reduce to the same `â€` prefix, so we add Latin-letter hits
+        // (`Ã©`, `Ã¶`, `Ã±`) to clear the three-distinct threshold.
+        let input = "He said â€\u{201C}helloâ€\u{201D}, then â€\u{201D} she replied. \
+                     CafÃ© Ã¶pen Ã± kids.";
+        let report = detect_mojibake(input).expect("should detect");
+        assert!(report.distinct_patterns >= 3);
+    }
+}

--- a/crates/lex-core/src/lex/mojibake.rs
+++ b/crates/lex-core/src/lex/mojibake.rs
@@ -28,13 +28,27 @@ const PATTERNS: &[&str] = &[
     // Latin-1 letters double-encoded: original UTF-8 byte pair (e.g.
     // `\xC3\xA9` for `é`) is read as two cp1252 chars (`Ã` + `©`) which
     // then re-encode to a 4-byte UTF-8 sequence displaying as `Ã©`.
+    // Lowercase Latin-1 letters double-encoded.
     "Ã©", "Ã¨", "Ãª", "Ã«", // e-family
-    "Ã ", "Ã¡", "Ã¢", "Ã£", "Ã¤", "Ã¥", // a-family
-    "Ã¬", "Ã­", "Ã®", "Ã¯", // i-family
+    // `Ã\u{A0}` is `Ã` + U+00A0 NBSP (the cp1252 mapping of byte 0xA0)
+    // and is the mojibake of `à` — not `Ã` + ASCII space, which is
+    // common in legitimate prose and would false-positive.
+    "Ã\u{A0}", "Ã¡", "Ã¢", "Ã£", "Ã¤", "Ã¥", // a-family
+    "Ã¬", "Ã\u{AD}", "Ã®",
+    "Ã¯", // i-family (`Ã\u{AD}` is `Ã` + U+00AD soft hyphen — escaped so clippy's invisible-character lint stays clean)
     "Ã²", "Ã³", "Ã´", "Ã¶", // o-family
     "Ã¹", "Ãº", "Ã»", "Ã¼", // u-family
     "Ã±", "Ã§", // tilde n, c-cedilla
     "ÃŸ", // sharp s
+    // Uppercase Latin-1 letters — common in titles, headings, and
+    // formal-document prose. Mojibake byte for `À` (U+00C0) is
+    // `\xC3\x80` → cp1252 `Ã€` (`Ã` + `€`). For `É` (U+00C9) → `Ã‰`
+    // (`Ã` + `‰`), and so on.
+    "Ã€", "Ã\u{81}", "Ã‚", "Ãƒ", "Ã„", "Ã…", // A-family (Á has U+0081)
+    "Ã‰", "ÃŠ", "Ã‹", // E-family (È encodes as `Ã\u{88}`, skipped to avoid invisible)
+    "Ã‘", // Ñ
+    "Ã“", "Ã”", "Ã–", // O-family
+    "Ãš", "Ã›", "Ãœ", // U-family
     // Smart-punctuation double-encodings all start with `â€`
     // (mojibake of the `\xE2\x80` Unicode-punctuation block prefix).
     // The trailing byte distinguishes em-dash / en-dash / curly quotes;


### PR DESCRIPTION
Four independent interop fixes, one commit per issue. Each one is red-green-commit.

## #611 — KaTeX CDN tags get SRI integrity hashes
Embeds `integrity="sha384-…"` on the three KaTeX 0.16.11 tags (CSS, core JS, auto-render JS). Browser rejects any CDN payload whose sha384 differs from the embedded hash. Hashes computed from the official release tarball at github.com/KaTeX/KaTeX/releases/tag/v0.16.11.

- `crates/lex-babel/src/formats/html/serializer.rs` — three `integrity=…` attrs
- `crates/lex-babel/tests/html/export.rs::test_katex_tags_have_sri_integrity_hashes` — verifies each hash

## #607 — paged-media `.lex-verbatim` pairs modern + legacy break-inside
Follow-up to the print-CSS work in `3d62044`. Every other paged-media element pairs the legacy `page-break-*` property with its modern `break-*` companion so Chromium's headless paged-media (which now treats `page-break-inside` as deprecated) keeps honoring the rule. The `.lex-verbatim` class — emitted on every `<pre>` from a verbatim block — only had the legacy form, so code blocks could still split across pages.

- `crates/lex-babel/css/baseline.css` — `.lex-verbatim { break-inside: avoid-page; page-break-inside: avoid; }`
- `crates/lex-babel/src/formats/html/mod.rs::test_baseline_css_keeps_verbatim_blocks_unsplit` — asserts both companion properties

## #608 — mojibake (UTF-8 double-encoding) detection on convert/format
`lexd convert` and `lexd format` scan their input for the two-character signatures of a UTF-8 → cp1252 → UTF-8 round-trip (`Ã©`, `Ã¶`, `â€…`, etc.) and print a one-shot warning to stderr when ≥3 distinct patterns appear. The conversion still runs to completion; detection is informational so authors can fix the file at the source rather than ship the corrupted bytes downstream into markdown / HTML / PDF outputs.

- `crates/lex-core/src/lex/mojibake.rs` — `detect_mojibake(input: &str) -> Option<MojibakeReport>`
- `crates/lex-cli/src/main.rs` — `--no-warnings` global flag, `LEX_QUIET=1` env, and the warning emitted in `handle_convert_command`
- `crates/lex-cli/tests/integration/mojibake.rs` — convert + format warn paths, both opt-outs, and the clean-input negative case
- Threshold of ≥3 distinct patterns keeps the false-positive rate near zero on legitimate prose containing isolated `Ã` or `â`. Auto-correction is out of scope — re-encoding mojibake is lossy in edge cases.

## #610 — drop the redundant `<div class="lex-content">` wrapper inside `<section>`
**Design choice: option 1 (list-based opt-out).** Suppress the `Event::StartContent` wrapper when the immediate parent is already a semantic content area. This narrows the redundancy without forcing a full CSS migration off the wrapper, and follows the same pattern shipped for `<dd>` in #604.

**Scoped to `<section>` for this PR** — the dominant case (every heading opens a section whose body was double-wrapped). The further targets listed in the issue (`<li>`, `<blockquote>`) are intentionally deferred: each needs its own CSS-compensation pass and snapshot review.

- `crates/lex-babel/src/formats/html/serializer.rs` — `parent_is_content_area` check covers both `dd` and `section`
- `crates/lex-babel/css/baseline.css` — direct-child padding-left rule replaces the wrapper's `padding-left: var(--lex-indent-content)`. Selector list: `section.lex-session > p, > .lex-list, > .lex-verbatim, > .lex-definition, > .lex-table, > blockquote, > figure, > section.lex-session`. Nested sessions stay visually identical.
- `crates/lex-babel/tests/html/export.rs::test_section_body_emits_no_redundant_content_wrapper` + `test_nested_sections_share_no_redundant_wrappers`
- Snapshots updated: kitchensink + three trifecta fixtures. No theme changes required (neither `theme-fancy-serif.css` nor `theme-modern.css` references `.lex-content` or `section.lex-session`).

## Verification
- `cargo test -p lex-babel` → 149 passed
- `cargo test -p lex-core --lib mojibake` → 5 passed
- `cargo test -p lexd --test integration mojibake` → 5 passed

https://claude.ai/code/session_012V9wacQnDditEGVUaKXdJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012V9wacQnDditEGVUaKXdJw)_