### PR TITLE
fix(dev-env): install cargo-nextest in cloud sessions

### DIFF
--- a/crates/lex-core/src/lex/parsing/analysis_test.rs
+++ b/crates/lex-core/src/lex/parsing/analysis_test.rs
@@ -1,12 +1,11 @@
-
 #[cfg(test)]
 mod analysis_tests {
     use crate::lex::parsing::ir::NodeType;
     use crate::lex::parsing::parser::parse_with_declarative_grammar;
     use crate::lex::token::line::LineToken;
+    use crate::lex::token::LineContainer;
     use crate::lex::token::LineType;
     use crate::lex::token::Token;
-    use crate::lex::token::LineContainer;
 
     fn make_line(text: &str, line_type: LineType) -> LineContainer {
         LineContainer::Token(LineToken {
@@ -40,10 +39,16 @@ mod analysis_tests {
             make_blank(),
             make_line("Content", LineType::ParagraphLine),
         ];
-        
+
         let nodes_flat = parse_with_declarative_grammar(tokens_flat, "source").unwrap();
-        println!("Flat nodes: {:?}", nodes_flat.iter().map(|n| n.node_type.clone()).collect::<Vec<_>>());
-        
+        println!(
+            "Flat nodes: {:?}",
+            nodes_flat
+                .iter()
+                .map(|n| n.node_type.clone())
+                .collect::<Vec<_>>()
+        );
+
         assert_eq!(nodes_flat[0].node_type, NodeType::Paragraph);
         assert_eq!(nodes_flat[1].node_type, NodeType::BlankLineGroup);
         assert_eq!(nodes_flat[2].node_type, NodeType::Paragraph);
@@ -52,32 +57,40 @@ mod analysis_tests {
         // Expected: Session
         let tokens_nested = vec![
             make_line("Title", LineType::SubjectOrListItemLine), // Needs to be potentially a subject
-            make_container(vec![
-                make_line("Content", LineType::ParagraphLine)
-            ]),
+            make_container(vec![make_line("Content", LineType::ParagraphLine)]),
         ];
 
         let nodes_nested = parse_with_declarative_grammar(tokens_nested, "source").unwrap();
-        println!("Nested nodes: {:?}", nodes_nested.iter().map(|n| n.node_type.clone()).collect::<Vec<_>>());
-        
+        println!(
+            "Nested nodes: {:?}",
+            nodes_nested
+                .iter()
+                .map(|n| n.node_type.clone())
+                .collect::<Vec<_>>()
+        );
+
         assert_eq!(nodes_nested[0].node_type, NodeType::Session);
     }
-    
+
     #[test]
     fn test_paragraph_followed_by_container() {
         // Case 3: ParagraphLine + Container
         // Does this become a Session or Paragraph + Container?
         // If it's a ParagraphLine, it usually doesn't start a session unless it's a SubjectLine.
         // But let's see what the parser does.
-        
+
         let tokens = vec![
             make_line("Para", LineType::ParagraphLine),
-            make_container(vec![
-                make_line("Child", LineType::ParagraphLine)
-            ]),
+            make_container(vec![make_line("Child", LineType::ParagraphLine)]),
         ];
-        
+
         let nodes = parse_with_declarative_grammar(tokens, "source").unwrap();
-        println!("Para + Container nodes: {:?}", nodes.iter().map(|n| n.node_type.clone()).collect::<Vec<_>>());
+        println!(
+            "Para + Container nodes: {:?}",
+            nodes
+                .iter()
+                .map(|n| n.node_type.clone())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/lex-core/tests/compile_fail/container_type_safety.rs
+++ b/crates/lex-core/tests/compile_fail/container_type_safety.rs
@@ -7,11 +7,15 @@ use lex_core::lex::ast::{Annotation, Definition, Label, Session, TextContent};
 fn main() {
     let label = Label::new("note".to_string());
     let session = Session::with_title("Nested".to_string());
-    
+
     // Test 1: Annotation should reject SessionContent
-    let _annotation = Annotation::new(label.clone(), vec![], vec![SessionContent::Session(session.clone())]);
-    
-    // Test 2: Definition should reject SessionContent  
+    let _annotation = Annotation::new(
+        label.clone(),
+        vec![],
+        vec![SessionContent::Session(session.clone())],
+    );
+
+    // Test 2: Definition should reject SessionContent
     let subject = TextContent::from_string("Term".to_string(), None);
     let _definition = Definition::new(subject, vec![SessionContent::Session(session)]);
 }

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -93,4 +93,38 @@ fi
 # (See e.g. lex-fmt/lexed for an Xvfb start, lex-fmt/nvim for pinned-bin
 # fetches.)
 
+# cargo-nextest. scripts/check-tests and lefthook.yml prefer nextest and
+# fall back to `cargo test`; CI uses nextest unconditionally. The cloud
+# image doesn't ship it, and `get.nexte.st` (the upstream installer
+# redirect) is blocked by the cloud network policy — so fetch the
+# prebuilt binary from the GitHub release via `gh` (auth'd with
+# GH_TOKEN) and drop it into ~/.cargo/bin.
+if ! command -v cargo-nextest >/dev/null 2>&1 \
+    && command -v cargo >/dev/null 2>&1 \
+    && command -v gh >/dev/null 2>&1; then
+  cargo_bin="${CARGO_HOME:-${HOME}/.cargo}/bin"
+  if [ -d "${cargo_bin}" ]; then
+    arch="$(uname -m)"
+    case "${arch}" in
+      x86_64)  nextest_target="x86_64-unknown-linux-gnu"  ;;
+      aarch64) nextest_target="aarch64-unknown-linux-gnu" ;;
+      *)       nextest_target="" ;;
+    esac
+    if [ -n "${nextest_target}" ]; then
+      tmpdir="$(mktemp -d)"
+      if gh release download \
+            --repo nextest-rs/nextest \
+            --pattern "cargo-nextest-*-${nextest_target}.tar.gz" \
+            --dir "${tmpdir}" --clobber >/dev/null 2>&1 \
+         && tar -xzf "${tmpdir}"/cargo-nextest-*.tar.gz \
+              -C "${cargo_bin}" cargo-nextest; then
+        :
+      else
+        echo "warning: cargo-nextest install failed; scripts/check-tests will fall back to cargo test" >&2
+      fi
+      rm -rf "${tmpdir}"
+    fi
+  fi
+fi
+
 exit 0

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -103,6 +103,7 @@ if ! command -v cargo-nextest >/dev/null 2>&1 \
     && command -v cargo >/dev/null 2>&1 \
     && command -v gh >/dev/null 2>&1; then
   cargo_bin="${CARGO_HOME:-${HOME}/.cargo}/bin"
+  mkdir -p "${cargo_bin}" 2>/dev/null || true
   if [ -d "${cargo_bin}" ]; then
     arch="$(uname -m)"
     case "${arch}" in


### PR DESCRIPTION
## Issue

Audited the cloud-session dev environment against the project's tooling expectations. Most of it is in good shape:

- `cargo build --workspace` ✅
- `cargo build -p lex-wasm --target wasm32-unknown-unknown` ✅ (wasm32 target preinstalled)
- `scripts/check-fmt` ✅
- `scripts/check-lint` ✅
- `scripts/check-tests` ✅ (via fallback — see below)
- `lefthook` binary present and `.git/hooks/pre-commit` wired by `setup-dev-env.sh` ✅
- Full `lefthook run pre-commit --all-files` ✅ (rustfmt + clippy + tests, 2259 tests pass)

The one gap is **`cargo-nextest` is not installed in the cloud image**. Both `scripts/check-tests` and `lefthook.yml`'s `tests` job prefer nextest and only fall back to `cargo test` when it's missing. CI (`.github/workflows/test-rust.yml` and `sandbox-tests.yml`) uses nextest unconditionally, so the fallback path produces a different output format than what reviewers see on CI failures, and serial-vs-parallel test scheduling differs.

The upstream installer at `get.nexte.st` is **blocked by the cloud network policy** (returns HTTP 403), so the conventional one-liner from the nextest docs doesn't work here either. That's likely why the existing setup script didn't already include it.

## Fix

In `scripts/setup-dev-env.sh`, below the canonical-template marker (so a future template re-sync from `arthur-debert/release` doesn't clobber it):

- Detect when `cargo-nextest` is missing.
- Use `gh release download --repo nextest-rs/nextest` to fetch the prebuilt binary for the current arch. `gh` is preinstalled and auth'd via `GH_TOKEN`, so it works under the cloud network policy where `get.nexte.st` does not.
- Extract `cargo-nextest` into `${CARGO_HOME:-$HOME/.cargo}/bin`.
- Best-effort: if the download or extract fails, log a warning and let the existing `cargo test` fallback in `scripts/check-tests` continue to work.

Idempotent — once nextest is on PATH (whether from a prior session or freshly installed), the `command -v cargo-nextest` guard short-circuits and the block is a no-op.

## Verification

- Ran the install branch from a clean state (`mv $CARGO_HOME/bin/cargo-nextest /tmp; bash scripts/setup-dev-env.sh`) — binary restored, `cargo nextest --version` reports `0.9.136`.
- Ran the idempotent branch with the binary present — script reaches `exit 0` without doing any work.
- Ran `lefthook run pre-commit --all-files` afterwards — clean pass, tests routed through nextest (2259 tests, ~53s).
- The commit on this branch itself went through the full pre-commit hook (rustfmt + clippy + nextest), confirming end-to-end behavior matches the local dev loop.

## Test plan

- [ ] Next cloud session in this repo starts with `cargo-nextest` available without manual intervention.
- [ ] Pre-commit hook routes test invocations through nextest (output format matches CI).
- [ ] No change to local-dev behavior — script still gates on `CLAUDE_CODE_REMOTE=true` and exits early outside the cloud.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiMf6Jz3TfEDJAXA7pd7Ew)_