### PR TITLE
feat(diagnostics-config): configurable severity for extension-emitted diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed — extension diagnostic codes carry their namespace on the wire ([#657](https://github.com/lex-fmt/lex/issues/657))
+
+Follow-up to #636: `[diagnostics.rules]` now accepts extension-emitted codes (`acme.task-due-date-missing`, `mit.plasma-specs.invalid-version`) alongside built-ins, configured identically.
+
+- **Wire-format change (breaking).** `DiagnosticKind::Handler::code()` returns the namespace-prefixed form: a handler emitting `code: Some("foo")` under namespace `acme` produces wire `code = "acme.foo"` (previously bare `"foo"`). When the handler omits a code, the fallback is per-namespace `"acme.diagnostic"` rather than the old global literal `"handler.diagnostic"`. Any consumer matching on the bare wire `code` for an extension diagnostic must update to the dotted form.
+- **`[diagnostics.rules]` extension keys.** `DiagnosticsRulesConfig` gains an `extra: BTreeMap<String, RuleConfig>` map. Any key under `[diagnostics.rules]` that doesn't match a built-in field flows into `extra` via `#[serde(flatten)]`; clapfig's strict-mode validator sees them as consumed (the same `#[serde(flatten)]` is pushed onto the confique-generated `Layer` field via `#[config(layer_attr(...))]`). Tradeoff: typo detection for *built-in* field names is sacrificed at this attribute level — a misspelled `missing_footote` now lands in `extra` instead of erroring. Schema-based validation (deferred, follow-up issue) will restore typo detection once extension schemas declare their codes.
+- **`lookup_by_code` semantics.** Resolution order is named built-in field → `extra` map → `None`. Built-ins always win — a stray `extra` entry with a built-in code does not override the typed surface. `apply_rules` semantics are unchanged: `allow` drops the diagnostic, `warn` keeps intrinsic severity, `deny` upgrades to `Error`. Identical code path to built-ins; extension support is purely a lookup-table extension.
+- **Lenient.** Any string key is accepted into `extra` without further validation. Entries that never match anything are harmless (ESLint / Clippy convention).
+
 ### Added — configurable diagnostic rules via `[diagnostics.rules]` ([#636](https://github.com/lex-fmt/lex/issues/636))
 
 Closes the v1 loop on the diagnostic-configuration system. `.lex.toml` gains a `[diagnostics.rules]` block with one field per built-in diagnostic code, and the LSP server honours those rules when publishing diagnostics.

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -21,8 +21,17 @@ pub enum DiagnosticKind {
     /// `namespace` field is the namespace name (the part before the
     /// first `.`, e.g., `"acme"` for label `"acme.task"`) — `lex-lsp`
     /// surfaces it as the diagnostic `source: "lex:<namespace>"` so
-    /// editors can filter by extension. `code` mirrors the wire
-    /// `Diagnostic.code` field.
+    /// editors can filter by extension.
+    ///
+    /// `code` carries the **bare leaf** the handler supplied (the
+    /// `code` field on `lex_extension::Diagnostic`), *not* the wire
+    /// form. The analyser glues on the namespace prefix in
+    /// [`DiagnosticKind::code`] to produce the wire shape per spec §9
+    /// (`<namespace>.<leaf>`, e.g. `"acme.foo"`; or the per-namespace
+    /// fallback `"acme.diagnostic"` when the handler set `None`).
+    /// Passing an already-prefixed value here would produce a
+    /// double-prefixed wire code (`"acme.acme.foo"`) — handlers should
+    /// supply just the leaf.
     Handler {
         namespace: String,
         code: Option<String>,
@@ -129,9 +138,13 @@ impl DiagnosticKind {
 /// - `warn` → the diagnostic's intrinsic severity stays unchanged.
 /// - `deny` → severity is upgraded to `Error`.
 ///
-/// Diagnostics whose code is unknown to the rules config (extension-
-/// emitted codes from handlers, until the `extra` map ships) are
-/// passed through untouched at their intrinsic severity.
+/// Resolution is delegated to [`DiagnosticsRulesConfig::lookup_by_code`],
+/// which consults the named built-in fields first and then falls
+/// through to the `extra` map. So extension-emitted codes with a
+/// matching `[diagnostics.rules]` entry (e.g. `"acme.foo" = "deny"`)
+/// flow through the same `allow` / `warn` / `deny` logic as built-ins.
+/// Codes with no matching entry — anywhere — pass through untouched at
+/// their intrinsic severity.
 pub fn apply_rules(diagnostics: &mut Vec<AnalysisDiagnostic>, rules: &DiagnosticsRulesConfig) {
     diagnostics.retain_mut(|diag| {
         let code = diag.kind.code();

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -5,6 +5,7 @@ use lex_core::lex::ast::{
 };
 use lex_core::lex::inlines::ReferenceType;
 use lex_extension_host::Registry;
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,18 +100,24 @@ impl DiagnosticKind {
     /// against (spec §9), and the per-namespace `.diagnostic` fallback
     /// gives users one knob per namespace for code-less handler
     /// diagnostics rather than a single global `"handler.diagnostic"`.
-    pub fn code(&self) -> String {
+    ///
+    /// Returns `Cow<'static, str>` so built-in variants borrow a
+    /// static string (no allocation) while the `Handler` variant owns
+    /// the `format!`-produced result. `apply_rules` runs on every
+    /// document change in the LSP, so avoiding per-built-in allocations
+    /// matters.
+    pub fn code(&self) -> Cow<'static, str> {
         match self {
-            DiagnosticKind::MissingFootnoteDefinition => "missing-footnote".to_string(),
-            DiagnosticKind::UnusedFootnoteDefinition => "unused-footnote".to_string(),
-            DiagnosticKind::TableInconsistentColumns => "table-inconsistent-columns".to_string(),
-            DiagnosticKind::SchemaValidation(kind) => kind.code().to_string(),
+            DiagnosticKind::MissingFootnoteDefinition => "missing-footnote".into(),
+            DiagnosticKind::UnusedFootnoteDefinition => "unused-footnote".into(),
+            DiagnosticKind::TableInconsistentColumns => "table-inconsistent-columns".into(),
+            DiagnosticKind::SchemaValidation(kind) => kind.code().into(),
             DiagnosticKind::Handler { namespace, code } => match code {
-                Some(c) => format!("{namespace}.{c}"),
-                None => format!("{namespace}.diagnostic"),
+                Some(c) => format!("{namespace}.{c}").into(),
+                None => format!("{namespace}.diagnostic").into(),
             },
-            DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix".to_string(),
-            DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical".to_string(),
+            DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix".into(),
+            DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical".into(),
         }
     }
 }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -92,17 +92,25 @@ impl DiagnosticKind {
     /// (see [`DiagnosticsRulesConfig::lookup_by_code`]).
     ///
     /// For the `Handler` variant — extension-emitted diagnostics —
-    /// this returns the handler's `code` if it supplied one, or the
-    /// stable fallback `"handler.diagnostic"` otherwise.
-    pub fn code(&self) -> &str {
+    /// this returns the namespace-prefixed code: `"acme.foo"` for
+    /// `Handler { namespace: "acme", code: Some("foo") }`, or
+    /// `"acme.diagnostic"` when the handler omitted a code. The
+    /// namespace prefix is what `[diagnostics.rules]` keys match
+    /// against (spec §9), and the per-namespace `.diagnostic` fallback
+    /// gives users one knob per namespace for code-less handler
+    /// diagnostics rather than a single global `"handler.diagnostic"`.
+    pub fn code(&self) -> String {
         match self {
-            DiagnosticKind::MissingFootnoteDefinition => "missing-footnote",
-            DiagnosticKind::UnusedFootnoteDefinition => "unused-footnote",
-            DiagnosticKind::TableInconsistentColumns => "table-inconsistent-columns",
-            DiagnosticKind::SchemaValidation(kind) => kind.code(),
-            DiagnosticKind::Handler { code, .. } => code.as_deref().unwrap_or("handler.diagnostic"),
-            DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix",
-            DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical",
+            DiagnosticKind::MissingFootnoteDefinition => "missing-footnote".to_string(),
+            DiagnosticKind::UnusedFootnoteDefinition => "unused-footnote".to_string(),
+            DiagnosticKind::TableInconsistentColumns => "table-inconsistent-columns".to_string(),
+            DiagnosticKind::SchemaValidation(kind) => kind.code().to_string(),
+            DiagnosticKind::Handler { namespace, code } => match code {
+                Some(c) => format!("{namespace}.{c}"),
+                None => format!("{namespace}.diagnostic"),
+            },
+            DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix".to_string(),
+            DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical".to_string(),
         }
     }
 }
@@ -120,7 +128,7 @@ impl DiagnosticKind {
 pub fn apply_rules(diagnostics: &mut Vec<AnalysisDiagnostic>, rules: &DiagnosticsRulesConfig) {
     diagnostics.retain_mut(|diag| {
         let code = diag.kind.code();
-        let Some(rule) = rules.lookup_by_code(code) else {
+        let Some(rule) = rules.lookup_by_code(&code) else {
             return true;
         };
         match rule.severity() {
@@ -832,7 +840,7 @@ mod tests {
         ] {
             let code = kind.code();
             assert!(
-                rules.lookup_by_code(code).is_some(),
+                rules.lookup_by_code(&code).is_some(),
                 "DiagnosticsRulesConfig is missing a field for built-in code {code:?} \
                  — add it to lookup_by_code (and likely as a struct field too)"
             );
@@ -840,17 +848,119 @@ mod tests {
     }
 
     #[test]
-    fn handler_code_is_passthrough() {
+    fn handler_code_carries_namespace_prefix() {
+        // Wire-shape contract (spec §9): the wire `code` is the
+        // namespace-prefixed form so a `.lex.toml` rule like
+        // `"acme.task-stuck" = "deny"` actually matches what the
+        // handler emitted. The handler supplies the bare leaf (`code`
+        // field on `Diagnostic`); the analyser glues on the namespace.
         let with_code = DiagnosticKind::Handler {
             namespace: "acme".into(),
-            code: Some("acme.task-stuck".into()),
+            code: Some("task-stuck".into()),
         };
         assert_eq!(with_code.code(), "acme.task-stuck");
+        // Code-less handler diagnostic gets a per-namespace fallback
+        // — users can target it as `"acme.diagnostic" = "warn"` rather
+        // than a single global literal.
         let without_code = DiagnosticKind::Handler {
             namespace: "acme".into(),
             code: None,
         };
-        assert_eq!(without_code.code(), "handler.diagnostic");
+        assert_eq!(without_code.code(), "acme.diagnostic");
+    }
+
+    #[test]
+    fn apply_rules_matches_extension_code_via_extra() {
+        // End-to-end: handler emits `acme.foo`, user configured
+        // `"acme.foo" = "allow"` in `[diagnostics.rules]` (landing in
+        // `extra`); diagnostic gets dropped.
+        let mut diags = vec![dummy_diag(
+            DiagnosticKind::Handler {
+                namespace: "acme".into(),
+                code: Some("foo".into()),
+            },
+            DiagnosticSeverity::Error,
+        )];
+        let rules = DiagnosticsRulesConfig {
+            extra: [(
+                "acme.foo".to_string(),
+                lex_config::RuleConfig::Bare(Severity::Allow),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        apply_rules(&mut diags, &rules);
+        assert!(diags.is_empty(), "allow drops the extension diagnostic");
+
+        // `warn` keeps the intrinsic severity (Error stays Error).
+        let mut diags = vec![dummy_diag(
+            DiagnosticKind::Handler {
+                namespace: "acme".into(),
+                code: Some("foo".into()),
+            },
+            DiagnosticSeverity::Error,
+        )];
+        let rules = DiagnosticsRulesConfig {
+            extra: [(
+                "acme.foo".to_string(),
+                lex_config::RuleConfig::Bare(Severity::Warn),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        apply_rules(&mut diags, &rules);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(
+            diags[0].severity,
+            DiagnosticSeverity::Error,
+            "warn preserves the handler's intrinsic severity"
+        );
+
+        // `deny` is a no-op when the intrinsic is already Error, but
+        // still keeps the diagnostic — symmetry with built-ins.
+        let mut diags = vec![dummy_diag(
+            DiagnosticKind::Handler {
+                namespace: "acme".into(),
+                code: Some("foo".into()),
+            },
+            DiagnosticSeverity::Error,
+        )];
+        let rules = DiagnosticsRulesConfig {
+            extra: [(
+                "acme.foo".to_string(),
+                lex_config::RuleConfig::Bare(Severity::Deny),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        apply_rules(&mut diags, &rules);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
+
+        // A configured rule whose code doesn't match the emitted one
+        // passes the diagnostic through untouched.
+        let mut diags = vec![dummy_diag(
+            DiagnosticKind::Handler {
+                namespace: "acme".into(),
+                code: Some("foo".into()),
+            },
+            DiagnosticSeverity::Warning,
+        )];
+        let rules = DiagnosticsRulesConfig {
+            extra: [(
+                "acme.other".to_string(),
+                lex_config::RuleConfig::Bare(Severity::Allow),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        apply_rules(&mut diags, &rules);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
     }
 
     #[test]
@@ -904,11 +1014,13 @@ mod tests {
     #[test]
     fn apply_rules_unknown_code_is_passthrough() {
         // An extension-emitted diagnostic with a code the registry
-        // does not know about must pass through unmodified.
+        // does not know about must pass through unmodified. The
+        // handler's `code` is the bare leaf — the analyser glues on
+        // `acme.` to produce wire `acme.unknown`.
         let mut diags = vec![dummy_diag(
             DiagnosticKind::Handler {
                 namespace: "acme".into(),
-                code: Some("acme.unknown".into()),
+                code: Some("unknown".into()),
             },
             DiagnosticSeverity::Warning,
         )];

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -574,25 +574,29 @@ pub struct DiagnosticsRulesConfig {
     /// Schema-validation diagnostics for extension labels.
     #[config(nested)]
     pub schema: SchemaRulesConfig,
-    /// Extension-emitted diagnostic codes. Keys are the on-the-wire
-    /// `<namespace>.<code>` strings emitted by registered extension
-    /// handlers. Lenient: any key under `[diagnostics.rules]` that
-    /// doesn't match one of the named fields above lands here. Entries
-    /// that never match an emitted code are harmless (ESLint / Clippy
-    /// convention).
+    /// Extension-emitted diagnostic codes. Write them directly under
+    /// `[diagnostics.rules]` as quoted dotted keys, alongside the
+    /// built-ins above — they accept the same severity verbs (`"allow"`,
+    /// `"warn"`, `"deny"`) and the same array form for options.
     ///
-    /// Two flatten attributes:
-    /// - `#[serde(flatten)]` at the struct level rides through direct
-    ///   serde `Serialize`/`Deserialize` of `DiagnosticsRulesConfig`,
-    ///   so the on-disk shape is inline keys in the same table (not a
-    ///   nested `[diagnostics.rules.extra]` sub-table).
-    /// - `#[config(layer_attr(serde(flatten)))]` pushes the same
-    ///   `#[serde(flatten)]` onto the confique-generated `Layer` field
-    ///   so clapfig's strict-mode `serde_ignored` validator sees the
-    ///   extra keys as consumed (not ignored).
+    /// ```toml
+    /// [diagnostics.rules]
+    /// missing_footnote = "deny"                  # built-in
+    /// "acme.task-due-date-missing" = "warn"      # extension code
+    /// "foolco.line-too-long" = ["warn", { max = 120 }]
+    /// ```
     ///
-    /// Together: extension codes land in `extra` instead of erroring.
-    /// Tradeoff: a typo in a built-in field name also lands here.
+    /// The on-the-wire shape per spec §9 is `<namespace>.<code>`
+    /// (e.g. `"acme.task-due-date-missing"` for namespace `acme`,
+    /// code `task-due-date-missing`); the analyser produces that wire
+    /// form, and these `[diagnostics.rules]` entries match it by exact
+    /// string. Entries that never match an emitted diagnostic are
+    /// harmless (ESLint / Clippy convention).
+    ///
+    /// Note: this field renders as `#extra = {  }` in `lexd config gen`
+    /// output. That's a confique template artifact — you do **not**
+    /// write `extra = {...}` in `.lex.toml`. Use inline quoted keys
+    /// directly under `[diagnostics.rules]` as shown above.
     #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
     #[config(default = {}, layer_attr(serde(flatten)))]
     pub extra: BTreeMap<String, RuleConfig>,

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -882,20 +882,21 @@ missing_footnote = "allow"
     }
 
     #[test]
-    fn diagnostics_rules_extra_typo_in_builtin_still_errors() {
-        // Strict-mode protection on built-in field names must stay
-        // intact: a typo in `missing_footnote` is not silently absorbed
-        // into `extra`. We rely on the fact that `extra`'s flatten map
-        // captures only keys serde_ignored saw as unmatched at the
-        // table level — bare-key typos like `missing_footote` still hit
-        // the named-field surface, where serde rejects the unknown
-        // field via `serde_ignored`.
+    fn diagnostics_rules_typo_in_builtin_lands_in_extra() {
+        // Documents the intentional tradeoff: because the `extra` map
+        // uses `#[serde(flatten)]`, it captures *every* key under
+        // `[diagnostics.rules]` that doesn't match a named field —
+        // including a misspelled built-in like `missing_footote`. The
+        // load succeeds and the typo lives quietly in `extra`,
+        // matching nothing.
         //
-        // The labels precedent (a wholly-free-form `[labels]` block)
-        // makes every leaf key a map entry; here, by contrast, the
-        // catch-all only fires for keys the named-field surface
-        // doesn't consume. So `acme.foo` lands in `extra`; a misspelled
-        // built-in like `missing_footote` is caught.
+        // Typo detection for *built-in* rule names is sacrificed in
+        // exchange for accepting extension codes lenient-style. The
+        // Schema Integration item (deferred from #657) restores typo
+        // detection later by validating `extra` keys against the
+        // resolved extension registry — at that point an `extra` key
+        // matching neither a built-in nor a registered extension code
+        // can be flagged.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(CONFIG_FILE_NAME);
         std::fs::write(
@@ -906,20 +907,13 @@ missing_footote = "warn"
 "#,
         )
         .unwrap();
-        let res = clapfig::Clapfig::builder::<LexConfig>()
+        let cfg = clapfig::Clapfig::builder::<LexConfig>()
             .app_name("lex")
             .file_name(CONFIG_FILE_NAME)
             .no_env()
             .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
-            .load();
-        // The typo lands as an extra key (since strict-mode flatten
-        // captures everything not matching a named field). Documented
-        // behaviour: typo detection for *built-in* rule names is
-        // sacrificed in exchange for accepting extension codes
-        // lenient-style. The Schema Integration item (deferred) would
-        // restore typo detection by validating `extra` keys against
-        // the resolved extension schema set at load time.
-        let cfg = res.expect("loads — typo gets absorbed into extra");
+            .load()
+            .expect("loads — typo gets absorbed into extra");
         assert_eq!(
             cfg.diagnostics
                 .rules
@@ -927,7 +921,14 @@ missing_footote = "warn"
                 .get("missing_footote")
                 .map(|r| r.severity()),
             Some(Severity::Warn),
-            "the misspelled key lands in `extra` for now"
+            "the misspelled key lands in `extra`"
+        );
+        // And the *real* built-in field stays at its intrinsic default
+        // — the typo did not partially-shadow it.
+        assert_eq!(
+            cfg.diagnostics.rules.missing_footnote.severity(),
+            Severity::Deny,
+            "the correctly-spelled built-in keeps its intrinsic default"
         );
     }
 

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -574,18 +574,37 @@ pub struct DiagnosticsRulesConfig {
     /// Schema-validation diagnostics for extension labels.
     #[config(nested)]
     pub schema: SchemaRulesConfig,
+    /// Extension-emitted diagnostic codes. Keys are the on-the-wire
+    /// `<namespace>.<code>` strings emitted by registered extension
+    /// handlers. Lenient: any key under `[diagnostics.rules]` that
+    /// doesn't match one of the named fields above lands here. Entries
+    /// that never match an emitted code are harmless (ESLint / Clippy
+    /// convention).
+    ///
+    /// Two flatten attributes:
+    /// - `#[serde(flatten)]` at the struct level rides through direct
+    ///   serde `Serialize`/`Deserialize` of `DiagnosticsRulesConfig`,
+    ///   so the on-disk shape is inline keys in the same table (not a
+    ///   nested `[diagnostics.rules.extra]` sub-table).
+    /// - `#[config(layer_attr(serde(flatten)))]` pushes the same
+    ///   `#[serde(flatten)]` onto the confique-generated `Layer` field
+    ///   so clapfig's strict-mode `serde_ignored` validator sees the
+    ///   extra keys as consumed (not ignored).
+    ///
+    /// Together: extension codes land in `extra` instead of erroring.
+    /// Tradeoff: a typo in a built-in field name also lands here.
+    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    #[config(default = {}, layer_attr(serde(flatten)))]
+    pub extra: BTreeMap<String, RuleConfig>,
 }
 
 impl DiagnosticsRulesConfig {
     /// Look up a rule by its on-the-wire code (e.g. `"missing-footnote"`
-    /// or `"schema.unknown-label"`).
+    /// or `"schema.unknown-label"` or `"acme.task-due-date-missing"`).
     ///
-    /// Returns `None` for codes the toolchain does not know about —
-    /// notably extension-emitted codes (`<namespace>.<code>`), which are
-    /// out of this struct's scope. Callers that want override semantics
-    /// for extension diagnostics will look those up in a future "extra"
-    /// map; until that surface lands, unknown codes fall through to the
-    /// emission site's intrinsic severity.
+    /// Resolution order: named built-in field → `extra` map → `None`.
+    /// Built-ins always win, so a stray `extra` entry with a built-in
+    /// code does not override the typed surface.
     pub fn lookup_by_code(&self, code: &str) -> Option<&RuleConfig> {
         match code {
             "missing-footnote" => Some(&self.missing_footnote),
@@ -605,7 +624,13 @@ impl DiagnosticsRulesConfig {
             "schema.param-type-mismatch" => Some(&self.schema.param_type_mismatch),
             "schema.bad-attachment" => Some(&self.schema.bad_attachment),
             "schema.body-shape-mismatch" => Some(&self.schema.body_shape_mismatch),
-            _ => None,
+            // Extension-emitted codes (`<namespace>.<code>`) ride here.
+            // Lenient: any key the user wrote in `[diagnostics.rules]`
+            // that didn't land on a named field above is matched by
+            // exact string. Schema-based validation against the
+            // resolved extension registry is deferred (issue #657
+            // "Schema Integration").
+            other => self.extra.get(other),
         }
     }
 }
@@ -781,6 +806,187 @@ missing_footnote = ["warn", { example_option = 42 }]
         assert_eq!(rule.severity(), Severity::Warn);
         let opts = rule.options().expect("array form keeps options");
         assert_eq!(opts.get("example_option"), Some(&toml::Value::Integer(42)));
+    }
+
+    #[test]
+    fn diagnostics_rules_extra_captures_extension_codes() {
+        // Extension codes (`<namespace>.<code>`) under [diagnostics.rules]
+        // ride in `extra`. Built-in fields next to them keep their
+        // intrinsic typing.
+        let cfg = load_from(
+            r#"
+[diagnostics.rules]
+missing_footnote = "allow"
+"acme.task-due-date-missing" = "deny"
+"foolco.bar" = ["warn", { max = 80 }]
+"#,
+        );
+        assert_eq!(
+            cfg.diagnostics.rules.missing_footnote.severity(),
+            Severity::Allow
+        );
+        let acme = cfg
+            .diagnostics
+            .rules
+            .extra
+            .get("acme.task-due-date-missing")
+            .expect("extension code lands in extra");
+        assert_eq!(acme.severity(), Severity::Deny);
+        let foolco = cfg
+            .diagnostics
+            .rules
+            .extra
+            .get("foolco.bar")
+            .expect("array-form extension code lands in extra");
+        assert_eq!(foolco.severity(), Severity::Warn);
+        assert_eq!(
+            foolco.options().and_then(|o| o.get("max")),
+            Some(&toml::Value::Integer(80))
+        );
+    }
+
+    #[test]
+    fn diagnostics_rules_extra_lookup_by_code_after_named_fields() {
+        // Drift coverage: a built-in code resolves through its named
+        // field even if `extra` happens to contain a same-named entry.
+        // Named fields win.
+        let mut extra: BTreeMap<String, RuleConfig> = BTreeMap::new();
+        extra.insert(
+            "missing-footnote".to_string(),
+            RuleConfig::Bare(Severity::Allow),
+        );
+        let rules = DiagnosticsRulesConfig {
+            missing_footnote: RuleConfig::Bare(Severity::Deny),
+            extra,
+            ..Default::default()
+        };
+        // `missing-footnote` is a built-in; the named field is consulted
+        // first and wins, even though `extra` carries a different value.
+        let resolved = rules.lookup_by_code("missing-footnote").unwrap();
+        assert_eq!(resolved.severity(), Severity::Deny);
+        // An extension code only the `extra` map knows about resolves
+        // through the catch-all path.
+        let rules = DiagnosticsRulesConfig {
+            extra: [("acme.foo".to_string(), RuleConfig::Bare(Severity::Allow))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let resolved = rules.lookup_by_code("acme.foo").unwrap();
+        assert_eq!(resolved.severity(), Severity::Allow);
+        assert!(rules.lookup_by_code("acme.unknown").is_none());
+    }
+
+    #[test]
+    fn diagnostics_rules_extra_typo_in_builtin_still_errors() {
+        // Strict-mode protection on built-in field names must stay
+        // intact: a typo in `missing_footnote` is not silently absorbed
+        // into `extra`. We rely on the fact that `extra`'s flatten map
+        // captures only keys serde_ignored saw as unmatched at the
+        // table level — bare-key typos like `missing_footote` still hit
+        // the named-field surface, where serde rejects the unknown
+        // field via `serde_ignored`.
+        //
+        // The labels precedent (a wholly-free-form `[labels]` block)
+        // makes every leaf key a map entry; here, by contrast, the
+        // catch-all only fires for keys the named-field surface
+        // doesn't consume. So `acme.foo` lands in `extra`; a misspelled
+        // built-in like `missing_footote` is caught.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(
+            &path,
+            r#"
+[diagnostics.rules]
+missing_footote = "warn"
+"#,
+        )
+        .unwrap();
+        let res = clapfig::Clapfig::builder::<LexConfig>()
+            .app_name("lex")
+            .file_name(CONFIG_FILE_NAME)
+            .no_env()
+            .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .load();
+        // The typo lands as an extra key (since strict-mode flatten
+        // captures everything not matching a named field). Documented
+        // behaviour: typo detection for *built-in* rule names is
+        // sacrificed in exchange for accepting extension codes
+        // lenient-style. The Schema Integration item (deferred) would
+        // restore typo detection by validating `extra` keys against
+        // the resolved extension schema set at load time.
+        let cfg = res.expect("loads — typo gets absorbed into extra");
+        assert_eq!(
+            cfg.diagnostics
+                .rules
+                .extra
+                .get("missing_footote")
+                .map(|r| r.severity()),
+            Some(Severity::Warn),
+            "the misspelled key lands in `extra` for now"
+        );
+    }
+
+    #[test]
+    fn diagnostics_rules_extra_round_trip() {
+        // load -> serialize -> load preserves both named built-ins and
+        // extra extension codes. Confirms `#[serde(flatten)]` rides
+        // through serialization as inline keys in the same table, not
+        // as a nested `extra` sub-table.
+        let cfg = load_from(
+            r#"
+[diagnostics.rules]
+unused_footnote = "deny"
+"acme.foo" = "warn"
+"bar.qux" = ["deny", { example = 1 }]
+"#,
+        );
+        let serialized = toml::to_string(&cfg).expect("serializes");
+        // Sanity-check the on-disk shape: extras live inline in
+        // `[diagnostics.rules]` (not under `[diagnostics.rules.extra]`).
+        assert!(
+            serialized.contains(r#""acme.foo" = "warn""#)
+                || serialized.contains(r#"'acme.foo' = "warn""#),
+            "extension key flattened inline; got:\n{serialized}"
+        );
+        assert!(
+            !serialized.contains("[diagnostics.rules.extra]"),
+            "extras must not nest under an `extra` sub-table; got:\n{serialized}"
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&path, &serialized).unwrap();
+        let reloaded = clapfig::Clapfig::builder::<LexConfig>()
+            .app_name("lex")
+            .file_name(CONFIG_FILE_NAME)
+            .no_env()
+            .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .load()
+            .expect("round-trips");
+        assert_eq!(
+            reloaded.diagnostics.rules.unused_footnote.severity(),
+            Severity::Deny
+        );
+        assert_eq!(
+            reloaded
+                .diagnostics
+                .rules
+                .extra
+                .get("acme.foo")
+                .map(|r| r.severity()),
+            Some(Severity::Warn)
+        );
+        let bar = reloaded
+            .diagnostics
+            .rules
+            .extra
+            .get("bar.qux")
+            .expect("array-form extension key round-trips");
+        assert_eq!(bar.severity(), Severity::Deny);
+        assert_eq!(
+            bar.options().and_then(|o| o.get("example")),
+            Some(&toml::Value::Integer(1))
+        );
     }
 
     #[test]

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1971,7 +1971,7 @@ fn to_lsp_diagnostic(diag: AnalysisDiagnostic) -> Diagnostic {
         AS::Hint => tower_lsp::lsp_types::DiagnosticSeverity::HINT,
     };
 
-    let code = diag.kind.code();
+    let code = diag.kind.code().into_owned();
 
     let source = match &diag.kind {
         DiagnosticKind::Handler { namespace, .. } => format!("lex:{namespace}"),

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1971,7 +1971,7 @@ fn to_lsp_diagnostic(diag: AnalysisDiagnostic) -> Diagnostic {
         AS::Hint => tower_lsp::lsp_types::DiagnosticSeverity::HINT,
     };
 
-    let code = diag.kind.code().to_string();
+    let code = diag.kind.code();
 
     let source = match &diag.kind {
         DiagnosticKind::Handler { namespace, .. } => format!("lex:{namespace}"),


### PR DESCRIPTION
Closes #657.

## Summary

`[diagnostics.rules]` now accepts extension-emitted codes (`acme.task-due-date-missing`, etc.) alongside built-ins, configured identically. Three pieces landed together:

1. **Wire-code shape.** `DiagnosticKind::Handler::code()` returns the namespace-prefixed form per spec §9 — `Handler { namespace: "acme", code: Some("foo") }.code() == "acme.foo"`. Code-less handler diagnostics get the per-namespace fallback `"acme.diagnostic"` (replacing the global `"handler.diagnostic"`). **Breaking** for consumers matching on the bare wire `code` for an extension diagnostic.

2. **`extra` map on `DiagnosticsRulesConfig`.** A new `extra: BTreeMap<String, RuleConfig>` field absorbs any `[diagnostics.rules]` key that doesn't match a built-in. The flatten attribute rides on both the public struct (`#[serde(flatten)]`) and the confique-generated `Layer` (`#[config(layer_attr(serde(flatten)))]`) so clapfig's strict-mode `serde_ignored` validator sees extras as consumed instead of rejecting them. The on-disk shape stays flat — users write `"acme.foo" = "deny"` inline in `[diagnostics.rules]`, **not** as a nested `extra` table.

3. **`lookup_by_code` semantics.** Resolution order is named built-in → `extra` map → `None`. Built-ins always win; a stray `extra` entry with a built-in code does not override the typed surface. `apply_rules` semantics are unchanged: `allow` drops, `warn` keeps intrinsic, `deny` upgrades to `Error`.

## Tradeoff (called out in the changelog)

The `#[serde(flatten)]` catch-all consumes **everything** the named-field surface doesn't match — including typos in built-in field names. `missing_footote = "warn"` now lands in `extra` instead of erroring as an unknown key. Typo detection for the typed surface is gone at this attribute level. The deferred Schema Integration item (from #657's background) restores typo detection by validating `extra` keys against the resolved extension registry at load time.

This came up explicitly while implementing: the alternative routes were either (a) disabling strict mode globally, or (b) a separate file-loading pass that bypasses clapfig. Both are worse. Filing an upstream feature request on `arthur-debert/clapfig` for per-field "catch-all opt-out" is a tracked follow-up — the PAT in this cloud session can't create issues on that repo, so the issue body is captured here and will be filed manually.

## Test plan

Existing 2381 tests pass. New tests:

- [x] `lex-analysis::handler_code_carries_namespace_prefix` — wire-shape contract for both `Some(code)` and `None` variants.
- [x] `lex-analysis::apply_rules_matches_extension_code_via_extra` — end-to-end through `apply_rules` for all four cases (allow / warn / deny / no-match).
- [x] `lex-config::diagnostics_rules_extra_captures_extension_codes` — clapfig load picks up flat extension keys (bare and array form) under `[diagnostics.rules]`.
- [x] `lex-config::diagnostics_rules_extra_lookup_by_code_after_named_fields` — built-in named field wins over a same-named `extra` entry.
- [x] `lex-config::diagnostics_rules_extra_round_trip` — load → serialize → load preserves both built-ins and extras; serialized shape is inline keys, **not** a nested `[diagnostics.rules.extra]` table.
- [x] `lex-config::diagnostics_rules_extra_typo_in_builtin_still_errors` — documents the tradeoff with an assertion: a misspelled built-in name lands in `extra`.

LSP-side: skipped a dedicated integration test. The LSP's only contact with the new code is the existing `apply_rules` call at `crates/lex-lsp/src/server.rs:461` — that's the same call path as built-ins, identical behaviour. Unit-testing apply_rules with `Handler` kinds covers the semantics; a workspace-level LSP test would re-verify wiring already exercised at the layer below.

## Deferred

- **Schema Integration** — extensions declaring their codes in schemas so `extra` keys can be typo-checked. Listed in #657's deferred section.
- **`lexd config gen` / `get` / `list` discovery for extension codes** — listed in #657's gap analysis (#3 "Discovery Channel"), out of scope here. Today the `extra` field renders as `#extra = {  }` in the template; the doc comment explicitly tells users not to write it that way and shows the correct inline shape.
- **Upstream clapfig feature request** — for per-field strict-mode opt-out so we can restore typo detection on the typed surface. PAT-scope blocker on filing the issue from this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_017yUQPKW9RG3pb556vHBUBg)_