### PR TITLE
fix(babel): export media as HTML/Markdown tags when authored with shortcut labels (#633)

### DIFF
--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -348,12 +348,17 @@ fn from_lex_verbatim(verbatim: &LexVerbatim, registry: &Registry) -> DocNode {
     // WireNode directly; we convert to IR by switching on the wire
     // variant — no re-dispatch on the label string.
     let label = verbatim.closing_data.label.value.clone();
+    // Pass semantic param values to handlers (outer quotes stripped,
+    // escapes resolved) — matches the policy lex-core uses for
+    // annotation dispatch (see `includes::annotation_to_wire`). The
+    // raw value with quotes is preserved on the IR `Verbatim`
+    // fallback below for round-trip serialisation.
     let params_object = serde_json::Value::Object(
         verbatim
             .closing_data
             .parameters
             .iter()
-            .map(|p| (p.key.clone(), serde_json::Value::String(p.value.clone())))
+            .map(|p| (p.key.clone(), serde_json::Value::String(p.unquoted_value())))
             .collect(),
     );
     let ctx = LabelCtx {

--- a/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
+++ b/crates/lex-babel/tests/html/snapshots/lib__html__export__kitchensink.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/lex-babel/tests/html/export.rs
-assertion_line: 856
 expression: snapshot_without_styles(&html)
 ---
 <!DOCTYPE html>
@@ -34,7 +33,7 @@ function example() {
     return "lex";
 }</code></pre></section><section class="lex-session lex-session-2"><h2>2. Second Root Session {{session}}</h2><p class="lex-paragraph">This session tests annotations with block content and marker-style verbatim blocks. {{paragraph}}</p><!-- lex:todo status="open" assignee="team" --><p class="lex-paragraph">This is a block annotation. {{paragraph}}</p><p class="lex-paragraph">It contains a paragraph and a list. {{paragraph}}</p><ul class="lex-list"><li class="lex-list-item">Task 1 to complete. {{list-item}}
 </li><li class="lex-list-item">Task 2 to complete. {{list-item}}
-</li></ul><!-- /lex:todo --><figure class="lex-image"><img src="&quot;logo.png&quot;" alt="&quot;Lex Logo&quot;" title="Image Reference (Marker Verbatim Block)"><figcaption>"Lex Logo"</figcaption></figure></section><p class="lex-paragraph">Final paragraph at the end of the document. {{paragraph}}</p>
+</li></ul><!-- /lex:todo --><figure class="lex-image"><img src="logo.png" alt="Lex Logo" title="Image Reference (Marker Verbatim Block)"><figcaption>Lex Logo</figcaption></figure></section><p class="lex-paragraph">Final paragraph at the end of the document. {{paragraph}}</p>
 </div>
 </body>
 </html>

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__export__kitchensink_markdown.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__export__kitchensink_markdown.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/lex-babel/tests/markdown/export.rs
-assertion_line: 299
 expression: md
 ---
 # Kitchensink Test Document
@@ -76,6 +75,6 @@ It contains a paragraph and a list. {{paragraph}}
 
 <!-- /lex:todo -->
 
-!["Lex Logo"]("logo.png" "Image Reference (Marker Verbatim Block)")
+![Lex Logo](logo.png "Image Reference (Marker Verbatim Block)")
 
 Final paragraph at the end of the document. {{paragraph}}

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -52,6 +52,7 @@
 // this module rather than churn the public surface.
 #![allow(clippy::result_large_err)]
 
+use crate::lex::assembling::stages::{ApplyTableConfig, NormalizeLabels};
 use crate::lex::assembling::AttachAnnotations;
 use crate::lex::ast::elements::container::GeneralContainer;
 use crate::lex::ast::elements::content_item::ContentItem;
@@ -462,6 +463,26 @@ pub fn resolve_from_source(
         stamp_doc(&mut doc, origin);
     }
 
+    // Normalise labels in the entry source BEFORE the resolve walk so
+    // shortcut spellings (`:: include ::`, `:: image ::`, …) are
+    // rewritten to their canonical form. The resolve dispatcher keys
+    // on `registry.schema_for(label)` with the canonical spelling, so
+    // without this an `:: include src=... ::` annotation would be
+    // skipped because no schema is registered under the bare alias.
+    //
+    // Permissive mode: unknown labels are left as-is rather than
+    // erroring. The standard parse pipeline enforces strict-mode
+    // namespace policy (`STRING_TO_AST`); the resolve entry point is
+    // a downstream stage that just needs the shortcut table applied
+    // so dispatch finds the right handler.
+    let mut doc =
+        NormalizeLabels::permissive()
+            .run(doc)
+            .map_err(|e| IncludeError::ParseFailed {
+                path: source_path.clone().unwrap_or_default(),
+                message: format!("label normalisation failed: {e}"),
+            })?;
+
     let mut chain: Vec<ResolveKey> = Vec::new();
     let mut state = ResolverState {
         config,
@@ -476,8 +497,30 @@ pub fn resolve_from_source(
     let doc = AttachAnnotations::new()
         .run(doc)
         .map_err(|e| IncludeError::ParseFailed {
-            path: source_path.unwrap_or_default(),
+            path: source_path.clone().unwrap_or_default(),
             message: format!("annotation attachment failed: {e}"),
+        })?;
+
+    // Re-normalise after splicing. Each included file is parsed via
+    // `parse_no_attach` (no normalisation), so shortcut labels in the
+    // spliced content — e.g. `:: image src=... ::` inside an included
+    // chapter — need rewriting before downstream IR/format passes can
+    // dispatch them.
+    let doc = NormalizeLabels::permissive()
+        .run(doc)
+        .map_err(|e| IncludeError::ParseFailed {
+            path: source_path.clone().unwrap_or_default(),
+            message: format!("label normalisation failed: {e}"),
+        })?;
+
+    // Apply table configuration so `:: table header=N align=... ::`
+    // annotations attached to tables (here or in spliced content) take
+    // effect — matches the order the standard pipeline runs them.
+    let doc = ApplyTableConfig::new()
+        .run(doc)
+        .map_err(|e| IncludeError::ParseFailed {
+            path: source_path.unwrap_or_default(),
+            message: format!("table config application failed: {e}"),
         })?;
 
     Ok(doc)

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -2341,3 +2341,117 @@ mod registry_dispatch {
         );
     }
 }
+
+// ============================================================================
+// Label-normalisation through the resolve pipeline (#633)
+// ============================================================================
+//
+// `resolve_from_source` runs `NormalizeLabels::permissive` so curated
+// shortcuts (`include`, `image`, `video`, `audio`, …) are canonicalised
+// to their `lex.*` form. Without this, downstream IR-build dispatch
+// for `lex.media.{image,video,audio}` never fires when authors use the
+// shortcut spelling and HTML/Markdown export drops the media payload
+// (#633).
+
+/// Walk all VerbatimBlocks in the tree and collect their closing
+/// labels. Used to assert that shortcut spellings reached the
+/// resolver's output as their canonical form.
+fn collect_verbatim_labels(items: &[ContentItem]) -> Vec<String> {
+    let mut out = Vec::new();
+    fn walk(items: &[ContentItem], out: &mut Vec<String>) {
+        for item in items {
+            match item {
+                ContentItem::VerbatimBlock(v) => {
+                    out.push(v.closing_data.label.value.clone());
+                }
+                ContentItem::Session(s) => walk(&s.children, out),
+                ContentItem::Annotation(a) => walk(&a.children, out),
+                ContentItem::Definition(d) => walk(&d.children, out),
+                ContentItem::List(l) => {
+                    for item in l.items.iter() {
+                        if let ContentItem::ListItem(li) = item {
+                            let kids: Vec<ContentItem> = li.children.iter().cloned().collect();
+                            walk(&kids, out);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    walk(items, &mut out);
+    out
+}
+
+#[test]
+fn resolve_canonicalises_image_shortcut_in_entry_source() {
+    let tree = fixture(
+        "Section:\n    Photo:\n    :: image src=\"foo.png\" ::\n",
+        &[],
+    )
+    .expect("resolve");
+    let labels = collect_verbatim_labels(tree.root_children());
+    assert!(
+        labels.contains(&"lex.media.image".to_string()),
+        "`:: image ::` shortcut must be normalised to `lex.media.image` so \
+         downstream IR-build dispatch can hydrate the media payload; got {labels:?}"
+    );
+}
+
+#[test]
+fn resolve_canonicalises_video_and_audio_shortcuts() {
+    let tree = fixture(
+        "Clips:\n    Video:\n    :: video src=\"v.mp4\" ::\n\n    Audio:\n    :: audio src=\"a.mp3\" ::\n",
+        &[],
+    )
+    .expect("resolve");
+    let labels = collect_verbatim_labels(tree.root_children());
+    assert!(
+        labels.contains(&"lex.media.video".to_string()),
+        "`:: video ::` shortcut must be normalised; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"lex.media.audio".to_string()),
+        "`:: audio ::` shortcut must be normalised; got {labels:?}"
+    );
+}
+
+#[test]
+fn resolve_canonicalises_image_shortcut_inside_included_file() {
+    let tree = fixture(
+        ":: include src=\"chapter.lex\" ::\n",
+        &[(
+            "/repo/chapter.lex",
+            "Section:\n    Photo:\n    :: image src=\"foo.png\" ::\n",
+        )],
+    )
+    .expect("resolve");
+    let labels = collect_verbatim_labels(tree.root_children());
+    assert!(
+        labels.contains(&"lex.media.image".to_string()),
+        "spliced content from an included file must also be normalised \
+         (the second NormalizeLabels pass runs after splicing); got {labels:?}"
+    );
+}
+
+#[test]
+fn resolve_fires_include_handler_for_bare_include_shortcut() {
+    // `:: include src=... ::` is the shortcut form of `:: lex.include ::`.
+    // The resolve dispatcher keys on `registry.schema_for(label)` with the
+    // canonical spelling, so without the pre-walk NormalizeLabels pass the
+    // shortcut form would be silently skipped (#633) — leaving the
+    // `include` annotation in the tree and the included content unspliced.
+    let tree = fixture(
+        ":: include src=\"frag.lex\" ::\n",
+        &[("/repo/frag.lex", "Hello from frag.\n")],
+    )
+    .expect("resolve");
+    assert!(
+        tree.root_paragraph_texts()
+            .iter()
+            .any(|t| t.contains("Hello from frag.")),
+        "the bare `:: include ::` shortcut must dispatch the `lex.include` \
+         handler so the target file's content is spliced in; root paragraphs: {:?}",
+        tree.root_paragraph_texts()
+    );
+}


### PR DESCRIPTION
Fixes #633.

## Summary

`lexd convert --to html` (and `--to markdown`) dropped media payloads when the source used the curated shortcut spellings — `:: image src=... ::`, `:: video ::`, `:: audio ::`. The handbook from the issue exported with no `<img>` tags at all; the eight diagrams disappeared from the output. Two root causes:

1. **The include resolver path skipped label normalisation.** `resolve_from_source` parsed via `parse_no_attach` and never ran `NormalizeLabels`, so shortcut labels stayed at their authored spelling. `from_lex_verbatim` looked up `lex.media.image` on the bare `image` label, the IR-build handler wasn't found, and the verbatim hydrated as a generic `DocNode::Verbatim` (`<pre>` in HTML, code fence in Markdown). The bare `:: include ::` shortcut was silently skipped for the same reason — the resolve dispatcher keys on canonical labels.
2. **Parameter values reached the IR-build dispatch with outer quotes intact.** Even on the standard pipeline path (which did normalise labels), `:: image src="foo.png" ::` produced ``&lt;img src="&quot;foo.png&quot;"&gt;`` because `from_lex_verbatim` shoved the raw `p.value` into the `LabelCtx` JSON instead of using `p.unquoted_value()` (the policy lex-core already uses for annotation dispatch in `includes::annotation_to_wire`).

## Fix

- `crates/lex-core/src/lex/includes.rs` — run `NormalizeLabels::permissive` twice in `resolve_from_source`: once before the resolve walk so include shortcuts dispatch to the `lex.include` handler, once after splicing so canonicalisation reaches labels inside the included files. Also run `ApplyTableConfig` after splicing to match the standard pipeline. Permissive mode leaves unknown labels alone; strict-mode namespace policy is still owned by `STRING_TO_AST`.
- `crates/lex-babel/src/ir/from_lex.rs` — unquote parameter values when building the IR-build `LabelCtx` (raw form is still kept on the `DocNode::Verbatim` fallback for round-trip serialisation).

## Test plan

- [x] `./scripts/rust-pre-commit` — 2263 tests pass (fmt + clippy + tests, 4 new regression tests).
- [x] Issue's `handbook.zip`: `lexd handbook.lex --to html -o out.html` now emits 8 ``&lt;img src="diagrams/..."&gt;`` tags (one per `:: image ::` annotation); `--to markdown` emits 8 `[alt](src ...)` images.
- [x] Snapshots `kitchensink.snap` (HTML) and `kitchensink_markdown.snap` (Markdown) refreshed — both previously baked the buggy quoted-src output (`src="&quot;logo.png&quot;"`, `["Lex Logo"]("logo.png" ...)`) as the expected baseline. New baselines are the corrected ``&lt;img src="logo.png" alt="Lex Logo"&gt;`` / `[Lex Logo](logo.png ...)`.
- [x] New tests in `crates/lex-core/src/lex/includes/tests.rs` cover the four shortcut paths through the resolver:
  - `resolve_canonicalises_image_shortcut_in_entry_source`
  - `resolve_canonicalises_video_and_audio_shortcuts`
  - `resolve_canonicalises_image_shortcut_inside_included_file` (also exercises the post-splice normalisation pass)
  - `resolve_fires_include_handler_for_bare_include_shortcut` (the bare-`include` dispatch path)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqDMwrz6ZU7Z8gNxWvScTv)_