### PR TITLE
feat(release): add trigger-release primitive (#640)

### DIFF
--- a/scripts/release/trigger-release
+++ b/scripts/release/trigger-release
@@ -41,12 +41,16 @@ NEW_VERSION="$1"
 # is intentionally narrower so the cross-repo driver gets a uniform
 # version-string shape across all six repos.
 if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "error: version must be X.Y.Z (got: $NEW_VERSION)" >&2
+    echo "trigger-release: version must be X.Y.Z (got: $NEW_VERSION)" >&2
     exit 2
 fi
 
 # Resolve the repo-local trigger script relative to this file so the
-# primitive works regardless of the caller's $PWD.
+# primitive works regardless of the caller's $PWD. cd into the repo
+# root before exec so the delegated `scripts/trigger-release` — which
+# calls `git rev-parse --show-toplevel` — finds a git repo even when
+# this primitive is invoked from outside the worktree.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
 exec "$REPO_ROOT/scripts/trigger-release" "$NEW_VERSION"

--- a/scripts/release/trigger-release
+++ b/scripts/release/trigger-release
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# trigger-release <new-version>
+# ----------------------------
+# Layer 0 release-trigger primitive (lex-fmt/lex#640).
+#
+# lex is the workflow_dispatch outlier in the chain. Unlike the other
+# five repos — which release on `on: push: tags: [v*]` — lex's
+# `.github/workflows/release.yml` only triggers via `workflow_dispatch`
+# with a `version` input. That's because the canonical rust-cli reusable
+# workflow it calls expects to drive the bump+commit+tag itself; the
+# `prepare-release` action has resume-on-existing-tag logic, so this
+# works fine when the cross-repo orchestrator has pre-bumped (detects
+# the tag, validates Cargo.toml matches, skips the bump, runs downstream
+# jobs).
+#
+# This script is the Layer-0 primitive the cross-repo orchestrator calls
+# to fire the release. It defers to the existing repo-local
+# `scripts/trigger-release` wrapper (a one-liner over
+# `gh workflow run release.yml -f version=...`) so the dispatch logic
+# stays DRY and lives in one place.
+#
+# Usage:  scripts/release/trigger-release <new-version>
+# Example: scripts/release/trigger-release 0.15.0
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") <new-version>" >&2
+    echo "  new-version   Bare semver string, e.g. 0.14.1 (no leading v)" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+NEW_VERSION="$1"
+
+# Bare X.Y.Z — strict, to match the orchestrator contract. The repo-local
+# `scripts/trigger-release` accepts richer inputs (bump levels like
+# `minor`, pre-release suffixes like `0.9.0-rc.1`); this Layer-0 primitive
+# is intentionally narrower so the cross-repo driver gets a uniform
+# version-string shape across all six repos.
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version must be X.Y.Z (got: $NEW_VERSION)" >&2
+    exit 2
+fi
+
+# Resolve the repo-local trigger script relative to this file so the
+# primitive works regardless of the caller's $PWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+exec "$REPO_ROOT/scripts/trigger-release" "$NEW_VERSION"


### PR DESCRIPTION
## Summary

Fourth Layer 0 release-trigger primitive at `scripts/release/trigger-release` (tracking issue #640).

lex is the workflow_dispatch outlier in the chain. Unlike the other five repos (which trigger on `on: push: tags: [v*]`), lex's `.github/workflows/release.yml` only triggers via `workflow_dispatch` with a `version` input — the canonical rust-cli reusable workflow it calls expects to drive the bump+commit+tag itself, and `prepare-release` has resume-on-existing-tag logic so this works fine when the cross-repo orchestrator has pre-bumped.

The new primitive is a thin wrapper that defers to the existing repo-local `scripts/trigger-release` (one-liner over `gh workflow run release.yml -f version=...`), keeping the dispatch logic DRY. It validates a bare `X.Y.Z` version up front so the cross-repo orchestrator gets a uniform version-string shape across all six repos.

## Test plan

- [x] `./scripts/release/trigger-release` (no args) → usage + exit 2
- [x] `./scripts/release/trigger-release abc` → version-format reject + exit 2
- [x] Real-version dispatch NOT exercised (would fire the release workflow)
- [x] Pre-commit hook (fmt, clippy, build, test) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)