### PR TITLE
feat(release): add release primitive scripts (#640)

### DIFF
--- a/scripts/release/get-commits-since-release
+++ b/scripts/release/get-commits-since-release
@@ -16,11 +16,12 @@
 set -euo pipefail
 
 # Find the most recent `vX.Y.Z` tag by version sort (not commit date —
-# rebases / out-of-order tagging shouldn't fool us).
-latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
+# rebases / out-of-order tagging shouldn't fool us). Use git's native
+# `--sort=-v:refname` (matches scripts/diff-since-release) so we don't
+# rely on an external `sort -V` whose behavior varies across BSD/GNU.
+latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
     | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-    | sort -V \
-    | tail -1 || true)
+    | head -1 || true)
 
 if [[ -z "$latest_tag" ]]; then
     echo "get-commits-since-release: no vX.Y.Z tags found in this repo" >&2

--- a/scripts/release/get-commits-since-release
+++ b/scripts/release/get-commits-since-release
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# get-commits-since-release — list commits since the latest `vX.Y.Z` tag.
+#
+# Layer 0 release primitive (tracking issue: lex-fmt/lex#640).
+#
+# Walks `git tag` for tags matching `vX.Y.Z` (final releases only —
+# pre-release tags like `v0.9.0-rc.1` are excluded; the orchestrator
+# wants the diff against the last *shipped* version). Prints each commit
+# since that tag as `<short-sha> <subject>`, one per line.
+#
+# Empty stdout means there are no new commits.
+# Exit code 0 either way; non-zero only on hard failure (no tags at all
+# yet, or not a git repo).
+#
+# Usage:  scripts/release/get-commits-since-release
+set -euo pipefail
+
+# Find the most recent `vX.Y.Z` tag by version sort (not commit date —
+# rebases / out-of-order tagging shouldn't fool us).
+latest_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V \
+    | tail -1 || true)
+
+if [[ -z "$latest_tag" ]]; then
+    echo "get-commits-since-release: no vX.Y.Z tags found in this repo" >&2
+    exit 1
+fi
+
+# `%h %s` = short sha + subject. No body, no decoration, no author —
+# downstream consumers eyeball this for a CHANGELOG draft.
+git log --pretty=format:'%h %s' "${latest_tag}..HEAD"
+# Ensure a trailing newline when there's any output (git log omits it).
+if [[ -n $(git log --pretty=format:'%h' "${latest_tag}..HEAD") ]]; then
+    printf '\n'
+fi

--- a/scripts/release/get-current-version
+++ b/scripts/release/get-current-version
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# get-current-version — print the current version of this repo (bare, no `v`).
+#
+# Layer 0 release primitive (tracking issue: lex-fmt/lex#640).
+#
+# Version source for lex-fmt/lex: the `version = "X.Y.Z"` field in every
+# crate Cargo.toml. There is no [workspace.package] in this workspace —
+# each crate carries its own version line, kept in lock-step by
+# `cargo set-version --workspace` at release time. We read lex-core's
+# version as the canonical one (it sits at the top of the dep order and
+# every other publishable crate pins it via `workspace.dependencies`).
+#
+# Usage:  scripts/release/get-current-version
+# Output: bare version on stdout, e.g. `0.14.0`
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+manifest="$repo_root/crates/lex-core/Cargo.toml"
+
+if [[ ! -f "$manifest" ]]; then
+    echo "get-current-version: cannot find $manifest" >&2
+    exit 1
+fi
+
+# Match the first `version = "..."` line in the [package] table.
+# lex-core's manifest opens with [package] so the first hit is correct.
+version=$(grep -E '^version = "' "$manifest" | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')
+
+if [[ -z "$version" ]]; then
+    echo "get-current-version: failed to parse version from $manifest" >&2
+    exit 1
+fi
+
+printf '%s\n' "$version"

--- a/scripts/release/update-release
+++ b/scripts/release/update-release
@@ -38,6 +38,25 @@ fi
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
+# --- 0. Upfront tool / state checks. --------------------------------------
+#
+# We rely on cargo-set-version (checked again below where it's used) and
+# python3 (used for the CHANGELOG rewrite further down). Fail fast on the
+# latter so we don't bump versions and then die mid-way.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "update-release: python3 required for CHANGELOG rewrite — install python3" >&2
+    exit 1
+fi
+
+# The comms submodule must be initialized — step 3 below cds into it and
+# runs git there. On a fresh clone without `--recurse-submodules` the
+# directory exists but `comms/.git` does not, and `(cd comms && git ...)`
+# fails opaquely. Detect that explicitly.
+if [[ ! -e "$repo_root/comms/.git" ]]; then
+    echo "update-release: comms submodule not initialized. Run: git submodule update --init" >&2
+    exit 1
+fi
+
 echo "update-release: bumping workspace to $new_version"
 
 # --- 1. Bump crate versions + workspace.dependencies pins. ----------------

--- a/scripts/release/update-release
+++ b/scripts/release/update-release
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# update-release <new-version> — apply a version bump to this repo.
+#
+# Layer 0 release primitive (tracking issue: lex-fmt/lex#640).
+#
+# Side effects (all staged via `git add`; caller is responsible for the
+# commit):
+#   1. Bumps every crate's `version = "..."` and the matching workspace
+#      dependency pins in the root `Cargo.toml` via
+#      `cargo set-version --workspace`. lex-wasm is bumped in lock-step
+#      with everyone else — only the crates.io publish step skips it
+#      (it has `publish = false`).
+#   2. Refreshes `Cargo.lock` with the new internal version pins via
+#      `cargo check --workspace --all-targets --exclude lex-wasm`.
+#   3. Updates the `comms` submodule to `origin/main` and stages the
+#      pointer bump.
+#   4. Renames `## [Unreleased]` → `## [<new-version>] - <YYYY-MM-DD>`
+#      in CHANGELOG.md and inserts a fresh empty `## [Unreleased]`
+#      section above it.
+#
+# Usage:  scripts/release/update-release <new-version>
+# Example: scripts/release/update-release 0.15.0
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $(basename "$0") <new-version>" >&2
+    exit 2
+fi
+
+new_version="$1"
+
+# Bare X.Y.Z[-prerelease] — match the validator in scripts/trigger-release.
+if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+    echo "update-release: version must be bare MAJOR.MINOR.PATCH[-PRE] (got: $new_version)" >&2
+    exit 2
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+echo "update-release: bumping workspace to $new_version"
+
+# --- 1. Bump crate versions + workspace.dependencies pins. ----------------
+#
+# `cargo set-version --workspace <ver>` walks every member, rewrites each
+# `[package].version`, AND rewrites the matching version field on
+# `[workspace.dependencies]` entries that point at a workspace member
+# (the eight `lex-* = { version = "...", path = "..." }` lines in root
+# Cargo.toml). This is the same call CI's release.yml uses.
+if ! cargo set-version --help >/dev/null 2>&1; then
+    echo "update-release: cargo-set-version not installed — run 'cargo install cargo-edit'" >&2
+    exit 1
+fi
+
+cargo set-version --workspace "$new_version"
+
+# --- 2. Refresh Cargo.lock. -----------------------------------------------
+#
+# After the manifest bump, every internal dep entry in Cargo.lock still
+# carries the old version. `cargo check` is the cheapest invocation that
+# forces a lockfile rewrite. lex-wasm is excluded only because compiling
+# its WASM bindings requires the wasm32 target; the manifest version
+# itself was bumped in step 1.
+echo "update-release: refreshing Cargo.lock"
+cargo check --workspace --all-targets --exclude lex-wasm --quiet
+
+# --- 3. Bump comms submodule pointer. ------------------------------------
+#
+# Submodule fetch + checkout of origin/main. The submodule update is
+# staged on the OUTER repo; the inner repo is left detached at the new
+# commit, which is the normal submodule-update state.
+echo "update-release: bumping comms submodule to origin/main"
+(cd comms && git fetch --quiet origin && git checkout --quiet origin/main)
+
+# --- 4. CHANGELOG roll. --------------------------------------------------
+#
+# Rename `## [Unreleased]` → `## [<new-version>] - <YYYY-MM-DD>` and
+# insert a fresh empty `## [Unreleased]` section directly above it.
+# We require an `## [Unreleased]` heading to exist — if it's missing
+# the changelog has drifted from convention and the caller should fix
+# it before retrying.
+changelog="$repo_root/CHANGELOG.md"
+today=$(date -u +%Y-%m-%d)
+
+if [[ ! -f "$changelog" ]]; then
+    echo "update-release: $changelog not found" >&2
+    exit 1
+fi
+
+if ! grep -qE '^## \[Unreleased\]' "$changelog"; then
+    echo "update-release: CHANGELOG.md has no '## [Unreleased]' heading — refusing to roll" >&2
+    exit 1
+fi
+
+# Use a small python helper for the rewrite — sed's in-place behavior
+# differs between GNU and BSD, and we want exactly one substitution.
+python3 - "$changelog" "$new_version" "$today" <<'PY'
+import sys, pathlib
+path, version, today = sys.argv[1:4]
+p = pathlib.Path(path)
+text = p.read_text()
+old = "## [Unreleased]"
+new = f"## [Unreleased]\n\n## [{version}] - {today}"
+# Replace only the first occurrence — defensive in case anything later
+# in the file happens to repeat the literal string.
+idx = text.find(old)
+if idx < 0:
+    sys.exit("update-release: '## [Unreleased]' not found after pre-check (race?)")
+p.write_text(text[:idx] + new + text[idx + len(old):])
+PY
+
+# --- 5. Stage everything. ------------------------------------------------
+echo "update-release: staging changes"
+git add Cargo.toml Cargo.lock comms CHANGELOG.md
+# Crate manifests touched by cargo-set-version.
+git add 'crates/*/Cargo.toml'
+
+echo "update-release: done. Review with 'git diff --cached' before committing."

--- a/scripts/trigger-release
+++ b/scripts/trigger-release
@@ -3,12 +3,16 @@ set -euo pipefail
 
 # Cut a release. Everything runs in CI — this just triggers it.
 #
-# Usage:  scripts/release <new-version>       e.g. scripts/release 0.9.0
-#    or:  scripts/release <bump-level>        e.g. scripts/release minor
-#                                                  (one of: major, minor, patch)
+# Usage:  scripts/trigger-release <new-version>   e.g. scripts/trigger-release 0.9.0
+#    or:  scripts/trigger-release <bump-level>    e.g. scripts/trigger-release minor
+#                                                      (one of: major, minor, patch)
 #
 # Pre-releases: pass a semver pre-release suffix to cut a release candidate
-# or beta, e.g. scripts/release 0.9.0-rc.1.
+# or beta, e.g. scripts/trigger-release 0.9.0-rc.1.
+#
+# Renamed from scripts/release in #640 to free up `scripts/release/` for the
+# Layer 0 release primitive scripts (get-current-version,
+# get-commits-since-release, update-release).
 #
 # What CI does (all on GitHub):
 #   1. Bumps the workspace version via `cargo set-version --workspace`


### PR DESCRIPTION
## Summary

Layer 0 of the cross-repo release automation (tracking issue #640). Adds three executable bash scripts under `scripts/release/` implementing the canonical primitive interface that the upcoming `release-lex` orchestrator will call:

- **`get-current-version`** — prints this repo's bare version (e.g. `0.14.0`) by parsing `crates/lex-core/Cargo.toml`. This workspace doesn't use `[workspace.package]` — each crate has its own `version = "..."` line kept in lock-step by `cargo set-version --workspace`. lex-core is the canonical source since every other publishable crate pins it via `workspace.dependencies`.
- **`get-commits-since-release`** — one line per commit (`<short-sha> <subject>`) since the most recent `vX.Y.Z` tag. Pre-release tags excluded. Empty stdout = none.
- **`update-release <new-version>`** — bumps every crate manifest + the four `workspace.dependencies` pins via `cargo set-version --workspace`, refreshes `Cargo.lock` (`cargo check --workspace --exclude lex-wasm`), fast-forwards `comms` to `origin/main`, and rolls `CHANGELOG.md` (`## [Unreleased]` → `## [<new-version>] - <YYYY-MM-DD>` with a fresh empty `## [Unreleased]` above). All touched files are `git add`-ed; caller commits.

## Notes

- The existing `scripts/release` (release-workflow trigger) is renamed to `scripts/trigger-release` to free up the directory name. The only in-repo reference outside historical CHANGELOG entries is the script's own docstring, which is updated. No CI uses the old path.
- Tested locally end-to-end: `get-current-version` prints `0.14.0`, `get-commits-since-release` shows the seven commits since `v0.14.0`, `update-release 99.99.99` cleanly stages a `Cargo.toml`/`Cargo.lock`/`comms`/`CHANGELOG.md` + 11 crate manifest bump.

## Test plan

- [x] `./scripts/release/get-current-version` prints `0.14.0`
- [x] `./scripts/release/get-commits-since-release` lists commits since `v0.14.0`
- [x] `./scripts/release/update-release 99.99.99` stages the expected file set and reverts cleanly
- [x] Pre-commit hook (fmt + clippy + build + test) passes

Tracking issue: #640