### PR TITLE
resolver: factor into transports + URL templates (companion to comms#60 spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed — `lex-extension-host` resolver factored into transports + URL templates ([#648](https://github.com/lex-fmt/lex/pull/648))
+
+Restructures the namespace resolver to match the new `extending-lex-stores.lex` companion spec. The previous model registered four peer fetchers (`GithubFetcher`, `GitlabFetcher`, `HttpsFetcher`, `GitSshFetcher`); the new model registers two transport fetchers (`HttpsFetcher`, `GitFetcher`) covering three schemes (`https`, `git`, `git+ssh`) and adds a URL-template layer (`github:`, `gitlab:`) that expands forge shorthands into transport URIs before dispatch.
+
+Public-API changes (visible to direct `lex-extension-host` consumers):
+
+- **Removed:** `resolve::fetcher::GithubFetcher`, `resolve::fetcher::GitlabFetcher`.
+- **Renamed:** `resolve::fetcher::GitSshFetcher` → `resolve::fetcher::GitFetcher`. The renamed fetcher claims both `git:` and `git+ssh:` schemes.
+- **Added:** `resolve::ResolveError::UnknownScheme` gains a `scheme: String` field that names the actual missing transport (after template expansion, if any) for clearer diagnostics.
+
+No behaviour change for end users: every stub still returns `FetchError::Unimplemented`; per-transport network implementations are tracked at [#562](https://github.com/lex-fmt/lex/issues/562) (now rescoped from "implement four fetchers" to "implement two fetchers + two templates").
+
 ## [0.14.1] - 2026-05-17
 
 ### Added — `lex-config` diagnostic rule types ([#636](https://github.com/lex-fmt/lex/issues/636))

--- a/crates/lex-extension-host/src/resolve/fetcher.rs
+++ b/crates/lex-extension-host/src/resolve/fetcher.rs
@@ -13,12 +13,16 @@
 //! decomposes the resolver into three real *transports* and N *URL
 //! templates*:
 //!
-//! - **Transports** are the [`Fetcher`] implementations in this module:
-//!   - `path:` — local filesystem read (in [`super::path`], special-cased
-//!     so it doesn't participate in registry dispatch).
-//!   - `https:` — HTTPS GET of a tarball/zip ([`HttpsFetcher`]).
-//!   - `git:` / `git+ssh:` — git clone ([`GitFetcher`]). Accepts any
-//!     URL form `git clone` accepts; the `git+ssh:` scheme is retained
+//! - **Transports** carry the actual data movement. Three ship today:
+//!   - `path:` — built-in local filesystem read, implemented in
+//!     [`super::path`]. Special-cased upstream of registry dispatch
+//!     (no [`Fetcher`] impl, no cache); listed here for completeness
+//!     of the transport set.
+//!   - `https:` — HTTPS GET of a tarball/zip, implemented as the
+//!     [`HttpsFetcher`] [`Fetcher`] in this module.
+//!   - `git:` / `git+ssh:` — git clone, implemented as the
+//!     [`GitFetcher`] [`Fetcher`] in this module. Accepts any URL
+//!     form `git clone` accepts; the `git+ssh:` scheme is retained
 //!     for backwards compatibility and dispatched to the same fetcher.
 //! - **URL templates** are forge-shorthands that expand into a
 //!   transport URI before registry dispatch. They live in

--- a/crates/lex-extension-host/src/resolve/fetcher.rs
+++ b/crates/lex-extension-host/src/resolve/fetcher.rs
@@ -1,25 +1,41 @@
-//! [`Fetcher`] trait — the contract per-scheme network resolvers
+//! [`Fetcher`] trait — the contract per-transport network resolvers
 //! implement.
 //!
 //! The host owns the cache (content-hashed lookup, TTL bookkeeping,
 //! `~/.cache/lex/labels/` layout); the fetcher only knows how to
 //! fetch one URI's contents to a directory. This split keeps the
-//! per-scheme implementation small — a github fetcher only needs to
-//! talk to github's tarball API, not understand lex's cache layout.
+//! per-transport implementation small — the git fetcher only needs to
+//! shell out to `git clone`, not understand lex's cache layout.
+//!
+//! ## Transports vs. URL templates
+//!
+//! The model (specified in `comms/specs/proposals/extending-lex-stores.lex`)
+//! decomposes the resolver into three real *transports* and N *URL
+//! templates*:
+//!
+//! - **Transports** are the [`Fetcher`] implementations in this module:
+//!   - `path:` — local filesystem read (in [`super::path`], special-cased
+//!     so it doesn't participate in registry dispatch).
+//!   - `https:` — HTTPS GET of a tarball/zip ([`HttpsFetcher`]).
+//!   - `git:` / `git+ssh:` — git clone ([`GitFetcher`]). Accepts any
+//!     URL form `git clone` accepts; the `git+ssh:` scheme is retained
+//!     for backwards compatibility and dispatched to the same fetcher.
+//! - **URL templates** are forge-shorthands that expand into a
+//!   transport URI before registry dispatch. They live in
+//!   [`super::template`] and have no `Fetcher` impl — they're pure
+//!   functions over URIs. `github:owner/repo` and `gitlab:owner/repo`
+//!   are the two templates shipped today.
 //!
 //! See [lex#562](https://github.com/lex-fmt/lex/issues/562) for the
-//! tracking issue covering the four real implementations
-//! (github/gitlab/https/git+ssh). This module ships the trait plus
-//! four stub fetchers that return [`FetchError::Unimplemented`] —
-//! same observable behaviour as the pre-machinery resolver, but
-//! plugged into the new dispatch so the implementer's PR only needs
-//! to swap out the stub for a real fetcher.
+//! tracking issue covering the two real transport implementations.
+//! Until those land, both fetchers ship as stubs that return
+//! [`FetchError::Unimplemented`] when the dispatch reaches them.
 
 use std::path::Path;
 
 use super::uri::ParsedUri;
 
-/// Per-scheme network resolver. Implementations fetch the URI's
+/// Per-transport network resolver. Implementations fetch the URI's
 /// contents into a caller-provided destination directory.
 ///
 /// ## Contract
@@ -43,9 +59,9 @@ pub trait Fetcher: Send + Sync {
 
     /// URI schemes this fetcher handles. Typically a single-element
     /// slice (one fetcher per scheme), but a fetcher can claim
-    /// multiple schemes if its implementation is shared (e.g., one
-    /// `HttpsFetcher` could handle both `https:` and `http:` if we
-    /// added the latter).
+    /// multiple schemes if its implementation is shared — e.g.,
+    /// [`GitFetcher`] claims both `git` and `git+ssh` because the
+    /// underlying `git clone` accepts both URL forms.
     ///
     /// Returned as `&'static [&'static str]` so the
     /// [`super::registry::FetcherRegistry`] can build its scheme map
@@ -59,7 +75,7 @@ pub trait Fetcher: Send + Sync {
     /// re-fetches.
     ///
     /// Default: `false` for any input. Fetchers should override
-    /// when they can confidently distinguish — e.g., a `GithubFetcher`
+    /// when they can confidently distinguish — e.g., [`GitFetcher`]
     /// would return `true` for `rev` matching `^[0-9a-f]{7,40}$`
     /// (SHA-ish) or `^v?\d+\.\d+`-ish (tag heuristic). Returning
     /// `false` from a default-impl-using fetcher is always safe
@@ -126,45 +142,13 @@ impl From<std::io::Error> for FetchError {
     }
 }
 
-/// Stub for the `github:` scheme. Returns
-/// [`FetchError::Unimplemented`]. Replace with a real
-/// implementation per lex#562.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct GithubFetcher;
-
-impl Fetcher for GithubFetcher {
-    fn fetch(&self, _uri: &ParsedUri, _dest: &Path) -> Result<(), FetchError> {
-        Err(FetchError::Unimplemented {
-            scheme: "github".into(),
-            message: "github: resolver not yet implemented (tracked at lex#562); use path: or --ext-schema for local schemas".into(),
-        })
-    }
-
-    fn schemes(&self) -> &'static [&'static str] {
-        &["github"]
-    }
-}
-
-/// Stub for the `gitlab:` scheme. Returns
-/// [`FetchError::Unimplemented`]. See [`GithubFetcher`].
-#[derive(Debug, Default, Clone, Copy)]
-pub struct GitlabFetcher;
-
-impl Fetcher for GitlabFetcher {
-    fn fetch(&self, _uri: &ParsedUri, _dest: &Path) -> Result<(), FetchError> {
-        Err(FetchError::Unimplemented {
-            scheme: "gitlab".into(),
-            message: "gitlab: resolver not yet implemented (tracked at lex#562); use path: or --ext-schema for local schemas".into(),
-        })
-    }
-
-    fn schemes(&self) -> &'static [&'static str] {
-        &["gitlab"]
-    }
-}
-
-/// Stub for the `https:` scheme. Returns
-/// [`FetchError::Unimplemented`]. See [`GithubFetcher`].
+/// Stub for the `https:` transport. Performs a single HTTPS GET of a
+/// tarball/zip and extracts it. Returns [`FetchError::Unimplemented`]
+/// until the real network code lands; tracked at lex#562.
+///
+/// This is also the underlying transport that `github:` and `gitlab:`
+/// URL templates expand into when their `via` knob picks https (the
+/// default).
 #[derive(Debug, Default, Clone, Copy)]
 pub struct HttpsFetcher;
 
@@ -181,20 +165,29 @@ impl Fetcher for HttpsFetcher {
     }
 }
 
-/// Stub for the `git+ssh:` scheme. Returns
-/// [`FetchError::Unimplemented`]. See [`GithubFetcher`].
+/// Stub for the `git:` / `git+ssh:` transport. Shells out to `git
+/// clone` (preferred over libgit2 for credential coverage; see
+/// `comms/specs/proposals/extending-lex-stores.lex` §6.3). Accepts any
+/// URL form `git clone` accepts — `https://...git`, `git@host:path`,
+/// `git+ssh://git@host/path` — across both registered schemes.
+///
+/// Returns [`FetchError::Unimplemented`] until the real shell-out code
+/// lands; tracked at lex#562. This is also the underlying transport
+/// that `github:` and `gitlab:` URL templates expand into when their
+/// `via` knob picks git (for private repositories needing the user's
+/// git credential setup).
 #[derive(Debug, Default, Clone, Copy)]
-pub struct GitSshFetcher;
+pub struct GitFetcher;
 
-impl Fetcher for GitSshFetcher {
+impl Fetcher for GitFetcher {
     fn fetch(&self, _uri: &ParsedUri, _dest: &Path) -> Result<(), FetchError> {
         Err(FetchError::Unimplemented {
-            scheme: "git+ssh".into(),
-            message: "git+ssh: resolver not yet implemented (tracked at lex#562); use path: or --ext-schema for local schemas".into(),
+            scheme: "git".into(),
+            message: "git: resolver not yet implemented (tracked at lex#562); use path: or --ext-schema for local schemas".into(),
         })
     }
 
     fn schemes(&self) -> &'static [&'static str] {
-        &["git+ssh"]
+        &["git", "git+ssh"]
     }
 }

--- a/crates/lex-extension-host/src/resolve/mod.rs
+++ b/crates/lex-extension-host/src/resolve/mod.rs
@@ -2,28 +2,34 @@
 //!
 //! A namespace declaration in `lex.toml` (or a `--ext-schema` flag)
 //! gives the host a URI; the resolver turns that URI into a
-//! filesystem directory the schema loader can scan. Five schemes
-//! are specified in the proposal (§4.2):
+//! filesystem directory the schema loader can scan. The model is
+//! specified in `comms/specs/proposals/extending-lex-stores.lex` and
+//! decomposes into:
 //!
-//! - `path:` — local filesystem path. No network, no cache. Resolved
-//!   relative to the workspace root unless absolute.
-//! - `github:` — `github:owner/repo[#rev][?subdir=…]`. Fetched +
-//!   cached at `~/.cache/lex/labels/<hash>/`.
-//! - `gitlab:` — same shape, gitlab.com.
-//! - `https:` — generic HTTPS tarball.
-//! - `git+ssh:` — explicit ssh remote.
+//! - **Three real transports** (one [`Fetcher`] each):
+//!   - `path:` — local filesystem path. No network, no cache.
+//!   - `https:` — HTTPS GET of a tarball/zip.
+//!   - `git:` / `git+ssh:` — git clone of a repository.
+//! - **N URL templates** that expand into one of the transports
+//!   above before dispatch:
+//!   - `github:owner/repo[#rev]` — github tarball (https) or clone (git).
+//!   - `gitlab:owner/repo[#rev]` — gitlab archive (https) or clone (git).
 //!
 //! ## Architecture
 //!
-//! The resolver has three layers:
+//! The resolver has four layers:
 //!
 //! - **URI parsing** ([`uri::ParsedUri`]) — splits the input string
 //!   into `scheme`, `body`, `rev`, `subdir` components. Pure
 //!   syntactic, no IO.
-//! - **Fetchers** ([`Fetcher`] trait + per-scheme impls) — each
-//!   scheme has an implementation that fetches the URI's contents
-//!   into a caller-provided directory. `path:` is built-in and
-//!   special-cased (no network, no cache); the four remote schemes
+//! - **URL-template expansion** ([`template::expand`]) — pure
+//!   functions that rewrite forge-shorthand URIs (`github:`,
+//!   `gitlab:`) into transport URIs (`https:`, `git:`). No-op for
+//!   URIs already in a transport scheme.
+//! - **Fetchers** ([`Fetcher`] trait + per-transport impls) — each
+//!   transport has an implementation that fetches the (expanded) URI's
+//!   contents into a caller-provided directory. `path:` is built-in
+//!   and special-cased (no network, no cache); the remote transports
 //!   are pluggable via the [`FetcherRegistry`].
 //! - **Cache** ([`ResolverCache`]) — content-keyed at
 //!   `~/.cache/lex/labels/<hash>/`. Caches fetched directories
@@ -31,13 +37,13 @@
 //!   TTL for mutable refs (branches, `None`). The fetcher tells the
 //!   cache which a given `rev` is.
 //!
-//! ## Status (post-machinery PR)
+//! ## Status
 //!
-//! The machinery (trait, registry, cache, dispatch) is in place.
-//! `path:` is the only fully-implemented scheme; the four remote
-//! schemes ship as stubs that return
+//! The machinery (trait, registry, templates, cache, dispatch) is in
+//! place. `path:` is the only fully-implemented transport; the two
+//! remote transports (`https:`, `git:`) ship as stubs that return
 //! [`FetchError::Unimplemented`] when the dispatch reaches them.
-//! Per-scheme network implementations are tracked at
+//! Per-transport network implementations are tracked at
 //! [lex#562](https://github.com/lex-fmt/lex/issues/562) — implementers
 //! plug their fetchers into [`default_fetcher_registry`] (or compose
 //! a custom registry) and the rest of the pipeline picks them up
@@ -47,6 +53,7 @@ pub mod cache;
 pub mod fetcher;
 mod path;
 pub mod registry;
+mod template;
 pub mod uri;
 
 use std::path::{Path, PathBuf};
@@ -119,7 +126,7 @@ impl std::fmt::Display for ResolveError {
         match self {
             ResolveError::UnknownScheme { uri } => write!(
                 f,
-                "namespace URI `{uri}` does not start with a known scheme (path:, github:, gitlab:, https:, git+ssh:)"
+                "namespace URI `{uri}` does not start with a known scheme (path:, https:, git:, git+ssh:, or the github:/gitlab: URL templates)"
             ),
             ResolveError::UriParseError { uri, source } => {
                 write!(f, "namespace URI `{uri}` is malformed: {source}")
@@ -169,10 +176,12 @@ impl std::error::Error for ResolveError {
 /// cache. Convenience wrapper around [`resolve_namespace_with`] for
 /// callers that don't need to override either.
 ///
-/// The default registry has stub fetchers for `github:`, `gitlab:`,
-/// `https:`, and `git+ssh:` that return [`FetchError::Unimplemented`]
-/// — same observable behaviour as the pre-machinery resolver.
-/// Per-scheme implementations are tracked at
+/// The default registry has stub fetchers for the `https:` and `git:`
+/// transports (the latter also claims `git+ssh:`); both return
+/// [`FetchError::Unimplemented`] — same observable behaviour as the
+/// pre-machinery resolver. `github:` and `gitlab:` are URL templates
+/// that expand into one of those transports before dispatch.
+/// Per-transport implementations are tracked at
 /// [lex#562](https://github.com/lex-fmt/lex/issues/562).
 ///
 /// The default cache lives at `$XDG_CACHE_HOME/lex/labels/` (falling
@@ -198,13 +207,17 @@ pub fn resolve_namespace(
 /// Dispatch:
 ///
 /// 1. Parse the URI ([`ParsedUri::parse`]). `path:` is special-cased
-///    here — it bypasses the registry + cache entirely and resolves
-///    against `workspace_root` like a local path.
-/// 2. Look up the fetcher for the URI's scheme in `registry`. Return
-///    [`ResolveError::UnknownScheme`] if no fetcher is registered.
-/// 3. Consult `cache` for the URI+rev. If hit (and still valid by
+///    here — it bypasses templates, registry, and cache, resolving
+///    directly against `workspace_root` like a local path.
+/// 2. Run URL-template expansion ([`template::expand`]) on the parsed
+///    URI. Forge shorthands (`github:`, `gitlab:`) become transport
+///    URIs; transport URIs pass through unchanged.
+/// 3. Look up the fetcher for the (expanded) URI's scheme in
+///    `registry`. Return [`ResolveError::UnknownScheme`] if no fetcher
+///    is registered.
+/// 4. Consult `cache` for the URI+rev. If hit (and still valid by
 ///    TTL / immutability), return the cached path.
-/// 4. Otherwise call `fetcher.fetch(uri, dest)` with a fresh cache
+/// 5. Otherwise call `fetcher.fetch(uri, dest)` with a fresh cache
 ///    directory. Record the fetch timestamp in the cache. Return the
 ///    path on success.
 pub fn resolve_namespace_with(
@@ -222,13 +235,18 @@ pub fn resolve_namespace_with(
         return path::resolve(&parsed, uri, workspace_root);
     }
 
+    let expanded = template::expand(parsed).map_err(|source| ResolveError::UriParseError {
+        uri: uri.to_string(),
+        source,
+    })?;
+
     let fetcher = registry
-        .get(&parsed.scheme)
+        .get(&expanded.scheme)
         .ok_or_else(|| ResolveError::UnknownScheme {
             uri: uri.to_string(),
         })?;
 
-    let schema_dir = cache.fetch_or_reuse(&parsed, fetcher.as_ref())?;
+    let schema_dir = cache.fetch_or_reuse(&expanded, fetcher.as_ref())?;
 
     Ok(ResolvedNamespace {
         schema_dir,
@@ -272,7 +290,13 @@ mod tests {
     }
 
     #[test]
-    fn github_scheme_through_default_registry_yields_unimplemented_fetch() {
+    fn github_template_expands_then_hits_unimplemented_https_fetch() {
+        // `github:` is a URL template that expands to an `https:` URI
+        // before dispatch. The fetch then fails at the (stubbed)
+        // https transport — note the reported scheme is the
+        // *transport* scheme, not the user-facing template scheme.
+        // The `Fetch.uri` field preserves the original user-facing
+        // URI for diagnostics.
         let workspace = tempfile::tempdir().unwrap();
         let registry = default_fetcher_registry();
         let (_tmp, cache) = fresh_cache();
@@ -285,32 +309,61 @@ mod tests {
         .unwrap_err();
         match err {
             ResolveError::Fetch {
+                uri,
                 source: FetchError::Unimplemented { scheme, .. },
-                ..
-            } => assert_eq!(scheme, "github"),
-            other => panic!("expected Fetch(Unimplemented {{ github }}), got: {other}"),
+            } => {
+                assert_eq!(scheme, "https", "expanded transport scheme");
+                assert_eq!(uri, "github:acme/lex-labels", "original URI preserved");
+            }
+            other => panic!("expected Fetch(Unimplemented {{ https }}), got: {other}"),
         }
     }
 
     #[test]
-    fn gitlab_https_git_ssh_all_unimplemented_through_default_registry() {
+    fn gitlab_template_expands_then_hits_unimplemented_https_fetch() {
         let workspace = tempfile::tempdir().unwrap();
         let registry = default_fetcher_registry();
         let (_tmp, cache) = fresh_cache();
-        for scheme in ["gitlab", "https", "git+ssh"] {
-            let uri = if scheme == "https" || scheme == "git+ssh" {
-                format!("{scheme}://example.com/foo")
-            } else {
-                format!("{scheme}:foo/bar")
-            };
-            let err =
-                resolve_namespace_with(&uri, workspace.path(), &registry, &cache).unwrap_err();
+        let err = resolve_namespace_with(
+            "gitlab:foolco/lex-labels",
+            workspace.path(),
+            &registry,
+            &cache,
+        )
+        .unwrap_err();
+        match err {
+            ResolveError::Fetch {
+                uri,
+                source: FetchError::Unimplemented { scheme, .. },
+            } => {
+                assert_eq!(scheme, "https");
+                assert_eq!(uri, "gitlab:foolco/lex-labels");
+            }
+            other => panic!("expected Fetch(Unimplemented {{ https }}), got: {other}"),
+        }
+    }
+
+    #[test]
+    fn transport_schemes_all_unimplemented_through_default_registry() {
+        let workspace = tempfile::tempdir().unwrap();
+        let registry = default_fetcher_registry();
+        let (_tmp, cache) = fresh_cache();
+        // `git:` and `git+ssh:` both route to the GitFetcher, which
+        // reports its primary scheme as `git`. `https:` routes to the
+        // HttpsFetcher.
+        let cases = [
+            ("https://example.com/foo.tar.gz", "https"),
+            ("git+ssh://git@example.com/foo.git", "git"),
+            ("git:https://example.com/foo.git", "git"),
+        ];
+        for (uri, expected_scheme) in cases {
+            let err = resolve_namespace_with(uri, workspace.path(), &registry, &cache).unwrap_err();
             match err {
                 ResolveError::Fetch {
                     source: FetchError::Unimplemented { scheme: s, .. },
                     ..
-                } => assert_eq!(s, scheme, "wrong scheme reported"),
-                other => panic!("expected Fetch(Unimplemented) for {scheme}, got: {other}"),
+                } => assert_eq!(s, expected_scheme, "wrong scheme reported for {uri}"),
+                other => panic!("expected Fetch(Unimplemented) for {uri}, got: {other}"),
             }
         }
     }

--- a/crates/lex-extension-host/src/resolve/mod.rs
+++ b/crates/lex-extension-host/src/resolve/mod.rs
@@ -6,10 +6,14 @@
 //! specified in `comms/specs/proposals/extending-lex-stores.lex` and
 //! decomposes into:
 //!
-//! - **Three real transports** (one [`Fetcher`] each):
-//!   - `path:` — local filesystem path. No network, no cache.
-//!   - `https:` — HTTPS GET of a tarball/zip.
-//!   - `git:` / `git+ssh:` — git clone of a repository.
+//! - **Three real transports**:
+//!   - `path:` — built-in local filesystem read. Special-cased
+//!     upstream of registry dispatch — no [`Fetcher`] impl, no cache.
+//!   - `https:` — HTTPS GET of a tarball/zip. Implemented by the
+//!     [`fetcher::HttpsFetcher`] in the registry.
+//!   - `git:` / `git+ssh:` — git clone of a repository. Implemented
+//!     by the [`fetcher::GitFetcher`] in the registry (claims both
+//!     schemes).
 //! - **N URL templates** that expand into one of the transports
 //!   above before dispatch:
 //!   - `github:owner/repo[#rev]` — github tarball (https) or clone (git).
@@ -81,8 +85,14 @@ pub struct ResolvedNamespace {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ResolveError {
-    /// URI didn't match any registered scheme.
-    UnknownScheme { uri: String },
+    /// URI didn't match any registered scheme. `scheme` is the actual
+    /// missing scheme — for plain transport URIs that matches the
+    /// scheme of `uri`, but for forge-template URIs (`github:`,
+    /// `gitlab:`) it's the *expanded* transport scheme (typically
+    /// `https`). That's what the diagnostic needs to name so the user
+    /// understands which transport fetcher is missing from the
+    /// registry, not just that the original URI failed.
+    UnknownScheme { uri: String, scheme: String },
     /// URI failed to parse syntactically (bad fragment, missing
     /// scheme, …). Distinct from `UnknownScheme`: the URI is
     /// malformed at the lex layer, not just pointed at a scheme we
@@ -124,10 +134,27 @@ pub enum ResolveError {
 impl std::fmt::Display for ResolveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ResolveError::UnknownScheme { uri } => write!(
-                f,
-                "namespace URI `{uri}` does not start with a known scheme (path:, https:, git:, git+ssh:, or the github:/gitlab: URL templates)"
-            ),
+            ResolveError::UnknownScheme { uri, scheme } => {
+                // When the URI's original scheme equals the missing
+                // scheme, no template expansion happened — give the
+                // plain "unknown scheme" phrasing. Otherwise the user
+                // wrote a forge template (`github:`/`gitlab:`) that
+                // expanded into a transport scheme they haven't
+                // registered; say that explicitly so the diagnostic
+                // points at what's actually missing.
+                let user_scheme = uri.split_once(':').map(|(s, _)| s).unwrap_or(uri);
+                if user_scheme == scheme {
+                    write!(
+                        f,
+                        "namespace URI `{uri}` uses transport scheme `{scheme}:` which has no registered fetcher (known: path:, https:, git:, git+ssh:, plus the github:/gitlab: URL templates)"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "namespace URI `{uri}` (a `{user_scheme}:` URL template) expands to transport scheme `{scheme}:` which has no registered fetcher (known: path:, https:, git:, git+ssh:)"
+                    )
+                }
+            }
             ResolveError::UriParseError { uri, source } => {
                 write!(f, "namespace URI `{uri}` is malformed: {source}")
             }
@@ -244,6 +271,7 @@ pub fn resolve_namespace_with(
         .get(&expanded.scheme)
         .ok_or_else(|| ResolveError::UnknownScheme {
             uri: uri.to_string(),
+            scheme: expanded.scheme.clone(),
         })?;
 
     let schema_dir = cache.fetch_or_reuse(&expanded, fetcher.as_ref())?;
@@ -276,7 +304,61 @@ mod tests {
         let (_tmp, cache) = fresh_cache();
         let err = resolve_namespace_with("ftp:server/path", workspace.path(), &registry, &cache)
             .unwrap_err();
-        assert!(matches!(err, ResolveError::UnknownScheme { .. }));
+        match err {
+            ResolveError::UnknownScheme { uri, scheme } => {
+                assert_eq!(uri, "ftp:server/path");
+                assert_eq!(scheme, "ftp");
+                // Plain transport URI (no template expansion) — the
+                // diagnostic should NOT use the "expands to" phrasing
+                // that's reserved for the template-expansion branch.
+                // (The "known schemes" footer mentions URL templates
+                // either way, so we discriminate on "expands to"
+                // instead.)
+                let msg = format!(
+                    "{}",
+                    ResolveError::UnknownScheme {
+                        uri,
+                        scheme: scheme.clone()
+                    }
+                );
+                assert!(
+                    !msg.contains("expands to"),
+                    "plain transport URI shouldn't use template-expansion phrasing: {msg}"
+                );
+            }
+            other => panic!("expected UnknownScheme, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn unknown_scheme_after_template_expansion_names_transport() {
+        // If a custom registry omits `https:`, a `github:` template
+        // expansion still produces an https URI, and the error needs
+        // to say "expands to transport scheme `https:`" rather than
+        // misleadingly claiming `github:` is unknown.
+        let workspace = tempfile::tempdir().unwrap();
+        let registry = FetcherRegistry::new(); // empty — no https registered
+        let (_tmp, cache) = fresh_cache();
+        let err = resolve_namespace_with("github:acme/repo", workspace.path(), &registry, &cache)
+            .unwrap_err();
+        match err {
+            ResolveError::UnknownScheme { uri, scheme } => {
+                assert_eq!(uri, "github:acme/repo");
+                assert_eq!(scheme, "https", "should report the expanded transport");
+                let msg = format!(
+                    "{}",
+                    ResolveError::UnknownScheme {
+                        uri: uri.clone(),
+                        scheme: scheme.clone()
+                    }
+                );
+                assert!(
+                    msg.contains("expands to") && msg.contains("`https:`"),
+                    "template-expansion diagnostic should name the expanded transport: {msg}"
+                );
+            }
+            other => panic!("expected UnknownScheme, got: {other}"),
+        }
     }
 
     #[test]

--- a/crates/lex-extension-host/src/resolve/registry.rs
+++ b/crates/lex-extension-host/src/resolve/registry.rs
@@ -5,16 +5,21 @@
 //! registry's keys are also `&'static str` — no allocation per
 //! lookup.
 //!
-//! Typical usage: construct via [`default_fetcher_registry`] for
-//! the standard four-scheme stub set, or build a custom registry
-//! with [`FetcherRegistry::new`] + [`FetcherRegistry::register`]
-//! when a host wants its own fetchers (in-process mocks for tests,
-//! custom internal schemes, etc.).
+//! Typical usage: construct via [`default_fetcher_registry`] for the
+//! standard two-transport stub set ([`HttpsFetcher`], [`GitFetcher`]),
+//! or build a custom registry with [`FetcherRegistry::new`] +
+//! [`FetcherRegistry::register`] when a host wants its own fetchers
+//! (in-process mocks for tests, custom internal schemes, etc.).
+//!
+//! Forge-shorthand schemes (`github:`, `gitlab:`) are *not* in the
+//! registry: they're URL templates that expand into a transport URI
+//! upstream of registry dispatch (see [`super::template`]). The
+//! registry only carries real transports.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::fetcher::{Fetcher, GitSshFetcher, GithubFetcher, GitlabFetcher, HttpsFetcher};
+use super::fetcher::{Fetcher, GitFetcher, HttpsFetcher};
 
 /// Maps URI schemes to [`Fetcher`] implementations. Clone is cheap
 /// (one `Arc` clone per registered fetcher).
@@ -65,22 +70,26 @@ impl std::fmt::Debug for FetcherRegistry {
     }
 }
 
-/// Construct a registry with the standard four-scheme stub fetcher
-/// set: [`GithubFetcher`], [`GitlabFetcher`], [`HttpsFetcher`],
-/// [`GitSshFetcher`]. Each returns
+/// Construct a registry with the standard two-transport stub fetcher
+/// set: [`HttpsFetcher`] (claims `https:`) and [`GitFetcher`] (claims
+/// both `git:` and `git+ssh:`). Each returns
 /// [`super::FetchError::Unimplemented`] from `fetch` — replace with
-/// a real implementation per lex#562 to make the scheme actually
+/// a real implementation per lex#562 to make the transport actually
 /// work.
 ///
 /// `path:` is NOT in the registry: it's special-cased at the
 /// [`super::resolve_namespace_with`] level (no cache, no fetcher,
 /// resolved directly against the workspace root).
+///
+/// `github:` and `gitlab:` are NOT in the registry either: they're
+/// URL templates that expand to transport URIs upstream of dispatch
+/// (see [`super::template`]). Adding more forge shorthands
+/// (bitbucket, gitea, codeberg, sourcehut) is template work, not
+/// fetcher work — the registry stays at two entries.
 pub fn default_fetcher_registry() -> FetcherRegistry {
     let mut r = FetcherRegistry::new();
-    r.register(Arc::new(GithubFetcher));
-    r.register(Arc::new(GitlabFetcher));
     r.register(Arc::new(HttpsFetcher));
-    r.register(Arc::new(GitSshFetcher));
+    r.register(Arc::new(GitFetcher));
     r
 }
 
@@ -89,13 +98,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_registry_has_four_schemes() {
+    fn default_registry_has_transport_schemes_only() {
         let r = default_fetcher_registry();
-        for s in ["github", "gitlab", "https", "git+ssh"] {
+        // Real transports.
+        for s in ["https", "git", "git+ssh"] {
             assert!(r.contains(s), "default registry missing `{s}:`");
         }
-        // `path:` is intentionally NOT in the registry.
+        // `path:` is intentionally NOT in the registry — special-cased
+        // upstream of dispatch.
         assert!(!r.contains("path"));
+        // `github:` and `gitlab:` are URL templates, not transports —
+        // they expand into one of the registered transports before
+        // dispatch reaches the registry.
+        assert!(!r.contains("github"));
+        assert!(!r.contains("gitlab"));
     }
 
     #[test]

--- a/crates/lex-extension-host/src/resolve/registry.rs
+++ b/crates/lex-extension-host/src/resolve/registry.rs
@@ -70,12 +70,13 @@ impl std::fmt::Debug for FetcherRegistry {
     }
 }
 
-/// Construct a registry with the standard two-transport stub fetcher
-/// set: [`HttpsFetcher`] (claims `https:`) and [`GitFetcher`] (claims
-/// both `git:` and `git+ssh:`). Each returns
-/// [`super::FetchError::Unimplemented`] from `fetch` — replace with
-/// a real implementation per lex#562 to make the transport actually
-/// work.
+/// Construct a registry with the standard transport-fetcher stub set:
+/// two [`Fetcher`] implementations covering three URI schemes —
+/// [`HttpsFetcher`] (claims `https:`) and [`GitFetcher`] (claims both
+/// `git:` and `git+ssh:`, since both URL forms feed the same
+/// `git clone`). Each fetcher returns [`super::FetchError::Unimplemented`]
+/// from `fetch` — replace with a real implementation per lex#562 to
+/// make the transport actually work.
 ///
 /// `path:` is NOT in the registry: it's special-cased at the
 /// [`super::resolve_namespace_with`] level (no cache, no fetcher,

--- a/crates/lex-extension-host/src/resolve/template.rs
+++ b/crates/lex-extension-host/src/resolve/template.rs
@@ -1,0 +1,154 @@
+//! URL-template expansion for forge shorthands.
+//!
+//! A URL template is a pure function over [`ParsedUri`] that turns a
+//! forge-shorthand URI into a transport URI. Templates have no
+//! [`super::Fetcher`] impl — they don't do any IO; they just rewrite
+//! the URI so the dispatch layer hands the expanded form to the right
+//! transport fetcher.
+//!
+//! Two templates ship today:
+//!
+//! - `github:owner/repo[#rev][?subdir=…]` — expands to a GitHub
+//!   tarball-API URL (`https:` transport, default) or a git clone URL
+//!   (`git:` transport, when `via = "git"` — knob plumbing pending,
+//!   see [#10.2 of the stores spec]). Tracked at lex#562 alongside the
+//!   underlying https/git fetchers.
+//! - `gitlab:owner/repo[#rev][?subdir=…]` — same shape, gitlab.com.
+//!
+//! New templates (bitbucket, gitea, codeberg, sourcehut) drop in here
+//! as additional `*_template` functions plus a match arm in [`expand`].
+
+use super::uri::{ParsedUri, UriParseError};
+
+/// Expand any URL-template URI into its underlying transport URI.
+/// Non-template URIs (`path:`, `https:`, `git:`, `git+ssh:`) pass
+/// through unchanged.
+///
+/// The `original` field of the returned [`ParsedUri`] is preserved
+/// from the input, so error messages can refer to what the user
+/// actually wrote (`github:acme/lex-labels`) rather than the expanded
+/// form (`https://api.github.com/...`). The `subdir` is also
+/// preserved across the expansion.
+pub(super) fn expand(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
+    match uri.scheme.as_str() {
+        "github" => github_template(uri),
+        "gitlab" => gitlab_template(uri),
+        _ => Ok(uri),
+    }
+}
+
+/// Expand `github:owner/repo[#rev]` into the GitHub tarball-API
+/// `https:` URI. Default ref is `HEAD` (the repo's default branch).
+///
+/// The `via` knob (https vs. git) is not yet plumbed through
+/// `lex-config`; templates currently default to https. When `via` is
+/// wired up, a `via = "git"` case will produce a
+/// `git:https://github.com/owner/repo.git` URI instead.
+fn github_template(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
+    let owner_repo = uri.body.trim_start_matches('/');
+    let rev = uri.rev.as_deref().unwrap_or("HEAD");
+    let expanded_str = format!("https://api.github.com/repos/{owner_repo}/tarball/{rev}");
+
+    let mut expanded = ParsedUri::parse(&expanded_str)?;
+    expanded.original = uri.original;
+    expanded.subdir = uri.subdir;
+    Ok(expanded)
+}
+
+/// Expand `gitlab:owner/repo[#rev]` into the GitLab archive-API
+/// `https:` URI. GitLab's archive endpoint is path-shaped rather than
+/// API-shaped: `https://gitlab.com/<owner>/<repo>/-/archive/<ref>/<repo>-<ref>.tar.gz`.
+/// Default ref is `HEAD`.
+fn gitlab_template(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
+    let owner_repo = uri.body.trim_start_matches('/');
+    let repo = owner_repo
+        .rsplit_once('/')
+        .map(|(_, r)| r)
+        .unwrap_or(owner_repo);
+    let rev = uri.rev.as_deref().unwrap_or("HEAD");
+    let expanded_str =
+        format!("https://gitlab.com/{owner_repo}/-/archive/{rev}/{repo}-{rev}.tar.gz");
+
+    let mut expanded = ParsedUri::parse(&expanded_str)?;
+    expanded.original = uri.original;
+    expanded.subdir = uri.subdir;
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_no_rev_expands_to_head_tarball() {
+        let input = ParsedUri::parse("github:acme/lex-labels").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.scheme, "https");
+        assert_eq!(
+            out.body,
+            "//api.github.com/repos/acme/lex-labels/tarball/HEAD"
+        );
+        assert_eq!(out.original, "github:acme/lex-labels");
+    }
+
+    #[test]
+    fn github_with_rev_expands_to_tagged_tarball() {
+        let input = ParsedUri::parse("github:acme/lex-labels#v1.2.0").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.scheme, "https");
+        assert_eq!(
+            out.body,
+            "//api.github.com/repos/acme/lex-labels/tarball/v1.2.0"
+        );
+    }
+
+    #[test]
+    fn github_preserves_subdir_across_expansion() {
+        let input = ParsedUri::parse("github:acme/lex-labels?subdir=schemas").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.scheme, "https");
+        assert_eq!(out.subdir.as_deref(), Some("schemas"));
+    }
+
+    #[test]
+    fn github_preserves_original_uri_for_diagnostics() {
+        let input = ParsedUri::parse("github:acme/lex-labels#main").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.original, "github:acme/lex-labels#main");
+    }
+
+    #[test]
+    fn gitlab_no_rev_expands_to_head_archive() {
+        let input = ParsedUri::parse("gitlab:foolco/lex-labels").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.scheme, "https");
+        assert_eq!(
+            out.body,
+            "//gitlab.com/foolco/lex-labels/-/archive/HEAD/lex-labels-HEAD.tar.gz"
+        );
+    }
+
+    #[test]
+    fn gitlab_with_rev_expands_to_tagged_archive() {
+        let input = ParsedUri::parse("gitlab:foolco/lex-labels#v2.1.0").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.scheme, "https");
+        assert_eq!(
+            out.body,
+            "//gitlab.com/foolco/lex-labels/-/archive/v2.1.0/lex-labels-v2.1.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn non_template_uri_passes_through_unchanged() {
+        for input_str in [
+            "path:./local",
+            "https://example.com/foo.tar.gz",
+            "git+ssh://git@host/repo.git#main",
+        ] {
+            let input = ParsedUri::parse(input_str).unwrap();
+            let out = expand(input.clone()).unwrap();
+            assert_eq!(out, input, "non-template URI was rewritten: {input_str}");
+        }
+    }
+}

--- a/crates/lex-extension-host/src/resolve/template.rs
+++ b/crates/lex-extension-host/src/resolve/template.rs
@@ -27,8 +27,11 @@ use super::uri::{ParsedUri, UriParseError};
 /// The `original` field of the returned [`ParsedUri`] is preserved
 /// from the input, so error messages can refer to what the user
 /// actually wrote (`github:acme/lex-labels`) rather than the expanded
-/// form (`https://api.github.com/...`). The `subdir` is also
-/// preserved across the expansion.
+/// form (`https://api.github.com/...`). The `rev` and `subdir` are
+/// also preserved across the expansion — `rev` in particular feeds
+/// [`super::Fetcher::is_immutable_rev`] for cache-TTL decisions, so
+/// dropping it would silently downgrade tag/SHA-pinned templates from
+/// indefinite caching to the 24-hour mutable-ref TTL.
 pub(super) fn expand(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
     match uri.scheme.as_str() {
         "github" => github_template(uri),
@@ -52,6 +55,12 @@ fn github_template(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
     let mut expanded = ParsedUri::parse(&expanded_str)?;
     expanded.original = uri.original;
     expanded.subdir = uri.subdir;
+    // Preserve rev so the cache TTL layer can ask the fetcher whether
+    // the rev is immutable. The URL embeds the rev too, but ParsedUri's
+    // rev field is what ResolverCache::fetch_or_reuse passes to
+    // Fetcher::is_immutable_rev — a None here would always be treated
+    // as mutable (24h TTL) even for tag/SHA-pinned templates.
+    expanded.rev = uri.rev;
     Ok(expanded)
 }
 
@@ -59,6 +68,12 @@ fn github_template(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
 /// `https:` URI. GitLab's archive endpoint is path-shaped rather than
 /// API-shaped: `https://gitlab.com/<owner>/<repo>/-/archive/<ref>/<repo>-<ref>.tar.gz`.
 /// Default ref is `HEAD`.
+///
+/// Refs containing `/` (e.g. `feature/foo`) are accepted multi-segment
+/// in the archive *path* (GitLab's web UI does this), but the archive
+/// *filename* uses `-` in place of `/` per GitLab's convention. Without
+/// the substitution the URL ends up with a stray path separator in the
+/// filename component (`…/lex-labels-feature/foo.tar.gz`).
 fn gitlab_template(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
     let owner_repo = uri.body.trim_start_matches('/');
     let repo = owner_repo
@@ -66,12 +81,14 @@ fn gitlab_template(uri: ParsedUri) -> Result<ParsedUri, UriParseError> {
         .map(|(_, r)| r)
         .unwrap_or(owner_repo);
     let rev = uri.rev.as_deref().unwrap_or("HEAD");
+    let rev_filename = rev.replace('/', "-");
     let expanded_str =
-        format!("https://gitlab.com/{owner_repo}/-/archive/{rev}/{repo}-{rev}.tar.gz");
+        format!("https://gitlab.com/{owner_repo}/-/archive/{rev}/{repo}-{rev_filename}.tar.gz");
 
     let mut expanded = ParsedUri::parse(&expanded_str)?;
     expanded.original = uri.original;
     expanded.subdir = uri.subdir;
+    expanded.rev = uri.rev;
     Ok(expanded)
 }
 
@@ -118,6 +135,25 @@ mod tests {
     }
 
     #[test]
+    fn github_preserves_rev_for_cache_immutability_check() {
+        // Regression: the expanded https URL embeds the rev in its path,
+        // but ParsedUri::rev must also be set so ResolverCache asks
+        // Fetcher::is_immutable_rev about the right value. Without
+        // this, tag/SHA-pinned github templates would silently cache
+        // with the mutable-ref 24h TTL.
+        let input = ParsedUri::parse("github:acme/lex-labels#v1.2.0").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.rev.as_deref(), Some("v1.2.0"));
+    }
+
+    #[test]
+    fn github_no_rev_leaves_rev_none() {
+        let input = ParsedUri::parse("github:acme/lex-labels").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.rev, None);
+    }
+
+    #[test]
     fn gitlab_no_rev_expands_to_head_archive() {
         let input = ParsedUri::parse("gitlab:foolco/lex-labels").unwrap();
         let out = expand(input).unwrap();
@@ -137,6 +173,29 @@ mod tests {
             out.body,
             "//gitlab.com/foolco/lex-labels/-/archive/v2.1.0/lex-labels-v2.1.0.tar.gz"
         );
+    }
+
+    #[test]
+    fn gitlab_slashed_rev_dashes_the_filename() {
+        // Regression: refs like `feature/foo` previously interpolated
+        // straight into the filename, producing
+        // `lex-labels-feature/foo.tar.gz` (extra path separator). The
+        // path portion keeps `/` (GitLab accepts multi-segment), the
+        // filename substitutes `-`.
+        let input = ParsedUri::parse("gitlab:foolco/lex-labels#feature/foo").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.scheme, "https");
+        assert_eq!(
+            out.body,
+            "//gitlab.com/foolco/lex-labels/-/archive/feature/foo/lex-labels-feature-foo.tar.gz"
+        );
+    }
+
+    #[test]
+    fn gitlab_preserves_rev_for_cache_immutability_check() {
+        let input = ParsedUri::parse("gitlab:foolco/lex-labels#v2.1.0").unwrap();
+        let out = expand(input).unwrap();
+        assert_eq!(out.rev.as_deref(), Some("v2.1.0"));
     }
 
     #[test]

--- a/crates/lex-fmt/src/setup.rs
+++ b/crates/lex-fmt/src/setup.rs
@@ -40,9 +40,10 @@
 //!
 //! ## What's NOT here
 //!
-//! - Network resolvers (github:/gitlab:/https:/git+ssh:). Those
-//!   live in the resolver and return `Unimplemented`; this boot
-//!   surfaces the error and continues. Tracked at lex#546.
+//! - Network resolvers (https:/git: transports; github:/gitlab: URL
+//!   templates that expand into them). Those live in the resolver
+//!   and return `Unimplemented`; this boot surfaces the error and
+//!   continues. Tracked at lex#546 and lex#562.
 //! - Third-party `transport: native` handlers. Only the bundled
 //!   `lex.*` built-ins use the native transport in v1; user-provided
 //!   native handlers would need an in-process registration path


### PR DESCRIPTION
## Summary

Refactors the namespace resolver to match the model in the new `extending-lex-stores.lex` spec (proposed in lex-fmt/comms#60): **three real transports + N URL templates**, rather than five peer schemes.

This is a structural / machinery PR. **No behaviour change for end users** — every scheme still resolves to `FetchError::Unimplemented`. What changes is the surface that real fetchers will plug into, and the dispatch model behind it. Per-transport network implementations remain tracked at #562 (now rescoped from "implement four fetchers" to "implement two fetchers + two templates").

## Commits

1. `spec: pull in extending-lex-stores companion proposal` — submodule bump that brings in the spec from comms#60.
2. `feat(extension-host): refactor resolver into transports + URL templates` — the machinery refactor.

## Changes

- **Remove** `GithubFetcher` and `GitlabFetcher` from `resolve/fetcher.rs`. They were not transports; they're URL templates that produce transport URIs.
- **Rename** `GitSshFetcher` → `GitFetcher`. It now claims both `git:` and `git+ssh:` schemes — the underlying `git clone` accepts every URL form either scheme produces.
- **Add** `resolve/template.rs` with `github_template` and `gitlab_template` pure functions that rewrite forge-shorthand URIs into transport URIs (defaulting to https tarball; the `via = "git"` knob plumbing is left for the lex-config follow-up). The original URI is preserved through expansion so diagnostics still refer to what the user wrote.
- **Wire** template expansion into `resolve_namespace_with` between URI parse and registry dispatch. The dispatch layer no longer sees `github:` / `gitlab:` schemes directly.
- **Shrink** `default_fetcher_registry` to two fetchers (`HttpsFetcher`, `GitFetcher`) covering three schemes (`https`, `git`, `git+ssh`).
- **Update** module-level docs and the `UnknownScheme` error message to reflect the new model.
- **Update** dispatch tests: github / gitlab template-expansion tests assert on the expanded transport scheme (`https`) while confirming the original URI is preserved in `Fetch.uri`. New `transport_schemes_all_unimplemented_through_default_registry` exercises https / git / git+ssh dispatch.
- **Add** template-level unit tests (no-rev, with-rev, subdir preservation, original-URI preservation, non-template pass-through).

## What this PR deliberately doesn't do

Per session scope agreed with the user — "spec + machinery refactor, stores in later sessions":

- No real HTTPS GET or git clone — `HttpsFetcher` and `GitFetcher` still return `Unimplemented`. That's #562's work.
- No `lex-config` schema changes. The new spec's primary-field dispatch (`path` / `url` / `git` / `tap` / `github` / `gitlab`) and the `via` knob are not yet exposed; current `lex.toml` still accepts only `tap` / `uri` / `rev` / `subdir`. Adding the new fields is a follow-up (and tracked implicitly by the spec).
- No sandbox / trust changes. Those remain on their existing track.

## Companion PR

Spec lives in lex-fmt/comms#60. The submodule bump in commit 1 pulls it in.

## Test plan

- [x] `cargo build --workspace --exclude lex-wasm` — clean.
- [x] `cargo nextest run --workspace --exclude lex-wasm` — all 2,278 tests pass.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --exclude lex-wasm --all-targets` — clean.
- [x] Stub-level behaviour preserved (`Unimplemented` still returned, original URI surfaces in diagnostics).
- [ ] CI to confirm on push.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2aGbJ1u2P1gNUGnroMKMU)_