### PR TITLE
fix(lex-babel): coalesce adjacent blank-line groups (#686)

### DIFF
--- a/crates/lex-babel/src/formats/lex/blank_coalesce.rs
+++ b/crates/lex-babel/src/formats/lex/blank_coalesce.rs
@@ -29,10 +29,18 @@ fn coalesce(items: &mut Vec<ContentItem>) {
             ContentItem::List(l) => coalesce(l.items.as_mut_vec()),
             ContentItem::Annotation(a) => coalesce(a.children.as_mut_vec()),
             ContentItem::Table(t) => {
+                // Mirror Table::accept: cell children, attached annotations,
+                // and the footnote list are all traversed on serialization.
                 for row in t.header_rows.iter_mut().chain(t.body_rows.iter_mut()) {
                     for cell in &mut row.cells {
                         coalesce(cell.children.as_mut_vec());
                     }
+                }
+                for ann in &mut t.annotations {
+                    coalesce(ann.children.as_mut_vec());
+                }
+                if let Some(list) = &mut t.footnotes {
+                    coalesce(list.items.as_mut_vec());
                 }
             }
             _ => {}

--- a/crates/lex-babel/src/formats/lex/blank_coalesce.rs
+++ b/crates/lex-babel/src/formats/lex/blank_coalesce.rs
@@ -1,0 +1,54 @@
+//! Coalesce adjacent blank-line groups before serialization (lex#686).
+//!
+//! The parser can split a single run of blank lines into multiple adjacent
+//! `BlankLineGroup` nodes — notably after a list, where the terminator peels one
+//! blank into its own group (`1` then `2` for three source blanks). The
+//! serializer emits each group against an absolute newline floor
+//! (`ensure_blank_lines`) rather than summing them, so two groups of `1` collapse
+//! to a single blank. The result is non-idempotent: 3 blanks → 2 → 1.
+//!
+//! Merging adjacent `BlankLineGroup`s into one (summing counts) makes blank-run
+//! emission a fixed point: any split that totals N serializes to `min(N, max)`,
+//! and re-parsing that output (however it re-splits) coalesces back to the same
+//! total. Purely a normalization — adjacent blank lines are one run regardless
+//! of node boundaries.
+
+use lex_core::lex::ast::{ContentItem, Document};
+
+pub fn coalesce_blank_line_groups(doc: &mut Document) {
+    coalesce(doc.root.children.as_mut_vec());
+}
+
+fn coalesce(items: &mut Vec<ContentItem>) {
+    // Recurse into every child container first.
+    for item in items.iter_mut() {
+        match item {
+            ContentItem::Session(s) => coalesce(s.children.as_mut_vec()),
+            ContentItem::Definition(d) => coalesce(d.children.as_mut_vec()),
+            ContentItem::ListItem(li) => coalesce(li.children.as_mut_vec()),
+            ContentItem::List(l) => coalesce(l.items.as_mut_vec()),
+            ContentItem::Annotation(a) => coalesce(a.children.as_mut_vec()),
+            ContentItem::Table(t) => {
+                for row in t.header_rows.iter_mut().chain(t.body_rows.iter_mut()) {
+                    for cell in &mut row.cells {
+                        coalesce(cell.children.as_mut_vec());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Merge runs of adjacent BlankLineGroups in this stream.
+    let mut out: Vec<ContentItem> = Vec::with_capacity(items.len());
+    for item in std::mem::take(items) {
+        if let ContentItem::BlankLineGroup(b) = &item {
+            if let Some(ContentItem::BlankLineGroup(prev)) = out.last_mut() {
+                prev.count += b.count;
+                continue;
+            }
+        }
+        out.push(item);
+    }
+    *items = out;
+}

--- a/crates/lex-babel/src/formats/lex/mod.rs
+++ b/crates/lex-babel/src/formats/lex/mod.rs
@@ -9,7 +9,7 @@ use crate::format::Format;
 use lex_core::lex::ast::Document;
 use lex_core::lex::transforms::standard::STRING_TO_AST;
 
-pub mod blank_coalesce;
+mod blank_coalesce;
 pub mod formatting_rules;
 pub mod serializer;
 

--- a/crates/lex-babel/src/formats/lex/mod.rs
+++ b/crates/lex-babel/src/formats/lex/mod.rs
@@ -9,9 +9,11 @@ use crate::format::Format;
 use lex_core::lex::ast::Document;
 use lex_core::lex::transforms::standard::STRING_TO_AST;
 
+pub mod blank_coalesce;
 pub mod formatting_rules;
 pub mod serializer;
 
+use blank_coalesce::coalesce_blank_line_groups;
 use formatting_rules::FormattingRules;
 use serializer::LexSerializer;
 ///
@@ -56,9 +58,14 @@ impl Format for LexFormat {
     }
 
     fn serialize(&self, doc: &Document) -> Result<String, FormatError> {
+        // Merge adjacent blank-line groups so blank-run emission is idempotent
+        // (lex#686). Operate on a clone to keep the `&Document` contract; a
+        // no-op for documents without adjacent blank groups.
+        let mut doc = doc.clone();
+        coalesce_blank_line_groups(&mut doc);
         let serializer = LexSerializer::new(self.rules.clone());
         serializer
-            .serialize(doc)
+            .serialize(&doc)
             .map_err(FormatError::SerializationError)
     }
 }

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -610,7 +610,6 @@ mod tests {
 //   - attached annotations            (#682)
 //   - tables                          (#683, #684)
 //   - nested/extended numbered lists  (#685)
-//   - 3+ blank lines *after* a list   (#686 — capped to 2 below)
 //   - a bare document title line       (#687 — generator leads with a 2-line
 //                                        paragraph, which is never title-absorbed)
 //   - random *leading* indent widths  (untriaged paragraph-merge edge, #681)
@@ -702,22 +701,19 @@ mod messy_proptest {
         })
     }
 
-    /// `is_list` lets the assembler cap the *following* blank run to <= 2,
-    /// dodging the open list/blank idempotence bug (#686) while still letting
-    /// non-list boundaries exercise the >2 -> 2 blank-clamp normalizer.
-    fn block() -> impl Strategy<Value = (bool, String)> {
+    fn block() -> impl Strategy<Value = String> {
         prop_oneof![
-            paragraph_block().prop_map(|s| (false, s)),
-            unordered_block().prop_map(|s| (true, s)),
-            numbered_block().prop_map(|s| (true, s)),
-            definition_block().prop_map(|s| (false, s)),
+            paragraph_block(),
+            unordered_block(),
+            numbered_block(),
+            definition_block(),
         ]
     }
 
     /// A whole document. To avoid the title bug (#687) it opens with a
     /// guaranteed two-line paragraph (never title-absorbed), then blocks
     /// separated by blank-line runs of random width (1..4 — the formatter
-    /// clamps to <= 2), capped to <= 2 after a list per #686.
+    /// clamps to <= 2, including the 3+-blanks-after-a-list case fixed in #686).
     fn messy_document() -> impl Strategy<Value = String> {
         (
             (words(), words()),
@@ -725,17 +721,10 @@ mod messy_proptest {
         )
             .prop_map(|((lead1, lead2), blocks)| {
                 let mut out = format!("{lead1}\n{lead2}\n");
-                let mut prev_is_list = false; // lead paragraph is not a list
-                for ((is_list, b), blanks) in blocks.iter() {
-                    let blanks = if prev_is_list {
-                        (*blanks).min(2)
-                    } else {
-                        *blanks
-                    };
-                    out.push_str(&"\n".repeat(blanks));
+                for (b, blanks) in blocks.iter() {
+                    out.push_str(&"\n".repeat(*blanks));
                     out.push_str(b);
                     out.push('\n');
-                    prev_is_list = *is_list;
                 }
                 out
             })


### PR DESCRIPTION
## Summary

Fixes [#686](https://github.com/lex-fmt/lex/issues/686): formatting was not idempotent when 3+ blank lines followed a list — `3 → 2 → 1` across reformats.

**Root cause:** the parser splits one run of post-list blanks into *multiple adjacent* `BlankLineGroup` nodes (the list terminator peels one blank into its own group: `1` then `2` for three source blanks). The serializer emits each group against an absolute newline floor (`ensure_blank_lines`) rather than summing them, so the groups don't accumulate; and the re-split differs on the next parse, so the count keeps dropping.

**Fix:** merge adjacent `BlankLineGroup`s (summing counts) before serialization, in `LexFormat::serialize` so every path (CLI `lexd format`, LSP) benefits. Any split totalling N now serializes to `min(N, max_blank_lines)`, and re-parsing that output (however it re-splits) coalesces back to the same total — a fixed point. Purely a normalization: adjacent blank lines are one run regardless of node boundaries.

Verified idempotent: `list → 3 blanks → para`, `list → 3 blanks → list`, `numbered → 3 blanks → para`.

The format-invariant proptest previously capped post-list blank runs to 2 to dodge this bug; that cap is removed, so the messy-input generator now actively exercises 3+ blanks after lists (stable across 3×400 cases).

## Checklist

- [x] Changelog — chore/n-a (formatter bug fix; `CHANGELOG.md` is generated)
- [x] Tests: `format_invariants` proptest now covers the case; full workspace green
- [x] `cargo fmt`/`clippy` via pre-commit

## Test plan

- `cargo test -p lex-babel` green; `cargo test --workspace --exclude lex-wasm` green