### PR TITLE
feat(ci): adopt rust-ci.yml reusable workflow (submodules: recursive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+# Thin caller for the canonical reusable Rust CI workflow at
+# arthur-debert/release. Replaces the previously hand-rolled `test` job
+# in test-rust.yml (setup-rust + clippy + nextest sequence).
+#
+# See docs/per-stack/rust-ci.md in arthur-debert/release for the full
+# input reference. The companion wasm + docs jobs that test-rust.yml
+# also carried live on in that file — they cover concerns this reusable
+# workflow deliberately doesn't (wasm-pack bundler build, cargo doc).
+#
+# `submodules: recursive` is required: lex's grammar / comms / etc live
+# in nested submodules — the checkout step needs to recurse to pick
+# them up. The release-side input was added in release#134 specifically
+# to unblock this adoption.
+#
+# `binary-name: lexd` matches release.yml's bin-name, so the check job
+# also builds and uploads `lexd-linux`. No e2e job runs (lex has no
+# bats suite), so `bats:` stays false.
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
+    with:
+      binary-name: lexd
+      submodules: 'recursive'

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -1,5 +1,23 @@
 name: Rust CI
 
+# Companion CI jobs for concerns the canonical reusable workflow at
+# arthur-debert/release/.github/workflows/rust-ci.yml deliberately
+# doesn't cover:
+#
+#   - `wasm`: wasm-pack bundler build for the lex-wasm crate. The
+#     reusable workflow's `extra-targets` knob installs the rustup
+#     target but doesn't run wasm-pack; lex needs the full
+#     wasm-pack-build + artifact-verify dance to keep the
+#     @lex-fmt/lex-wasm npm publish path warm.
+#
+#   - `docs`: `cargo doc` across the workspace (excluding lex-wasm,
+#     whose feature gates collide with rustdoc's default config).
+#     This is a required status check ("Documentation") per the
+#     main-branch-protection ruleset.
+#
+# The PR-time `test` job that used to live here has been replaced by
+# the thin caller at .github/workflows/ci.yml.
+
 on:
   push:
     branches: ['**']
@@ -10,37 +28,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Check formatting
-        run: cargo fmt -- --check
-
-      - name: Clippy
-        run: cargo clippy --workspace --exclude lex-wasm --all-targets --all-features -- -D warnings
-
-      - name: Build
-        run: cargo build --workspace --exclude lex-wasm
-
-      - name: Test
-        run: cargo nextest run --workspace --exclude lex-wasm
-
   wasm:
     name: WASM build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adopt the canonical reusable Rust CI workflow at
`arthur-debert/release/.github/workflows/rust-ci.yml@take-iii`, closing
the lex-side adoption blocker tracked from `release#132` (umbrella) and
unblocked by `release#134`, which added a `submodules` input
accepting `'recursive'` for nested submodules.

- New `.github/workflows/ci.yml` — thin caller with
  `binary-name: lexd` and `submodules: 'recursive'`. Runs the
  canonical `bin/check` umbrella (fmt + clippy + nextest) plus a
  release-binary build/upload of `lexd`. No bats e2e (lex doesn't
  have a bats suite).
- `test-rust.yml` trimmed: the PR-time `test` job is removed
  (now lives in `ci.yml`). The `wasm` and `docs` jobs stay — they
  cover concerns `rust-ci.yml` deliberately doesn't (wasm-pack
  bundler build and `cargo doc`).

Reference adopters tracking the same shape on `take-iii`: dodot,
padz, burgertocow, clapfig, standout.

## Required-checks rename

Per `release/`'s `docs/per-stack/rust-ci.md` "Required-checks
rename" section, reusable-workflow callee jobs are prefixed by the
caller's job ID. The old `Test` check is replaced by `ci / check`.
The repo's `main-branch-protection` ruleset is being updated in
tandem to require `ci / check` and `Documentation`.

## Test plan

- [ ] CI runs end-to-end with `submodules: recursive` checking out the comms submodule
- [ ] `ci / check` runs `bin/check` (fmt + clippy + nextest workspace)
- [ ] `ci / check` builds `lexd` in release mode and uploads `lexd-linux`
- [ ] `wasm` job still runs (wasm-pack bundler build)
- [ ] `Documentation` (docs job) still runs and passes