### PR TITLE
fix: serialize attached annotations (#682) via accurate annotation locations (#693)

### DIFF
--- a/crates/lex-babel/src/formats/lex/annotation_inline.rs
+++ b/crates/lex-babel/src/formats/lex/annotation_inline.rs
@@ -45,15 +45,17 @@ fn child_is_empty(item: &ContentItem) -> bool {
     }
 }
 
-/// Drop the empty-paragraph artifact from a marker annotation, recursing into
-/// genuine block children.
+/// Normalize an annotation's body. A marker (`:: label ::`) re-parses with a
+/// lone empty-paragraph artifact; clear it so the marker emits without a body.
+/// A genuine block body is left intact — including its blank-line separators
+/// between paragraphs — and recursed into so nested annotations inline.
 fn clean_annotation(ann: &mut Annotation) {
-    let kept: Vec<ContentItem> = std::mem::take(ann.children.as_mut_vec())
-        .into_iter()
-        .filter(|c| !child_is_empty(c))
-        .collect();
-    *ann.children.as_mut_vec() = kept;
-    process_stream(ann.children.as_mut_vec());
+    let has_real_body = ann.children.iter().any(|c| !child_is_empty(c));
+    if has_real_body {
+        process_stream(ann.children.as_mut_vec());
+    } else {
+        ann.children.as_mut_vec().clear();
+    }
 }
 
 pub fn inline_attached_annotations(doc: &mut Document) {
@@ -153,7 +155,9 @@ fn process_stream(items: &mut Vec<ContentItem>) {
             }
             ContentItem::Paragraph(p) => bubble.append(&mut p.annotations),
             ContentItem::VerbatimBlock(v) => bubble.append(&mut v.annotations),
-            ContentItem::Annotation(a) => process_stream(a.children.as_mut_vec()),
+            // Annotation children are processed by `clean_annotation` below
+            // (recursing once); do not recurse here too, or nested annotations
+            // would be processed 2^depth times.
             // Table annotations are emitted by Table::accept; leave in place.
             _ => {}
         }
@@ -163,11 +167,20 @@ fn process_stream(items: &mut Vec<ContentItem>) {
         items.push(ContentItem::Annotation(ann));
     }
     // Clean every annotation now in this stream (bubbled-in plus any that were
-    // already inline), then restore source order across the whole stream.
+    // already inline) — recurses into block bodies exactly once.
     for item in items.iter_mut() {
         if let ContentItem::Annotation(a) = item {
             clean_annotation(a);
         }
     }
-    items.sort_by_key(item_key);
+    // Restore source order so reinserted annotations land where they were
+    // authored — but only when every item shares one source origin. After
+    // include expansion a stream can mix coordinate spaces from different files,
+    // where a positional sort would scramble already-correct order (#682 review).
+    let mixed_origin = items
+        .iter()
+        .any(|i| i.range().origin_path != items[0].range().origin_path);
+    if !items.is_empty() && !mixed_origin {
+        items.sort_by_key(item_key);
+    }
 }

--- a/crates/lex-babel/src/formats/lex/annotation_inline.rs
+++ b/crates/lex-babel/src/formats/lex/annotation_inline.rs
@@ -1,0 +1,173 @@
+//! Re-insert attached annotations into the content stream for serialization
+//! (lex#682).
+//!
+//! The parser's `attach_annotations` stage moves annotation nodes out of the
+//! content stream onto each element's `annotations` field. The Lex serializer
+//! walks the stream and so never emits them — silent content loss on format.
+//!
+//! This reverses that: each attached annotation is placed back into the content
+//! stream at its original source position (now that annotations carry an
+//! accurate `location` — see lex#693), so a re-parse re-attaches it to the same
+//! element. An annotation whose location falls inside its owning element's span
+//! was a container-end annotation and goes into that element's child stream;
+//! otherwise it sat beside the element and goes in the parent stream. Each
+//! stream is then sorted by source position, weaving annotations back among the
+//! existing children (and their `BlankLineGroup`s) in source order.
+//!
+//! Document/root annotations are emitted at the document head, each followed by
+//! a blank line, so they re-attach to the `Document` (the document-start rule),
+//! regardless of where they sat in the source.
+//!
+//! `Table` annotations are left untouched — `Table::accept` already emits them.
+
+use lex_core::lex::ast::elements::BlankLineGroup;
+use lex_core::lex::ast::traits::AstNode;
+use lex_core::lex::ast::{Annotation, ContentItem, Document};
+
+/// Source-order sort key for a content item.
+fn item_key(item: &ContentItem) -> (usize, usize, usize) {
+    let r = item.range();
+    (r.start.line, r.start.column, r.span.start)
+}
+
+/// Whether an annotation's recovered body is empty — a marker (`:: label ::`)
+/// re-parses with a single empty `Paragraph` child, which would otherwise make
+/// the serializer emit the block-open form (`:: label`). Treat such bodies as
+/// absent so the marker round-trips.
+fn child_is_empty(item: &ContentItem) -> bool {
+    match item {
+        ContentItem::BlankLineGroup(_) => true,
+        ContentItem::Paragraph(p) => p.lines.iter().all(|l| match l {
+            ContentItem::TextLine(tl) => tl.content.as_string().trim().is_empty(),
+            _ => true,
+        }),
+        _ => false,
+    }
+}
+
+/// Drop the empty-paragraph artifact from a marker annotation, recursing into
+/// genuine block children.
+fn clean_annotation(ann: &mut Annotation) {
+    let kept: Vec<ContentItem> = std::mem::take(ann.children.as_mut_vec())
+        .into_iter()
+        .filter(|c| !child_is_empty(c))
+        .collect();
+    *ann.children.as_mut_vec() = kept;
+    process_stream(ann.children.as_mut_vec());
+}
+
+pub fn inline_attached_annotations(doc: &mut Document) {
+    let mut doc_anns = std::mem::take(&mut doc.annotations);
+    doc_anns.append(&mut doc.root.annotations);
+    doc_anns.sort_by_key(|a| (a.location.start.line, a.location.start.column));
+
+    process_stream(doc.root.children.as_mut_vec());
+
+    if !doc_anns.is_empty() {
+        let children = doc.root.children.as_mut_vec();
+        let mut head: Vec<ContentItem> = Vec::with_capacity(doc_anns.len() * 2 + children.len());
+        for mut ann in doc_anns {
+            clean_annotation(&mut ann);
+            head.push(ContentItem::Annotation(ann));
+            head.push(ContentItem::BlankLineGroup(BlankLineGroup {
+                count: 1,
+                source_tokens: Vec::new(),
+                location: Default::default(),
+            }));
+        }
+        head.append(children);
+        *children = head;
+    }
+}
+
+/// Split annotations attached to one element: those whose source line falls
+/// within the element's `[lo, hi]` span were container-end annotations and go
+/// into the element's own `children`; the rest bubble to the parent stream.
+fn route(
+    anns: &mut Vec<Annotation>,
+    lo: usize,
+    hi: usize,
+    children: &mut Vec<ContentItem>,
+    bubble: &mut Vec<Annotation>,
+) {
+    for ann in std::mem::take(anns) {
+        if (lo..=hi).contains(&ann.location.start.line) {
+            children.push(ContentItem::Annotation(ann));
+        } else {
+            bubble.push(ann);
+        }
+    }
+}
+
+/// Rebuild a stream: pull attached annotations off each element, route them
+/// inward (container-end) or to this level, recurse, then re-sort by source
+/// order so annotations land where they were authored.
+fn process_stream(items: &mut Vec<ContentItem>) {
+    let mut bubble: Vec<Annotation> = Vec::new();
+
+    for item in items.iter_mut() {
+        match item {
+            ContentItem::Session(s) => {
+                let (lo, hi) = (s.location.start.line, s.location.end.line);
+                route(
+                    &mut s.annotations,
+                    lo,
+                    hi,
+                    s.children.as_mut_vec(),
+                    &mut bubble,
+                );
+                process_stream(s.children.as_mut_vec());
+            }
+            ContentItem::Definition(d) => {
+                let (lo, hi) = (d.location.start.line, d.location.end.line);
+                route(
+                    &mut d.annotations,
+                    lo,
+                    hi,
+                    d.children.as_mut_vec(),
+                    &mut bubble,
+                );
+                process_stream(d.children.as_mut_vec());
+            }
+            ContentItem::ListItem(li) => {
+                let (lo, hi) = (li.location.start.line, li.location.end.line);
+                route(
+                    &mut li.annotations,
+                    lo,
+                    hi,
+                    li.children.as_mut_vec(),
+                    &mut bubble,
+                );
+                process_stream(li.children.as_mut_vec());
+            }
+            ContentItem::List(l) => {
+                let (lo, hi) = (l.location.start.line, l.location.end.line);
+                route(
+                    &mut l.annotations,
+                    lo,
+                    hi,
+                    l.items.as_mut_vec(),
+                    &mut bubble,
+                );
+                process_stream(l.items.as_mut_vec());
+            }
+            ContentItem::Paragraph(p) => bubble.append(&mut p.annotations),
+            ContentItem::VerbatimBlock(v) => bubble.append(&mut v.annotations),
+            ContentItem::Annotation(a) => process_stream(a.children.as_mut_vec()),
+            // Table annotations are emitted by Table::accept; leave in place.
+            _ => {}
+        }
+    }
+
+    for ann in bubble {
+        items.push(ContentItem::Annotation(ann));
+    }
+    // Clean every annotation now in this stream (bubbled-in plus any that were
+    // already inline), then restore source order across the whole stream.
+    for item in items.iter_mut() {
+        if let ContentItem::Annotation(a) = item {
+            clean_annotation(a);
+        }
+    }
+    items.sort_by_key(item_key);
+}

--- a/crates/lex-babel/src/formats/lex/mod.rs
+++ b/crates/lex-babel/src/formats/lex/mod.rs
@@ -9,10 +9,12 @@ use crate::format::Format;
 use lex_core::lex::ast::Document;
 use lex_core::lex::transforms::standard::STRING_TO_AST;
 
+mod annotation_inline;
 mod blank_coalesce;
 pub mod formatting_rules;
 pub mod serializer;
 
+use annotation_inline::inline_attached_annotations;
 use blank_coalesce::coalesce_blank_line_groups;
 use formatting_rules::FormattingRules;
 use serializer::LexSerializer;
@@ -58,10 +60,12 @@ impl Format for LexFormat {
     }
 
     fn serialize(&self, doc: &Document) -> Result<String, FormatError> {
-        // Merge adjacent blank-line groups so blank-run emission is idempotent
-        // (lex#686). Operate on a clone to keep the `&Document` contract; a
-        // no-op for documents without adjacent blank groups.
+        // Operate on a clone to keep the `&Document` contract. Re-insert
+        // annotations the parser attached to elements so they aren't dropped
+        // (lex#682), then merge adjacent blank-line groups so blank-run emission
+        // (including blanks the inlining introduces) is idempotent (lex#686).
         let mut doc = doc.clone();
+        inline_attached_annotations(&mut doc);
         coalesce_blank_line_groups(&mut doc);
         let serializer = LexSerializer::new(self.rules.clone());
         serializer

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -626,6 +626,12 @@ mod tests {
     use lex_core::lex::testing::lexplore::{ElementType, Lexplore};
     use lex_core::lex::testing::text_diff::assert_text_eq;
 
+    /// Drive the bare `LexSerializer` directly. NOTE: this bypasses
+    /// `LexFormat::serialize`'s pre/post passes (annotation inlining, blank
+    /// coalescing, trailing-blank trim), so its output can differ from
+    /// `lexd format`. Use `format_full` when the full pipeline matters (e.g.
+    /// annotation cases). Kept for the many element tests that assert the
+    /// serializer's raw structural output.
     fn format_source(source: &str) -> String {
         let format = super::super::LexFormat::default();
         let doc = format.parse(source).unwrap();

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -120,6 +120,18 @@ impl LexSerializer {
             }
         }
         doc.root.accept(&mut self);
+
+        // Normalize trailing blank lines to a single newline unless configured
+        // to preserve them. Block elements (annotations, verbatim) can leave a
+        // structural trailing blank when they are the last node; trimming here
+        // keeps the document tail idempotent.
+        if !self.rules.preserve_trailing_blanks {
+            let end = self.output.trim_end_matches('\n').len();
+            self.output.truncate(end);
+            if !self.output.is_empty() {
+                self.output.push('\n');
+            }
+        }
         Ok(self.output)
     }
 
@@ -327,10 +339,11 @@ impl Visitor for LexSerializer {
             }
         }
 
-        // Only add closing :: for short-form annotations (no children)
-        if annotation.children.is_empty() {
-            header.push_str(" ::");
-        }
+        // Always close the header with ` ::`. The open form (`:: label`) is not
+        // valid annotation syntax — the parser drops it — so a block annotation
+        // must be `:: label ::` followed by its indented body to round-trip
+        // (lex#682).
+        header.push_str(" ::");
 
         self.write_line(&header);
 
@@ -342,6 +355,12 @@ impl Visitor for LexSerializer {
     fn leave_annotation(&mut self, annotation: &Annotation) {
         if !annotation.children.is_empty() {
             self.indent_level -= 1;
+            // A block annotation's body is closed by a dedent; the parser
+            // consumes the following blank line as part of that close (it is not
+            // a `BlankLineGroup` in the AST, like the pre-verbatim blank in
+            // lex#505), so without re-emitting it a following sibling is parsed
+            // as part of the body. Emit it so the block round-trips (lex#682).
+            self.ensure_blank_lines(1);
         }
     }
 
@@ -616,6 +635,17 @@ mod tests {
         serializer.output
     }
 
+    /// Format through the full `LexFormat` pipeline (annotation inlining +
+    /// blank coalescing), i.e. what `lexd format` actually does — as opposed to
+    /// driving the bare `LexSerializer`. Needed for annotation cases, where the
+    /// pipeline strips the empty-paragraph marker artifact.
+    fn format_full(source: &str) -> String {
+        use crate::format::Format;
+        let format = super::super::LexFormat::default();
+        let doc = format.parse(source).unwrap();
+        format.serialize(&doc).unwrap()
+    }
+
     // ==== Form-preserving roundtrip tests (#584 PR 3) =====================
 
     #[test]
@@ -867,27 +897,26 @@ mod tests {
     #[test]
     fn test_annotation_01_marker_simple() {
         let source = Lexplore::load(ElementType::Annotation, 1).source();
-        let formatted = format_source(&source);
-        // Document-level annotations should be preserved
-        assert_eq!(formatted, ":: note\n");
+        let formatted = format_full(&source);
+        // Marker annotation: closed `:: label ::` form (the open form is invalid
+        // and dropped on re-parse — lex#682).
+        assert_eq!(formatted, ":: note ::\n");
     }
 
     #[test]
     fn test_annotation_02_with_params() {
         let source = Lexplore::load(ElementType::Annotation, 2).source();
-        let formatted = format_source(&source);
-        // Document-level annotations should be preserved
-        assert_eq!(formatted, ":: warning severity=high\n");
+        let formatted = format_full(&source);
+        assert_eq!(formatted, ":: warning severity=high ::\n");
     }
 
     #[test]
     fn test_annotation_05_block_paragraph() {
         let source = Lexplore::load(ElementType::Annotation, 5).source();
-        let formatted = format_source(&source);
-        // Document-level annotations should be preserved
+        let formatted = format_full(&source);
         assert_eq!(
             formatted,
-            ":: note\n    This is an important note that requires a detailed explanation.\n"
+            ":: note ::\n    This is an important note that requires a detailed explanation.\n"
         );
     }
 

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -422,40 +422,31 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 // listed case still fails (so the list cannot rot — when a bug is fixed the
 // test tells you to delete the entry) and logs the excluded set on each run.
 //
-// Bugs:
-//   #682 — attached annotations dropped on serialize
-//   #683 — table colspan (>>) dropped
+// Bugs (shipped fixes removed their entries here):
 //   #684 — table footnote list emitted outside the block
 //   #685 — list renumbering not idempotent (nested/extended)
-// The element-fixture failures span these plus edge cases still under triage;
-// they are tracked against the umbrella issue #681.
+//   #696 — residual annotation round-trip edges (doc-level block-annotation
+//          re-attachment; deeply-nested annotation-example body indentation)
+//   #681 — umbrella for remaining mixed/untriaged element-fixture sweep failures
 // -----------------------------------------------------------------------------
 
 const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[
-    // `:: notes ::` attaches to the footnote list; the formatter drops it (#682),
-    // demoting the list to a plain numbered list.
-    ("footnotes_doc_scoped", "#682"),
-    ("footnotes_section_scoped", "#682"),
-    ("ref_tk_citation_annref", "#682"),
+    ("ref_tk_citation_annref", "#696"),
     ("table_with_footnotes", "#684"),
 ];
 
-const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[("list.lex", "#685")];
+const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[("escaping.lex", "#696"), ("list.lex", "#685")];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    ("annotation-reference.lex", "#682"),
-    ("annotation.lex", "#682"),
+    ("annotation.lex", "#696"),
     ("data.lex", "#681"),
-    ("escaping.lex", "#681"),
-    ("footnotes.lex", "#682"),
+    ("escaping.lex", "#696"),
     ("label.lex", "#681"),
-    ("lex.include.lex", "#681"),
-    ("list.lex", "#681"),
+    ("list.lex", "#685"),
     ("parameter.lex", "#681"),
     ("table.lex", "#684"),
-    ("verbatim.lex", "#681"),
 ];
 
 #[cfg(test)]

--- a/crates/lex-core/src/lex/building/ast_nodes.rs
+++ b/crates/lex-core/src/lex/building/ast_nodes.rs
@@ -317,13 +317,15 @@ pub(super) fn data_node(data: DataExtraction, source_location: &SourceLocation) 
 /// Create an Annotation AST node from a Data node and child content.
 pub(super) fn annotation_node(data: Data, content: Vec<ContentElement>) -> ContentItem {
     let child_items: Vec<ContentItem> = content.iter().cloned().map(ContentItem::from).collect();
-    // An annotation always begins at its `::` marker (the Data location). Anchor
-    // the location START there and only extend the END over child content — a
-    // child carrying a default/zero location (e.g. a marker's empty-paragraph
-    // artifact) must not be able to drag the annotation's start back to line 0,
-    // which would lose its real source position (#693). `blank_lines_between`
-    // keys attachment distance on the END line, so anchoring the start does not
-    // change attachment behavior.
+    // Anchor the annotation's location START at the `Data` (label/params) span
+    // and only extend the END over child content. A child carrying a default or
+    // zero location (e.g. a marker's empty-paragraph re-parse artifact) must not
+    // be able to drag the start back to line 0, which would lose the
+    // annotation's real source position (#693). `blank_lines_between` keys
+    // attachment distance on the END line, so anchoring the start does not
+    // change attachment behavior. (The label span sits just inside the opening
+    // `::`; close enough for ordering and distance — the markers themselves are
+    // not separately tracked in `DataExtraction`.)
     let location = annotation_location(&data.location, &child_items);
 
     let annotation = Annotation::from_data(data, content).at(location);

--- a/crates/lex-core/src/lex/building/ast_nodes.rs
+++ b/crates/lex-core/src/lex/building/ast_nodes.rs
@@ -317,11 +317,35 @@ pub(super) fn data_node(data: DataExtraction, source_location: &SourceLocation) 
 /// Create an Annotation AST node from a Data node and child content.
 pub(super) fn annotation_node(data: Data, content: Vec<ContentElement>) -> ContentItem {
     let child_items: Vec<ContentItem> = content.iter().cloned().map(ContentItem::from).collect();
-    let location = aggregate_locations(data.location.clone(), &child_items);
+    // An annotation always begins at its `::` marker (the Data location). Anchor
+    // the location START there and only extend the END over child content — a
+    // child carrying a default/zero location (e.g. a marker's empty-paragraph
+    // artifact) must not be able to drag the annotation's start back to line 0,
+    // which would lose its real source position (#693). `blank_lines_between`
+    // keys attachment distance on the END line, so anchoring the start does not
+    // change attachment behavior.
+    let location = annotation_location(&data.location, &child_items);
 
     let annotation = Annotation::from_data(data, content).at(location);
 
     ContentItem::Annotation(annotation)
+}
+
+/// Compute an annotation's location: start fixed at the `::` marker (`primary`),
+/// end extended to cover the marker and any child content.
+fn annotation_location(primary: &Range, children: &[ContentItem]) -> Range {
+    let mut end_pos = primary.end;
+    let mut end_byte = primary.span.end;
+    for item in children {
+        let r = item.range();
+        if r.end > end_pos {
+            end_pos = r.end;
+            end_byte = r.span.end;
+        } else if r.end == end_pos {
+            end_byte = end_byte.max(r.span.end);
+        }
+    }
+    Range::new(primary.span.start..end_byte, primary.start, end_pos)
 }
 
 // ============================================================================

--- a/crates/lex-core/src/lex/includes.rs
+++ b/crates/lex-core/src/lex/includes.rs
@@ -640,15 +640,14 @@ fn process_resolves(
 
         match resolve_one_invocation(&annotation, state, kind)? {
             ResolveOutcome::Spliced(splice_items) => {
-                // Replace the annotation with `[annotation, ...splice_items]`.
-                // The annotation itself stays in the children list immediately
-                // before the splice, so the post-resolution AttachAnnotations
-                // pass moves it onto the first spliced node by the standard
-                // "attach to next sibling" rule.
-                let mut replacement = Vec::with_capacity(splice_items.len() + 1);
-                replacement.push(ContentItem::Annotation(annotation));
-                replacement.extend(splice_items);
-                children.splice(i..=i, replacement);
+                // Expansion replaces the directive with the included content. The
+                // `lex.include` annotation is consumed — drop it. (It used to be
+                // kept in the stream as provenance, relying on the serializer
+                // dropping attached annotations; now that the serializer emits
+                // them (lex#682), keeping it would leak `:: lex.include ::` into
+                // expanded output. Origin provenance is tracked on
+                // `Range.origin_path`, not this node.)
+                children.splice(i..=i, splice_items);
             }
             ResolveOutcome::Unexpanded => {
                 // Handler opted out of expanding this invocation. The

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -434,13 +434,6 @@ fn assert_origins(tree: &Tree, expected: &[&str]) {
     );
 }
 
-/// Assert that the include annotation with `src=expected_src` is preserved
-/// somewhere in the resolved tree.
-///
-/// "Preserved" means: attached to a node's `.annotations`, sitting in
-/// `Document.annotations` (the natural landing spot for top-of-document
-/// includes per standard lex annotation attachment), or — rarely — still
-/// in a children list as a peer item.
 /// Assert the `lex.include` directive for `expected_src` was *consumed* by
 /// expansion: the spliced content replaces it and no `lex.include` annotation
 /// with that src survives anywhere in the merged tree. (Origin provenance is

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -441,18 +441,24 @@ fn assert_origins(tree: &Tree, expected: &[&str]) {
 /// `Document.annotations` (the natural landing spot for top-of-document
 /// includes per standard lex annotation attachment), or — rarely — still
 /// in a children list as a peer item.
-fn assert_include_annotation_attached(tree: &Tree, expected_src: &str) {
-    // Document-level first.
+/// Assert the `lex.include` directive for `expected_src` was *consumed* by
+/// expansion: the spliced content replaces it and no `lex.include` annotation
+/// with that src survives anywhere in the merged tree. (Origin provenance is
+/// tracked on `Range.origin_path`, not on a preserved annotation — keeping the
+/// annotation would leak `:: lex.include ::` into expanded output now that the
+/// serializer emits attached annotations, lex#682.)
+fn assert_include_directive_consumed(tree: &Tree, expected_src: &str) {
     for ann in &tree.doc.annotations {
-        if ann.is_include() && ann.include_src().as_deref() == Some(expected_src) {
-            return;
-        }
+        assert!(
+            !(ann.is_include() && ann.include_src().as_deref() == Some(expected_src)),
+            "lex.include src={expected_src:?} should be consumed by expansion, but remains a document annotation"
+        );
     }
     let mut found = false;
     walk_for_attached_include(tree.root_children(), expected_src, &mut found);
     assert!(
-        found,
-        "no preserved lex.include annotation found with src={expected_src:?}"
+        !found,
+        "lex.include src={expected_src:?} should be consumed by expansion, but a preserved annotation remains"
     );
 }
 
@@ -547,7 +553,7 @@ fn include_with_top_level_session_at_root_is_allowed() {
 
     assert_eq!(tree.root_session_titles(), vec!["1. Chapter One"]);
     assert_no_unresolved_includes(&tree);
-    assert_include_annotation_attached(&tree, "chapter.lex");
+    assert_include_directive_consumed(&tree, "chapter.lex");
 }
 
 #[test]
@@ -624,8 +630,8 @@ fn multiple_includes_in_same_parent_are_independent() {
         tree.root_session_titles(),
         vec!["1. Chapter A", "2. Chapter B"]
     );
-    assert_include_annotation_attached(&tree, "a.lex");
-    assert_include_annotation_attached(&tree, "b.lex");
+    assert_include_directive_consumed(&tree, "a.lex");
+    assert_include_directive_consumed(&tree, "b.lex");
     assert_no_unresolved_includes(&tree);
 }
 


### PR DESCRIPTION
## Summary

Closes the headline formatter content-loss bug from the #681 suite: **annotations attached to elements were silently dropped on format**. Two commits:

1. **#693 (lex-core)** — anchor an annotation's `location` at its `::` marker. A marker annotation re-parses with an empty-paragraph artifact child whose span starts at byte 0, which dragged the annotation's location to line 0. Anchoring the start at the marker (extending the end over real children) gives every annotation an accurate source position. `blank_lines_between` keys attachment distance on the *end* line (unchanged), so attachment behavior is identical — confirmed by the full `attach_annotations` suite.

2. **#682 (lex-babel)** — re-insert attached annotations into the content stream before serialization, at their source position (now reliable thanks to #693), so a re-parse re-attaches each to the same element. Plus the serializer fixes this requires:
   - **Always close** annotation headers (`:: label ::`). The open form `:: label` is invalid — the parser drops it — so block annotations must close and indent their body.
   - **Re-emit the dedent-consumed blank** after a block annotation (like the pre-verbatim blank, lex#505), else a following sibling is swallowed into the body.
   - **Trim trailing blank lines** (`preserve_trailing_blanks = false`) so block elements stay idempotent at the document tail.
   - **Strip the empty-paragraph marker artifact** so markers emit as `:: label ::`.
   - **Includes:** expansion now drops the consumed `lex.include` directive (it previously kept it as attached provenance, relying on the serializer dropping attached annotations — which would now leak `:: lex.include ::` into expanded output). Origin provenance remains on `Range.origin_path`.

## Result

Element-level annotations, footnotes (`:: notes ::`), annotation-references, `lex.include`, and `verbatim` now round-trip both invariants. The format-invariant Tier-2 fixture failures dropped from 11 → 7; targeted footnote cases and `annotation-reference` now pass.

Before this, `lexd format` silently deleted every annotation (and every `:: lex.include ::` directive) from any document — a serious data-loss bug.

## Residual edges (quarantined, tracked in #696)

- Doc-level **block** annotation re-attaches to the next element instead of the `Document` (`ref_tk_citation_annref`).
- Deeply-nested annotation-**example** body indentation isn't idempotent in meta-docs (`escaping.lex`, `annotation.lex`). On `main` these "passed" only because the annotations were dropped; preserving them surfaced the indentation wobble.

These are listed in the suite's known-failure tables with the anti-rot guard.

## Checklist

- [x] Changelog — chore/n-a (formatter + parser bug fix; `CHANGELOG.md` is generated)
- [x] Tests: `format_invariants` updated (footnotes/annotation-reference/lex.include/verbatim now pass); `attach_annotations` suite green; includes unit tests updated to assert the directive is consumed; full workspace green
- [x] `cargo fmt`/`clippy` via pre-commit

## Test plan

- `cargo test --workspace --exclude lex-wasm` green