### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-05-17
+
 ### Added — `lex-config` diagnostic rule types ([#636](https://github.com/lex-fmt/lex/issues/636))
 
 Foundation types for the diagnostic-configuration tracking issue. `lex-config` now exports `Severity` (`Allow` / `Warn` / `Deny`), `RuleConfig` (an untagged enum accepting either `"warn"` or `["warn", { … }]` on disk), and the `RuleOptions` alias (`BTreeMap<String, toml::Value>`). No consumers yet — the runtime consumption surface (`DiagnosticsRulesConfig` struct, registry, emission-site wiring) lands in follow-up PRs on the same issue. Public crate API addition, hence the Unreleased note.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-analysis"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ignore",
  "lex-core",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "lex-babel"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "comrak",
  "html5ever",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "lex-config"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "clapfig",
  "confique",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "lex-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "comrak",
  "criterion",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "lex-extension"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "lex-extension-host"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "landlock",
  "lex-extension",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "lex-fmt"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "lex-analysis",
  "lex-babel",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "lex-analysis",
  "lex-babel",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "lex-wasm"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "lexd"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "lexd-lsp"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "clapfig",
  "lex-analysis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-lex-core = { version = "0.14.0", path = "crates/lex-core" }
-lex-babel = { version = "0.14.0", path = "crates/lex-babel", default-features = false }
-lex-config = { version = "0.14.0", path = "crates/lex-config" }
-lex-analysis = { version = "0.14.0", path = "crates/lex-analysis" }
-lex-extension = { version = "0.14.0", path = "crates/lex-extension" }
-lex-extension-host = { version = "0.14.0", path = "crates/lex-extension-host", default-features = false }
-lex-fmt = { version = "0.14.0", path = "crates/lex-fmt" }
-lex-lsp-core = { version = "0.14.0", path = "crates/lex-lsp-core" }
+lex-core = { version = "0.14.1", path = "crates/lex-core" }
+lex-babel = { version = "0.14.1", path = "crates/lex-babel", default-features = false }
+lex-config = { version = "0.14.1", path = "crates/lex-config" }
+lex-analysis = { version = "0.14.1", path = "crates/lex-analysis" }
+lex-extension = { version = "0.14.1", path = "crates/lex-extension" }
+lex-extension-host = { version = "0.14.1", path = "crates/lex-extension-host", default-features = false }
+lex-fmt = { version = "0.14.1", path = "crates/lex-fmt" }
+lex-lsp-core = { version = "0.14.1", path = "crates/lex-lsp-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/lex-analysis/Cargo.toml
+++ b/crates/lex-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-analysis"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Semantic analysis for the lex format"

--- a/crates/lex-babel/Cargo.toml
+++ b/crates/lex-babel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-babel"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Format conversion library for the lex format"

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lexd"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Command-line interface for the lex format"

--- a/crates/lex-config/Cargo.toml
+++ b/crates/lex-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-config"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 authors = ["lex contributors"]

--- a/crates/lex-core/Cargo.toml
+++ b/crates/lex-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-core"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Parser library for the lex format"

--- a/crates/lex-extension-host/Cargo.toml
+++ b/crates/lex-extension-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-extension-host"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 authors = ["lex contributors"]

--- a/crates/lex-extension/Cargo.toml
+++ b/crates/lex-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-extension"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 authors = ["lex contributors"]

--- a/crates/lex-fmt/Cargo.toml
+++ b/crates/lex-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-fmt"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Canonical Rust embedder API for the lex document format. Hosts Engine::builder() plus the boot helpers shared by lexd and lexd-lsp."

--- a/crates/lex-lsp-core/Cargo.toml
+++ b/crates/lex-lsp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-lsp-core"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Sync language-server core for the lex format. Powers both the stdio LSP server (lexd-lsp) and the WASM bindings (lex-wasm)."

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lexd-lsp"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Language Server Protocol implementation for the lex format"

--- a/crates/lex-wasm/Cargo.toml
+++ b/crates/lex-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-wasm"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["lex contributors"]
 description = "WASM bindings for Lex language analysis"


### PR DESCRIPTION
Cut by `release-lex` (Layer 1). Part of lex-fmt/lex#640.