### PR TITLE
refactor(diagnostics-config): drop extra-flatten workaround; migrate to clapfig::Schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e368fe4b981b163314a6aa77001fcf023083e9c8779ce7970270d2680d44ff1"
+checksum = "8f0867581be4f52887e9534e40ffe2e9e6301d91ee26f7517a5e7fa4d2c45d2c"
 dependencies = [
  "clap",
  "clapfig-derive",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "clapfig-derive"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6681f5669b900b3a8d2bfd2c3ab3c35862353b9d3cad9423c550dd890eaeb0"
+checksum = "dff02bff776367075aaa498b56539544f2577f1ed70f2e2fd07182941af1b4ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db2a4a2699f79b6479a91417baf343582a8a895f7e68df1c70300848261a35"
+checksum = "505a26808385951f834adcdee65a513053cbc3bbb38a9d21e1fea817dc0e8eba"
 dependencies = [
  "clap",
  "confique",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8503a118d7897f2a647299a3c28a9c971939c37c8d9b0fd84722061c7f26f42f"
+checksum = "8e368fe4b981b163314a6aa77001fcf023083e9c8779ce7970270d2680d44ff1"
 dependencies = [
  "clap",
  "clapfig-derive",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "clapfig-derive"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbdfcbcc0c5f4deabf8a8ea5d5dff4c63aa3cdec938146332591b71a3fc92e4"
+checksum = "6e6681f5669b900b3a8d2bfd2c3ab3c35862353b9d3cad9423c550dd890eaeb0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d6887dbff923bb26244ce00903d9200e6fa35f2e60c447941a0852a3c8cc2f"
+checksum = "8503a118d7897f2a647299a3c28a9c971939c37c8d9b0fd84722061c7f26f42f"
 dependencies = [
  "clap",
  "clapfig-derive",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "clapfig-derive"
-version = "0.20.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce3b78d2dcf849215e3f17b2e53b23c107cd5636dd99fa3e0071072ba95d275"
+checksum = "1dbdfcbcc0c5f4deabf8a8ea5d5dff4c63aa3cdec938146332591b71a3fc92e4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,11 +315,12 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a72ca080ffc51119948e88b6304f368ec4c62f7a1c9ae7815c19ad0c9fc46fc"
+checksum = "e6d6887dbff923bb26244ce00903d9200e6fa35f2e60c447941a0852a3c8cc2f"
 dependencies = [
  "clap",
+ "clapfig-derive",
  "confique",
  "directories",
  "serde",
@@ -328,6 +329,17 @@ dependencies = [
  "thiserror",
  "toml 0.8.23",
  "toml_edit",
+]
+
+[[package]]
+name = "clapfig-derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce3b78d2dcf849215e3f17b2e53b23c107cd5636dd99fa3e0071072ba95d275"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -700,7 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1146,7 +1158,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1251,7 +1263,6 @@ name = "lex-config"
 version = "0.14.1"
 dependencies = [
  "clapfig",
- "confique",
  "lex-babel",
  "serde",
  "tempfile",
@@ -2069,7 +2080,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2357,7 +2368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28332bb44a9e7e7f1aa43ce4d97b6d1b27323a1fc160d4cfe0089245e1750845"
 dependencies = [
  "foldhash 0.2.0",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2474,7 +2485,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3184,7 +3195,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clapfig"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505a26808385951f834adcdee65a513053cbc3bbb38a9d21e1fea817dc0e8eba"
+checksum = "3a72ca080ffc51119948e88b6304f368ec4c62f7a1c9ae7815c19ad0c9fc46fc"
 dependencies = [
  "clap",
  "confique",
@@ -700,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1146,7 +1146,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2357,7 +2357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28332bb44a9e7e7f1aa43ce4d97b6d1b27323a1fc160d4cfe0089245e1750845"
 dependencies = [
  "foldhash 0.2.0",
- "hashbrown 0.17.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2474,7 +2474,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.6", features = ["derive"] }
-clapfig = { version = "0.21.1", features = ["derive"] }
+clapfig = { version = "0.21.2", features = ["derive"] }
 confique = { version = "0.4", features = ["toml"] }
 insta = "1.47"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.6", features = ["derive"] }
-clapfig = "0.20"
+clapfig = "0.20.1"
 confique = { version = "0.4", features = ["toml"] }
 insta = "1.47"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.6", features = ["derive"] }
-clapfig = "0.17"
+clapfig = "0.20"
 confique = { version = "0.4", features = ["toml"] }
 insta = "1.47"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.6", features = ["derive"] }
-clapfig = "0.20.1"
+clapfig = { version = "0.21.1", features = ["derive"] }
 confique = { version = "0.4", features = ["toml"] }
 insta = "1.47"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.6", features = ["derive"] }
-clapfig = { version = "0.21.2", features = ["derive"] }
+clapfig = { version = "0.21.3", features = ["derive"] }
 confique = { version = "0.4", features = ["toml"] }
 insta = "1.47"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.6", features = ["derive"] }
-clapfig = { version = "0.21.3", features = ["derive"] }
+clapfig = { version = "0.21.4", features = ["derive"] }
 confique = { version = "0.4", features = ["toml"] }
 insta = "1.47"
 tokio = { version = "1", features = ["full"] }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -1,5 +1,5 @@
 use crate::inline::extract_references;
-use lex_config::{DiagnosticsRulesConfig, Severity};
+use lex_config::{DiagnosticsRulesConfig, RuleConfig, Severity};
 use lex_core::lex::ast::{
     Annotation, ContentItem, Document, Range, Session, Table, TableRow, TextContent,
 };
@@ -138,17 +138,19 @@ impl DiagnosticKind {
 /// - `warn` → the diagnostic's intrinsic severity stays unchanged.
 /// - `deny` → severity is upgraded to `Error`.
 ///
-/// Resolution is delegated to [`DiagnosticsRulesConfig::lookup_by_code`],
-/// which consults the named built-in fields first and then falls
-/// through to the `extra` map. So extension-emitted codes with a
-/// matching `[diagnostics.rules]` entry (e.g. `"acme.foo" = "deny"`)
-/// flow through the same `allow` / `warn` / `deny` logic as built-ins.
-/// Codes with no matching entry — anywhere — pass through untouched at
-/// their intrinsic severity.
-pub fn apply_rules(diagnostics: &mut Vec<AnalysisDiagnostic>, rules: &DiagnosticsRulesConfig) {
+/// `lookup_rule` is the resolution function — typically
+/// [`LoadedLexConfig::lookup_diagnostic_rule`](lex_config::LoadedLexConfig::lookup_diagnostic_rule),
+/// which consults the named built-in fields first and the
+/// extension-rules side-channel second. Diagnostics whose code has no
+/// matching entry on either surface pass through untouched at their
+/// intrinsic severity.
+pub fn apply_rules<F>(diagnostics: &mut Vec<AnalysisDiagnostic>, lookup_rule: F)
+where
+    F: Fn(&str) -> Option<RuleConfig>,
+{
     diagnostics.retain_mut(|diag| {
         let code = diag.kind.code();
-        let Some(rule) = rules.lookup_by_code(&code) else {
+        let Some(rule) = lookup_rule(&code) else {
             return true;
         };
         match rule.severity() {
@@ -207,7 +209,7 @@ pub fn analyze_with_rules(
     rules: &DiagnosticsRulesConfig,
 ) -> Vec<AnalysisDiagnostic> {
     let mut diagnostics = analyze_with_registry(document, registry);
-    apply_rules(&mut diagnostics, rules);
+    apply_rules(&mut diagnostics, |code| rules.lookup_by_code(code).cloned());
     diagnostics
 }
 
@@ -890,10 +892,29 @@ mod tests {
     }
 
     #[test]
-    fn apply_rules_matches_extension_code_via_extra() {
+    fn apply_rules_matches_extension_code_via_side_channel() {
         // End-to-end: handler emits `acme.foo`, user configured
-        // `"acme.foo" = "allow"` in `[diagnostics.rules]` (landing in
-        // `extra`); diagnostic gets dropped.
+        // `"acme.foo" = "allow"` in `[diagnostics.rules]` (now
+        // captured into the LSP's `extension_diagnostic_rules`
+        // side-channel by the `on_unknown_key` callback rather than
+        // landing in a `#[serde(flatten)] extra` map); diagnostic
+        // gets dropped.
+        use std::collections::BTreeMap;
+        // The closure mirrors `LoadedLexConfig::lookup_diagnostic_rule`:
+        // built-in first, side-channel second.
+        let lookup = |code: &str, side: &BTreeMap<String, lex_config::RuleConfig>| {
+            DiagnosticsRulesConfig::default()
+                .lookup_by_code(code)
+                .cloned()
+                .or_else(|| side.get(code).cloned())
+        };
+
+        let side: BTreeMap<String, lex_config::RuleConfig> = [(
+            "acme.foo".to_string(),
+            lex_config::RuleConfig::Bare(Severity::Allow),
+        )]
+        .into_iter()
+        .collect();
         let mut diags = vec![dummy_diag(
             DiagnosticKind::Handler {
                 namespace: "acme".into(),
@@ -901,19 +922,16 @@ mod tests {
             },
             DiagnosticSeverity::Error,
         )];
-        let rules = DiagnosticsRulesConfig {
-            extra: [(
-                "acme.foo".to_string(),
-                lex_config::RuleConfig::Bare(Severity::Allow),
-            )]
-            .into_iter()
-            .collect(),
-            ..Default::default()
-        };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| lookup(code, &side));
         assert!(diags.is_empty(), "allow drops the extension diagnostic");
 
         // `warn` keeps the intrinsic severity (Error stays Error).
+        let side: BTreeMap<String, lex_config::RuleConfig> = [(
+            "acme.foo".to_string(),
+            lex_config::RuleConfig::Bare(Severity::Warn),
+        )]
+        .into_iter()
+        .collect();
         let mut diags = vec![dummy_diag(
             DiagnosticKind::Handler {
                 namespace: "acme".into(),
@@ -921,16 +939,7 @@ mod tests {
             },
             DiagnosticSeverity::Error,
         )];
-        let rules = DiagnosticsRulesConfig {
-            extra: [(
-                "acme.foo".to_string(),
-                lex_config::RuleConfig::Bare(Severity::Warn),
-            )]
-            .into_iter()
-            .collect(),
-            ..Default::default()
-        };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| lookup(code, &side));
         assert_eq!(diags.len(), 1);
         assert_eq!(
             diags[0].severity,
@@ -940,6 +949,12 @@ mod tests {
 
         // `deny` is a no-op when the intrinsic is already Error, but
         // still keeps the diagnostic — symmetry with built-ins.
+        let side: BTreeMap<String, lex_config::RuleConfig> = [(
+            "acme.foo".to_string(),
+            lex_config::RuleConfig::Bare(Severity::Deny),
+        )]
+        .into_iter()
+        .collect();
         let mut diags = vec![dummy_diag(
             DiagnosticKind::Handler {
                 namespace: "acme".into(),
@@ -947,21 +962,18 @@ mod tests {
             },
             DiagnosticSeverity::Error,
         )];
-        let rules = DiagnosticsRulesConfig {
-            extra: [(
-                "acme.foo".to_string(),
-                lex_config::RuleConfig::Bare(Severity::Deny),
-            )]
-            .into_iter()
-            .collect(),
-            ..Default::default()
-        };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| lookup(code, &side));
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
 
         // A configured rule whose code doesn't match the emitted one
         // passes the diagnostic through untouched.
+        let side: BTreeMap<String, lex_config::RuleConfig> = [(
+            "acme.other".to_string(),
+            lex_config::RuleConfig::Bare(Severity::Allow),
+        )]
+        .into_iter()
+        .collect();
         let mut diags = vec![dummy_diag(
             DiagnosticKind::Handler {
                 namespace: "acme".into(),
@@ -969,16 +981,7 @@ mod tests {
             },
             DiagnosticSeverity::Warning,
         )];
-        let rules = DiagnosticsRulesConfig {
-            extra: [(
-                "acme.other".to_string(),
-                lex_config::RuleConfig::Bare(Severity::Allow),
-            )]
-            .into_iter()
-            .collect(),
-            ..Default::default()
-        };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| lookup(code, &side));
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
     }
@@ -993,7 +996,7 @@ mod tests {
             missing_footnote: lex_config::RuleConfig::Bare(Severity::Allow),
             ..Default::default()
         };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| rules.lookup_by_code(code).cloned());
         assert!(diags.is_empty(), "allow should drop the diagnostic");
     }
 
@@ -1007,7 +1010,7 @@ mod tests {
             table_inconsistent_columns: lex_config::RuleConfig::Bare(Severity::Deny),
             ..Default::default()
         };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| rules.lookup_by_code(code).cloned());
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Error);
     }
@@ -1022,7 +1025,7 @@ mod tests {
             table_inconsistent_columns: lex_config::RuleConfig::Bare(Severity::Warn),
             ..Default::default()
         };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| rules.lookup_by_code(code).cloned());
         assert_eq!(diags.len(), 1);
         assert_eq!(
             diags[0].severity,
@@ -1045,7 +1048,7 @@ mod tests {
             DiagnosticSeverity::Warning,
         )];
         let rules = DiagnosticsRulesConfig::default();
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| rules.lookup_by_code(code).cloned());
         assert_eq!(diags.len(), 1, "unknown codes should pass through");
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
     }
@@ -1072,7 +1075,7 @@ mod tests {
             table_inconsistent_columns: lex_config::RuleConfig::Bare(Severity::Deny),
             ..Default::default()
         };
-        apply_rules(&mut diags, &rules);
+        apply_rules(&mut diags, |code| rules.lookup_by_code(code).cloned());
         assert_eq!(diags.len(), 2);
         assert_eq!(diags[0].kind, DiagnosticKind::UnusedFootnoteDefinition);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -25,7 +25,7 @@
 use lexd::transforms;
 
 use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint};
-use clapfig::{Boundary, Clapfig, ClapfigBuilder, ConfigCommand, SearchPath};
+use clapfig::{Boundary, Clapfig, ConfigCommand, SchemaConfigBuilder, SearchPath};
 use lex_analysis::semantic_tokens::collect_semantic_tokens;
 use lex_babel::{
     formats::lex::formatting_rules::FormattingRules, transforms::serialize_to_lex_with_rules,
@@ -947,9 +947,16 @@ fn handle_labels_command(top: &ArgMatches, sub: &ArgMatches) -> i32 {
     }
 }
 
-/// Build a clapfig builder with search paths and CLI overrides from parsed args.
-fn make_builder(matches: &ArgMatches) -> ClapfigBuilder<LexConfig> {
-    let mut builder = Clapfig::builder::<LexConfig>()
+/// Build a clapfig builder with search paths and CLI overrides from
+/// parsed args. The `on_unknown_key` callback accepts extension-emitted
+/// diagnostic codes under `[diagnostics.rules]` so they don't error
+/// strict-mode validation. The CLI doesn't consume the side-channel —
+/// only the LSP runs `apply_rules` — so the captured entries are
+/// discarded.
+fn make_builder(matches: &ArgMatches) -> SchemaConfigBuilder<LexConfig> {
+    let discard_captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let cb = lex_config::extension_rules_unknown_key_callback(discard_captured);
+    let mut builder = Clapfig::schema_builder::<LexConfig>()
         .app_name("lex")
         .file_name(CONFIG_FILE_NAME)
         .search_paths(vec![
@@ -958,7 +965,8 @@ fn make_builder(matches: &ArgMatches) -> ClapfigBuilder<LexConfig> {
             SearchPath::Cwd,
         ])
         .persist_scope("local", SearchPath::Cwd)
-        .persist_scope("user", SearchPath::Platform);
+        .persist_scope("user", SearchPath::Platform)
+        .on_unknown_key(cb);
 
     // Explicit config file path
     if let Some(path) = matches.get_one::<String>("config-path") {
@@ -1620,10 +1628,12 @@ mod tests {
     use super::*;
 
     fn test_config() -> LexConfig {
-        Clapfig::builder::<LexConfig>()
+        let discard = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .no_env()
             .search_paths(vec![])
+            .on_unknown_key(lex_config::extension_rules_unknown_key_callback(discard))
             .load()
             .expect("defaults to load")
     }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -948,14 +948,12 @@ fn handle_labels_command(top: &ArgMatches, sub: &ArgMatches) -> i32 {
 }
 
 /// Build a clapfig builder with search paths and CLI overrides from
-/// parsed args. The `on_unknown_key` callback accepts extension-emitted
-/// diagnostic codes under `[diagnostics.rules]` so they don't error
-/// strict-mode validation. The CLI doesn't consume the side-channel —
-/// only the LSP runs `apply_rules` — so the captured entries are
-/// discarded.
+/// parsed args. `accept_dotted_extension_keys_in` lets extension-
+/// emitted diagnostic codes under `[diagnostics.rules]` pass strict-
+/// mode validation without errors. The CLI doesn't consume the
+/// collected entries — only the LSP runs `apply_rules` — so they're
+/// ignored at load time.
 fn make_builder(matches: &ArgMatches) -> SchemaConfigBuilder<LexConfig> {
-    let discard_captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-    let cb = lex_config::extension_rules_unknown_key_callback(discard_captured);
     let mut builder = Clapfig::schema_builder::<LexConfig>()
         .app_name("lex")
         .file_name(CONFIG_FILE_NAME)
@@ -966,7 +964,10 @@ fn make_builder(matches: &ArgMatches) -> SchemaConfigBuilder<LexConfig> {
         ])
         .persist_scope("local", SearchPath::Cwd)
         .persist_scope("user", SearchPath::Platform)
-        .on_unknown_key(cb);
+        .accept_dotted_extension_keys_in(
+            lex_config::DIAGNOSTICS_RULES_PATH,
+            clapfig::UnknownKeyDecision::Collect,
+        );
 
     // Explicit config file path
     if let Some(path) = matches.get_one::<String>("config-path") {
@@ -1628,12 +1629,14 @@ mod tests {
     use super::*;
 
     fn test_config() -> LexConfig {
-        let discard = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .no_env()
             .search_paths(vec![])
-            .on_unknown_key(lex_config::extension_rules_unknown_key_callback(discard))
+            .accept_dotted_extension_keys_in(
+                lex_config::DIAGNOSTICS_RULES_PATH,
+                clapfig::UnknownKeyDecision::Collect,
+            )
             .load()
             .expect("defaults to load")
     }

--- a/crates/lex-config/Cargo.toml
+++ b/crates/lex-config/Cargo.toml
@@ -10,11 +10,10 @@ keywords = ["config", "lex"]
 categories = ["config"]
 
 [dependencies]
-confique = { workspace = true }
+clapfig = { workspace = true }
 serde = { workspace = true }
 toml = "0.8"
 lex-babel = { workspace = true }
 
 [dev-dependencies]
-clapfig = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -484,14 +484,15 @@ pub struct ConvertConfig {
 #[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct PdfConfig {
     /// Page profile used when exporting to PDF ("lexed" or "mobile").
-    /// `PdfPageSize` is a custom serde-deserializable enum (not a
-    /// `clapfig::Schema` type), so this is a `LeafType::Value` leaf —
-    /// serde handles the string-to-variant conversion on deserialize.
+    /// `PdfPageSize` derives `clapfig::Schema` (unit-only enum), but
+    /// field-level defaults are not yet permitted on nested-Schema
+    /// fields, so this stays a `#[clapfig(value)]` leaf with a string
+    /// default that serde resolves to the typed variant on load.
     #[clapfig(value, default = "lexed")]
     pub size: PdfPageSize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Schema, Serialize, Deserialize)]
 pub enum PdfPageSize {
     #[serde(rename = "lexed")]
     LexEd,
@@ -710,89 +711,39 @@ impl LoadedLexConfig {
     }
 }
 
-/// Shared `(key, value)` collector handed to
-/// [`extension_rules_unknown_key_callback`]. The callback pushes
-/// accepted extension-rule entries here; the loader drains it into
-/// [`LoadedLexConfig::extension_diagnostic_rules`] via
-/// [`collect_extension_diagnostic_rules`].
-pub type CapturedExtensionRules =
-    std::sync::Arc<std::sync::Mutex<Vec<(String, Option<toml::Value>)>>>;
+/// Dotted-path prefix under which extension-emitted diagnostic codes
+/// live (`<namespace>.<code>` style keys, e.g.
+/// `"acme.task-due-date-missing" = "warn"`). Used with clapfig's
+/// [`accept_dotted_extension_keys_in`](clapfig::SchemaConfigBuilder::accept_dotted_extension_keys_in)
+/// helper: any unknown key in this subtree whose remainder contains a
+/// `.` is treated as an extension code and routed to the collected-
+/// unknowns list; bare typos at this level or typos inside
+/// `[diagnostics.rules.schema]` still fail strict-mode validation.
+pub const DIAGNOSTICS_RULES_PATH: &str = "diagnostics.rules";
 
-/// Names of nested-struct fields under `[diagnostics.rules]`. The
-/// `on_unknown_key` predicate must reject unknown keys *inside* one of
-/// these subtrees (typos in `SchemaRulesConfig` fields, e.g.
-/// `[diagnostics.rules.schema] unkown_label = "warn"`). Keep this list
-/// in sync with the actual nested fields on
-/// [`DiagnosticsRulesConfig`] — the `known_nested_sections_in_sync`
-/// test asserts that.
-const DIAGNOSTICS_RULES_NESTED_SECTIONS: &[&str] = &["schema"];
-
-/// Build the `on_unknown_key` callback that distinguishes
-/// extension-emitted diagnostic codes (which we accept and capture)
-/// from typos (which we reject so clapfig surfaces them as
-/// `UnknownKeys` errors with line numbers).
+/// Drain clapfig's [`CollectedUnknown`](clapfig::CollectedUnknown) list
+/// into a [`BTreeMap<String, RuleConfig>`] suitable for
+/// [`LoadedLexConfig::extension_diagnostic_rules`].
 ///
-/// The callback also captures accepted entries' parsed values into
-/// `captured` so the loader can build
-/// [`LoadedLexConfig::extension_diagnostic_rules`] without a
-/// side-channel re-parse — the macro-driven path routes
-/// `UnknownKeyContext::value` through the runtime pipeline, so the
-/// value is populated even for quoted-dotted keys like
-/// `"acme.task-due-date-missing" = "warn"`.
-///
-/// Returns a closure suitable for
-/// [`clapfig::SchemaConfigBuilder::on_unknown_key`].
-pub fn extension_rules_unknown_key_callback(
-    captured: CapturedExtensionRules,
-) -> impl Fn(&clapfig::UnknownKeyContext<'_>) -> clapfig::UnknownKeyDecision + Send + Sync + 'static
-{
-    move |ctx: &clapfig::UnknownKeyContext<'_>| {
-        let Some(rest) = ctx.path.strip_prefix("diagnostics.rules.") else {
-            return clapfig::UnknownKeyDecision::Reject;
-        };
-        let first_segment = rest.split('.').next().unwrap_or("");
-        if DIAGNOSTICS_RULES_NESTED_SECTIONS.contains(&first_segment) {
-            // Unknown key inside a typed nested section (e.g.
-            // `[diagnostics.rules.schema] unkown_label = "warn"`) is a
-            // typo — surface it.
-            return clapfig::UnknownKeyDecision::Reject;
-        }
-        if !rest.contains('.') {
-            // Single-segment remainder = bare typo of a built-in field
-            // at the `[diagnostics.rules]` level (e.g.
-            // `missing_footote = "warn"`).
-            return clapfig::UnknownKeyDecision::Reject;
-        }
-        // Multi-segment, first segment not a known nested section →
-        // treat as `<namespace>.<code>` extension key. Capture for
-        // later transfer into `LoadedLexConfig`.
-        captured
-            .lock()
-            .expect("captured mutex not poisoned")
-            .push((rest.to_string(), ctx.value.cloned()));
-        clapfig::UnknownKeyDecision::Accept
-    }
-}
-
-/// Drain a callback-collected `(key, value)` list into a typed
-/// `BTreeMap<String, RuleConfig>`, deserializing each value through
-/// serde so the `RuleConfig` `Bare` vs `WithOptions` sum dispatch
-/// happens at this boundary.
-///
-/// Entries whose value the callback could not resolve (`None`) or
-/// whose serde deserialization fails are silently dropped — the
-/// clapfig accept decision has already been made and the load
-/// succeeded; this finalization step is best-effort. The clapfig
-/// builder is the right surface to surface deserialize errors with
-/// file+line context, not this finalization step.
+/// Only paths under [`DIAGNOSTICS_RULES_PATH`] are kept; the dotted
+/// remainder becomes the map key (e.g.
+/// `diagnostics.rules.acme.task-due-date-missing` →
+/// `acme.task-due-date-missing`). Entries whose `value` is `None` or
+/// which fail to deserialize as a [`RuleConfig`] are silently dropped
+/// — the clapfig accept decision has already been made and the load
+/// succeeded; this finalization step is best-effort.
 pub fn collect_extension_diagnostic_rules(
-    captured: Vec<(String, Option<toml::Value>)>,
+    unknowns: Vec<clapfig::CollectedUnknown>,
 ) -> BTreeMap<String, RuleConfig> {
+    let prefix = format!("{DIAGNOSTICS_RULES_PATH}.");
     let mut out = BTreeMap::new();
-    for (key, value) in captured {
-        let Some(v) = value else { continue };
-        if let Ok(rule) = v.try_into() {
-            out.insert(key, rule);
+    for u in unknowns {
+        let Some(key) = u.path.strip_prefix(&prefix) else {
+            continue;
+        };
+        let Some(value) = u.value else { continue };
+        if let Ok(rule) = value.try_into() {
+            out.insert(key.to_string(), rule);
         }
     }
     out
@@ -801,18 +752,19 @@ pub fn collect_extension_diagnostic_rules(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
 
     fn load_defaults() -> LexConfig {
-        let captured = Arc::new(Mutex::new(Vec::new()));
-        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
-        clapfig::Clapfig::schema_builder::<LexConfig>()
+        let (config, _unknowns) = clapfig::Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .no_env()
             .search_paths(vec![])
-            .on_unknown_key(cb)
-            .load()
-            .expect("defaults to load")
+            .accept_dotted_extension_keys_in(
+                DIAGNOSTICS_RULES_PATH,
+                clapfig::UnknownKeyDecision::Collect,
+            )
+            .load_with_unknowns()
+            .expect("defaults to load");
+        config
     }
 
     #[test]
@@ -831,23 +783,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(CONFIG_FILE_NAME);
         std::fs::write(&path, toml_body).unwrap();
-        let captured = Arc::new(Mutex::new(Vec::new()));
-        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
-        let config = clapfig::Clapfig::schema_builder::<LexConfig>()
+        let (config, unknowns) = clapfig::Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .file_name(CONFIG_FILE_NAME)
             .no_env()
             .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
-            .on_unknown_key(cb)
-            .load()
+            .accept_dotted_extension_keys_in(
+                DIAGNOSTICS_RULES_PATH,
+                clapfig::UnknownKeyDecision::Collect,
+            )
+            .load_with_unknowns()
             .expect("loads");
-        let captured = Arc::try_unwrap(captured)
-            .expect("captured Arc has no remaining holders after load")
-            .into_inner()
-            .expect("captured mutex not poisoned");
         LoadedLexConfig {
             config,
-            extension_diagnostic_rules: collect_extension_diagnostic_rules(captured),
+            extension_diagnostic_rules: collect_extension_diagnostic_rules(unknowns),
         }
     }
 
@@ -1010,35 +959,36 @@ missing_footnote = "allow"
         assert!(loaded.lookup_diagnostic_rule("acme.unknown").is_none());
     }
 
+    fn load_expecting_error(toml_body: &str) -> clapfig::ClapfigError {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&path, toml_body).unwrap();
+        clapfig::Clapfig::schema_builder::<LexConfig>()
+            .app_name("lex")
+            .file_name(CONFIG_FILE_NAME)
+            .no_env()
+            .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .accept_dotted_extension_keys_in(
+                DIAGNOSTICS_RULES_PATH,
+                clapfig::UnknownKeyDecision::Collect,
+            )
+            .load_with_unknowns()
+            .expect_err("typo must surface as an unknown-key error")
+    }
+
     #[test]
     fn diagnostics_rules_typo_in_builtin_errors() {
         // Headline behaviour change vs PR #658: dropping the
         // `#[serde(flatten)] extra` catch-all means typos in built-in
         // field names are rejected by clapfig's strict-mode validator
         // again — they no longer land silently in `extra`.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(CONFIG_FILE_NAME);
-        std::fs::write(
-            &path,
+        let err = load_expecting_error(
             r#"
 [diagnostics.rules]
 missing_footote = "warn"
 "#,
-        )
-        .unwrap();
-        let captured = Arc::new(Mutex::new(Vec::new()));
-        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
-        let err = clapfig::Clapfig::schema_builder::<LexConfig>()
-            .app_name("lex")
-            .file_name(CONFIG_FILE_NAME)
-            .no_env()
-            .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
-            .on_unknown_key(cb)
-            .load()
-            .expect_err("typo must surface as an unknown-key error");
-        let keys = err
-            .unknown_keys()
-            .expect("error variant carries UnknownKeys");
+        );
+        let keys = err.unknown_keys().expect("UnknownKeys variant");
         assert!(
             keys.iter().any(|k| k.key.ends_with("missing_footote")),
             "the misspelled key is reported: {keys:?}"
@@ -1047,53 +997,25 @@ missing_footote = "warn"
 
     #[test]
     fn diagnostics_rules_typo_inside_nested_section_errors() {
-        // The `on_unknown_key` predicate must NOT accept a typo inside
-        // a nested-built-in section (`[diagnostics.rules.schema]`) just
-        // because the dotted path has more than two segments — the
-        // first segment must not be a known nested section. This is
-        // the failure mode Gemini called out in the original review on
-        // PR #664.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(CONFIG_FILE_NAME);
-        std::fs::write(
-            &path,
+        // `accept_dotted_extension_keys_in` must NOT accept a typo
+        // inside a nested-built-in section (`[diagnostics.rules.schema]`)
+        // just because the dotted path has more than two segments. The
+        // clapfig-side predicate honours the schema's nested-field
+        // shape — `schema` is a typed nested object, not an open-ended
+        // extension namespace — so an unknown key under it stays a
+        // strict-mode violation. This is the failure mode Gemini
+        // flagged on the original PR #664 plan.
+        let err = load_expecting_error(
             r#"
 [diagnostics.rules.schema]
 unkown_label = "warn"
 "#,
-        )
-        .unwrap();
-        let captured = Arc::new(Mutex::new(Vec::new()));
-        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
-        let err = clapfig::Clapfig::schema_builder::<LexConfig>()
-            .app_name("lex")
-            .file_name(CONFIG_FILE_NAME)
-            .no_env()
-            .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
-            .on_unknown_key(cb)
-            .load()
-            .expect_err("typo inside nested section must error");
+        );
         let keys = err.unknown_keys().expect("UnknownKeys variant");
         assert!(
             keys.iter().any(|k| k.key.ends_with("unkown_label")),
             "the misspelled nested key is reported: {keys:?}"
         );
-    }
-
-    #[test]
-    fn known_nested_sections_in_sync_with_struct_fields() {
-        // The `on_unknown_key` predicate's list of "known nested
-        // section names" must match the actual nested-struct fields
-        // on `DiagnosticsRulesConfig`. If a new nested section is
-        // added to the struct but not added to the const, typos in
-        // that section's keys would be silently accepted as extension
-        // codes — exactly the bug we're protecting against.
-        //
-        // Hard-coded ground truth: as of now, the only nested-struct
-        // field on `DiagnosticsRulesConfig` is `schema`. Adding a new
-        // nested-struct field requires updating both this assertion
-        // and `DIAGNOSTICS_RULES_NESTED_SECTIONS`.
-        assert_eq!(DIAGNOSTICS_RULES_NESTED_SECTIONS, &["schema"]);
     }
 
     // Per-config-struct `default_for_tests` helpers — the new macro

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -1,10 +1,10 @@
 //! Shared configuration for the Lex toolchain.
 //!
 //! Defines [`LexConfig`] — the config struct consumed by all Lex applications.
-//! Defaults are compiled into the struct via `#[config(default)]`. Loading and
+//! Defaults are compiled into the struct via `#[clapfig(default)]`. Loading and
 //! layering is handled by [clapfig](https://docs.rs/clapfig) in the CLI.
 
-use confique::Config;
+use clapfig::Schema;
 use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -342,74 +342,71 @@ pub fn load_labels_from_toml(path: impl AsRef<Path>) -> Result<LabelsConfig, Lab
 }
 
 /// Top-level configuration consumed by Lex applications.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct LexConfig {
     /// Formatting rules.
-    #[config(nested)]
     pub formatting: FormattingConfig,
     /// Inspect output options.
-    #[config(nested)]
     pub inspect: InspectConfig,
     /// Format-specific conversion options.
-    #[config(nested)]
     pub convert: ConvertConfig,
     /// Diagnostics options.
-    #[config(nested)]
     pub diagnostics: DiagnosticsConfig,
     /// Include-resolution options.
-    #[config(nested)]
     pub includes: IncludesConfig,
     /// Extension-namespace declarations. The map shape is
     /// free-form (each key is a namespace name; the value is a
-    /// `NamespaceSpec`), so the field is a leaf rather than a
-    /// nested confique struct — confique sees an opaque
-    /// `BTreeMap<String, NamespaceSpec>`. The `lexd labels`
+    /// sum-typed `NamespaceSpec`), so the field is declared as a
+    /// `LeafType::Value` escape hatch via `#[clapfig(value)]` —
+    /// clapfig accepts any TOML at this key and serde does the
+    /// shape-validation on the deserialize side. The `lexd labels`
     /// subcommand and the boot helper read individual entries via
     /// [`load_labels_from_toml`] for richer error messages
     /// (reserved-namespace check, table-form validation, …).
-    /// Declaring the field here is what makes clapfig's strict
-    /// unknown-keys check accept `[labels]` blocks in `.lex.toml`.
-    #[config(default = {})]
+    #[clapfig(value, optional)]
+    #[serde(default)]
     pub labels: BTreeMap<String, NamespaceSpec>,
 }
 
 /// Formatting-related configuration groups.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct FormattingConfig {
     /// Formatting rules for lex output.
-    #[config(nested)]
     pub rules: FormattingRulesConfig,
     /// Automatically format documents on save (consumed by editors).
-    #[config(default = false)]
+    #[clapfig(default = false)]
     pub format_on_save: bool,
 }
 
 /// Mirrors the knobs exposed by the Lex formatter.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct FormattingRulesConfig {
     /// Number of blank lines inserted before a session title.
-    #[config(default = 1)]
+    #[clapfig(default = 1)]
     pub session_blank_lines_before: usize,
     /// Number of blank lines inserted after a session title.
-    #[config(default = 1)]
+    #[clapfig(default = 1)]
     pub session_blank_lines_after: usize,
     /// Normalize list markers to predictable markers.
-    #[config(default = true)]
+    #[clapfig(default = true)]
     pub normalize_seq_markers: bool,
     /// Character for unordered list items when normalization is enabled.
-    #[config(default = "-")]
+    /// `char` isn't in clapfig's native leaf-type vocabulary, so this is
+    /// a `LeafType::Value` escape hatch — serde converts the single-char
+    /// TOML string on deserialize.
+    #[clapfig(value, default = "-")]
     pub unordered_seq_marker: char,
     /// Maximum consecutive blank lines kept in output.
-    #[config(default = 2)]
+    #[clapfig(default = 2)]
     pub max_blank_lines: usize,
     /// Whitespace string for each indentation level.
-    #[config(default = "    ")]
+    #[clapfig(default = "    ")]
     pub indent_string: String,
     /// Preserve trailing blank lines at the end of a document.
-    #[config(default = false)]
+    #[clapfig(default = false)]
     pub preserve_trailing_blanks: bool,
     /// Normalize verbatim fences back to canonical :: form.
-    #[config(default = true)]
+    #[clapfig(default = true)]
     pub normalize_verbatim_markers: bool,
 }
 
@@ -444,54 +441,53 @@ impl From<&FormattingRulesConfig> for FormattingRules {
 }
 
 /// Controls AST-related inspect output.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct InspectConfig {
     /// AST visualization options.
-    #[config(nested)]
     pub ast: InspectAstConfig,
     /// Nodemap visualization options.
-    #[config(nested)]
     pub nodemap: NodemapConfig,
 }
 
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct InspectAstConfig {
     /// Include annotations, titles, markers, and other metadata in AST visualizations.
-    #[config(default = false)]
+    #[clapfig(default = false)]
     pub include_all_properties: bool,
     /// Show line numbers next to AST entries.
-    #[config(default = true)]
+    #[clapfig(default = true)]
     pub show_line_numbers: bool,
 }
 
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct NodemapConfig {
     /// Render ANSI-colored blocks instead of Base2048 glyphs.
-    #[config(default = false)]
+    #[clapfig(default = false)]
     pub color_blocks: bool,
     /// Render Base2048 glyphs but color them with ANSI codes.
-    #[config(default = false)]
+    #[clapfig(default = false)]
     pub color_characters: bool,
     /// Append high-level summary statistics under the node map output.
-    #[config(default = false)]
+    #[clapfig(default = false)]
     pub show_summary: bool,
 }
 
 /// Format-specific conversion knobs.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct ConvertConfig {
     /// PDF export options.
-    #[config(nested)]
     pub pdf: PdfConfig,
     /// HTML export options.
-    #[config(nested)]
     pub html: HtmlConfig,
 }
 
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct PdfConfig {
     /// Page profile used when exporting to PDF ("lexed" or "mobile").
-    #[config(default = "lexed")]
+    /// `PdfPageSize` is a custom serde-deserializable enum (not a
+    /// `clapfig::Schema` type), so this is a `LeafType::Value` leaf —
+    /// serde handles the string-to-variant conversion on deserialize.
+    #[clapfig(value, default = "lexed")]
     pub size: PdfPageSize,
 }
 
@@ -503,24 +499,23 @@ pub enum PdfPageSize {
     Mobile,
 }
 
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct HtmlConfig {
     /// Theme for HTML export.
-    #[config(default = "default")]
+    #[clapfig(default = "default")]
     pub theme: String,
     /// Optional path to a custom CSS file to append after the baseline CSS.
     pub custom_css: Option<String>,
 }
 
 /// Diagnostics options.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct DiagnosticsConfig {
     /// Per-rule severity overrides. Each entry takes either a bare
     /// severity string (`"allow"`, `"warn"`, `"deny"`) or an array
     /// form (`["warn", { option = value }]`) carrying rule-specific
     /// options — see [`RuleConfig`]. The defaults shown next to each
     /// rule are the intrinsic defaults; uncomment a line to override.
-    #[config(nested)]
     pub rules: DiagnosticsRulesConfig,
 }
 
@@ -530,38 +525,45 @@ pub struct DiagnosticsConfig {
 /// the description that surfaces in `lexd config gen` output, so
 /// authoring conventions for these doc comments matter: write them as
 /// user-facing prose, lead with what triggers the diagnostic, finish
-/// with the intrinsic default. Extension-emitted codes
-/// (`<namespace>.<code>`) and forward-looking prefix globs are not
-/// fields on this struct — they ride in the embedded map of `extra`
-/// once that surface lands.
+/// with the intrinsic default.
+///
+/// `RuleConfig` is a serde-untagged sum (`"warn"` *or*
+/// `["warn", { max = 80 }]`), so every field carries `#[clapfig(value)]`
+/// — the leaf is a `LeafType::Value` escape hatch in the schema, and
+/// serde does the shape validation on deserialize. clapfig's typo
+/// detection on the *field names themselves* still applies: a
+/// misspelled built-in like `missing_footote` is rejected as an unknown
+/// key. Extension-emitted codes (`<namespace>.<code>`) ride in via
+/// `on_unknown_key` and a side-channel populated by the loader — they
+/// are not fields on this struct.
 ///
 /// `Default` returns every field at [`Severity::Warn`] regardless of
 /// each rule's *intrinsic* default. Real production loads run through
-/// clapfig and honour the `#[config(default = "...")]` annotations.
+/// clapfig and honour the `#[clapfig(default = "...")]` annotations.
 /// `Default` is here so tests and ad-hoc embedders can construct an
 /// instance without going through the clapfig pipeline.
-#[derive(Debug, Clone, Default, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Schema, Serialize, Deserialize)]
 pub struct DiagnosticsRulesConfig {
     /// A footnote reference like `[42]` has no corresponding
     /// definition in the document. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub missing_footnote: RuleConfig,
     /// A footnote definition appears in the document but no
     /// reference points at it. Intrinsic default: warn.
-    #[config(default = "warn")]
+    #[clapfig(value, default = "warn")]
     pub unused_footnote: RuleConfig,
     /// A table row has a different number of columns than the
     /// table's header row. Intrinsic default: warn.
-    #[config(default = "warn")]
+    #[clapfig(value, default = "warn")]
     pub table_inconsistent_columns: RuleConfig,
     /// A label uses the reserved `doc.*` prefix, which is no longer
     /// valid under the current label policy. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub forbidden_label_prefix: RuleConfig,
     /// A `lex.*` literal references a canonical that the toolchain
     /// does not recognise — typically a typo or a label written for
     /// a future core schema. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub unknown_lex_canonical: RuleConfig,
     /// Spellcheck diagnostics. Intrinsic default: warn. **Currently
     /// not consulted at emission time** — spellcheck emits through a
@@ -569,46 +571,22 @@ pub struct DiagnosticsRulesConfig {
     /// present so the value lives in the user-facing config schema;
     /// runtime wiring lands when spellcheck moves over to the
     /// `AnalysisDiagnostic` / `DiagnosticKind` pipeline.
-    #[config(default = "warn")]
+    #[clapfig(value, default = "warn")]
     pub spellcheck: RuleConfig,
     /// Schema-validation diagnostics for extension labels.
-    #[config(nested)]
     pub schema: SchemaRulesConfig,
-    /// Extension-emitted diagnostic codes. Write them directly under
-    /// `[diagnostics.rules]` as quoted dotted keys, alongside the
-    /// built-ins above — they accept the same severity verbs (`"allow"`,
-    /// `"warn"`, `"deny"`) and the same array form for options.
-    ///
-    /// ```toml
-    /// [diagnostics.rules]
-    /// missing_footnote = "deny"                  # built-in
-    /// "acme.task-due-date-missing" = "warn"      # extension code
-    /// "foolco.line-too-long" = ["warn", { max = 120 }]
-    /// ```
-    ///
-    /// The on-the-wire shape per spec §9 is `<namespace>.<code>`
-    /// (e.g. `"acme.task-due-date-missing"` for namespace `acme`,
-    /// code `task-due-date-missing`); the analyser produces that wire
-    /// form, and these `[diagnostics.rules]` entries match it by exact
-    /// string. Entries that never match an emitted diagnostic are
-    /// harmless (ESLint / Clippy convention).
-    ///
-    /// Note: this field renders as `#extra = {  }` in `lexd config gen`
-    /// output. That's a confique template artifact — you do **not**
-    /// write `extra = {...}` in `.lex.toml`. Use inline quoted keys
-    /// directly under `[diagnostics.rules]` as shown above.
-    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
-    #[config(default = {}, layer_attr(serde(flatten)))]
-    pub extra: BTreeMap<String, RuleConfig>,
 }
 
 impl DiagnosticsRulesConfig {
     /// Look up a rule by its on-the-wire code (e.g. `"missing-footnote"`
-    /// or `"schema.unknown-label"` or `"acme.task-due-date-missing"`).
+    /// or `"schema.unknown-label"`).
     ///
-    /// Resolution order: named built-in field → `extra` map → `None`.
-    /// Built-ins always win, so a stray `extra` entry with a built-in
-    /// code does not override the typed surface.
+    /// Only consults named built-in fields. Extension-emitted codes
+    /// (`<namespace>.<code>`) live in a separate side-channel map
+    /// populated by the loader's `on_unknown_key` callback and stored
+    /// on [`LoadedLexConfig::extension_diagnostic_rules`]; use
+    /// [`LoadedLexConfig::lookup_diagnostic_rule`] to consult both
+    /// surfaces with a single call.
     pub fn lookup_by_code(&self, code: &str) -> Option<&RuleConfig> {
         match code {
             "missing-footnote" => Some(&self.missing_footnote),
@@ -628,13 +606,7 @@ impl DiagnosticsRulesConfig {
             "schema.param-type-mismatch" => Some(&self.schema.param_type_mismatch),
             "schema.bad-attachment" => Some(&self.schema.bad_attachment),
             "schema.body-shape-mismatch" => Some(&self.schema.body_shape_mismatch),
-            // Extension-emitted codes (`<namespace>.<code>`) ride here.
-            // Lenient: any key the user wrote in `[diagnostics.rules]`
-            // that didn't land on a named field above is matched by
-            // exact string. Schema-based validation against the
-            // resolved extension registry is deferred (issue #657
-            // "Schema Integration").
-            other => self.extra.get(other),
+            _ => None,
         }
     }
 }
@@ -643,35 +615,35 @@ impl DiagnosticsRulesConfig {
 /// schema pre-validation checks the analyser performs before
 /// dispatching to an extension handler. See the Extending Lex
 /// proposal (`comms/specs/proposals/extending-lex.lex`) §13.2.
-#[derive(Debug, Clone, Default, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Schema, Serialize, Deserialize)]
 pub struct SchemaRulesConfig {
     /// A label is invoked whose namespace is registered, but no
     /// schema entry exists for the label itself. Typically a typo
     /// or an out-of-version label. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub unknown_label: RuleConfig,
     /// A label invocation omits a parameter the schema marks as
     /// required. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub missing_param: RuleConfig,
     /// A label parameter's value does not match the type the schema
     /// declares. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub param_type_mismatch: RuleConfig,
     /// A label attaches to a container shape the schema disallows
     /// (e.g. attaching a paragraph-only label to a session).
     /// Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub bad_attachment: RuleConfig,
     /// A label body's shape (`none` / `text` / `lex`) does not match
     /// the schema's declared body kind. Intrinsic default: deny.
-    #[config(default = "deny")]
+    #[clapfig(value, default = "deny")]
     pub body_shape_mismatch: RuleConfig,
 }
 
 /// Include-resolution options consumed by `lexd convert`, `lexd inspect`,
 /// and the LSP. `lexd format` never expands includes regardless.
-#[derive(Debug, Clone, Config, Serialize, Deserialize)]
+#[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct IncludesConfig {
     /// Resolution root for include path resolution.
     ///
@@ -687,31 +659,158 @@ pub struct IncludesConfig {
     pub root: Option<String>,
     /// Maximum include depth. Default 8. Hitting the limit is an error,
     /// not a silent truncation.
-    #[config(default = 8)]
+    #[clapfig(default = 8)]
     pub max_depth: usize,
     /// Maximum total include count across the document (DoS bound).
     /// Default 1000. Caps fan-out — `max_depth` alone bounds chain
     /// length but a doc with thousands of includes at depth 1 still
     /// blows past it.
-    #[config(default = 1000)]
+    #[clapfig(default = 1000)]
     pub max_total_includes: usize,
     /// Maximum size of any single included file in bytes (DoS bound).
     /// Default 10 MiB (10485760). Files larger than this are rejected
     /// before any bytes hit memory. Used by `FsLoader`; the in-memory
     /// `MemoryLoader` doesn't enforce a size limit.
-    #[config(default = 10485760)]
+    #[clapfig(default = 10485760)]
     pub max_file_size: u64,
+}
+
+/// Typed configuration plus the side-channel map of extension-emitted
+/// diagnostic rules. Returned by [`apply_extension_rules_callback`]-aware
+/// loaders.
+///
+/// The typed [`LexConfig`] holds built-in fields exactly. Extension
+/// diagnostic codes (`<namespace>.<code>` entries under
+/// `[diagnostics.rules]`) live in `extension_diagnostic_rules` so that
+/// dropping the previous `#[serde(flatten)]` catch-all restored typo
+/// detection on built-in field names while still accepting the open-
+/// ended extension key space.
+#[derive(Debug, Clone)]
+pub struct LoadedLexConfig {
+    pub config: LexConfig,
+    /// Side-channel map of extension-emitted diagnostic rules keyed by
+    /// their on-the-wire code (`<namespace>.<code>`). Populated from
+    /// `[diagnostics.rules]` entries accepted by the loader's
+    /// `on_unknown_key` callback.
+    pub extension_diagnostic_rules: BTreeMap<String, RuleConfig>,
+}
+
+impl LoadedLexConfig {
+    /// Look up a `[diagnostics.rules]` entry by its on-the-wire code,
+    /// consulting built-in fields first and the extension side-channel
+    /// second. Built-ins always win — a stray extension key that
+    /// happens to spell a built-in code does not override the typed
+    /// surface.
+    pub fn lookup_diagnostic_rule(&self, code: &str) -> Option<&RuleConfig> {
+        self.config
+            .diagnostics
+            .rules
+            .lookup_by_code(code)
+            .or_else(|| self.extension_diagnostic_rules.get(code))
+    }
+}
+
+/// Shared `(key, value)` collector handed to
+/// [`extension_rules_unknown_key_callback`]. The callback pushes
+/// accepted extension-rule entries here; the loader drains it into
+/// [`LoadedLexConfig::extension_diagnostic_rules`] via
+/// [`collect_extension_diagnostic_rules`].
+pub type CapturedExtensionRules =
+    std::sync::Arc<std::sync::Mutex<Vec<(String, Option<toml::Value>)>>>;
+
+/// Names of nested-struct fields under `[diagnostics.rules]`. The
+/// `on_unknown_key` predicate must reject unknown keys *inside* one of
+/// these subtrees (typos in `SchemaRulesConfig` fields, e.g.
+/// `[diagnostics.rules.schema] unkown_label = "warn"`). Keep this list
+/// in sync with the actual nested fields on
+/// [`DiagnosticsRulesConfig`] — the `known_nested_sections_in_sync`
+/// test asserts that.
+const DIAGNOSTICS_RULES_NESTED_SECTIONS: &[&str] = &["schema"];
+
+/// Build the `on_unknown_key` callback that distinguishes
+/// extension-emitted diagnostic codes (which we accept and capture)
+/// from typos (which we reject so clapfig surfaces them as
+/// `UnknownKeys` errors with line numbers).
+///
+/// The callback also captures accepted entries' parsed values into
+/// `captured` so the loader can build
+/// [`LoadedLexConfig::extension_diagnostic_rules`] without a
+/// side-channel re-parse — the macro-driven path routes
+/// `UnknownKeyContext::value` through the runtime pipeline, so the
+/// value is populated even for quoted-dotted keys like
+/// `"acme.task-due-date-missing" = "warn"`.
+///
+/// Returns a closure suitable for
+/// [`clapfig::SchemaConfigBuilder::on_unknown_key`].
+pub fn extension_rules_unknown_key_callback(
+    captured: CapturedExtensionRules,
+) -> impl Fn(&clapfig::UnknownKeyContext<'_>) -> clapfig::UnknownKeyDecision + Send + Sync + 'static
+{
+    move |ctx: &clapfig::UnknownKeyContext<'_>| {
+        let Some(rest) = ctx.path.strip_prefix("diagnostics.rules.") else {
+            return clapfig::UnknownKeyDecision::Reject;
+        };
+        let first_segment = rest.split('.').next().unwrap_or("");
+        if DIAGNOSTICS_RULES_NESTED_SECTIONS.contains(&first_segment) {
+            // Unknown key inside a typed nested section (e.g.
+            // `[diagnostics.rules.schema] unkown_label = "warn"`) is a
+            // typo — surface it.
+            return clapfig::UnknownKeyDecision::Reject;
+        }
+        if !rest.contains('.') {
+            // Single-segment remainder = bare typo of a built-in field
+            // at the `[diagnostics.rules]` level (e.g.
+            // `missing_footote = "warn"`).
+            return clapfig::UnknownKeyDecision::Reject;
+        }
+        // Multi-segment, first segment not a known nested section →
+        // treat as `<namespace>.<code>` extension key. Capture for
+        // later transfer into `LoadedLexConfig`.
+        captured
+            .lock()
+            .expect("captured mutex not poisoned")
+            .push((rest.to_string(), ctx.value.cloned()));
+        clapfig::UnknownKeyDecision::Accept
+    }
+}
+
+/// Drain a callback-collected `(key, value)` list into a typed
+/// `BTreeMap<String, RuleConfig>`, deserializing each value through
+/// serde so the `RuleConfig` `Bare` vs `WithOptions` sum dispatch
+/// happens at this boundary.
+///
+/// Entries whose value the callback could not resolve (`None`) or
+/// whose serde deserialization fails are silently dropped — the
+/// clapfig accept decision has already been made and the load
+/// succeeded; this finalization step is best-effort. The clapfig
+/// builder is the right surface to surface deserialize errors with
+/// file+line context, not this finalization step.
+pub fn collect_extension_diagnostic_rules(
+    captured: Vec<(String, Option<toml::Value>)>,
+) -> BTreeMap<String, RuleConfig> {
+    let mut out = BTreeMap::new();
+    for (key, value) in captured {
+        let Some(v) = value else { continue };
+        if let Ok(rule) = v.try_into() {
+            out.insert(key, rule);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     fn load_defaults() -> LexConfig {
-        clapfig::Clapfig::builder::<LexConfig>()
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
+        clapfig::Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .no_env()
             .search_paths(vec![])
+            .on_unknown_key(cb)
             .load()
             .expect("defaults to load")
     }
@@ -725,16 +824,31 @@ mod tests {
     }
 
     fn load_from(toml_body: &str) -> LexConfig {
+        load_wrapper_from(toml_body).config
+    }
+
+    fn load_wrapper_from(toml_body: &str) -> LoadedLexConfig {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(CONFIG_FILE_NAME);
         std::fs::write(&path, toml_body).unwrap();
-        clapfig::Clapfig::builder::<LexConfig>()
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
+        let config = clapfig::Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .file_name(CONFIG_FILE_NAME)
             .no_env()
             .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .on_unknown_key(cb)
             .load()
-            .expect("loads")
+            .expect("loads");
+        let captured = Arc::try_unwrap(captured)
+            .expect("captured Arc has no remaining holders after load")
+            .into_inner()
+            .expect("captured mutex not poisoned");
+        LoadedLexConfig {
+            config,
+            extension_diagnostic_rules: collect_extension_diagnostic_rules(captured),
+        }
     }
 
     #[test]
@@ -813,11 +927,13 @@ missing_footnote = ["warn", { example_option = 42 }]
     }
 
     #[test]
-    fn diagnostics_rules_extra_captures_extension_codes() {
+    fn diagnostics_rules_extension_codes_land_in_side_channel() {
         // Extension codes (`<namespace>.<code>`) under [diagnostics.rules]
-        // ride in `extra`. Built-in fields next to them keep their
-        // intrinsic typing.
-        let cfg = load_from(
+        // are no longer struct fields — they ride in the
+        // `LoadedLexConfig::extension_diagnostic_rules` side-channel
+        // populated by the loader's `on_unknown_key` callback. Built-in
+        // fields next to them keep their intrinsic typing.
+        let loaded = load_wrapper_from(
             r#"
 [diagnostics.rules]
 missing_footnote = "allow"
@@ -826,22 +942,18 @@ missing_footnote = "allow"
 "#,
         );
         assert_eq!(
-            cfg.diagnostics.rules.missing_footnote.severity(),
+            loaded.config.diagnostics.rules.missing_footnote.severity(),
             Severity::Allow
         );
-        let acme = cfg
-            .diagnostics
-            .rules
-            .extra
+        let acme = loaded
+            .extension_diagnostic_rules
             .get("acme.task-due-date-missing")
-            .expect("extension code lands in extra");
+            .expect("extension code captured in side-channel");
         assert_eq!(acme.severity(), Severity::Deny);
-        let foolco = cfg
-            .diagnostics
-            .rules
-            .extra
+        let foolco = loaded
+            .extension_diagnostic_rules
             .get("foolco.bar")
-            .expect("array-form extension code lands in extra");
+            .expect("array-form extension code captured");
         assert_eq!(foolco.severity(), Severity::Warn);
         assert_eq!(
             foolco.options().and_then(|o| o.get("max")),
@@ -850,53 +962,60 @@ missing_footnote = "allow"
     }
 
     #[test]
-    fn diagnostics_rules_extra_lookup_by_code_after_named_fields() {
-        // Drift coverage: a built-in code resolves through its named
-        // field even if `extra` happens to contain a same-named entry.
-        // Named fields win.
-        let mut extra: BTreeMap<String, RuleConfig> = BTreeMap::new();
-        extra.insert(
-            "missing-footnote".to_string(),
-            RuleConfig::Bare(Severity::Allow),
+    fn loaded_lookup_diagnostic_rule_consults_both_surfaces() {
+        // Drift coverage: built-ins win over a same-named side-channel
+        // entry; an extension code only the side-channel knows about
+        // resolves through the second path.
+        let loaded = LoadedLexConfig {
+            config: LexConfig {
+                formatting: FormattingConfig {
+                    rules: FormattingRulesConfig::default_for_tests(),
+                    format_on_save: false,
+                },
+                inspect: InspectConfig::default_for_tests(),
+                convert: ConvertConfig::default_for_tests(),
+                diagnostics: DiagnosticsConfig {
+                    rules: DiagnosticsRulesConfig {
+                        missing_footnote: RuleConfig::Bare(Severity::Deny),
+                        ..Default::default()
+                    },
+                },
+                includes: IncludesConfig::default_for_tests(),
+                labels: BTreeMap::new(),
+            },
+            extension_diagnostic_rules: [
+                (
+                    "missing-footnote".to_string(),
+                    RuleConfig::Bare(Severity::Allow),
+                ),
+                ("acme.foo".to_string(), RuleConfig::Bare(Severity::Allow)),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        // Built-in wins over the same-named side-channel entry.
+        assert_eq!(
+            loaded
+                .lookup_diagnostic_rule("missing-footnote")
+                .map(|r| r.severity()),
+            Some(Severity::Deny)
         );
-        let rules = DiagnosticsRulesConfig {
-            missing_footnote: RuleConfig::Bare(Severity::Deny),
-            extra,
-            ..Default::default()
-        };
-        // `missing-footnote` is a built-in; the named field is consulted
-        // first and wins, even though `extra` carries a different value.
-        let resolved = rules.lookup_by_code("missing-footnote").unwrap();
-        assert_eq!(resolved.severity(), Severity::Deny);
-        // An extension code only the `extra` map knows about resolves
-        // through the catch-all path.
-        let rules = DiagnosticsRulesConfig {
-            extra: [("acme.foo".to_string(), RuleConfig::Bare(Severity::Allow))]
-                .into_iter()
-                .collect(),
-            ..Default::default()
-        };
-        let resolved = rules.lookup_by_code("acme.foo").unwrap();
-        assert_eq!(resolved.severity(), Severity::Allow);
-        assert!(rules.lookup_by_code("acme.unknown").is_none());
+        // Side-channel entries resolve through the second path.
+        assert_eq!(
+            loaded
+                .lookup_diagnostic_rule("acme.foo")
+                .map(|r| r.severity()),
+            Some(Severity::Allow)
+        );
+        assert!(loaded.lookup_diagnostic_rule("acme.unknown").is_none());
     }
 
     #[test]
-    fn diagnostics_rules_typo_in_builtin_lands_in_extra() {
-        // Documents the intentional tradeoff: because the `extra` map
-        // uses `#[serde(flatten)]`, it captures *every* key under
-        // `[diagnostics.rules]` that doesn't match a named field —
-        // including a misspelled built-in like `missing_footote`. The
-        // load succeeds and the typo lives quietly in `extra`,
-        // matching nothing.
-        //
-        // Typo detection for *built-in* rule names is sacrificed in
-        // exchange for accepting extension codes lenient-style. The
-        // Schema Integration item (deferred from #657) restores typo
-        // detection later by validating `extra` keys against the
-        // resolved extension registry — at that point an `extra` key
-        // matching neither a built-in nor a registered extension code
-        // can be flagged.
+    fn diagnostics_rules_typo_in_builtin_errors() {
+        // Headline behaviour change vs PR #658: dropping the
+        // `#[serde(flatten)] extra` catch-all means typos in built-in
+        // field names are rejected by clapfig's strict-mode validator
+        // again — they no longer land silently in `extra`.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(CONFIG_FILE_NAME);
         std::fs::write(
@@ -907,91 +1026,136 @@ missing_footote = "warn"
 "#,
         )
         .unwrap();
-        let cfg = clapfig::Clapfig::builder::<LexConfig>()
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
+        let err = clapfig::Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .file_name(CONFIG_FILE_NAME)
             .no_env()
             .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .on_unknown_key(cb)
             .load()
-            .expect("loads — typo gets absorbed into extra");
-        assert_eq!(
-            cfg.diagnostics
-                .rules
-                .extra
-                .get("missing_footote")
-                .map(|r| r.severity()),
-            Some(Severity::Warn),
-            "the misspelled key lands in `extra`"
-        );
-        // And the *real* built-in field stays at its intrinsic default
-        // — the typo did not partially-shadow it.
-        assert_eq!(
-            cfg.diagnostics.rules.missing_footnote.severity(),
-            Severity::Deny,
-            "the correctly-spelled built-in keeps its intrinsic default"
+            .expect_err("typo must surface as an unknown-key error");
+        let keys = err
+            .unknown_keys()
+            .expect("error variant carries UnknownKeys");
+        assert!(
+            keys.iter().any(|k| k.key.ends_with("missing_footote")),
+            "the misspelled key is reported: {keys:?}"
         );
     }
 
     #[test]
-    fn diagnostics_rules_extra_round_trip() {
-        // load -> serialize -> load preserves both named built-ins and
-        // extra extension codes. Confirms `#[serde(flatten)]` rides
-        // through serialization as inline keys in the same table, not
-        // as a nested `extra` sub-table.
-        let cfg = load_from(
-            r#"
-[diagnostics.rules]
-unused_footnote = "deny"
-"acme.foo" = "warn"
-"bar.qux" = ["deny", { example = 1 }]
-"#,
-        );
-        let serialized = toml::to_string(&cfg).expect("serializes");
-        // Sanity-check the on-disk shape: extras live inline in
-        // `[diagnostics.rules]` (not under `[diagnostics.rules.extra]`).
-        assert!(
-            serialized.contains(r#""acme.foo" = "warn""#)
-                || serialized.contains(r#"'acme.foo' = "warn""#),
-            "extension key flattened inline; got:\n{serialized}"
-        );
-        assert!(
-            !serialized.contains("[diagnostics.rules.extra]"),
-            "extras must not nest under an `extra` sub-table; got:\n{serialized}"
-        );
+    fn diagnostics_rules_typo_inside_nested_section_errors() {
+        // The `on_unknown_key` predicate must NOT accept a typo inside
+        // a nested-built-in section (`[diagnostics.rules.schema]`) just
+        // because the dotted path has more than two segments — the
+        // first segment must not be a known nested section. This is
+        // the failure mode Gemini called out in the original review on
+        // PR #664.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(CONFIG_FILE_NAME);
-        std::fs::write(&path, &serialized).unwrap();
-        let reloaded = clapfig::Clapfig::builder::<LexConfig>()
+        std::fs::write(
+            &path,
+            r#"
+[diagnostics.rules.schema]
+unkown_label = "warn"
+"#,
+        )
+        .unwrap();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let cb = extension_rules_unknown_key_callback(Arc::clone(&captured));
+        let err = clapfig::Clapfig::schema_builder::<LexConfig>()
             .app_name("lex")
             .file_name(CONFIG_FILE_NAME)
             .no_env()
             .search_paths(vec![clapfig::SearchPath::Path(dir.path().to_path_buf())])
+            .on_unknown_key(cb)
             .load()
-            .expect("round-trips");
-        assert_eq!(
-            reloaded.diagnostics.rules.unused_footnote.severity(),
-            Severity::Deny
+            .expect_err("typo inside nested section must error");
+        let keys = err.unknown_keys().expect("UnknownKeys variant");
+        assert!(
+            keys.iter().any(|k| k.key.ends_with("unkown_label")),
+            "the misspelled nested key is reported: {keys:?}"
         );
-        assert_eq!(
-            reloaded
-                .diagnostics
-                .rules
-                .extra
-                .get("acme.foo")
-                .map(|r| r.severity()),
-            Some(Severity::Warn)
-        );
-        let bar = reloaded
-            .diagnostics
-            .rules
-            .extra
-            .get("bar.qux")
-            .expect("array-form extension key round-trips");
-        assert_eq!(bar.severity(), Severity::Deny);
-        assert_eq!(
-            bar.options().and_then(|o| o.get("example")),
-            Some(&toml::Value::Integer(1))
-        );
+    }
+
+    #[test]
+    fn known_nested_sections_in_sync_with_struct_fields() {
+        // The `on_unknown_key` predicate's list of "known nested
+        // section names" must match the actual nested-struct fields
+        // on `DiagnosticsRulesConfig`. If a new nested section is
+        // added to the struct but not added to the const, typos in
+        // that section's keys would be silently accepted as extension
+        // codes — exactly the bug we're protecting against.
+        //
+        // Hard-coded ground truth: as of now, the only nested-struct
+        // field on `DiagnosticsRulesConfig` is `schema`. Adding a new
+        // nested-struct field requires updating both this assertion
+        // and `DIAGNOSTICS_RULES_NESTED_SECTIONS`.
+        assert_eq!(DIAGNOSTICS_RULES_NESTED_SECTIONS, &["schema"]);
+    }
+
+    // Per-config-struct `default_for_tests` helpers — the new macro
+    // doesn't auto-`Default` like confique did, and we want one place
+    // each struct can be constructed for unit tests that don't go
+    // through the full clapfig pipeline. Production loads always run
+    // through clapfig and pick up the `#[clapfig(default = ...)]`
+    // annotations.
+    impl FormattingRulesConfig {
+        fn default_for_tests() -> Self {
+            FormattingRulesConfig {
+                session_blank_lines_before: 1,
+                session_blank_lines_after: 1,
+                normalize_seq_markers: true,
+                unordered_seq_marker: '-',
+                max_blank_lines: 2,
+                indent_string: "    ".to_string(),
+                preserve_trailing_blanks: false,
+                normalize_verbatim_markers: true,
+            }
+        }
+    }
+
+    impl InspectConfig {
+        fn default_for_tests() -> Self {
+            InspectConfig {
+                ast: InspectAstConfig {
+                    include_all_properties: false,
+                    show_line_numbers: true,
+                },
+                nodemap: NodemapConfig {
+                    color_blocks: false,
+                    color_characters: false,
+                    show_summary: false,
+                },
+            }
+        }
+    }
+
+    impl ConvertConfig {
+        fn default_for_tests() -> Self {
+            ConvertConfig {
+                pdf: PdfConfig {
+                    size: PdfPageSize::LexEd,
+                },
+                html: HtmlConfig {
+                    theme: "default".to_string(),
+                    custom_css: None,
+                },
+            }
+        }
+    }
+
+    impl IncludesConfig {
+        fn default_for_tests() -> Self {
+            IncludesConfig {
+                root: None,
+                max_depth: 8,
+                max_total_includes: 1000,
+                max_file_size: 10_485_760,
+            }
+        }
     }
 
     #[test]

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -484,11 +484,7 @@ pub struct ConvertConfig {
 #[derive(Debug, Clone, Schema, Serialize, Deserialize)]
 pub struct PdfConfig {
     /// Page profile used when exporting to PDF ("lexed" or "mobile").
-    /// `PdfPageSize` derives `clapfig::Schema` (unit-only enum), but
-    /// field-level defaults are not yet permitted on nested-Schema
-    /// fields, so this stays a `#[clapfig(value)]` leaf with a string
-    /// default that serde resolves to the typed variant on load.
-    #[clapfig(value, default = "lexed")]
+    #[clapfig(default = "lexed")]
     pub size: PdfPageSize,
 }
 

--- a/crates/lex-config/src/rule_config.rs
+++ b/crates/lex-config/src/rule_config.rs
@@ -32,7 +32,7 @@ pub enum Severity {
 impl Default for Severity {
     /// Tests and ad-hoc construction of [`RuleConfig`] default to
     /// [`Severity::Warn`]. The *real* per-rule intrinsic defaults are
-    /// declared as `#[config(default = "...")]` on each
+    /// declared as `#[clapfig(value, default = "...")]` on each
     /// [`crate::DiagnosticsRulesConfig`] field and applied by clapfig
     /// during config load.
     fn default() -> Self {

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -30,7 +30,10 @@ use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use lex_babel::templates::{
     build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
 };
-use lex_config::{LabelsConfig, LexConfig, CONFIG_FILE_NAME};
+use lex_config::{
+    collect_extension_diagnostic_rules, extension_rules_unknown_key_callback, LabelsConfig,
+    LexConfig, LoadedLexConfig, CONFIG_FILE_NAME,
+};
 use lex_core::lex::ast::links::{DocumentLink as AstDocumentLink, LinkType};
 use lex_core::lex::ast::range::SourceLocation;
 use lex_core::lex::ast::{Document, Position as AstPosition, Range as AstRange};
@@ -280,7 +283,7 @@ pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
     documents: DocumentStore,
     features: Arc<P>,
     workspace_roots: RwLock<Vec<PathBuf>>,
-    config: RwLock<LexConfig>,
+    config: RwLock<LoadedLexConfig>,
     /// Extension registry + boot diagnostics, lazily populated on first
     /// extension-aware request (hover/completion/code_action). Held for
     /// the lifetime of the workspace; rebuilt when workspace folders
@@ -360,7 +363,7 @@ where
             roots.first().cloned()?
         };
         let labels_config = LabelsConfig {
-            namespaces: self.config.read().await.labels.clone(),
+            namespaces: self.config.read().await.config.labels.clone(),
         };
 
         // boot_registry does synchronous filesystem IO (schema load,
@@ -457,8 +460,11 @@ where
         let mut diagnostics: Vec<Diagnostic> = include_diags;
         if let Some(entry) = self.documents.get(&uri).await {
             let mut analysis_diags = analyze_diagnostics(&entry.document);
-            let rules = self.config.read().await.diagnostics.rules.clone();
-            apply_rules(&mut analysis_diags, &rules);
+            let cfg = self.config.read().await;
+            apply_rules(&mut analysis_diags, |code| {
+                cfg.lookup_diagnostic_rule(code).cloned()
+            });
+            drop(cfg);
             diagnostics.extend(analysis_diags.into_iter().map(to_lsp_diagnostic));
         }
 
@@ -516,10 +522,10 @@ where
         let path = absolutize_path(&path);
 
         let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&path, &cfg);
-        let max_depth = cfg.includes.max_depth;
-        let max_total_includes = cfg.includes.max_total_includes;
-        let max_file_size = cfg.includes.max_file_size;
+        let inc_root = inc_root_for(&path, &cfg.config);
+        let max_depth = cfg.config.includes.max_depth;
+        let max_total_includes = cfg.config.includes.max_total_includes;
+        let max_file_size = cfg.config.includes.max_file_size;
         drop(cfg);
 
         let resolve_config = ResolveConfig {
@@ -577,7 +583,7 @@ where
 
         let host_path = absolutize_path(&uri.to_file_path().ok()?);
         let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&host_path, &cfg);
+        let inc_root = inc_root_for(&host_path, &cfg.config);
         drop(cfg);
 
         let target = lex_core::lex::includes::resolve_file_reference(
@@ -622,7 +628,7 @@ where
 
         let host_path = absolutize_path(&uri.to_file_path().ok()?);
         let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&host_path, &cfg);
+        let inc_root = inc_root_for(&host_path, &cfg.config);
         drop(cfg);
 
         let target = lex_core::lex::includes::resolve_file_reference(
@@ -693,7 +699,7 @@ where
     /// Build formatting rules from stored config, with per-request LSP overrides on top.
     async fn resolve_formatting_rules(&self, options: &FormattingOptions) -> FormattingRules {
         let config = self.config.read().await;
-        let mut rules = FormattingRules::from(&config.formatting.rules);
+        let mut rules = FormattingRules::from(&config.config.formatting.rules);
 
         // Layer per-request LSP overrides (editors can send lex.* properties)
         apply_formatting_overrides(&mut rules, options);
@@ -702,8 +708,11 @@ where
     }
 }
 
-/// Load a [`LexConfig`] via clapfig, searching from an optional workspace root.
-fn load_config(workspace_root: Option<&Path>) -> LexConfig {
+/// Load a [`LoadedLexConfig`] via clapfig, searching from an optional
+/// workspace root. The wrapper carries both the typed [`LexConfig`] and
+/// the side-channel map of extension-emitted diagnostic rules captured
+/// from `[diagnostics.rules]` via the `on_unknown_key` callback.
+fn load_config(workspace_root: Option<&Path>) -> LoadedLexConfig {
     let mut search_paths = vec![SearchPath::Platform];
     if let Some(root) = workspace_root {
         search_paths.push(SearchPath::Path(root.to_path_buf()));
@@ -711,20 +720,35 @@ fn load_config(workspace_root: Option<&Path>) -> LexConfig {
         search_paths.push(SearchPath::Ancestors(Boundary::Marker(".git")));
         search_paths.push(SearchPath::Cwd);
     }
-    Clapfig::builder::<LexConfig>()
+    load_with(search_paths, false).unwrap_or_else(|_| {
+        // Fall back to compiled defaults if config loading fails.
+        load_with(vec![], true).expect("compiled defaults must load")
+    })
+}
+
+fn load_with(
+    search_paths: Vec<SearchPath>,
+    no_env: bool,
+) -> std::result::Result<LoadedLexConfig, clapfig::ClapfigError> {
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let cb = extension_rules_unknown_key_callback(std::sync::Arc::clone(&captured));
+    let mut builder = Clapfig::schema_builder::<LexConfig>()
         .app_name("lex")
         .file_name(CONFIG_FILE_NAME)
         .search_paths(search_paths)
-        .load()
-        .unwrap_or_else(|_| {
-            // Fall back to compiled defaults if config loading fails
-            Clapfig::builder::<LexConfig>()
-                .app_name("lex")
-                .no_env()
-                .search_paths(vec![])
-                .load()
-                .expect("compiled defaults must load")
-        })
+        .on_unknown_key(cb);
+    if no_env {
+        builder = builder.no_env();
+    }
+    let config = builder.load()?;
+    let captured = std::sync::Arc::try_unwrap(captured)
+        .expect("captured Arc has no remaining holders after load")
+        .into_inner()
+        .expect("captured mutex not poisoned");
+    Ok(LoadedLexConfig {
+        config,
+        extension_diagnostic_rules: collect_extension_diagnostic_rules(captured),
+    })
 }
 
 fn best_matching_root(roots: &[PathBuf], document_path: &Path) -> Option<PathBuf> {
@@ -1708,7 +1732,7 @@ where
         let host_indent = range.start.character as usize;
 
         let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&host_path, &cfg);
+        let inc_root = inc_root_for(&host_path, &cfg.config);
         drop(cfg);
 
         let edit = extract::build_extract_workspace_edit(

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -31,8 +31,8 @@ use lex_babel::templates::{
     build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
 };
 use lex_config::{
-    collect_extension_diagnostic_rules, extension_rules_unknown_key_callback, LabelsConfig,
-    LexConfig, LoadedLexConfig, CONFIG_FILE_NAME,
+    collect_extension_diagnostic_rules, LabelsConfig, LexConfig, LoadedLexConfig, CONFIG_FILE_NAME,
+    DIAGNOSTICS_RULES_PATH,
 };
 use lex_core::lex::ast::links::{DocumentLink as AstDocumentLink, LinkType};
 use lex_core::lex::ast::range::SourceLocation;
@@ -730,24 +730,21 @@ fn load_with(
     search_paths: Vec<SearchPath>,
     no_env: bool,
 ) -> std::result::Result<LoadedLexConfig, clapfig::ClapfigError> {
-    let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-    let cb = extension_rules_unknown_key_callback(std::sync::Arc::clone(&captured));
     let mut builder = Clapfig::schema_builder::<LexConfig>()
         .app_name("lex")
         .file_name(CONFIG_FILE_NAME)
         .search_paths(search_paths)
-        .on_unknown_key(cb);
+        .accept_dotted_extension_keys_in(
+            DIAGNOSTICS_RULES_PATH,
+            clapfig::UnknownKeyDecision::Collect,
+        );
     if no_env {
         builder = builder.no_env();
     }
-    let config = builder.load()?;
-    let captured = std::sync::Arc::try_unwrap(captured)
-        .expect("captured Arc has no remaining holders after load")
-        .into_inner()
-        .expect("captured mutex not poisoned");
+    let (config, unknowns) = builder.load_with_unknowns()?;
     Ok(LoadedLexConfig {
         config,
-        extension_diagnostic_rules: collect_extension_diagnostic_rules(captured),
+        extension_diagnostic_rules: collect_extension_diagnostic_rules(unknowns),
     })
 }
 


### PR DESCRIPTION
## Summary

Removes PR #658's `[diagnostics.rules]` workaround. Migrates `lex-config` from `confique::Config` to `#[derive(clapfig::Schema)]` (clapfig 0.21.4), drops the `#[serde(flatten)] extra: BTreeMap` catch-all, restores typo detection on built-in rule names, and keeps extension diagnostic codes working through clapfig's built-in `accept_dotted_extension_keys_in` predicate + `load_with_unknowns` capture.

## Background

#658 landed extension-emitted diagnostic codes (`"acme.task-due-date-missing" = "warn"`) under `[diagnostics.rules]` via a `#[serde(flatten)] extra: BTreeMap<String, RuleConfig>` field. The catch-all consumed **everything** the typed surface didn't match — including typos in built-in field names. `missing_footote = "warn"` (typo) landed silently in `extra` instead of erroring.

The fix arrived in five clapfig releases:
- **0.20.0** — `strict_at` + `on_unknown_key` + runtime schemas
- **0.20.1** — `LeafType::Value` for sum-typed leaves like `RuleConfig`
- **0.21.0–0.21.2** — `#[derive(clapfig::Schema)]` + macro fixes for `#[clapfig(value)]` on non-scalar types
- **0.21.3** — `accept_dotted_extension_keys_in`, `UnknownKeyDecision::Collect`, `load_with_unknowns` (collapsed the hand-rolled callback machinery to one builder method)
- **0.21.4** — field-level defaults on unit-enum-typed fields (let `PdfPageSize` drop its escape hatch)

## What changed

### `crates/lex-config/src/lib.rs`
- All confique-derived structs switch to `#[derive(clapfig::Schema)]`.
- `PdfPageSize` derives `Schema` and the `size` field becomes a typed enum leaf — `lexd config gen` emits `# Allowed: "lexed" | "mobile"` above the line.
- Fields whose Rust type is a true serde-untagged sum (`RuleConfig`, `BTreeMap<String, NamespaceSpec>`) keep `#[clapfig(value)]` — those shapes have no native `LeafType` equivalent.
- **`DiagnosticsRulesConfig::extra` field is removed.** Typo detection on built-in field names is restored — `missing_footote` errors at clapfig's strict-mode validator with a line number.
- New `LoadedLexConfig` wrapper holds the typed `LexConfig` plus a side-channel `extension_diagnostic_rules: BTreeMap<String, RuleConfig>`.
- The wrapper's lookup helper consults built-in fields first and the side-channel second — built-ins always win, matching PR #658's semantics.

### Loader wiring (LSP + CLI)
- `Clapfig::schema_builder::<LexConfig>().accept_dotted_extension_keys_in("diagnostics.rules", UnknownKeyDecision::Collect).load_with_unknowns()` — one builder call captures extension codes alongside the typed config.
- `collect_extension_diagnostic_rules(unknowns)` deserializes the captured values into `RuleConfig` and drops anything that doesn't deserialize.

### `crates/lex-analysis/src/diagnostics.rs`
- `apply_rules` signature changes from `&DiagnosticsRulesConfig` to a generic `lookup_rule: impl Fn(&str) -> Option<RuleConfig>` closure. Lets callers consult both built-in rules and the extension side-channel through one entry point.

### `crates/lex-config/Cargo.toml`
- `confique` removed; `clapfig` moves from dev-deps to deps.

## What's restored vs PR #658

| | Before (#658) | After |
|---|---|---|
| `"acme.foo" = "warn"` under `[diagnostics.rules]` works | ✅ | ✅ |
| Bare typo (`missing_footote`) errors at load with line number | ❌ (lands in `extra`) | ✅ |
| Typo inside nested section (`[diagnostics.rules.schema] unkown_label`) errors | ❌ | ✅ |
| `lexd config gen` shows typed enum constraints (e.g. `# Allowed: "lexed" \| "mobile"`) | partial | ✅ for `PdfPageSize`; still untyped for `RuleConfig` / `NamespaceSpec` (true sum types) |
| Env-var unknown keys validated against schema | ❌ | ✅ (clapfig 0.21.3 closed the env-layer validation gap) |
| Typo in dotted extension code (`"acme.tpyo"` when handler emits `acme.typo`) errors | ❌ | ❌ — same as before; requires schema integration (deferred from #657) |

## Test plan

- [x] 2381 tests pass across the workspace (`cargo test --workspace --exclude lex-wasm`). No regressions.
- [x] New `lex-config` tests:
  - `diagnostics_rules_typo_in_builtin_errors` — bare typos surface as `UnknownKeys` with line numbers.
  - `diagnostics_rules_typo_inside_nested_section_errors` — typos under `[diagnostics.rules.schema]` still error.
  - `diagnostics_rules_extension_codes_land_in_side_channel` — end-to-end path.
  - `loaded_lookup_diagnostic_rule_consults_both_surfaces` — built-in-wins ordering.
- [x] `lex-analysis::apply_rules_matches_extension_code_via_side_channel` — replicates PR #658's allow/warn/deny semantics for extension codes through the new closure-based `apply_rules`.
- [x] `cargo clippy --workspace -- -D warnings` clean.

## Commits

1. `fccc703f` bump clapfig 0.17 → 0.20
2. `ad6d775d` bump 0.20.0 → 0.20.1
3. `e3ea5085` bump 0.20.1 → 0.21.1
4. `96a4b3a6` refactor: migrate to clapfig::Schema; drop extra-flatten workaround
5. `b12ff27f` adopt clapfig 0.21.3 helpers (drop hand-rolled callback, drift constant, drift-guard test)
6. `5a250c5d` drop `#[clapfig(value)]` on `PdfPageSize` field (clapfig 0.21.4)

Each version-bump commit corresponds to an upstream release that unlocked the next piece of the refactor. Squashing all six into one merge commit is fine — the progression is recorded in the review thread for context.