### PR TITLE
fix(lex-babel): emit blank line after document title (#687)

### DIFF
--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -112,6 +112,12 @@ impl LexSerializer {
                 self.output.push('\n');
             }
             self.consecutive_newlines = 1;
+            // A blank line must separate the title from the body; otherwise the
+            // first body line is absorbed into the title on reparse (lex#687).
+            // Skip when there is no body (avoids a stray trailing blank).
+            if !doc.root.children.is_empty() {
+                self.ensure_blank_lines(1);
+            }
         }
         doc.root.accept(&mut self);
         Ok(self.output)

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -446,8 +446,6 @@ const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[("list.lex", "#685")];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    ("XXX-document-simple.lex", "#681"),
-    ("XXX-document-tricky.lex", "#681"),
     ("annotation-reference.lex", "#682"),
     ("annotation.lex", "#682"),
     ("data.lex", "#681"),


### PR DESCRIPTION
## Summary

Fixes [#687](https://github.com/lex-fmt/lex/issues/687), one of the two severe formatter content-loss bugs surfaced by the #681 invariant suite.

The serializer emitted the document title followed by a single newline. On reparse the first body line was absorbed into the title — the title was lost and the body structure changed (`format` was not semantics-preserving for any titled document). This emits a blank line between the title and the body when a body exists; a title-only document gets no stray trailing blank.

Verification is built in: the two format-invariant fixtures quarantined for this bug (`XXX-document-simple`, `XXX-document-tricky`) are removed from the Tier-2 known-failure list and now pass — the suite's anti-rot assertion confirms the fix.

```
# before
Title
Body words here      # <- title merged into paragraph on reparse

# after
Title

Body words here
```

## On #682 (the other severe bug — deferred to its own PR)

I attempted to bundle #682 (attached annotations dropped on serialize) here, but it needs more than a quick fix: the parser's attachment pass moves annotations onto each element's `annotations` field **without preserving a reliable source location**, so a location-ordered reinsertion misplaces them (e.g. a `:: notes ::` that belongs before a list lands right after the title). Doing it correctly means reconstructing the before/after-target relationship the attachment pass consumed (or emitting attached annotations from the serializer's traversal with that relationship). That's its own focused PR — filed work continues against #682.

## Checklist

- [x] Changelog — chore/n-a (bug fix in formatter; `CHANGELOG.md` is generated)
- [x] Tests: covered by `format_invariants` (Tier 2 fixtures now pass); full workspace green
- [x] `cargo fmt`/`clippy` via pre-commit

## Test plan

- `cargo test -p lex-babel` (208 unit + 181 lib) green
- `cargo test --workspace --exclude lex-wasm` green