### PR TITLE
chore(test): retire #681 umbrella, split residuals into #699/#700

### DIFF
--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -629,7 +629,7 @@ mod tests {
 //   - nested/extended numbered lists  (#685)
 //   - a bare document title line       (#687 — generator leads with a 2-line
 //                                        paragraph, which is never title-absorbed)
-//   - random *leading* indent widths  (untriaged paragraph-merge edge, #681)
+//   - random *leading* indent widths  (paragraph-merge-on-indent edge, #699)
 // Widen this generator as those are fixed.
 // -----------------------------------------------------------------------------
 

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -452,8 +452,11 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 // test tells you to delete the entry) and logs the excluded set on each run.
 //
 // Bugs (shipped fixes removed their entries here):
-//   #681 — umbrella for remaining mixed/untriaged element-fixture sweep failures
-//          (e.g. paragraph merge of siblings distinguished only by irregular indent)
+//   #699 — formatter merges paragraphs separated only by indentation
+//   #700 — open-form annotation dropped, collapsing its container
+// (The lex#681 umbrella is closed: its deliverable — this suite — shipped and
+// every bug it originally found is fixed. The two residual Tier-2 fixture gaps
+// were triaged out into the focused issues above.)
 // -----------------------------------------------------------------------------
 
 const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
@@ -463,14 +466,14 @@ const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // annotation.lex no longer fails on the #696 annotation edges; its residual
-    // Tier-2 gap is a paragraph merge — two sibling paragraphs distinguished only
-    // by an irregular extra indent level collapse into one when re-indented. That
-    // is the untriaged paragraph-merge edge tracked under the #681 umbrella.
-    ("annotation.lex", "#681"),
-    ("data.lex", "#681"),
-    ("label.lex", "#681"),
-    ("parameter.lex", "#681"),
+    // Sibling paragraphs distinguished only by (alignment) indentation merge into
+    // one when the formatter normalizes the indent — #699.
+    ("annotation.lex", "#699"),
+    ("label.lex", "#699"),
+    ("parameter.lex", "#699"),
+    // An open-form annotation (`:: label` with no closing `::`) is dropped, so the
+    // definition it bodies collapses to a paragraph on reformat — #700.
+    ("data.lex", "#700"),
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #681.

The lex#681 umbrella is complete: its deliverable — the `format_invariants` suite (PR #688) — shipped, and every bug it originally surfaced is fixed and merged (#682, #683, #684, #685, #686, #687, plus #696 and the table span-resolution fixes from #698's review round).

The four remaining Tier-2 fixture failures it tracked were triaged into two focused, well-understood issues:

- **#699** — formatter merges paragraphs separated only by (alignment) indentation: `annotation.lex`, `label.lex`, `parameter.lex`. Sibling paragraphs whose continuation lines carry extra hanging-indent whitespace get parsed as separate sub-paragraphs, then re-parse as one after the formatter normalizes the indent. (Idempotent; semantic-preservation only.)
- **#700** — open-form annotation (`:: label` with no closing `::`) is silently dropped, so the definition it bodies collapses to a paragraph on reformat: `data.lex`. Upstream parser behavior, not a serializer defect.

This PR just re-points the `TIER2_FIXTURE_KNOWN_FAIL` entries from `#681` to `#699`/`#700` (keeping the anti-rot assertions meaningful) and updates the module note. No code changes; suite stays green.

## Test plan
- `cargo test -p lex-babel --test lib format_invariants` — 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)