### PR TITLE
test(sandbox): probe landlock enforcement, not just ruleset create

### DIFF
--- a/crates/lex-extension-host/tests/sandbox_enforcement.rs
+++ b/crates/lex-extension-host/tests/sandbox_enforcement.rs
@@ -91,14 +91,21 @@ fn landlock_available() -> bool {
     // probe tests below, but on a trivial binary. If `spawn()`
     // succeeds the kernel enforces landlock; if it fails the probe
     // tests can't meaningfully run and should skip.
-    let mut cmd = std::process::Command::new("/bin/true");
-    if LinuxSandbox
-        .apply_to(&mut cmd, Capabilities::default())
-        .is_err()
-    {
-        return false;
-    }
-    cmd.status().is_ok()
+    //
+    // Cache via OnceLock: every test in this module calls this, the
+    // answer is deterministic per process, and a /bin/true spawn per
+    // call is gratuitous.
+    static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        let mut cmd = std::process::Command::new("/bin/true");
+        if LinuxSandbox
+            .apply_to(&mut cmd, Capabilities::default())
+            .is_err()
+        {
+            return false;
+        }
+        cmd.status().is_ok()
+    })
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/lex-extension-host/tests/sandbox_enforcement.rs
+++ b/crates/lex-extension-host/tests/sandbox_enforcement.rs
@@ -77,16 +77,28 @@ fn net_probe_succeeds_under_null_sandbox() {
 
 #[cfg(target_os = "linux")]
 fn landlock_available() -> bool {
-    // `Access` trait must be in scope for `AccessFs::from_all`.
-    use landlock::{Access, AccessFs, Ruleset, RulesetAttr, ABI};
-    // Probe by creating an unbound ruleset. Doesn't call
-    // `restrict_self` so the test process is unaffected. Failure here
-    // means the kernel doesn't support landlock.
-    let abi = ABI::V1;
-    Ruleset::default()
-        .handle_access(AccessFs::from_all(abi))
-        .and_then(|r| r.create())
-        .is_ok()
+    // Probe whether the kernel actually *enforces* landlock, not just
+    // whether a ruleset can be constructed. In some container envs
+    // (notably Claude Code on the web) `Ruleset::create()` returns Ok
+    // but the subsequent `restrict_self()` returns
+    // `RulesetStatus::NotEnforced`, and `LinuxSandbox`'s `pre_exec`
+    // treats that as fail-closed — `spawn()` then errors with `EINVAL`.
+    //
+    // We can't call `restrict_self()` directly in the test runner:
+    // it's irreversible and would lock the runner out of every later
+    // test. Instead, drive the real `LinuxSandbox` apply path against
+    // `/bin/true` — that exercises the same kernel codepath as the
+    // probe tests below, but on a trivial binary. If `spawn()`
+    // succeeds the kernel enforces landlock; if it fails the probe
+    // tests can't meaningfully run and should skip.
+    let mut cmd = std::process::Command::new("/bin/true");
+    if LinuxSandbox
+        .apply_to(&mut cmd, Capabilities::default())
+        .is_err()
+    {
+        return false;
+    }
+    cmd.status().is_ok()
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Extracted from #629. Standalone test-infrastructure fix: \`landlock_available()\` previously short-circuited on \`Ruleset::create()\` succeeding, but some container envs (Claude Code Cloud is the recurring case) allow ruleset creation while \`restrict_self()\` returns \`RulesetStatus::NotEnforced\`. The probe tests' \`spawn()\` then errors with \`EINVAL\` instead of cleanly skipping.

Fix: drive the real \`LinuxSandbox::apply_to\` path against \`/bin/true\` so detection exercises the same kernel codepath as the probe tests. Spawn ok ⇒ Landlock is enforced; spawn err ⇒ skip.

## Why this is split out

\`#629\` mixed this fix with edits to \`scripts/setup-dev-env.sh\`. The dev-env half is being subsumed by the cross-repo setup-dev-env.sh consolidation in \`arthur-debert/release\` (and a separate PR to update \`#629\` to the canonical template). This PR carries only the test-infrastructure fix so it can land as a regular bug fix.

## Test plan

- [ ] CI's existing sandbox-enforcement tests pass
- [ ] The probe correctly skips on cloud envs where Landlock is non-enforced (manually verified by running the test under Claude Code Cloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)