### PR TITLE
chore: move app-specific scripts/dev to app-bin/dev

### DIFF
--- a/app-bin/dev/Dockerfile.sandbox
+++ b/app-bin/dev/Dockerfile.sandbox
@@ -1,6 +1,6 @@
 # Linux dev container for exercising the sandbox tests on a macOS host.
 #
-# Used by scripts/dev/sandbox-test-linux.sh. CI runs the same tests on
+# Used by app-bin/dev/sandbox-test-linux.sh. CI runs the same tests on
 # ubuntu-latest directly; this image only exists so a contributor on
 # macOS can run the Linux-only sandbox suite locally without spinning
 # up a VM.

--- a/app-bin/dev/sandbox-test-linux.sh
+++ b/app-bin/dev/sandbox-test-linux.sh
@@ -4,8 +4,8 @@
 # the same suite on ubuntu-latest directly via .github/workflows/sandbox-tests.yml.
 #
 # Usage:
-#   scripts/dev/sandbox-test-linux.sh                # nextest sandbox:: in lex-extension-host
-#   scripts/dev/sandbox-test-linux.sh <cmd> [args]   # run an arbitrary command in the container
+#   app-bin/dev/sandbox-test-linux.sh                # nextest sandbox:: in lex-extension-host
+#   app-bin/dev/sandbox-test-linux.sh <cmd> [args]   # run an arbitrary command in the container
 #
 # Notes:
 # - The image is built on first run; subsequent runs reuse it. To force
@@ -28,14 +28,14 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 IMAGE="lex-sandbox-dev:latest"
-DOCKERFILE="$REPO_ROOT/scripts/dev/Dockerfile.sandbox"
+DOCKERFILE="$REPO_ROOT/app-bin/dev/Dockerfile.sandbox"
 PLATFORM_FLAG=()
 if [[ -n "${SANDBOX_PLATFORM:-}" ]]; then
     PLATFORM_FLAG=(--platform "$SANDBOX_PLATFORM")
 fi
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/scripts/dev"
+    docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/app-bin/dev"
 fi
 
 if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Move `scripts/dev/` (sandbox-test-linux.sh + Dockerfile.sandbox) to `app-bin/dev/`
- These are local dev tools for running Linux sandbox tests on macOS, not CI infrastructure
- Update internal path references in both files

`scripts/setup-dev-env.sh` stays in place.

## Test plan
- [ ] `app-bin/dev/sandbox-test-linux.sh` runs correctly (builds Docker image, runs sandbox tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)