### PR TITLE
fix(lex): close the lex#681 round-trip residuals (#699, #700, #702, #703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## Unreleased
 
+### Fixed — paragraph lines split only by indentation no longer merge on format ([#699](https://github.com/lex-fmt/lex/issues/699))
+
+A paragraph whose continuation lines were merely more-indented (alignment / hanging indent) was split into separate sibling paragraphs by the parser, then re-merged into one paragraph after formatting normalized the indent — a silent semantic change across a round-trip. Such hanging-indent continuations now fold back into the paragraph at parse time (real blank-line breaks are preserved).
+### Changed — removed the open-form data marker; unrecognized `:: label` lines are kept as text ([#700](https://github.com/lex-fmt/lex/issues/700))
+
+There was never a real "open form" of a data marker. A `:: label` with no closing `::` was classified as a distinct token that no grammar rule consumed, so the parser silently dropped such lines (and a definition whose sole body was one collapsed into a paragraph). Following Lex's rule that anything unrecognized becomes a paragraph — be forgiving, never lose content — these lines now classify as paragraph text.
+
+- **New diagnostic.** An `unclosed-annotation` Warning flags a paragraph line shaped like `:: label …` with no closing `::`, so authors know it looks like metadata but is treated as content. Configurable via `[diagnostics.rules]`.
+- `LineType::DataLine` and its classifier are removed. Closed-form `:: label ::` (annotations, verbatim closings) is unchanged.
+### Fixed — table column alignment is read from the markdown separator row ([#702](https://github.com/lex-fmt/lex/issues/702))
+
+The separator row's colon hints (`:---` left, `---:` right, `:---:` center) were detected only to be discarded; alignment was sourced solely from the `:: table align=… ::` parameter. Markdown-style aligned tables now keep their alignment across a format round-trip. The explicit `align=` parameter still overrides the separator row.
+### Fixed — annotation parameters keep their comma separator on format ([#703](https://github.com/lex-fmt/lex/issues/703))
+
+The Lex serializer joined annotation parameters with a space instead of a comma, so `:: warning type=critical, id=123 ::` re-serialized as `:: warning type=critical id=123 ::` and re-parsed to a single parameter. Parameters now re-emit comma-separated.
 ### Changed — extension diagnostic codes carry their namespace on the wire ([#657](https://github.com/lex-fmt/lex/issues/657))
 
 Follow-up to #636: `[diagnostics.rules]` now accepts extension-emitted codes (`acme.task-due-date-missing`, `mit.plasma-specs.invalid-version`) alongside built-ins, configured identically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,6 @@
 
 ## Unreleased
 
-### Fixed — paragraph lines split only by indentation no longer merge on format ([#699](https://github.com/lex-fmt/lex/issues/699))
-
-A paragraph whose continuation lines were merely more-indented (alignment / hanging indent) was split into separate sibling paragraphs by the parser, then re-merged into one paragraph after formatting normalized the indent — a silent semantic change across a round-trip. Such hanging-indent continuations now fold back into the paragraph at parse time (real blank-line breaks are preserved).
-### Changed — removed the open-form data marker; unrecognized `:: label` lines are kept as text ([#700](https://github.com/lex-fmt/lex/issues/700))
-
-There was never a real "open form" of a data marker. A `:: label` with no closing `::` was classified as a distinct token that no grammar rule consumed, so the parser silently dropped such lines (and a definition whose sole body was one collapsed into a paragraph). Following Lex's rule that anything unrecognized becomes a paragraph — be forgiving, never lose content — these lines now classify as paragraph text.
-
-- **New diagnostic.** An `unclosed-annotation` Warning flags a paragraph line shaped like `:: label …` with no closing `::`, so authors know it looks like metadata but is treated as content. Configurable via `[diagnostics.rules]`.
-- `LineType::DataLine` and its classifier are removed. Closed-form `:: label ::` (annotations, verbatim closings) is unchanged.
-### Fixed — table column alignment is read from the markdown separator row ([#702](https://github.com/lex-fmt/lex/issues/702))
-
-The separator row's colon hints (`:---` left, `---:` right, `:---:` center) were detected only to be discarded; alignment was sourced solely from the `:: table align=… ::` parameter. Markdown-style aligned tables now keep their alignment across a format round-trip. The explicit `align=` parameter still overrides the separator row.
-### Fixed — annotation parameters keep their comma separator on format ([#703](https://github.com/lex-fmt/lex/issues/703))
-
-The Lex serializer joined annotation parameters with a space instead of a comma, so `:: warning type=critical, id=123 ::` re-serialized as `:: warning type=critical id=123 ::` and re-parsed to a single parameter. Parameters now re-emit comma-separated.
 ### Changed — extension diagnostic codes carry their namespace on the wire ([#657](https://github.com/lex-fmt/lex/issues/657))
 
 Follow-up to #636: `[diagnostics.rules]` now accepts extension-emitted codes (`acme.task-due-date-missing`, `mit.plasma-specs.invalid-version`) alongside built-ins, configured identically.

--- a/CHANGELOG/unreleased-pr-699.md
+++ b/CHANGELOG/unreleased-pr-699.md
@@ -1,0 +1,3 @@
+### Fixed — paragraph lines split only by indentation no longer merge on format ([#699](https://github.com/lex-fmt/lex/issues/699))
+
+A paragraph whose continuation lines were merely more-indented (alignment / hanging indent) was split into separate sibling paragraphs by the parser, then re-merged into one paragraph after formatting normalized the indent — a silent semantic change across a round-trip. Such hanging-indent continuations now fold back into the paragraph at parse time (real blank-line breaks are preserved).

--- a/CHANGELOG/unreleased-pr-700.md
+++ b/CHANGELOG/unreleased-pr-700.md
@@ -1,0 +1,6 @@
+### Changed — removed the open-form data marker; unrecognized `:: label` lines are kept as text ([#700](https://github.com/lex-fmt/lex/issues/700))
+
+There was never a real "open form" of a data marker. A `:: label` with no closing `::` was classified as a distinct token that no grammar rule consumed, so the parser silently dropped such lines (and a definition whose sole body was one collapsed into a paragraph). Following Lex's rule that anything unrecognized becomes a paragraph — be forgiving, never lose content — these lines now classify as paragraph text.
+
+- **New diagnostic.** An `unclosed-annotation` Warning flags a paragraph line shaped like `:: label …` with no closing `::`, so authors know it looks like metadata but is treated as content. Configurable via `[diagnostics.rules]`.
+- `LineType::DataLine` and its classifier are removed. Closed-form `:: label ::` (annotations, verbatim closings) is unchanged.

--- a/CHANGELOG/unreleased-pr-702.md
+++ b/CHANGELOG/unreleased-pr-702.md
@@ -1,0 +1,3 @@
+### Fixed — table column alignment is read from the markdown separator row ([#702](https://github.com/lex-fmt/lex/issues/702))
+
+The separator row's colon hints (`:---` left, `---:` right, `:---:` center) were detected only to be discarded; alignment was sourced solely from the `:: table align=… ::` parameter. Markdown-style aligned tables now keep their alignment across a format round-trip. The explicit `align=` parameter still overrides the separator row.

--- a/CHANGELOG/unreleased-pr-703.md
+++ b/CHANGELOG/unreleased-pr-703.md
@@ -1,0 +1,3 @@
+### Fixed — annotation parameters keep their comma separator on format ([#703](https://github.com/lex-fmt/lex/issues/703))
+
+The Lex serializer joined annotation parameters with a space instead of a comma, so `:: warning type=critical, id=123 ::` re-serialized as `:: warning type=critical id=123 ::` and re-parsed to a single parameter. Parameters now re-emit comma-separated.

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -47,6 +47,12 @@ pub enum DiagnosticKind {
     /// typo (`lex.fooar`) or a label authored against a future
     /// version of the core schemas.
     UnknownLexCanonical,
+    /// A paragraph line that looks like an annotation header (`:: label`)
+    /// but has no closing `::`. There is no "open form" — such a line is
+    /// kept as paragraph text rather than dropped (lex#700) — so this
+    /// warns the author that what looks like metadata is being treated as
+    /// content. The fix is to close the marker: `:: label ::`.
+    UnclosedAnnotation,
 }
 
 /// Severity for analysis-emitted diagnostics. The analyser populates
@@ -127,6 +133,7 @@ impl DiagnosticKind {
             },
             DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix".into(),
             DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical".into(),
+            DiagnosticKind::UnclosedAnnotation => "unclosed-annotation".into(),
         }
     }
 }
@@ -194,8 +201,70 @@ pub fn analyze_with_registry(document: &Document, registry: &Registry) -> Vec<An
     check_footnotes(document, &mut diagnostics);
     check_tables(document, &mut diagnostics);
     check_labels(document, &mut diagnostics);
+    check_unclosed_annotations(document, &mut diagnostics);
     crate::label_dispatch::dispatch_labels(document, registry, &mut diagnostics);
     diagnostics
+}
+
+/// Warn on paragraph lines that look like an annotation header but never close
+/// the `:: ::` marker (lex#700). There is no "open form": `:: label` with no
+/// closing `::` is not a recognized element, so the parser keeps it as paragraph
+/// text rather than dropping it. This surfaces that — the author likely meant an
+/// annotation and forgot the trailing `::`.
+fn check_unclosed_annotations(document: &Document, diagnostics: &mut Vec<AnalysisDiagnostic>) {
+    fn emit(
+        tl: &lex_core::lex::ast::elements::paragraph::TextLine,
+        out: &mut Vec<AnalysisDiagnostic>,
+    ) {
+        if looks_like_unclosed_annotation(tl.text()) {
+            out.push(AnalysisDiagnostic {
+                range: tl.location.clone(),
+                severity: DiagnosticSeverity::Warning,
+                kind: DiagnosticKind::UnclosedAnnotation,
+                message: "this line looks like an annotation but has no closing `::`, \
+                          so it is treated as text. Close the marker to make it an \
+                          annotation, e.g. `:: label ::`."
+                    .to_string(),
+            });
+        }
+    }
+
+    fn walk(item: &ContentItem, out: &mut Vec<AnalysisDiagnostic>) {
+        if let ContentItem::Paragraph(p) = item {
+            for line in &p.lines {
+                if let ContentItem::TextLine(tl) = line {
+                    emit(tl, out);
+                }
+            }
+        }
+        if let Some(children) = item.children() {
+            for child in children {
+                walk(child, out);
+            }
+        }
+    }
+
+    for child in &document.root.children {
+        walk(child, diagnostics);
+    }
+}
+
+/// True when a line is shaped like an annotation header (`:: label …`) but has no
+/// closing `::`. Detection is intentionally a lightweight text heuristic — by the
+/// time content reaches the analyser, a *closed* annotation is already its own
+/// node, so any `::`-leading paragraph line is the unclosed shape.
+fn looks_like_unclosed_annotation(text: &str) -> bool {
+    let Some(rest) = text.trim().strip_prefix("::") else {
+        return false;
+    };
+    // A second `::` means a closed marker — not the unclosed shape.
+    if rest.contains("::") {
+        return false;
+    }
+    // Require whitespace after the opening marker, then a label-shaped token
+    // (label.lex: a letter, then letters/digits/`_`/`-`/`.`).
+    let label = rest.trim_start();
+    rest.len() != label.len() && label.chars().next().is_some_and(|c| c.is_alphabetic())
 }
 
 /// Run the analyser with both an extension registry and a
@@ -616,6 +685,42 @@ mod tests {
     use super::*;
     use lex_core::lex::parsing::process_full_permissive;
     use lex_core::lex::testing::lexplore::Lexplore;
+
+    fn unclosed_annotation_diags(source: &str) -> Vec<AnalysisDiagnostic> {
+        let doc = process_full_permissive(source).expect("permissive parse");
+        analyze(&doc)
+            .into_iter()
+            .filter(|d| d.kind == DiagnosticKind::UnclosedAnnotation)
+            .collect()
+    }
+
+    #[test]
+    fn unclosed_annotation_warns_on_open_form() {
+        // `:: note severity=high` (no closing `::`) parses as a paragraph; the
+        // analyser flags it so the author knows it isn't an annotation (lex#700).
+        let diags = unclosed_annotation_diags("Open form:\n\t:: note severity=high\n");
+        assert_eq!(diags.len(), 1, "expected one unclosed-annotation warning");
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
+        assert_eq!(diags[0].kind.code(), "unclosed-annotation");
+    }
+
+    #[test]
+    fn unclosed_annotation_silent_on_closed_form_and_prose() {
+        // A properly closed annotation is its own node, not a flagged paragraph.
+        assert!(unclosed_annotation_diags(":: note severity=high ::\n\nBody.\n").is_empty());
+        // Prose that merely mentions `::` is not flagged.
+        assert!(unclosed_annotation_diags("Use :: to start a marker.\n").is_empty());
+    }
+
+    #[test]
+    fn looks_like_unclosed_annotation_heuristic() {
+        assert!(looks_like_unclosed_annotation(":: note"));
+        assert!(looks_like_unclosed_annotation("    :: note severity=high"));
+        assert!(!looks_like_unclosed_annotation(":: note ::"));
+        assert!(!looks_like_unclosed_annotation("::note")); // no whitespace after marker
+        assert!(!looks_like_unclosed_annotation("::")); // no label
+        assert!(!looks_like_unclosed_annotation("just prose"));
+    }
 
     fn footnote_diags(doc: &Document) -> Vec<AnalysisDiagnostic> {
         analyze(doc)

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -257,9 +257,18 @@ fn looks_like_unclosed_annotation(text: &str) -> bool {
     let Some(rest) = text.trim().strip_prefix("::") else {
         return false;
     };
-    // A second `::` means a closed marker — not the unclosed shape.
-    if rest.contains("::") {
-        return false;
+    // A second *structural* `::` means a closed marker — not the unclosed shape.
+    // Scan quote-aware so a `::` inside a quoted parameter value (e.g.
+    // `:: note foo=":: value"`) does not count as a close, matching how the
+    // lexer's structural-marker detection treats it.
+    let mut in_quotes = false;
+    let mut chars = rest.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            ':' if !in_quotes && chars.peek() == Some(&':') => return false,
+            _ => {}
+        }
     }
     // Require whitespace after the opening marker, then a label-shaped token
     // (label.lex: a letter, then letters/digits/`_`/`-`/`.`).
@@ -716,7 +725,13 @@ mod tests {
     fn looks_like_unclosed_annotation_heuristic() {
         assert!(looks_like_unclosed_annotation(":: note"));
         assert!(looks_like_unclosed_annotation("    :: note severity=high"));
+        // A `::` inside a quoted value is not a structural close, so this is still
+        // an unclosed annotation (lex#704 review).
+        assert!(looks_like_unclosed_annotation(":: note foo=\":: value\""));
         assert!(!looks_like_unclosed_annotation(":: note ::"));
+        assert!(!looks_like_unclosed_annotation(
+            ":: note foo=\":: value\" ::"
+        )); // real close
         assert!(!looks_like_unclosed_annotation("::note")); // no whitespace after marker
         assert!(!looks_like_unclosed_annotation("::")); // no label
         assert!(!looks_like_unclosed_annotation("just prose"));

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -357,13 +357,14 @@ impl Visitor for LexSerializer {
         let params = &annotation.data.parameters;
 
         let mut header = format!(":: {label}");
-        if !params.is_empty() {
-            for param in params {
-                header.push(' ');
-                header.push_str(&param.key);
-                header.push('=');
-                header.push_str(&param.value);
-            }
+        // Parameters are comma-separated: the parser treats the comma as the only
+        // parameter separator (whitespace is ignored), so emitting them space-only
+        // collapses `k1=v1, k2=v2` into a single `k1=v1 k2=v2` value on re-parse.
+        for (i, param) in params.iter().enumerate() {
+            header.push_str(if i == 0 { " " } else { ", " });
+            header.push_str(&param.key);
+            header.push('=');
+            header.push_str(&param.value);
         }
 
         // Always close the header with ` ::`. The open form (`:: label`) is not
@@ -993,6 +994,17 @@ mod tests {
         let source = Lexplore::load(ElementType::Annotation, 2).source();
         let formatted = format_full(&source);
         assert_eq!(formatted, ":: warning severity=high ::\n");
+    }
+
+    #[test]
+    fn test_annotation_multi_param_keeps_comma_separator() {
+        // The parser uses the comma as the only parameter separator, so a
+        // space-only join collapses `k1=v1, k2=v2` into a single value on
+        // re-parse (lex#703). The formatted output must keep the comma and be a
+        // fixed point.
+        let formatted = format_full(":: warning type=critical, id=123 ::\n");
+        assert_eq!(formatted, ":: warning type=critical, id=123 ::\n");
+        assert_eq!(format_full(&formatted), formatted, "must be idempotent");
     }
 
     #[test]

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -465,10 +465,6 @@ const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // Multi-parameter annotations re-serialize without the comma separator, so the
-    // params collapse on re-parse — #703. (The paragraph-merge half of this fixture
-    // was #699, now fixed.)
-    ("parameter.lex", "#703"),
     // An open-form annotation (`:: label` with no closing `::`) is dropped, so the
     // definition it bodies collapses to a paragraph on reformat — #700.
     ("data.lex", "#700"),

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -602,6 +602,24 @@ mod tests {
             check_semantic_preserved,
         );
     }
+
+    /// The `table_aligned_header` Tier-2 case only proves alignment is *symmetric*
+    /// across a round-trip — it would also pass if alignment were dropped on both
+    /// sides (the old #702 blind spot). This asserts the stronger property: the
+    /// markdown separator-row alignment hints are actually *retained* in the
+    /// formatted output, not flattened to a plain `---` separator.
+    #[test]
+    fn table_separator_alignment_is_retained() {
+        let src =
+            "Stats:\n    | Name | Score |\n    |:---|---:|\n    | Alice | 10 |\n:: table ::\n";
+        let formatted = format(src).expect("format");
+        assert!(
+            formatted.contains(":---") && formatted.contains("---:"),
+            "alignment markers must survive formatting (lex#702); got:\n{formatted}"
+        );
+        // And re-emitting is a fixed point.
+        assert_eq!(format(&formatted).expect("reformat"), formatted);
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -452,7 +452,6 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 // test tells you to delete the entry) and logs the excluded set on each run.
 //
 // Bugs (shipped fixes removed their entries here):
-//   #699 — formatter merges paragraphs separated only by indentation
 //   #700 — open-form annotation dropped, collapsing its container
 // (The lex#681 umbrella is closed: its deliverable — this suite — shipped and
 // every bug it originally found is fixed. The two residual Tier-2 fixture gaps
@@ -466,11 +465,10 @@ const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // Sibling paragraphs distinguished only by (alignment) indentation merge into
-    // one when the formatter normalizes the indent — #699.
-    ("annotation.lex", "#699"),
-    ("label.lex", "#699"),
-    ("parameter.lex", "#699"),
+    // Multi-parameter annotations re-serialize without the comma separator, so the
+    // params collapse on re-parse — #703. (The paragraph-merge half of this fixture
+    // was #699, now fixed.)
+    ("parameter.lex", "#703"),
     // An open-form annotation (`:: label` with no closing `::`) is dropped, so the
     // definition it bodies collapses to a paragraph on reformat — #700.
     ("data.lex", "#700"),
@@ -629,8 +627,8 @@ mod tests {
 //   - nested/extended numbered lists  (#685)
 //   - a bare document title line       (#687 — generator leads with a 2-line
 //                                        paragraph, which is never title-absorbed)
-//   - random *leading* indent widths  (paragraph-merge-on-indent edge, #699)
-// Widen this generator as those are fixed.
+// Widen this generator as those are fixed. (The paragraph-merge-on-indent edge,
+// #699, is now fixed — hanging-indent continuations fold back into the paragraph.)
 // -----------------------------------------------------------------------------
 
 #[cfg(test)]

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -451,11 +451,12 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 // listed case still fails (so the list cannot rot — when a bug is fixed the
 // test tells you to delete the entry) and logs the excluded set on each run.
 //
-// Bugs (shipped fixes removed their entries here):
-//   #700 — open-form annotation dropped, collapsing its container
 // (The lex#681 umbrella is closed: its deliverable — this suite — shipped and
-// every bug it originally found is fixed. The two residual Tier-2 fixture gaps
-// were triaged out into the focused issues above.)
+// every bug it originally found is fixed. The residual Tier-2 fixture failures
+// were triaged into focused issues — #699 (paragraph merge), #700 (open-form
+// drop), #703 (annotation comma) — all now fixed, so every list below is empty.
+// Re-populate only when a newly-filed formatter bug needs to keep the suite
+// green while it is open.)
 // -----------------------------------------------------------------------------
 
 const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
@@ -464,11 +465,7 @@ const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[];
 
-const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // An open-form annotation (`:: label` with no closing `::`) is dropped, so the
-    // definition it bodies collapses to a paragraph on reformat — #700.
-    ("data.lex", "#700"),
-];
+const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 #[cfg(test)]
 mod tests {

--- a/crates/lex-core/src/lex/ast/elements/verbatim.rs
+++ b/crates/lex-core/src/lex/ast/elements/verbatim.rs
@@ -33,7 +33,7 @@
 //!
 //! | Element  | Prec. Blank | Head        | Blank    | Content  | Tail            |
 //! |----------|-------------|-------------|----------|----------|-----------------|
-//! | Verbatim | Optional    | SubjectLine | Optional | Optional | dedent+DataLine |
+//! | Verbatim | Optional    | SubjectLine | Optional | Optional | dedent+DataMarkerLine |
 //!
 //! Parsing Verbatim Blocks
 //!

--- a/crates/lex-core/src/lex/building/api.rs
+++ b/crates/lex-core/src/lex/building/api.rs
@@ -303,8 +303,10 @@ pub fn table_from_lines(
     // Actual config from :: table :: annotation is applied later in assembly.
     let data = extraction::extract_table_data(subject_token, content_tokens, source);
 
-    // 2. Create table with defaults
-    let alignments: Vec<crate::lex::ast::TableCellAlignment> = Vec::new();
+    // 2. Create table, seeding per-column alignment from the markdown separator
+    //    row (`:---`, `---:`, `:---:`). The `:: table align=… ::` parameter, if
+    //    present, overrides these in a later assembly stage (apply_table_config).
+    let alignments = data.alignments.clone();
     let mut table_item = ast_nodes::table_node(data, &alignments, source_location);
 
     // 3. Attach config annotation to the table if present

--- a/crates/lex-core/src/lex/building/api.rs
+++ b/crates/lex-core/src/lex/building/api.rs
@@ -299,8 +299,10 @@ pub fn table_from_lines(
     source: &str,
     source_location: &SourceLocation,
 ) -> ContentItem {
-    // 1. Extract table data with default config (header=1, no alignment).
-    // Actual config from :: table :: annotation is applied later in assembly.
+    // 1. Extract table data. Column alignment is seeded from the markdown
+    //    separator row here; header split defaults to header=1. The `:: table
+    //    header=N align=… ::` annotation can override both later in assembly
+    //    (the align param takes precedence over the separator row).
     let data = extraction::extract_table_data(subject_token, content_tokens, source);
 
     // 2. Create table, seeding per-column alignment from the markdown separator

--- a/crates/lex-core/src/lex/building/extraction/table.rs
+++ b/crates/lex-core/src/lex/building/extraction/table.rs
@@ -15,6 +15,7 @@
 
 use super::verbatim::extract_verbatim_block_data;
 use crate::lex::ast::elements::verbatim::VerbatimBlockMode;
+use crate::lex::ast::TableCellAlignment;
 use crate::lex::escape::split_respecting_escape_with_ranges;
 use crate::lex::token::LineToken;
 use std::borrow::Cow;
@@ -58,6 +59,11 @@ pub(in crate::lex::building) struct TableData {
     pub body_rows: Vec<TableRowData>,
     pub footnotes: Vec<FootnoteLineData>,
     pub mode: VerbatimBlockMode,
+    /// Per-column alignment read from the markdown separator row
+    /// (`:---`, `---:`, `:---:`). Empty when the table has no separator row.
+    /// The `:: table align=… ::` parameter, applied later in assembly,
+    /// overrides this.
+    pub alignments: Vec<TableCellAlignment>,
 }
 
 /// Extract table data from the verbatim-like outer structure.
@@ -84,6 +90,7 @@ pub(in crate::lex::building) fn extract_table_data(
 
     // Parse the wall-stripped content lines into rows and extract footnotes
     let classified = classify_lines(&group.content_lines);
+    let alignments = parse_separator_alignments(&group.content_lines);
     let is_multiline = detect_multiline(&classified);
     let raw_rows = if is_multiline {
         parse_multiline_rows(&classified)
@@ -117,6 +124,7 @@ pub(in crate::lex::building) fn extract_table_data(
         body_rows,
         footnotes,
         mode,
+        alignments,
     }
 }
 
@@ -567,6 +575,42 @@ fn is_separator_line(line: &str) -> bool {
         .all(|c| matches!(c, '|' | '-' | ':' | '+' | ' ' | '='))
 }
 
+/// Read per-column alignment from the table's markdown separator row.
+///
+/// The separator row encodes alignment with leading/trailing colons on each
+/// column segment: `:---` → left, `---:` → right, `:---:` → center, `---` →
+/// none. Returns the per-column alignments for the first separator row found,
+/// or an empty vec when the table has no separator row.
+///
+/// Without this, the colon hints are dropped on parse and the formatter
+/// re-emits a plain `---` separator — a silent loss across a round-trip
+/// (lex#702). The `:: table align=… ::` parameter still overrides these in a
+/// later assembly stage.
+fn parse_separator_alignments(
+    content_lines: &[(String, ByteRange<usize>)],
+) -> Vec<TableCellAlignment> {
+    for (text, _) in content_lines {
+        let trimmed = text.trim();
+        if !trimmed.starts_with('|') || !is_separator_line(trimmed) {
+            continue;
+        }
+        return trimmed
+            .trim_matches('|')
+            .split('|')
+            .map(|segment| {
+                let seg = segment.trim();
+                match (seg.starts_with(':'), seg.ends_with(':')) {
+                    (true, true) => TableCellAlignment::Center,
+                    (true, false) => TableCellAlignment::Left,
+                    (false, true) => TableCellAlignment::Right,
+                    (false, false) => TableCellAlignment::None,
+                }
+            })
+            .collect();
+    }
+    Vec::new()
+}
+
 /// Extract footnote lines from trailing non-pipe content.
 ///
 /// Footnotes are non-pipe lines that appear after the last pipe row.
@@ -714,6 +758,19 @@ mod tests {
         assert!(is_separator_line("| --- | --- |"));
         assert!(!is_separator_line("| hello | world |"));
         assert!(!is_separator_line("| --- | data |"));
+    }
+
+    #[test]
+    fn test_parse_separator_alignments() {
+        use TableCellAlignment::*;
+        fn aligns(sep: &str) -> Vec<TableCellAlignment> {
+            parse_separator_alignments(&[(sep.to_string(), 0..sep.len())])
+        }
+        assert_eq!(aligns("|:---|---:|"), vec![Left, Right]);
+        assert_eq!(aligns("|:---:|---|"), vec![Center, None]);
+        assert_eq!(aligns("| :--- | ---: | :---: |"), vec![Left, Right, Center]);
+        // No separator row → no alignments.
+        assert!(aligns("| a | b |").is_empty());
     }
 
     #[test]

--- a/crates/lex-core/src/lex/escape.rs
+++ b/crates/lex-core/src/lex/escape.rs
@@ -959,7 +959,7 @@ mod tests {
     }
 
     #[test]
-    fn structural_markers_data_line_with_quoted_marker() {
+    fn structural_markers_single_opening_with_quoted_marker() {
         use crate::lex::token::Token;
         // :: test.note foo=":: value"  (no closing ::)
         let tokens = vec![

--- a/crates/lex-core/src/lex/lexing/line_classification.rs
+++ b/crates/lex-core/src/lex/lexing/line_classification.rs
@@ -57,11 +57,14 @@ pub struct ParsedListMarker {
 /// Classification follows this specific order (important for correctness):
 /// 1. Blank lines
 /// 2. Data marker lines (:: label params? ::, closed form)
-/// 3. Data lines (:: label params? without closing ::)
-/// 4. List lines starting with list marker AND ending with colon -> SubjectOrListItemLine
-/// 5. List lines (starting with list marker)
-/// 6. Subject lines (ending with colon)
-/// 7. Default to paragraph
+/// 3. List lines starting with list marker AND ending with colon -> SubjectOrListItemLine
+/// 4. List lines (starting with list marker)
+/// 5. Subject lines (ending with colon)
+/// 6. Default to paragraph
+///
+/// Note: there is no "open form" data line. A `:: label` with no closing `::` is
+/// not a recognized element, so it falls through to a paragraph like any other
+/// unrecognized text — Lex keeps content rather than dropping it.
 pub fn classify_line_tokens(tokens: &[Token]) -> LineType {
     if tokens.is_empty() {
         return LineType::ParagraphLine;
@@ -75,11 +78,6 @@ pub fn classify_line_tokens(tokens: &[Token]) -> LineType {
     // DATA_MARKER_LINE: Data marker in closed form (:: label params? ::)
     if is_data_marker_line(tokens) {
         return LineType::DataMarkerLine;
-    }
-
-    // DATA_LINE: :: label params? without closing ::
-    if is_data_line(tokens) {
-        return LineType::DataLine;
     }
 
     // Check if line both starts with list marker AND ends with colon
@@ -155,58 +153,6 @@ fn is_data_marker_line(tokens: &[Token]) -> bool {
     // Require a label between the markers
     let header_tokens = &tokens[first_marker_idx + 1..second_marker_idx];
     analyze_annotation_header_tokens(header_tokens).has_label
-}
-
-/// Check if a line is a data line (:: label params? without closing ::)
-///
-/// Uses quote-aware marker detection so that `::` inside quoted parameter
-/// values does not disqualify a line from being a data line.
-fn is_data_line(tokens: &[Token]) -> bool {
-    if tokens.is_empty() {
-        return false;
-    }
-
-    // Find structural markers (outside quoted regions)
-    let structural = find_structural_lex_markers(tokens);
-    if structural.is_empty() {
-        return false;
-    }
-
-    // Data lines have exactly one structural marker (no closing ::)
-    if structural.len() >= 2 {
-        return false;
-    }
-
-    let first_marker_idx = structural[0];
-
-    // First marker must be at the start (after optional whitespace/indentation)
-    for token in &tokens[..first_marker_idx] {
-        if !matches!(token, Token::Indentation | Token::Whitespace(_)) {
-            return false;
-        }
-    }
-
-    // After first marker we expect whitespace
-    if first_marker_idx + 1 >= tokens.len()
-        || !matches!(tokens[first_marker_idx + 1], Token::Whitespace(_))
-    {
-        return false;
-    }
-
-    // Collect header tokens (until newline) and ensure we have a label
-    let mut header_tokens = Vec::new();
-    for token in tokens[first_marker_idx + 1..].iter() {
-        if matches!(token, Token::BlankLine(_)) {
-            continue;
-        }
-        header_tokens.push(token.clone());
-    }
-
-    if header_tokens.is_empty() {
-        return false;
-    }
-
-    analyze_annotation_header_tokens(&header_tokens).has_label
 }
 
 /// Parse a list marker at the start of a line (after optional indentation).
@@ -451,14 +397,17 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_data_line() {
+    fn test_open_form_data_marker_is_paragraph() {
+        // `:: label` with no closing `::` is not a recognized element (there is
+        // no "open form"). It falls through to a paragraph so its content is
+        // preserved rather than dropped (lex#700).
         let tokens = vec![
             Token::LexMarker,
             Token::Whitespace(1),
             Token::Text("label".to_string()),
             Token::BlankLine(Some("\n".to_string())),
         ];
-        assert_eq!(classify_line_tokens(&tokens), LineType::DataLine);
+        assert_eq!(classify_line_tokens(&tokens), LineType::ParagraphLine);
     }
 
     #[test]
@@ -611,8 +560,12 @@ mod tests {
     }
 
     #[test]
-    fn test_lex_marker_inside_quoted_value_data_line() {
-        // :: test.note foo=":: value"  (no closing ::)
+    fn test_lex_marker_inside_quoted_value_not_a_closing_marker() {
+        // :: test.note foo=":: value"  (no real closing :: — the inner one is
+        // inside a quoted value). It is not a closed-form data marker, and with
+        // the open form gone it falls through to a paragraph (lex#700). The
+        // point of this regression is that the quoted `::` is NOT mistaken for a
+        // structural closing marker (which would make it a DataMarkerLine).
         let tokens = vec![
             Token::LexMarker,
             Token::Whitespace(1),
@@ -627,6 +580,6 @@ mod tests {
             Token::Quote,
             Token::BlankLine(Some("\n".to_string())),
         ];
-        assert_eq!(classify_line_tokens(&tokens), LineType::DataLine);
+        assert_eq!(classify_line_tokens(&tokens), LineType::ParagraphLine);
     }
 }

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -586,7 +586,107 @@ pub fn parse_with_declarative_grammar(
     tokens: Vec<LineContainer>,
     source: &str,
 ) -> Result<Vec<ParseNode>, String> {
+    let tokens = fold_prose_continuations(tokens);
     parse_with_declarative_grammar_internal(tokens, source, true, true)
+}
+
+/// True when a line token is paragraph prose (a `ParagraphLine` or `DialogLine`).
+fn is_prose_line(token: &crate::lex::token::LineToken) -> bool {
+    matches!(
+        token.line_type,
+        LineType::ParagraphLine | LineType::DialogLine
+    )
+}
+
+/// True when a run of line containers is *prose only* — it carries no structural
+/// element (list, definition, table, annotation, verbatim) and so would parse to
+/// nothing but paragraphs. A deeper-indented run of this shape is a hanging-indent
+/// continuation of the preceding paragraph, not a nested block.
+///
+/// The check mirrors the paragraph boundaries the matcher uses:
+///   - paragraph / dialog / blank lines are always prose;
+///   - a subject line is prose *unless* it heads a container (subject + container
+///     is a definition or table) — a lone trailing-colon line is just prose;
+///   - a nested container is prose only if its own contents are prose;
+///   - anything else (list markers, data markers) disqualifies the run.
+fn is_prose_only_run(children: &[LineContainer]) -> bool {
+    let mut idx = 0;
+    while idx < children.len() {
+        match &children[idx] {
+            LineContainer::Token(t) => match t.line_type {
+                LineType::ParagraphLine | LineType::DialogLine | LineType::BlankLine => {}
+                LineType::SubjectLine | LineType::SubjectOrListItemLine => {
+                    // Subject + container is a definition/table header, not prose.
+                    if matches!(children.get(idx + 1), Some(LineContainer::Container { .. })) {
+                        return false;
+                    }
+                }
+                _ => return false,
+            },
+            LineContainer::Container { children: inner } => {
+                if !is_prose_only_run(inner) {
+                    return false;
+                }
+            }
+        }
+        idx += 1;
+    }
+    true
+}
+
+/// Append every leaf line of a container to `out`, dissolving nesting.
+fn dissolve_prose_into(container: LineContainer, out: &mut Vec<LineContainer>) {
+    match container {
+        token @ LineContainer::Token(_) => out.push(token),
+        LineContainer::Container { children } => {
+            for child in children {
+                dissolve_prose_into(child, out);
+            }
+        }
+    }
+}
+
+/// Fold hanging-indent continuations back into their paragraph's level (lex#699).
+///
+/// The tokenizer turns *any* indent increase into a nested `LineContainer`, so a
+/// paragraph whose continuation lines are merely more-indented (alignment / hanging
+/// indent) gets split: the deeper lines land in a child container and are later
+/// promoted to a *sibling* paragraph. The serializer then re-emits every paragraph
+/// line at one normalized indent, and the two siblings re-parse as a single
+/// paragraph — a silent semantic change across a format round-trip.
+///
+/// The grammar defines a paragraph as consecutive lines that stop only at list /
+/// definition starts (grammar-core.lex `<paragraph>`), never at a bare indent
+/// increase. So when a prose token is immediately followed by a *pure-prose*
+/// container, we dissolve that container into the current level. Any blank lines
+/// the tokenizer tucked inside the deeper container resurface as real separators at
+/// this level — exactly what the formatter would emit — so paragraph breaks are
+/// preserved while spurious indent-only splits are not.
+///
+/// Containers that carry structure (lists, definitions, annotations, tables) are
+/// never dissolved, and a container not preceded by prose (an annotation/definition
+/// body, an orphaned block) is left untouched.
+fn fold_prose_continuations(children: Vec<LineContainer>) -> Vec<LineContainer> {
+    let mut result: Vec<LineContainer> = Vec::with_capacity(children.len());
+
+    for item in children {
+        let dissolve = matches!(result.last(), Some(LineContainer::Token(t)) if is_prose_line(t))
+            && matches!(&item, LineContainer::Container { children } if is_prose_only_run(children));
+
+        if dissolve {
+            dissolve_prose_into(item, &mut result);
+            continue;
+        }
+
+        match item {
+            LineContainer::Container { children } => result.push(LineContainer::Container {
+                children: fold_prose_continuations(children),
+            }),
+            token => result.push(token),
+        }
+    }
+
+    result
 }
 
 /// Internal parsing function with nesting level tracking

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -605,17 +605,20 @@ fn is_prose_line(token: &crate::lex::token::LineToken) -> bool {
 ///
 /// The check mirrors the paragraph boundaries the matcher uses:
 ///   - paragraph / dialog / blank lines are always prose;
-///   - a subject line is prose *unless* it heads a container (subject + container
-///     is a definition or table) — a lone trailing-colon line is just prose;
+///   - a plain subject line is prose *unless* it heads a container (subject +
+///     container is a definition or table) — a lone trailing-colon line is just
+///     prose;
 ///   - a nested container is prose only if its own contents are prose;
-///   - anything else (list markers, data markers) disqualifies the run.
+///   - anything starting with a list marker (`ListLine`, `SubjectOrListItemLine`)
+///     or a data marker disqualifies the run — a run of those is a list, which
+///     must keep its own structure, not be flattened into a paragraph.
 fn is_prose_only_run(children: &[LineContainer]) -> bool {
     let mut idx = 0;
     while idx < children.len() {
         match &children[idx] {
             LineContainer::Token(t) => match t.line_type {
                 LineType::ParagraphLine | LineType::DialogLine | LineType::BlankLine => {}
-                LineType::SubjectLine | LineType::SubjectOrListItemLine => {
+                LineType::SubjectLine => {
                     // Subject + container is a definition/table header, not prose.
                     if matches!(children.get(idx + 1), Some(LineContainer::Container { .. })) {
                         return false;
@@ -792,4 +795,51 @@ fn parse_with_declarative_grammar_internal(
     }
 
     Ok(items)
+}
+
+#[cfg(test)]
+mod prose_continuation_tests {
+    use super::*;
+    use crate::lex::token::LineToken;
+
+    fn line(line_type: LineType) -> LineContainer {
+        LineContainer::Token(LineToken {
+            source_tokens: vec![],
+            token_spans: vec![],
+            line_type,
+        })
+    }
+
+    fn container(children: Vec<LineContainer>) -> LineContainer {
+        LineContainer::Container { children }
+    }
+
+    #[test]
+    fn prose_run_accepts_paragraph_and_lone_subject() {
+        use LineType::*;
+        // A hanging-indent continuation: paragraph lines, a blank, and a lone
+        // trailing-colon subject line (not heading a container) are all prose.
+        assert!(is_prose_only_run(&[
+            line(ParagraphLine),
+            line(SubjectLine),
+            line(BlankLine),
+        ]));
+    }
+
+    #[test]
+    fn prose_run_rejects_list_markers() {
+        use LineType::*;
+        // A run of list-marker lines is a list, never prose — folding it into the
+        // preceding paragraph would flatten real structure (lex#704 review).
+        assert!(!is_prose_only_run(&[
+            line(SubjectOrListItemLine),
+            line(SubjectOrListItemLine),
+        ]));
+        assert!(!is_prose_only_run(&[line(ListLine)]));
+        // A subject line that *heads* a container is a definition/table, not prose.
+        assert!(!is_prose_only_run(&[
+            line(SubjectLine),
+            container(vec![line(ParagraphLine)]),
+        ]));
+    }
 }

--- a/crates/lex-core/src/lex/parsing/parser/grammar.rs
+++ b/crates/lex-core/src/lex/parsing/parser/grammar.rs
@@ -44,7 +44,7 @@
 //!     a few consequential marks in lines (blank, data, subject, list) having them
 //!     denormalized is required to have parsing simpler.
 //!
-//!     The definitive set is the LineType enum (blank, data marker, data, subject,
+//!     The definitive set is the LineType enum (blank, data marker, subject,
 //!     list, subject-or-list-item, paragraph, dialog, indent, dedent), and containers are
 //!     a separate structural node, not a line token.
 //!

--- a/crates/lex-core/src/lex/token/line.rs
+++ b/crates/lex-core/src/lex/token/line.rs
@@ -14,7 +14,7 @@
 //!     consequential marks in lines (blank, data, subject, list) having them denormalized is
 //!     required to have parsing simpler.
 //!
-//!     The LineType enum is the definitive set: blank, annotation start, data, subject, list,
+//!     The LineType enum is the definitive set: blank, data marker, subject, list,
 //!     subject-or-list-item, paragraph, dialog, indent, dedent. Containers are a separate
 //!     structural node, not a line token.
 //!
@@ -24,7 +24,6 @@
 //!
 //!         - BlankLine: empty or whitespace only
 //!         - DataMarkerLine: a data marker in closed form (:: label params? ::)
-//!         - DataLine: :: label params? (no closing :: marker)
 //!         - SubjectLine: Line ending with colon (could be subject/definition/session title)
 //!         - ListLine: Line starting with list marker (-, 1., a., I., etc.)
 //!         - SubjectOrListItemLine: Line starting with list marker and ending with colon
@@ -97,9 +96,6 @@ pub enum LineType {
     /// Used for both annotation headers and verbatim closing lines.
     DataMarkerLine,
 
-    /// Data line: :: label params? (no closing :: marker)
-    DataLine,
-
     /// Line ending with colon (could be subject/definition/session title)
     SubjectLine,
 
@@ -137,7 +133,6 @@ impl fmt::Display for LineType {
         let name = match self {
             LineType::BlankLine => "BLANK_LINE",
             LineType::DataMarkerLine => "DATA_MARKER_LINE",
-            LineType::DataLine => "DATA_LINE",
             LineType::SubjectLine => "SUBJECT_LINE",
             LineType::ListLine => "LIST_LINE",
             LineType::SubjectOrListItemLine => "SUBJECT_OR_LIST_ITEM_LINE",
@@ -164,7 +159,6 @@ impl LineType {
         let name = match self {
             LineType::BlankLine => "blank-line",
             LineType::DataMarkerLine => "data-marker-line",
-            LineType::DataLine => "data-line",
             LineType::SubjectLine => "subject-line",
             LineType::ListLine => "list-line",
             LineType::SubjectOrListItemLine => "subject-or-list-item-line",


### PR DESCRIPTION
## Summary

Fixes the remaining formatter round-trip residuals split out of the lex#681 umbrella, plus one new serializer bug found along the way. The format-invariant known-fail list is now **empty**.

## What changed (one commit per issue)

- **#699 — hanging-indent paragraph merge.** The tokenizer turns any indent increase into a nested `LineContainer`, so a paragraph whose continuation lines were merely more-indented was split into a sibling paragraph and re-merged on format. A new pre-pass (`fold_prose_continuations`) dissolves a *prose-only* container back into its parent level before parsing, preserving real blank-line breaks.
- **#703 (new) — annotation params lost their comma.** `:: warning type=critical, id=123 ::` re-serialized space-joined as `:: warning type=critical id=123 ::`, collapsing two params into one on reparse. Now comma-separated.
- **#700 — removed the open-form data marker.** `LineType::DataLine` (a `:: label` with no closing `::`) was consumed by nothing and silently dropped. Removed it entirely; such lines now fall through to a paragraph (Lex's "never lose content" rule), plus a new `unclosed-annotation` **Warning** diagnostic. Spec text is updated in a companion comms PR.
- **#702 — table alignment from the markdown separator row.** `:---`/`---:`/`:---:` were detected only to be discarded. Now parsed into per-column alignment during extraction; the `:: table align=… ::` parameter still overrides.

## Checklist

- [x] Changelog updated (fragments for #699, #700, #702, #703)
- [x] Project umbrella check passes locally (`cargo test --workspace --exclude lex-wasm`, fmt, clippy all green)
- [x] Tests added or updated for behavior changes

## Notes for reviewers

- Regression tests added at every layer: line classification, the new diagnostic, `parse_separator_alignments`, and round-trip invariant cases (incl. `table_separator_alignment_is_retained`, which asserts the markers actually survive — the prior case only proved symmetry).
- #703 was filed separately because it's a distinct serializer bug, not part of #699 (parameter.lex was mis-attributed to #699; its paragraph-merge half was #699, the comma half is #703).
- The comms submodule pin is intentionally **not** bumped here — the spec-text removal for #700 is a separate comms PR; this PR is green against the current pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)