### PR TITLE
fix(lex-babel): preserve table colspan markers on format (#683)

### DIFF
--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -519,6 +519,18 @@ fn compute_column_widths(
     widths
 }
 
+/// Append one `| text |`-style cell padded to `width` to `out` (the leading
+/// `|` of the row, and the `|` after each cell, are emitted here).
+fn push_cell(out: &mut String, text: &str, width: usize) {
+    out.push(' ');
+    out.push_str(text);
+    for _ in text.chars().count()..width {
+        out.push(' ');
+    }
+    out.push(' ');
+    out.push('|');
+}
+
 fn format_pipe_row(row: &TableRow, widths: &[usize], col_count: usize) -> String {
     let mut out = String::from("|");
     let mut col = 0;
@@ -527,36 +539,27 @@ fn format_pipe_row(row: &TableRow, widths: &[usize], col_count: usize) -> String
             break;
         }
         let span = cell.colspan.max(1);
-        let span_width: usize = widths[col..(col + span).min(widths.len())]
-            .iter()
-            .sum::<usize>()
-            + (span.saturating_sub(1)) * 3; // `| ` + ` ` between cells
-        let text = cell.content.as_string().trim();
-        out.push(' ');
-        // Padding to the spanned width (1 cell uses widths[col]).
-        let pad_target = if span == 1 {
-            widths.get(col).copied().unwrap_or(0)
-        } else {
-            span_width
-        };
-        let visible_len = text.chars().count();
-        out.push_str(text);
-        for _ in visible_len..pad_target {
-            out.push(' ');
+        // Content lives in the top-left cell of the span, at its own column
+        // width; each absorbed column re-emits a `>>` marker so the column grid
+        // (and the colspan) survive a re-parse (lex#683). Without this the cell
+        // was merged into one wide column and the span was lost.
+        push_cell(
+            &mut out,
+            cell.content.as_string().trim(),
+            widths.get(col).copied().unwrap_or(0),
+        );
+        col += 1;
+        for _ in 1..span {
+            if col >= col_count {
+                break;
+            }
+            push_cell(&mut out, ">>", widths.get(col).copied().unwrap_or(0));
+            col += 1;
         }
-        out.push(' ');
-        out.push('|');
-        col += span;
     }
     // Pad trailing empty cells.
     while col < col_count {
-        out.push(' ');
-        let w = widths.get(col).copied().unwrap_or(0);
-        for _ in 0..w {
-            out.push(' ');
-        }
-        out.push(' ');
-        out.push('|');
+        push_cell(&mut out, "", widths.get(col).copied().unwrap_or(0));
         col += 1;
     }
     out

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -543,23 +543,21 @@ fn format_pipe_row(row: &TableRow, widths: &[usize], col_count: usize) -> String
         // width; each absorbed column re-emits a `>>` marker so the column grid
         // (and the colspan) survive a re-parse (lex#683). Without this the cell
         // was merged into one wide column and the span was lost.
-        push_cell(
-            &mut out,
-            cell.content.as_string().trim(),
-            widths.get(col).copied().unwrap_or(0),
-        );
+        // `col < col_count` here and `widths.len() == col_count`, so direct
+        // indexing is in-bounds.
+        push_cell(&mut out, cell.content.as_string().trim(), widths[col]);
         col += 1;
         for _ in 1..span {
             if col >= col_count {
                 break;
             }
-            push_cell(&mut out, ">>", widths.get(col).copied().unwrap_or(0));
+            push_cell(&mut out, ">>", widths[col]);
             col += 1;
         }
     }
     // Pad trailing empty cells.
     while col < col_count {
-        push_cell(&mut out, "", widths.get(col).copied().unwrap_or(0));
+        push_cell(&mut out, "", widths[col]);
         col += 1;
     }
     out

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -431,7 +431,7 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 // they are tracked against the umbrella issue #681.
 // -----------------------------------------------------------------------------
 
-const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[("table_colspan", "#683")];
+const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[
     // `:: notes ::` attaches to the footnote list; the formatter drops it (#682),
@@ -440,7 +440,6 @@ const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[
     ("footnotes_section_scoped", "#682"),
     ("ref_tk_citation_annref", "#682"),
     ("table_with_footnotes", "#684"),
-    ("table_colspan", "#683"),
 ];
 
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[("list.lex", "#685")];


### PR DESCRIPTION
## Summary

Fixes [#683](https://github.com/lex-fmt/lex/issues/683): the formatter dropped table colspan markers, collapsing the column grid and losing the span on re-parse (also non-idempotent).

`format_pipe_row` rendered a `colspan>1` cell as one wide column and advanced past the absorbed columns, never emitting `>>`. So `| span | >> | c |` became `| span       | c |` — two visual columns instead of three. Now the content goes in the top-left cell at its own column width and each absorbed column re-emits a `>>` marker, so the grid and the colspan round-trip:

```
Grid:
    | A    | B   | C   |
    | ---- | --- | --- |
    | span | >>  | c   |
:: table ::
```

`table_colspan` is removed from the format-invariant known-failure lists — it now passes Tier 1 (idempotence) and Tier 2 (semantic preservation), confirmed by the suite's anti-rot assertion.

## Scope

- **Colspan `>>` only.** Rowspan `^^` is the sibling bug [#694](https://github.com/lex-fmt/lex/issues/694), filed separately — it needs cross-row absorbed-cell tracking in `emit_pipe_table`, unlike this single-row fix.
- **#684 (footnote placement) not included here** — it's architecturally entangled (the footnote list is traversed by `Table::accept` for other visitors, and emitting it inside the block before the closer needs an `accept` reorder or a serializer suppress-mode). Tracked on #684.

## Checklist

- [x] Changelog — chore/n-a (formatter bug fix; `CHANGELOG.md` is generated)
- [x] Tests: `format_invariants` `table_colspan` now passes both tiers; full workspace green
- [x] `cargo fmt`/`clippy` via pre-commit

## Test plan

- `cargo test -p lex-babel` green; `cargo test --workspace --exclude lex-wasm` green