### PR TITLE
chore: lint cleanup for strict shell-quality gate

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -48,6 +48,7 @@ Time to read a file, parse it, and emit HTML.
 | `080-gentle-introduction` (Tier B) | 24.1 KB | 60.6 ms | 1.8 ms | 241 ms |
 
 **Observations**:
+
 - `cmark` shows the floor: ~0.3 ms of real work even on 24 KB. The C reference impl is single-pass, no extensions.
 - `lexd` sits in the middle tier — 7–34× slower than `cmark` end-to-end (gap widens with doc size as parse work dominates over equal startup cost), 4–19× faster than `pandoc` (gap narrows with doc size as `pandoc`'s processing catches up to its 25 ms startup).
 - `lexd format`, `lexd → md`, and `lexd → html` agree within 1–2% on every fixture. Parse cost dominates entirely; once parsed, the IR transform + serializer is < 10% on top. **The only number that matters end-to-end is parse time.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Lex is a plain text format for structured documents — more expressive than Mar
 
 This is the unified Rust workspace containing all Lex crates and specifications.
 
-```
+```text
 crates/
   lex-core/       Parser crate (crates.io)
   lex-analysis/   Stateless semantic analysis (crates.io)
@@ -61,6 +61,7 @@ Editor UIs download pre-built lexd-lsp binaries from this repo's releases,
 and tree-sitter artifacts from lex-fmt/tree-sitter-lex releases.
 
 For local development, set `LEX_LSP_PATH` to point editors at a local build:
+
 ```sh
 cargo build -p lexd-lsp
 LEX_LSP_PATH=./target/debug/lexd-lsp

--- a/crates/lex-babel/docs/epics/interop-architecture/01-umbrella.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/01-umbrella.md
@@ -2,7 +2,7 @@
 
 **Title:** babel: interop architecture work-stream — symmetrize the IR, unify label dispatch, retire the markdown HACK
 
-**Filed:** https://github.com/lex-fmt/lex/issues/613
+**Filed:** <https://github.com/lex-fmt/lex/issues/613>
 
 ---
 
@@ -24,7 +24,7 @@ The lex-babel layer was built when the language spec was smaller and the extensi
 
 These are not four independent issues. The dependency order is forced:
 
-```
+```text
 (A) Symmetric IR
        ↓
        ├──→ enables (B) Unified dispatch surface (extensions can register against

--- a/crates/lex-babel/docs/epics/interop-architecture/02-sub-a-symmetric-ir.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/02-sub-a-symmetric-ir.md
@@ -2,7 +2,7 @@
 
 **Title:** babel/ir: advance IR ↔ Lex symmetry — Phase 3b document annotations, reference sub-types, round-trip audit
 
-**Filed:** https://github.com/lex-fmt/lex/issues/614
+**Filed:** <https://github.com/lex-fmt/lex/issues/614>
 
 ---
 

--- a/crates/lex-babel/docs/epics/interop-architecture/03-sub-b-unified-registry.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/03-sub-b-unified-registry.md
@@ -2,7 +2,7 @@
 
 **Title:** babel/extensions: unify the two label-dispatch surfaces (IR-build dispatch + render dispatch) into one registry shape
 
-**Filed:** https://github.com/lex-fmt/lex/issues/615
+**Filed:** <https://github.com/lex-fmt/lex/issues/615>
 
 ---
 
@@ -27,7 +27,7 @@ Both gate on the same `Registry` schema. Both are correct in isolation. Together
 
 **Single Registry surface** with two lifecycle hook kinds, both registered alongside one schema:
 
-```
+```text
 LabelSchema {
     name: "lex.tabular.table",
     on_ir_build: Some(table_from_verbatim),   // IR-construction hook

--- a/crates/lex-babel/docs/epics/interop-architecture/04-sub-c-render-dispatch-ir.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/04-sub-c-render-dispatch-ir.md
@@ -2,7 +2,7 @@
 
 **Title:** babel: migrate render_dispatch from lex-core AST to the IR
 
-**Filed:** https://github.com/lex-fmt/lex/issues/616
+**Filed:** <https://github.com/lex-fmt/lex/issues/616>
 
 ---
 

--- a/crates/lex-babel/docs/epics/interop-architecture/05-sub-d-markdown-hack.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/05-sub-d-markdown-hack.md
@@ -60,11 +60,11 @@ impl<'a> SpliceState<'a> {
 
 1. **`tree_to_events` and `crates/lex-babel/src/ir/events.rs` are not modified.** The IR/events layer stays exactly as it is today. The splice concern lives entirely in the consumption layer (`common/splice.rs` + each format's walker).
 
-2. **The HACK comment block (`serializer.rs:441-503`) is deleted.**
+1. **The HACK comment block (`serializer.rs:441-503`) is deleted.**
 
-3. **The hardcoded metadata-label whitelist** (`author, note, title, date, tags, category, template`) is removed. Document-level labels are registered as `doc.title`, `doc.author`, `doc.date`, `doc.tags`, `doc.category`, `doc.template` (per Sub B) with `on_render` hooks emitting YAML frontmatter; `note` is content-level and handled via the generic annotation path.
+1. **The hardcoded metadata-label whitelist** (`author, note, title, date, tags, category, template`) is removed. Document-level labels are registered as `doc.title`, `doc.author`, `doc.date`, `doc.tags`, `doc.category`, `doc.template` (per Sub B) with `on_render` hooks emitting YAML frontmatter; `note` is content-level and handled via the generic annotation path.
 
-4. **HTML's current splice-sentinel mechanism migrates to `SpliceState` in the same PR.** The post-DOM string-replacement code in `formats/html/serializer.rs` (around `replace_splice_sentinels`) retires. We end with one splice mechanism, not two.
+1. **HTML's current splice-sentinel mechanism migrates to `SpliceState` in the same PR.** The post-DOM string-replacement code in `formats/html/serializer.rs` (around `replace_splice_sentinels`) retires. We end with one splice mechanism, not two.
 
 ## Why this is better than the original "typed event" proposal
 

--- a/crates/lex-babel/docs/epics/interop-architecture/05-sub-d-markdown-hack.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/05-sub-d-markdown-hack.md
@@ -2,7 +2,7 @@
 
 **Title:** babel/markdown: retire the HACK at serializer.rs:484 — adopt format-passthrough splice helper
 
-**Filed:** https://github.com/lex-fmt/lex/issues/617
+**Filed:** <https://github.com/lex-fmt/lex/issues/617>
 
 ---
 
@@ -49,7 +49,7 @@ impl<'a> SpliceState<'a> {
 }
 ```
 
-2. **Each format adapter wires `SpliceState` into its event walk** (~5 LOC of wiring) and provides a 1-line `emit_raw_passthrough(content)` callback:
+1. **Each format adapter wires `SpliceState` into its event walk** (~5 LOC of wiring) and provides a 1-line `emit_raw_passthrough(content)` callback:
 
 | Format | `emit_raw_passthrough` implementation |
 |---|---|
@@ -58,13 +58,13 @@ impl<'a> SpliceState<'a> {
 | (Future) Pandoc | `push_child(parent, Block::RawBlock("markdown".into(), content.to_string()))` |
 | (Future) LaTeX | `output.push_str(content)` |
 
-3. **`tree_to_events` and `crates/lex-babel/src/ir/events.rs` are not modified.** The IR/events layer stays exactly as it is today. The splice concern lives entirely in the consumption layer (`common/splice.rs` + each format's walker).
+1. **`tree_to_events` and `crates/lex-babel/src/ir/events.rs` are not modified.** The IR/events layer stays exactly as it is today. The splice concern lives entirely in the consumption layer (`common/splice.rs` + each format's walker).
 
-4. **The HACK comment block (`serializer.rs:441-503`) is deleted.**
+2. **The HACK comment block (`serializer.rs:441-503`) is deleted.**
 
-5. **The hardcoded metadata-label whitelist** (`author, note, title, date, tags, category, template`) is removed. Document-level labels are registered as `doc.title`, `doc.author`, `doc.date`, `doc.tags`, `doc.category`, `doc.template` (per Sub B) with `on_render` hooks emitting YAML frontmatter; `note` is content-level and handled via the generic annotation path.
+3. **The hardcoded metadata-label whitelist** (`author, note, title, date, tags, category, template`) is removed. Document-level labels are registered as `doc.title`, `doc.author`, `doc.date`, `doc.tags`, `doc.category`, `doc.template` (per Sub B) with `on_render` hooks emitting YAML frontmatter; `note` is content-level and handled via the generic annotation path.
 
-6. **HTML's current splice-sentinel mechanism migrates to `SpliceState` in the same PR.** The post-DOM string-replacement code in `formats/html/serializer.rs` (around `replace_splice_sentinels`) retires. We end with one splice mechanism, not two.
+4. **HTML's current splice-sentinel mechanism migrates to `SpliceState` in the same PR.** The post-DOM string-replacement code in `formats/html/serializer.rs` (around `replace_splice_sentinels`) retires. We end with one splice mechanism, not two.
 
 ## Why this is better than the original "typed event" proposal
 

--- a/crates/lex-cli/completions/lex.bash
+++ b/crates/lex-cli/completions/lex.bash
@@ -1,5 +1,5 @@
 _lex() {
-    local i cur opts cmd
+    local i cur opts cmd transforms word
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
         cur="$2"

--- a/crates/lex-cli/completions/lex.bash
+++ b/crates/lex-cli/completions/lex.bash
@@ -1,12 +1,11 @@
 _lex() {
-    local i cur prev opts cmd
+    local i cur opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
         cur="$2"
     else
         cur="${COMP_WORDS[COMP_CWORD]}"
     fi
-    prev="$3"
     cmd=""
     opts=""
 
@@ -28,6 +27,7 @@ _lex() {
 
             # Handle flags
             if [[ ${cur} == -* ]] ; then
+                # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -42,12 +42,14 @@ _lex() {
 
             # First positional argument: file path
             if [[ ${arg_count} -eq 0 ]]; then
+                # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
                 COMPREPLY=( $(compgen -f -- "${cur}") )
                 return 0
             fi
 
             # Second positional argument: transform format
             if [[ ${arg_count} -eq 1 ]]; then
+                # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
                 COMPREPLY=( $(compgen -W "${transforms}" -- "${cur}") )
                 return 0
             fi

--- a/crates/lex-lsp/COMMANDS.md
+++ b/crates/lex-lsp/COMMANDS.md
@@ -5,41 +5,49 @@ This document lists the commands supported by the Lex Language Server (`lex-lsp`
 ## Commands
 
 ### `lex.echo`
+
 **Title:** Echo
 **Category:** Lex
 **Description:** Echo back the input arguments. Useful for testing connection.
 
 ### `lex.import`
+
 **Title:** Import Document
 **Category:** Lex
 **Description:** Import a document from another format (e.g., Markdown) into Lex format.
 
 ### `lex.export`
+
 **Title:** Export Document
 **Category:** Lex
 **Description:** Export the current Lex document to another format (e.g., HTML, PDF, Markdown).
 
 ### `lex.next_annotation`
+
 **Title:** Next Annotation
 **Category:** Lex
 **Description:** Navigate to the next annotation in the document.
 
 ### `lex.previous_annotation`
+
 **Title:** Previous Annotation
 **Category:** Lex
 **Description:** Navigate to the previous annotation in the document.
 
 ### `lex.resolve_annotation`
+
 **Title:** Resolve Annotation
 **Category:** Lex
 **Description:** Mark the annotation at the current cursor position as resolved.
 
 ### `lex.toggle_annotations`
+
 **Title:** Toggle Annotations
 **Category:** Lex
 **Description:** Toggle the resolution status of the annotation at the current cursor position.
 
 ### `lex.insert_asset`
+
 **Title:** Insert Asset
 **Category:** Lex
 **Description:** Build a verbatim-style reference to an external asset (image, video, audio, or generic data) based on the selected file path.
@@ -47,6 +55,7 @@ This document lists the commands supported by the Lex Language Server (`lex-lsp`
 **Response:** `{ "text": string, "cursorOffset": number }` – `text` contains the formatted Lex snippet, `cursorOffset` indicates where the editor should place the caret after insertion.
 
 ### `lex.insert_verbatim`
+
 **Title:** Insert Verbatim Block
 **Category:** Lex
 **Description:** Insert a verbatim block whose subject, label, `src` parameter, and body are inferred from the chosen file path. Text files are inlined with proper indentation, while binary files fall back to media/data labels.

--- a/multi-repo-bootstrap-plan.md
+++ b/multi-repo-bootstrap-plan.md
@@ -40,7 +40,7 @@ clone-lex-repos [--all] [--with-setup] [--depth=N] [--refresh] <repo>...
 
 Hard-coded in the script (one source of truth):
 
-```
+```text
 lex comms mkdocs-lex vscode lexed nvim tree-sitter-lex zed-lex
 ```
 
@@ -50,7 +50,7 @@ When a new sibling repo joins the org, this list is updated and the script is re
 
 The script prints a tab-separated summary on stdout that agents can parse:
 
-```
+```text
 repo            path                            status
 comms           /tmp/lex-fmt/comms              cloned
 vscode          /tmp/lex-fmt/vscode             skipped-exists

--- a/tree-sitter-plan.md
+++ b/tree-sitter-plan.md
@@ -26,7 +26,7 @@ The grammar itself is **regular at each indent level**. Once indent/dedent bound
 
 ## Architecture
 
-```
+```text
                     grammar.js                    scanner.c
                     ──────────                    ─────────
                     Block rules:                  Indent stack management
@@ -50,7 +50,7 @@ The grammar itself is **regular at each indent level**. Once indent/dedent bound
 | INDENT token | Emitted when indent level increases |
 | DEDENT token(s) | Emitted when indent level decreases (possibly multiple) |
 | NEWLINE token | Emitted at line boundaries and EOF (gives grammar line-awareness) |
-| annotation_marker | `:: ` at line start or mid-line (detects double-colon prefix) |
+| annotation_marker | `::` at line start or mid-line (detects double-colon prefix) |
 | annotation_end_marker | `::` alone on a line (closing marker for annotation blocks) |
 | list_item_line | Full line starting with list marker (-, 1., a), (1), etc.) |
 | subject_content | Full line ending with `:` (for definitions and verbatim blocks) |
@@ -60,7 +60,7 @@ The grammar itself is **regular at each indent level**. Once indent/dedent bound
 
 ### grammar.js Node Hierarchy
 
-```
+```text
 document
 ├── metadata?                     (:: annotations before content)
 ├── document_title?               (title + blank, no indented content)
@@ -86,7 +86,7 @@ document
 
 Both start with a content line followed by indented content. The **only** difference is a blank line.
 
-```
+```text
 Definition:           ← subject line (ends with :)
     content           ← INDENT immediately follows
 
@@ -132,6 +132,7 @@ Consumers that need attachment semantics (editors, tooling) can implement a simp
 Inline formatting (`*bold*`, `_italic_`, `` `code` ``, `#math#`, `[ref]`) will be parsed **within the grammar**, not deferred to a post-processing pass. This gives tree-sitter full incremental parsing of inline edits.
 
 Inline nesting rules use `prec()`:
+
 - Bold can contain italic, code, math, references
 - Italic can contain bold, code, math, references
 - Code, math, references are leaf nodes (no nesting)


### PR DESCRIPTION
Content-only pre-cleaning ahead of release/'s strict-gate tightening (release#288). The future gate runs shellcheck at `--severity=info` (down from `warning`) and markdownlint with MD056 still on. This PR fixes the owned (non-symlink, non-vendor, non-fixture) shell + markdown so the repo passes that strict gate. No managed config (`.release/`, symlinked lint configs) was touched.

## Finding categories fixed

**Shell** (`crates/lex-cli/completions/lex.bash`):
- SC2034 — removed the genuinely-unused `prev` local (real fix).
- SC2207 ×3 — `COMPREPLY=( $(compgen …) )` is the intentional, bash-3-compatible completion idiom (`mapfile -t` is bash-4+ only); kept with a documented `# shellcheck disable=SC2207`.

**Markdown** (auto-fix + hand-fix):
- MD040 ×8 — bare code fences given `text` (ASCII diagrams / dir trees / pseudocode).
- MD032, MD031, MD022, MD034, MD029, MD038 — mechanical fixes via `markdownlint --fix` (blank-line spacing around lists/fences/headings, angle-bracketed bare URL, ordered-list renumber to 1/1/1, code-span spacing).

Excluded as not-owned: `.release/` symlinks, `bin/share/semver-tool/*` (symlinks), `vendor/semver-tool/*`, and `crates/lex-babel/tests/fixtures/*.md` (deliberately-malformed markdown parser test inputs).

## Proof (local strict lint)

CI still runs the relaxed config, so verification is local strict lint:

```text
shellcheck --severity=info  → 0 findings on all owned shell files
  (bin/check-fmt, bin/check-lint, bin/release,
   app-bin/dev/sandbox-test-linux.sh, crates/lex-cli/completions/lex.bash)

markdownlint --config {MD013:false,line-length:false,MD060:false,table-column-style:false}
  → 0 findings on all 16 owned md files
```

Completion file passes `bash -n`; no test suite references it (static distribution artifact), so no behavioral change.