### PR TITLE
feat(diagnostics-config): add DiagnosticsRulesConfig (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added — `lex-config` diagnostic rule types ([#636](https://github.com/lex-fmt/lex/issues/636))
 
-Foundation types for the diagnostic-configuration tracking issue. `lex-config` now exports `Severity` (`Allow` / `Warn` / `Deny`), `RuleConfig` (an untagged enum accepting either `"warn"` or `["warn", { … }]` on disk), and the `RuleOptions` alias (`BTreeMap<String, toml::Value>`). No consumers yet — the runtime consumption surface (`DiagnosticsRulesConfig` struct, registry, emission-site wiring) lands in follow-up PRs on the same issue. Public crate API addition, hence the Unreleased note.
+Foundation types for the diagnostic-configuration tracking issue. `lex-config` now exports `Severity` (`Allow` / `Warn` / `Deny`), `RuleConfig` (an untagged enum accepting either `"warn"` or `["warn", { … }]` on disk), and the `RuleOptions` alias (`BTreeMap<String, toml::Value>`). No consumers yet — the runtime consumption surface (registry, emission-site wiring) lands in follow-up PRs on the same issue. Public crate API addition, hence the Unreleased note.
+
+### Changed — `[diagnostics.rules]` block in `.lex.toml` ([#636](https://github.com/lex-fmt/lex/issues/636))
+
+`DiagnosticsConfig` gains a `rules: DiagnosticsRulesConfig` nested struct with one field per built-in diagnostic code, each carrying its description as a doc comment and its intrinsic severity as the `#[config(default)]`. Schema-validation codes live in a `[diagnostics.rules.schema]` sub-table. `lexd config gen` now emits the full catalog automatically. **Breaking:** the previous `diagnostics.spellcheck = bool` knob is replaced by `[diagnostics.rules].spellcheck = "warn" | "allow" | "deny"` — any existing `.lex.toml` using the boolean form fails strict-key validation. Wiring of the runtime registry against this schema lands in the next PR on this issue.
 
 ## [0.14.0] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added — `lex-config` diagnostic rule types ([#636](https://github.com/lex-fmt/lex/issues/636))
 
-Foundation types for the diagnostic-configuration tracking issue. `lex-config` now exports `Severity` (`Allow` / `Warn` / `Deny`), `RuleConfig` (an untagged enum accepting either `"warn"` or `["warn", { … }]` on disk), and the `RuleOptions` alias (`BTreeMap<String, toml::Value>`). No consumers yet — the runtime consumption surface (registry, emission-site wiring) lands in follow-up PRs on the same issue. Public crate API addition, hence the Unreleased note.
+Foundation types for the diagnostic-configuration tracking issue. `lex-config` now exports `Severity` (`Allow` / `Warn` / `Deny`), `RuleConfig` (an untagged enum accepting either `"warn"` or `["warn", { … }]` on disk), and the `RuleOptions` alias (`BTreeMap<String, toml::Value>`). The runtime consumption surface (registry, emission-site wiring in `lex-analysis`, `[diagnostics.rules]` in `.lex.toml`) lands in follow-up PRs on the same issue — this PR ships only the value types. Public crate API addition, hence the Unreleased note.
 
 ### Changed — `[diagnostics.rules]` block in `.lex.toml` ([#636](https://github.com/lex-fmt/lex/issues/636))
 

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -435,10 +435,11 @@ pub struct HtmlConfig {
 /// Diagnostics options.
 #[derive(Debug, Clone, Config, Serialize, Deserialize)]
 pub struct DiagnosticsConfig {
-    /// Per-rule severity overrides. Each entry maps a diagnostic code
-    /// to a severity ("allow", "warn", or "deny"). The defaults shown
-    /// next to each rule are the intrinsic defaults — uncomment a line
-    /// to override one.
+    /// Per-rule severity overrides. Each entry takes either a bare
+    /// severity string (`"allow"`, `"warn"`, `"deny"`) or an array
+    /// form (`["warn", { option = value }]`) carrying rule-specific
+    /// options — see [`RuleConfig`]. The defaults shown next to each
+    /// rule are the intrinsic defaults; uncomment a line to override.
     #[config(nested)]
     pub rules: DiagnosticsRulesConfig,
 }
@@ -487,8 +488,8 @@ pub struct DiagnosticsRulesConfig {
 
 /// Schema-validation diagnostics. Each field maps to one of the
 /// schema pre-validation checks the analyser performs before
-/// dispatching to an extension handler. See
-/// [`extending-lex.lex`](../specs/proposals/extending-lex.lex) §13.2.
+/// dispatching to an extension handler. See the Extending Lex
+/// proposal (`comms/specs/proposals/extending-lex.lex`) §13.2.
 #[derive(Debug, Clone, Config, Serialize, Deserialize)]
 pub struct SchemaRulesConfig {
     /// A label is invoked whose namespace is registered, but no

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -485,7 +485,7 @@ pub struct DiagnosticsRulesConfig {
     pub schema: SchemaRulesConfig,
 }
 
-/// Schema-validation diagnostics. Each field maps to one of the six
+/// Schema-validation diagnostics. Each field maps to one of the
 /// schema pre-validation checks the analyser performs before
 /// dispatching to an extension handler. See
 /// [`extending-lex.lex`](../specs/proposals/extending-lex.lex) §13.2.

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -435,9 +435,84 @@ pub struct HtmlConfig {
 /// Diagnostics options.
 #[derive(Debug, Clone, Config, Serialize, Deserialize)]
 pub struct DiagnosticsConfig {
-    /// Enable spellcheck diagnostics.
-    #[config(default = true)]
-    pub spellcheck: bool,
+    /// Per-rule severity overrides. Each entry maps a diagnostic code
+    /// to a severity ("allow", "warn", or "deny"). The defaults shown
+    /// next to each rule are the intrinsic defaults — uncomment a line
+    /// to override one.
+    #[config(nested)]
+    pub rules: DiagnosticsRulesConfig,
+}
+
+/// Per-rule severity for diagnostics.
+///
+/// One field per built-in diagnostic code. Each field's doc comment is
+/// the description that surfaces in `lexd config gen` output, so
+/// authoring conventions for these doc comments matter: write them as
+/// user-facing prose, lead with what triggers the diagnostic, finish
+/// with the intrinsic default. Extension-emitted codes
+/// (`<namespace>.<code>`) and forward-looking prefix globs are not
+/// fields on this struct — they ride in the embedded map of `extra`
+/// once that surface lands.
+#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+pub struct DiagnosticsRulesConfig {
+    /// A footnote reference like `[42]` has no corresponding
+    /// definition in the document. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub missing_footnote: RuleConfig,
+    /// A footnote definition appears in the document but no
+    /// reference points at it. Intrinsic default: warn.
+    #[config(default = "warn")]
+    pub unused_footnote: RuleConfig,
+    /// A table row has a different number of columns than the
+    /// table's header row. Intrinsic default: warn.
+    #[config(default = "warn")]
+    pub table_inconsistent_columns: RuleConfig,
+    /// A label uses the reserved `doc.*` prefix, which is no longer
+    /// valid under the current label policy. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub forbidden_label_prefix: RuleConfig,
+    /// A `lex.*` literal references a canonical that the toolchain
+    /// does not recognise — typically a typo or a label written for
+    /// a future core schema. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub unknown_lex_canonical: RuleConfig,
+    /// Spellcheck diagnostics. Set to "allow" to suppress
+    /// document-wide. Intrinsic default: warn.
+    #[config(default = "warn")]
+    pub spellcheck: RuleConfig,
+    /// Schema-validation diagnostics for extension labels.
+    #[config(nested)]
+    pub schema: SchemaRulesConfig,
+}
+
+/// Schema-validation diagnostics. Each field maps to one of the six
+/// schema pre-validation checks the analyser performs before
+/// dispatching to an extension handler. See
+/// [`extending-lex.lex`](../specs/proposals/extending-lex.lex) §13.2.
+#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+pub struct SchemaRulesConfig {
+    /// A label is invoked whose namespace is registered, but no
+    /// schema entry exists for the label itself. Typically a typo
+    /// or an out-of-version label. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub unknown_label: RuleConfig,
+    /// A label invocation omits a parameter the schema marks as
+    /// required. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub missing_param: RuleConfig,
+    /// A label parameter's value does not match the type the schema
+    /// declares. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub param_type_mismatch: RuleConfig,
+    /// A label attaches to a container shape the schema disallows
+    /// (e.g. attaching a paragraph-only label to a session).
+    /// Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub bad_attachment: RuleConfig,
+    /// A label body's shape (`none` / `text` / `lex`) does not match
+    /// the schema's declared body kind. Intrinsic default: deny.
+    #[config(default = "deny")]
+    pub body_shape_mismatch: RuleConfig,
 }
 
 /// Include-resolution options consumed by `lexd convert`, `lexd inspect`,
@@ -493,6 +568,94 @@ mod tests {
         assert_eq!(config.formatting.rules.session_blank_lines_before, 1);
         assert!(config.inspect.ast.show_line_numbers);
         assert_eq!(config.convert.pdf.size, PdfPageSize::LexEd);
+    }
+
+    fn load_from(toml_body: &str) -> LexConfig {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&path, toml_body).unwrap();
+        clapfig::Clapfig::builder::<LexConfig>()
+            .app_name("lex")
+            .file_name(CONFIG_FILE_NAME)
+            .no_env()
+            .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .load()
+            .expect("loads")
+    }
+
+    #[test]
+    fn diagnostics_rules_defaults_in_place() {
+        let cfg = load_defaults();
+        assert_eq!(
+            cfg.diagnostics.rules.missing_footnote.severity(),
+            Severity::Deny
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.unused_footnote.severity(),
+            Severity::Warn
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.table_inconsistent_columns.severity(),
+            Severity::Warn
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.forbidden_label_prefix.severity(),
+            Severity::Deny
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.unknown_lex_canonical.severity(),
+            Severity::Deny
+        );
+        assert_eq!(cfg.diagnostics.rules.spellcheck.severity(), Severity::Warn);
+        assert_eq!(
+            cfg.diagnostics.rules.schema.unknown_label.severity(),
+            Severity::Deny
+        );
+    }
+
+    #[test]
+    fn diagnostics_rules_user_overrides_apply() {
+        let cfg = load_from(
+            r#"
+[diagnostics.rules]
+missing_footnote = "allow"
+table_inconsistent_columns = "deny"
+
+[diagnostics.rules.schema]
+unknown_label = "warn"
+"#,
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.missing_footnote.severity(),
+            Severity::Allow
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.table_inconsistent_columns.severity(),
+            Severity::Deny
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.schema.unknown_label.severity(),
+            Severity::Warn
+        );
+        // Untouched rules retain their intrinsic defaults.
+        assert_eq!(
+            cfg.diagnostics.rules.forbidden_label_prefix.severity(),
+            Severity::Deny
+        );
+    }
+
+    #[test]
+    fn diagnostics_rules_accept_array_form() {
+        let cfg = load_from(
+            r#"
+[diagnostics.rules]
+missing_footnote = ["warn", { example_option = 42 }]
+"#,
+        );
+        let rule = &cfg.diagnostics.rules.missing_footnote;
+        assert_eq!(rule.severity(), Severity::Warn);
+        let opts = rule.options().expect("array form keeps options");
+        assert_eq!(opts.get("example_option"), Some(&toml::Value::Integer(42)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Part of #636 (PR 2 of 3). **Depends on #637 — merge that first.**

Adds the `[diagnostics.rules]` block to `.lex.toml` as a nested confique struct with one field per built-in diagnostic code:

- `missing_footnote` (default `deny`)
- `unused_footnote` (default `warn`)
- `table_inconsistent_columns` (default `warn`)
- `forbidden_label_prefix` (default `deny`)
- `unknown_lex_canonical` (default `deny`)
- `spellcheck` (default `warn`)
- `schema.*` (nested `SchemaRulesConfig`, all default `deny`): `unknown_label`, `missing_param`, `param_type_mismatch`, `bad_attachment`, `body_shape_mismatch`

Each field's doc comment is the user-facing rule description and its `#[config(default = ...)]` is the intrinsic severity. `lexd config gen` now emits the entire catalog automatically — one TOML block per code with description, default, and uncomment-to-override example.

## Breaking change

The previous `diagnostics.spellcheck = true | false` boolean is replaced by `rules.spellcheck = "warn" | "allow" | "deny"`. No code outside lex-config consumed the boolean field, so the runtime impact is zero — only TOML files using the old form need to migrate.

## What this PR does *not* do

- No runtime registry consumption — emission sites in lex-analysis still hard-code their severity. PR 3 of #636 wires the registry through analysis.
- No drift test enforcing that every `DiagnosticKind` variant has a matching field — this lands in PR 3 where lex-analysis ↔ lex-config visibility is naturally arranged.

## Test plan

- [x] 3 new lex-config tests covering: default-construction, user-override merging, array-form acceptance via the real `.lex.toml` load path
- [x] `cargo run -- config gen` produces an annotated `[diagnostics.rules]` block (verified against the design spec)
- [x] Full workspace test suite green (`cargo test --workspace --exclude lex-wasm`)
- [x] `cargo fmt --check` + `cargo clippy -D warnings` clean
- [x] `scripts/rust-pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)