### PR TITLE
feat(#659): validate extension [diagnostics.rules] keys against the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ## Unreleased
 
+### Added — extensions declare diagnostic codes; the host validates `[diagnostics.rules]` against them ([#659](https://github.com/lex-fmt/lex/issues/659))
+
+Extension-emitted `[diagnostics.rules]` entries (`<namespace>.<code>`) are now schema-validated against the resolved registry, so a misspelled or undeclared code no longer silently retunes nothing.
+
+- **Schema declares codes.** `lex_extension::schema::Schema` gains an optional `diagnostics` list — each entry carries `code`, an optional `description`, and a `default_severity` (defaulting to `warning`). The field is additive: schemas that omit it load with no declared codes, and built-in `lex.*` schemas declare none (they surface diagnostics through `lex-analysis`, not the extension code path).
+- **Registry accessor.** `Registry::declared_diagnostic_codes(namespace)` aggregates and de-dupes the codes a namespace's schemas declare, returning `None` for an unregistered namespace so callers can distinguish "unknown namespace" from "known namespace, undeclared code".
+- **Host validation.** `lex_fmt::validate_extension_diagnostic_rules` classifies each rule key: an unregistered namespace passes (rules may be staged ahead of installing the extension), a declared code passes, and an undeclared code under a registered namespace is reported as a dead letter with a closest-match "did you mean … ?" suggestion and the list of declared codes. The LSP runs this after registry boot and surfaces findings via `window/showMessage`.
+### Fixed — paragraph lines split only by indentation no longer merge on format ([#699](https://github.com/lex-fmt/lex/issues/699))
+
+A paragraph whose continuation lines were merely more-indented (alignment / hanging indent) was split into separate sibling paragraphs by the parser, then re-merged into one paragraph after formatting normalized the indent — a silent semantic change across a round-trip. Such hanging-indent continuations now fold back into the paragraph at parse time (real blank-line breaks are preserved).
+### Changed — removed the open-form data marker; unrecognized `:: label` lines are kept as text ([#700](https://github.com/lex-fmt/lex/issues/700))
+
+There was never a real "open form" of a data marker. A `:: label` with no closing `::` was classified as a distinct token that no grammar rule consumed, so the parser silently dropped such lines (and a definition whose sole body was one collapsed into a paragraph). Following Lex's rule that anything unrecognized becomes a paragraph — be forgiving, never lose content — these lines now classify as paragraph text.
+
+- **New diagnostic.** An `unclosed-annotation` Warning flags a paragraph line shaped like `:: label …` with no closing `::`, so authors know it looks like metadata but is treated as content. Configurable via `[diagnostics.rules]`.
+- `LineType::DataLine` and its classifier are removed. Closed-form `:: label ::` (annotations, verbatim closings) is unchanged.
+### Fixed — table column alignment is read from the markdown separator row ([#702](https://github.com/lex-fmt/lex/issues/702))
+
+The separator row's colon hints (`:---` left, `---:` right, `:---:` center) were detected only to be discarded; alignment was sourced solely from the `:: table align=… ::` parameter. Markdown-style aligned tables now keep their alignment across a format round-trip. The explicit `align=` parameter still overrides the separator row.
+### Fixed — annotation parameters keep their comma separator on format ([#703](https://github.com/lex-fmt/lex/issues/703))
+
+The Lex serializer joined annotation parameters with a space instead of a comma, so `:: warning type=critical, id=123 ::` re-serialized as `:: warning type=critical id=123 ::` and re-parsed to a single parameter. Parameters now re-emit comma-separated.
 ### Changed — extension diagnostic codes carry their namespace on the wire ([#657](https://github.com/lex-fmt/lex/issues/657))
 
 Follow-up to #636: `[diagnostics.rules]` now accepts extension-emitted codes (`acme.task-due-date-missing`, `mit.plasma-specs.invalid-version`) alongside built-ins, configured identically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,6 @@
 
 ## Unreleased
 
-### Added — extensions declare diagnostic codes; the host validates `[diagnostics.rules]` against them ([#659](https://github.com/lex-fmt/lex/issues/659))
-
-Extension-emitted `[diagnostics.rules]` entries (`<namespace>.<code>`) are now schema-validated against the resolved registry, so a misspelled or undeclared code no longer silently retunes nothing.
-
-- **Schema declares codes.** `lex_extension::schema::Schema` gains an optional `diagnostics` list — each entry carries `code`, an optional `description`, and a `default_severity` (defaulting to `warning`). The field is additive: schemas that omit it load with no declared codes, and built-in `lex.*` schemas declare none (they surface diagnostics through `lex-analysis`, not the extension code path).
-- **Registry accessor.** `Registry::declared_diagnostic_codes(namespace)` aggregates and de-dupes the codes a namespace's schemas declare, returning `None` for an unregistered namespace so callers can distinguish "unknown namespace" from "known namespace, undeclared code".
-- **Host validation.** `lex_fmt::validate_extension_diagnostic_rules` classifies each rule key: an unregistered namespace passes (rules may be staged ahead of installing the extension), a declared code passes, and an undeclared code under a registered namespace is reported as a dead letter with a closest-match "did you mean … ?" suggestion and the list of declared codes. The LSP runs this after registry boot and surfaces findings via `window/showMessage`.
-### Fixed — paragraph lines split only by indentation no longer merge on format ([#699](https://github.com/lex-fmt/lex/issues/699))
-
-A paragraph whose continuation lines were merely more-indented (alignment / hanging indent) was split into separate sibling paragraphs by the parser, then re-merged into one paragraph after formatting normalized the indent — a silent semantic change across a round-trip. Such hanging-indent continuations now fold back into the paragraph at parse time (real blank-line breaks are preserved).
-### Changed — removed the open-form data marker; unrecognized `:: label` lines are kept as text ([#700](https://github.com/lex-fmt/lex/issues/700))
-
-There was never a real "open form" of a data marker. A `:: label` with no closing `::` was classified as a distinct token that no grammar rule consumed, so the parser silently dropped such lines (and a definition whose sole body was one collapsed into a paragraph). Following Lex's rule that anything unrecognized becomes a paragraph — be forgiving, never lose content — these lines now classify as paragraph text.
-
-- **New diagnostic.** An `unclosed-annotation` Warning flags a paragraph line shaped like `:: label …` with no closing `::`, so authors know it looks like metadata but is treated as content. Configurable via `[diagnostics.rules]`.
-- `LineType::DataLine` and its classifier are removed. Closed-form `:: label ::` (annotations, verbatim closings) is unchanged.
-### Fixed — table column alignment is read from the markdown separator row ([#702](https://github.com/lex-fmt/lex/issues/702))
-
-The separator row's colon hints (`:---` left, `---:` right, `:---:` center) were detected only to be discarded; alignment was sourced solely from the `:: table align=… ::` parameter. Markdown-style aligned tables now keep their alignment across a format round-trip. The explicit `align=` parameter still overrides the separator row.
-### Fixed — annotation parameters keep their comma separator on format ([#703](https://github.com/lex-fmt/lex/issues/703))
-
-The Lex serializer joined annotation parameters with a space instead of a comma, so `:: warning type=critical, id=123 ::` re-serialized as `:: warning type=critical id=123 ::` and re-parsed to a single parameter. Parameters now re-emit comma-separated.
 ### Changed — extension diagnostic codes carry their namespace on the wire ([#657](https://github.com/lex-fmt/lex/issues/657))
 
 Follow-up to #636: `[diagnostics.rules]` now accepts extension-emitted codes (`acme.task-due-date-missing`, `mit.plasma-specs.invalid-version`) alongside built-ins, configured identically.

--- a/CHANGELOG/unreleased-pr-659.md
+++ b/CHANGELOG/unreleased-pr-659.md
@@ -1,0 +1,7 @@
+### Added — extensions declare diagnostic codes; the host validates `[diagnostics.rules]` against them ([#659](https://github.com/lex-fmt/lex/issues/659))
+
+Extension-emitted `[diagnostics.rules]` entries (`<namespace>.<code>`) are now schema-validated against the resolved registry, so a misspelled or undeclared code no longer silently retunes nothing.
+
+- **Schema declares codes.** `lex_extension::schema::Schema` gains an optional `diagnostics` list — each entry carries `code`, an optional `description`, and a `default_severity` (defaulting to `warning`). The field is additive: schemas that omit it load with no declared codes, and built-in `lex.*` schemas declare none (they surface diagnostics through `lex-analysis`, not the extension code path).
+- **Registry accessor.** `Registry::declared_diagnostic_codes(namespace)` aggregates and de-dupes the codes a namespace's schemas declare, returning `None` for an unregistered namespace so callers can distinguish "unknown namespace" from "known namespace, undeclared code".
+- **Host validation.** `lex_fmt::validate_extension_diagnostic_rules` classifies each rule key: an unregistered namespace passes (rules may be staged ahead of installing the extension), a declared code passes, and an undeclared code under a registered namespace is reported as a dead letter with a closest-match "did you mean … ?" suggestion and the list of declared codes. The LSP runs this after registry boot and surfaces findings via `window/showMessage`.

--- a/crates/lex-analysis/src/label_dispatch.rs
+++ b/crates/lex-analysis/src/label_dispatch.rs
@@ -604,6 +604,7 @@ mod tests {
             capabilities: Capabilities::default(),
             hooks,
             handler: None,
+            diagnostics: Vec::new(),
         }
     }
 
@@ -713,6 +714,7 @@ mod tests {
                 ..HookSet::default()
             },
             handler: None,
+            diagnostics: Vec::new(),
         };
         // Handler that should NOT be called — schema pre-validation
         // catches the missing param before dispatch.

--- a/crates/lex-babel/src/render_dispatch.rs
+++ b/crates/lex-babel/src/render_dispatch.rs
@@ -432,6 +432,7 @@ mod tests {
                 ..HookSet::default()
             },
             handler: None,
+            diagnostics: Vec::new(),
         }
     }
 

--- a/crates/lex-babel/tests/markdown/annotations.rs
+++ b/crates/lex-babel/tests/markdown/annotations.rs
@@ -111,6 +111,7 @@ fn schema(label: &str, formats: &[&str]) -> Schema {
             ..HookSet::default()
         },
         handler: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/builtins/doc.rs
+++ b/crates/lex-core/src/lex/builtins/doc.rs
@@ -79,6 +79,7 @@ fn doc_schema(label: &'static str, description: &'static str) -> Schema {
             ..HookSet::default()
         },
         handler: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/builtins/media.rs
+++ b/crates/lex-core/src/lex/builtins/media.rs
@@ -59,6 +59,7 @@ fn media_schema(
             ..HookSet::default()
         },
         handler: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/builtins/metadata.rs
+++ b/crates/lex-core/src/lex/builtins/metadata.rs
@@ -63,6 +63,7 @@ fn metadata_schema(label: &'static str, description: &'static str) -> Schema {
         capabilities: Capabilities::default(),
         hooks: HookSet::default(),
         handler: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -437,6 +437,9 @@ pub fn lex_include_schema() -> Schema {
         // Native built-ins skip the handler-spec field — the registry
         // dispatches in-process via `Box<dyn LexHandler>`.
         handler: None,
+        // Built-ins surface diagnostics through lex-analysis, not the
+        // extension diagnostic-code path, so they declare none here.
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/builtins/notes.rs
+++ b/crates/lex-core/src/lex/builtins/notes.rs
@@ -44,6 +44,7 @@ pub fn lex_notes_schema() -> Schema {
         capabilities: Capabilities::default(),
         hooks: HookSet::default(),
         handler: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -160,6 +160,7 @@ pub fn lex_tabular_table_schema() -> Schema {
             ..HookSet::default()
         },
         handler: None,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/lex-core/src/lex/includes/tests.rs
+++ b/crates/lex-core/src/lex/includes/tests.rs
@@ -1890,6 +1890,7 @@ mod registry_dispatch {
                 ..HookSet::default()
             },
             handler: None,
+            diagnostics: Vec::new(),
         }
     }
 
@@ -2193,6 +2194,7 @@ mod registry_dispatch {
                     ..HookSet::default()
                 },
                 handler: None,
+                diagnostics: Vec::new(),
             }
         }
 
@@ -2292,6 +2294,7 @@ mod registry_dispatch {
                 ..HookSet::default()
             },
             handler: None,
+            diagnostics: Vec::new(),
         };
 
         let registry = Registry::new();

--- a/crates/lex-extension-host/src/lib.rs
+++ b/crates/lex-extension-host/src/lib.rs
@@ -62,7 +62,7 @@
 //!         /* ... rest of Schema ... */
 //! #       description: None, params: Default::default(), attaches_to: vec![],
 //! #       body: Default::default(), verbatim_label: false,
-//! #       capabilities: Default::default(), handler: None,
+//! #       capabilities: Default::default(), handler: None, diagnostics: Vec::new(),
 //!     }],
 //!     Box::new(AcmeHandler),
 //! ).expect("registration ok");

--- a/crates/lex-extension-host/src/registry.rs
+++ b/crates/lex-extension-host/src/registry.rs
@@ -16,13 +16,14 @@
 //! render, and LSP-request paths. Internal state lives behind a
 //! [`RwLock`]; dispatch methods take `&self`.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::RwLock;
 
 use lex_extension::{
-    CodeAction, Completion, Diagnostic, DiagnosticSeverity, Format, FormatCtx, HandlerError, Hover,
-    LabelCtx, LexAnnotationOut, LexHandler, Range, RenderOut, Schema, WireNode,
+    CodeAction, Completion, Diagnostic, DiagnosticDecl, DiagnosticSeverity, Format, FormatCtx,
+    HandlerError, Hover, LabelCtx, LexAnnotationOut, LexHandler, Range, RenderOut, Schema,
+    WireNode,
 };
 
 /// The namespace registry.
@@ -182,6 +183,33 @@ impl Registry {
         let ns_name = inner.label_to_namespace.get(label)?;
         let ns = inner.namespaces.get(ns_name)?;
         ns.schemas.get(label).cloned()
+    }
+
+    /// Diagnostic codes declared across all of a namespace's schemas.
+    ///
+    /// Returns `None` when `namespace` isn't registered — letting callers
+    /// tell "namespace unknown, nothing to validate against" (a
+    /// forward-compatible pass-through) apart from "namespace known but
+    /// declares no such code" (a dead-letter `[diagnostics.rules]`
+    /// entry). Returns `Some(vec)` — possibly empty — for a registered
+    /// namespace.
+    ///
+    /// Codes are de-duplicated across the namespace's schemas and
+    /// returned sorted by code for stable diagnostics; the first
+    /// declaration of a given code wins on description / default
+    /// severity.
+    pub fn declared_diagnostic_codes(&self, namespace: &str) -> Option<Vec<DiagnosticDecl>> {
+        let inner = self.inner.read().expect("registry poisoned");
+        let ns = inner.namespaces.get(namespace)?;
+        let mut by_code: BTreeMap<String, DiagnosticDecl> = BTreeMap::new();
+        for schema in ns.schemas.values() {
+            for decl in &schema.diagnostics {
+                by_code
+                    .entry(decl.code.clone())
+                    .or_insert_with(|| decl.clone());
+            }
+        }
+        Some(by_code.into_values().collect())
     }
 
     /// Whether a namespace is registered and currently healthy (no panic
@@ -538,6 +566,7 @@ mod tests {
             capabilities: Capabilities::default(),
             hooks: HookSet::default(),
             handler: None,
+            diagnostics: Vec::new(),
         }
     }
 
@@ -1013,5 +1042,56 @@ mod tests {
             .expect_err("must error");
         assert_eq!(err.code.as_deref(), Some("handler.internal"));
         assert!(err.message.contains("ir_build boom"));
+    }
+
+    fn schema_with_diagnostics(label: &str, codes: &[&str]) -> Schema {
+        let mut s = schema(label);
+        s.diagnostics = codes
+            .iter()
+            .map(|c| DiagnosticDecl {
+                code: (*c).into(),
+                description: None,
+                default_severity: DiagnosticSeverity::Warning,
+            })
+            .collect();
+        s
+    }
+
+    #[test]
+    fn declared_diagnostic_codes_unknown_namespace_is_none() {
+        let r = Registry::new();
+        assert!(r.declared_diagnostic_codes("acme").is_none());
+    }
+
+    #[test]
+    fn declared_diagnostic_codes_registered_but_empty_is_some_empty() {
+        let r = Registry::new();
+        r.register_namespace("acme", vec![schema("acme.thing")], Box::new(NoOp))
+            .unwrap();
+        let codes = r.declared_diagnostic_codes("acme").expect("registered");
+        assert!(codes.is_empty());
+    }
+
+    #[test]
+    fn declared_diagnostic_codes_aggregates_dedupes_and_sorts() {
+        let r = Registry::new();
+        r.register_namespace(
+            "acme",
+            vec![
+                schema_with_diagnostics("acme.task", &["due-date-missing", "overdue"]),
+                // Second schema repeats `overdue` and adds `blocked` —
+                // the accessor de-dupes and returns sorted codes.
+                schema_with_diagnostics("acme.note", &["overdue", "blocked"]),
+            ],
+            Box::new(NoOp),
+        )
+        .unwrap();
+        let codes: Vec<String> = r
+            .declared_diagnostic_codes("acme")
+            .unwrap()
+            .into_iter()
+            .map(|d| d.code)
+            .collect();
+        assert_eq!(codes, vec!["blocked", "due-date-missing", "overdue"]);
     }
 }

--- a/crates/lex-extension-host/src/registry.rs
+++ b/crates/lex-extension-host/src/registry.rs
@@ -201,8 +201,15 @@ impl Registry {
     pub fn declared_diagnostic_codes(&self, namespace: &str) -> Option<Vec<DiagnosticDecl>> {
         let inner = self.inner.read().expect("registry poisoned");
         let ns = inner.namespaces.get(namespace)?;
+        // `schemas` is a `HashMap`, so iterate in a stable order (by
+        // label) before de-duping — otherwise "first declaration wins"
+        // would depend on hash iteration order, making the
+        // description / default-severity of a code that two schemas
+        // declare differently non-deterministic.
+        let mut schemas: Vec<&Schema> = ns.schemas.values().collect();
+        schemas.sort_by(|a, b| a.label.cmp(&b.label));
         let mut by_code: BTreeMap<String, DiagnosticDecl> = BTreeMap::new();
-        for schema in ns.schemas.values() {
+        for schema in schemas {
             for decl in &schema.diagnostics {
                 by_code
                     .entry(decl.code.clone())

--- a/crates/lex-extension-host/src/schema/loader.rs
+++ b/crates/lex-extension-host/src/schema/loader.rs
@@ -898,6 +898,11 @@ label: ns.y
                 command: Vec::new(),
                 timeout_ms: None,
             }),
+            diagnostics: vec![lex_extension::schema::DiagnosticDecl {
+                code: "thing-incomplete".into(),
+                description: Some("The thing is incomplete.".into()),
+                default_severity: lex_extension::DiagnosticSeverity::Warning,
+            }],
         };
 
         let yaml = serde_yaml::to_string(&original).expect("serialises");

--- a/crates/lex-extension/src/lib.rs
+++ b/crates/lex-extension/src/lib.rs
@@ -65,8 +65,8 @@ pub use wire::{
 };
 
 pub use schema::{
-    BodyKind, BodyPresence, BodyShape, Capabilities, EnumValue, HandlerSpec, HandlerTransport,
-    HookSet, ParamSpec, ParamType, RenderHook, Schema,
+    BodyKind, BodyPresence, BodyShape, Capabilities, DiagnosticDecl, EnumValue, HandlerSpec,
+    HandlerTransport, HookSet, ParamSpec, ParamType, RenderHook, Schema,
 };
 
 /// The wire-format protocol version exchanged in the `initialize` handshake.

--- a/crates/lex-extension/src/schema.rs
+++ b/crates/lex-extension/src/schema.rs
@@ -9,6 +9,8 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::wire::DiagnosticSeverity;
+
 /// One label's schema. Mirrors the YAML format documented in the *Extending
 /// Lex* proposal §13.2.
 ///
@@ -49,6 +51,41 @@ pub struct Schema {
     /// editor UX from the schema alone) omit this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handler: Option<HandlerSpec>,
+    /// Diagnostic codes this label's handler can emit. Declaring them
+    /// lets the host schema-validate `[diagnostics.rules]` entries
+    /// against the resolved registry — a `<namespace>.<code>` rule
+    /// whose `<code>` matches nothing declared here is a dead letter
+    /// the host can flag — and lets `config`/editor tooling surface the
+    /// available codes with their descriptions and default severity.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<DiagnosticDecl>,
+}
+
+/// One diagnostic code a namespace's handler can emit, declared in the
+/// label's schema.
+///
+/// The [`code`](Self::code) is the bare leaf (e.g.
+/// `task-due-date-missing`) — exactly what a handler stamps on the
+/// `code` field of an emitted `Diagnostic`. Combined with the owning
+/// namespace it forms the on-the-wire `<namespace>.<code>` key the user
+/// writes under `[diagnostics.rules]`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticDecl {
+    /// Bare leaf code, matching `Diagnostic.code` set by the handler.
+    pub code: String,
+    /// Human-readable summary, surfaced in config templates and editor
+    /// hover.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Intrinsic severity, used when the user hasn't overridden the
+    /// code under `[diagnostics.rules]`. Defaults to `warning`.
+    #[serde(default = "default_decl_severity")]
+    pub default_severity: DiagnosticSeverity,
+}
+
+fn default_decl_severity() -> DiagnosticSeverity {
+    DiagnosticSeverity::Warning
 }
 
 /// One parameter declaration.
@@ -301,6 +338,18 @@ mod tests {
                 command: vec!["acme-comment-handler".into()],
                 timeout_ms: Some(2000),
             }),
+            diagnostics: vec![
+                DiagnosticDecl {
+                    code: "unresolved-thread".into(),
+                    description: Some("A comment thread has no resolution.".into()),
+                    default_severity: DiagnosticSeverity::Warning,
+                },
+                DiagnosticDecl {
+                    code: "missing-author".into(),
+                    description: None,
+                    default_severity: DiagnosticSeverity::Error,
+                },
+            ],
         }
     }
 
@@ -370,5 +419,57 @@ mod tests {
         let bs = BodyShape::default();
         assert_eq!(bs.kind, BodyKind::None);
         assert_eq!(bs.presence, BodyPresence::Optional);
+    }
+
+    #[test]
+    fn schema_without_diagnostics_field_loads_empty() {
+        // Schemas that don't declare diagnostics still load — the field
+        // defaults to an empty vec, not an error.
+        let s: Schema =
+            serde_json::from_str(r#"{"schema_version": 1, "label": "acme.task"}"#).unwrap();
+        assert!(s.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn diagnostic_decl_default_severity_is_warning() {
+        // `default_severity` is optional; omitting it yields `warning`,
+        // matching the doc contract.
+        let s: Schema = serde_json::from_str(
+            r#"{"schema_version": 1, "label": "acme.task",
+                "diagnostics": [{"code": "due-date-missing"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(s.diagnostics.len(), 1);
+        assert_eq!(s.diagnostics[0].code, "due-date-missing");
+        assert_eq!(s.diagnostics[0].description, None);
+        assert_eq!(
+            s.diagnostics[0].default_severity,
+            DiagnosticSeverity::Warning
+        );
+    }
+
+    #[test]
+    fn diagnostic_decl_explicit_severity_parses() {
+        let s: Schema = serde_json::from_str(
+            r#"{"schema_version": 1, "label": "acme.task",
+                "diagnostics": [{"code": "due-date-missing",
+                                 "description": "Task lacks a due date.",
+                                 "default_severity": "error"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(s.diagnostics[0].default_severity, DiagnosticSeverity::Error);
+        assert_eq!(
+            s.diagnostics[0].description.as_deref(),
+            Some("Task lacks a due date.")
+        );
+    }
+
+    #[test]
+    fn diagnostic_decl_rejects_unknown_field() {
+        assert!(serde_json::from_str::<Schema>(
+            r#"{"schema_version": 1, "label": "acme.task",
+                "diagnostics": [{"code": "due-date-missing", "severty": "warn"}]}"#,
+        )
+        .is_err());
     }
 }

--- a/crates/lex-extension/src/schema.rs
+++ b/crates/lex-extension/src/schema.rs
@@ -78,14 +78,51 @@ pub struct DiagnosticDecl {
     /// hover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Intrinsic severity, used when the user hasn't overridden the
-    /// code under `[diagnostics.rules]`. Defaults to `warning`.
-    #[serde(default = "default_decl_severity")]
+    /// Declared intrinsic severity. This is *declaration metadata* —
+    /// surfaced by config-generation and editor tooling so authors and
+    /// users see a code's intended level. It is **not** yet read by the
+    /// runtime diagnostic pipeline: a handler-emitted diagnostic's own
+    /// `Diagnostic.severity` still determines its intrinsic severity,
+    /// and `[diagnostics.rules]` overrides apply on top of that.
+    /// Defaults to `warning`.
+    ///
+    /// Parsed strictly (unlike the permissive wire
+    /// [`DiagnosticSeverity`] deserializer): an unknown value is a
+    /// schema error, consistent with the schema loader's
+    /// `deny_unknown_fields` contract, rather than silently degrading to
+    /// `info`.
+    #[serde(
+        default = "default_decl_severity",
+        deserialize_with = "deserialize_strict_severity"
+    )]
     pub default_severity: DiagnosticSeverity,
 }
 
 fn default_decl_severity() -> DiagnosticSeverity {
     DiagnosticSeverity::Warning
+}
+
+/// Strict `default_severity` parser: accepts exactly the four known
+/// severities and rejects anything else, so a typo (`warn`, `erorr`)
+/// fails the schema load instead of deserialising to `info` the way the
+/// wire [`DiagnosticSeverity`] deserializer intentionally does for
+/// forward-compatible handler payloads.
+fn deserialize_strict_severity<'de, D>(deserializer: D) -> Result<DiagnosticSeverity, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{Error, Unexpected};
+    let s = String::deserialize(deserializer)?;
+    match s.as_str() {
+        "error" => Ok(DiagnosticSeverity::Error),
+        "warning" => Ok(DiagnosticSeverity::Warning),
+        "info" => Ok(DiagnosticSeverity::Info),
+        "hint" => Ok(DiagnosticSeverity::Hint),
+        _ => Err(D::Error::invalid_value(
+            Unexpected::Str(&s),
+            &"one of: error, warning, info, hint",
+        )),
+    }
 }
 
 /// One parameter declaration.
@@ -471,5 +508,22 @@ mod tests {
                 "diagnostics": [{"code": "due-date-missing", "severty": "warn"}]}"#,
         )
         .is_err());
+    }
+
+    #[test]
+    fn diagnostic_decl_rejects_unknown_severity_value() {
+        // Strict, unlike the permissive wire deserializer: a typo'd
+        // severity (`warn` instead of `warning`) is a schema error, not
+        // a silent downgrade to `info`.
+        for bad in [r#""warn""#, r#""erorr""#, r#""fatal""#] {
+            let src = format!(
+                r#"{{"schema_version": 1, "label": "acme.task",
+                    "diagnostics": [{{"code": "x", "default_severity": {bad}}}]}}"#
+            );
+            assert!(
+                serde_json::from_str::<Schema>(&src).is_err(),
+                "expected `{bad}` to be rejected"
+            );
+        }
     }
 }

--- a/crates/lex-fmt/src/diag_rules.rs
+++ b/crates/lex-fmt/src/diag_rules.rs
@@ -57,20 +57,25 @@ pub fn validate_extension_diagnostic_rules(
 ) -> Vec<DiagnosticRuleFinding> {
     let mut findings = Vec::new();
     for key in extension_rules.keys() {
-        // Split on the FIRST dot: `acme.task-due-date-missing` →
-        // namespace `acme`, code `task-due-date-missing`. Bare keys
-        // (no dot) can't reach this map — the config loader rejects
-        // unknown un-dotted keys under `[diagnostics.rules]` at load —
-        // so a missing dot is defensive and skipped.
-        let Some((namespace, code)) = key.split_once('.') else {
-            continue;
-        };
-        // `None` → namespace not registered → forward-compatible
-        // pass-through (the user may install the extension later).
-        let Some(declared) = registry.declared_diagnostic_codes(namespace) else {
+        // Resolve the namespace by longest registered prefix, not a
+        // first-dot split: namespaces can themselves contain dots
+        // (`mit.plasma-specs`), so `mit.plasma-specs.invalid-version`
+        // must attribute to namespace `mit.plasma-specs` / code
+        // `invalid-version`, not namespace `mit`. `None` → no registered
+        // namespace is a prefix → forward-compatible pass-through (the
+        // user may install the extension later).
+        let Some((namespace, code, declared)) = resolve_namespace(key, registry) else {
             continue;
         };
         if declared.iter().any(|d| d.code == code) {
+            continue;
+        }
+        // The per-namespace `<namespace>.diagnostic` fallback is the
+        // wire code for a handler diagnostic emitted with no explicit
+        // `code` (see `lex_analysis::diagnostics`). It's host-generated
+        // rather than schema-declared, but users legitimately target it
+        // under `[diagnostics.rules]`, so it's never a dead letter.
+        if code == HANDLER_FALLBACK_CODE {
             continue;
         }
         findings.push(DiagnosticRuleFinding {
@@ -79,6 +84,30 @@ pub fn validate_extension_diagnostic_rules(
         });
     }
     findings
+}
+
+/// Leaf code of the per-namespace handler-diagnostic fallback
+/// (`<namespace>.diagnostic`), kept in sync with
+/// `lex_analysis::diagnostics::DiagnosticKind::Handler::code`.
+const HANDLER_FALLBACK_CODE: &str = "diagnostic";
+
+/// Split `key` into `(namespace, code, declared_codes)` using the
+/// longest dotted prefix that names a registered namespace. Returns
+/// `None` when no prefix is registered.
+fn resolve_namespace<'a>(
+    key: &'a str,
+    registry: &Registry,
+) -> Option<(&'a str, &'a str, Vec<DiagnosticDecl>)> {
+    // `match_indices` yields dot positions left-to-right, so the last
+    // registered prefix we see is the longest one.
+    let mut best: Option<(usize, Vec<DiagnosticDecl>)> = None;
+    for (idx, _) in key.match_indices('.') {
+        if let Some(declared) = registry.declared_diagnostic_codes(&key[..idx]) {
+            best = Some((idx, declared));
+        }
+    }
+    let (idx, declared) = best?;
+    Some((&key[..idx], &key[idx + 1..], declared))
 }
 
 fn format_finding(namespace: &str, code: &str, declared: &[DiagnosticDecl]) -> String {
@@ -94,11 +123,18 @@ fn format_finding(namespace: &str, code: &str, declared: &[DiagnosticDecl]) -> S
             " (namespace `{namespace}` declares no diagnostic codes)"
         ));
     } else {
-        let list = declared
+        // Cap the list so a namespace with many codes doesn't produce an
+        // unreadable, multi-line editor notification.
+        const MAX_LISTED: usize = 10;
+        let mut list = declared
             .iter()
+            .take(MAX_LISTED)
             .map(|d| d.code.as_str())
             .collect::<Vec<_>>()
             .join(", ");
+        if declared.len() > MAX_LISTED {
+            list.push_str(&format!(", … (+{} more)", declared.len() - MAX_LISTED));
+        }
         msg.push_str(&format!(" (declared codes: {list})"));
     }
     msg
@@ -267,5 +303,63 @@ mod tests {
         assert_eq!(levenshtein("abc", "abd"), 1);
         assert_eq!(levenshtein("tsak", "task"), 2);
         assert_eq!(levenshtein("", "abc"), 3);
+    }
+
+    fn registry_with_dotted_namespace(codes: &[&str]) -> Registry {
+        let r = Registry::new();
+        r.register_namespace(
+            "mit.plasma-specs",
+            vec![schema_with_diagnostics("mit.plasma-specs.lint", codes)],
+            Box::new(NoOp),
+        )
+        .unwrap();
+        r
+    }
+
+    #[test]
+    fn dotted_namespace_resolves_by_longest_registered_prefix() {
+        // Namespace itself contains a dot. A first-dot split would
+        // misread the namespace as `mit`; longest-prefix resolution
+        // gets `mit.plasma-specs` / code `invalid-version`.
+        let reg = registry_with_dotted_namespace(&["invalid-version"]);
+        // Declared code under the dotted namespace → passes.
+        assert!(validate_extension_diagnostic_rules(
+            &rules(&["mit.plasma-specs.invalid-version"]),
+            &reg
+        )
+        .is_empty());
+        // Undeclared code under the dotted namespace → flagged, and the
+        // message attributes it to the full namespace.
+        let found = validate_extension_diagnostic_rules(&rules(&["mit.plasma-specs.bogus"]), &reg);
+        assert_eq!(found.len(), 1);
+        assert!(
+            found[0].message.contains("namespace `mit.plasma-specs`"),
+            "{}",
+            found[0].message
+        );
+    }
+
+    #[test]
+    fn handler_fallback_diagnostic_code_is_not_a_dead_letter() {
+        // `<namespace>.diagnostic` is the host-generated wire code for a
+        // handler diagnostic emitted with no explicit code. It's a
+        // legitimate `[diagnostics.rules]` target even though no schema
+        // declares it.
+        let reg = registry_with_acme(&["task-due-date-missing"]);
+        assert!(validate_extension_diagnostic_rules(&rules(&["acme.diagnostic"]), &reg).is_empty());
+    }
+
+    #[test]
+    fn long_declared_code_list_is_truncated_in_message() {
+        let many: Vec<String> = (0..25).map(|i| format!("code-{i:02}")).collect();
+        let refs: Vec<&str> = many.iter().map(String::as_str).collect();
+        let reg = registry_with_acme(&refs);
+        let found = validate_extension_diagnostic_rules(&rules(&["acme.nope"]), &reg);
+        assert_eq!(found.len(), 1);
+        assert!(
+            found[0].message.contains("(+15 more)"),
+            "{}",
+            found[0].message
+        );
     }
 }

--- a/crates/lex-fmt/src/diag_rules.rs
+++ b/crates/lex-fmt/src/diag_rules.rs
@@ -1,0 +1,271 @@
+//! Validate extension-emitted `[diagnostics.rules]` entries against the
+//! resolved registry.
+//!
+//! `[diagnostics.rules]` accepts two key spaces. Built-in codes
+//! (`missing_footnote`, `spellcheck`, …) are typed fields on
+//! [`lex_config::DiagnosticsRulesConfig`] — clapfig validates them at
+//! load and rejects typos. Extension codes (`<namespace>.<code>`, e.g.
+//! `acme.task-due-date-missing`) are open-ended, so they land in
+//! [`lex_config::LoadedLexConfig::extension_diagnostic_rules`]
+//! unchecked: any dotted key the loader doesn't recognise is accepted.
+//!
+//! That leniency hides a class of mistakes — a rule whose `<code>` is
+//! misspelled, or names a code the namespace never declares, silently
+//! matches nothing. The diagnostic it was meant to retune is never
+//! retuned and nothing says so. Once a namespace's schema declares its
+//! diagnostic codes (`lex_extension::schema::DiagnosticDecl`), the host
+//! can cross-check each rule against the registry and surface the dead
+//! letters.
+//!
+//! Classification of each `<namespace>.<code>` entry:
+//!
+//! - **Namespace not registered** — pass silently. Matches the labels
+//!   system's bounded-extensibility rule: users may stage rules ahead of
+//!   installing the extension that provides them.
+//! - **Namespace registered, `<code>` declared** — pass. The happy path.
+//! - **Namespace registered, `<code>` not declared** — a finding, with a
+//!   closest-match suggestion and the list of codes the namespace does
+//!   declare.
+
+use std::collections::BTreeMap;
+
+use lex_config::RuleConfig;
+use lex_extension::DiagnosticDecl;
+use lex_extension_host::Registry;
+
+/// A dead-letter `[diagnostics.rules]` entry: a `<namespace>.<code>`
+/// rule whose namespace is registered but doesn't declare the code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticRuleFinding {
+    /// The offending on-the-wire key (`<namespace>.<code>`).
+    pub key: String,
+    /// Human-readable explanation, including a suggestion when a declared
+    /// code is a near miss and the list of declared codes.
+    pub message: String,
+}
+
+/// Cross-check every extension diagnostic-rule key against the registry.
+///
+/// `extension_rules` is
+/// [`LoadedLexConfig::extension_diagnostic_rules`](lex_config::LoadedLexConfig::extension_diagnostic_rules)
+/// — the side-channel map of `<namespace>.<code>` rules the loader
+/// collected. Returns one [`DiagnosticRuleFinding`] per dead-letter
+/// entry, in the input's (sorted) key order.
+pub fn validate_extension_diagnostic_rules(
+    extension_rules: &BTreeMap<String, RuleConfig>,
+    registry: &Registry,
+) -> Vec<DiagnosticRuleFinding> {
+    let mut findings = Vec::new();
+    for key in extension_rules.keys() {
+        // Split on the FIRST dot: `acme.task-due-date-missing` →
+        // namespace `acme`, code `task-due-date-missing`. Bare keys
+        // (no dot) can't reach this map — the config loader rejects
+        // unknown un-dotted keys under `[diagnostics.rules]` at load —
+        // so a missing dot is defensive and skipped.
+        let Some((namespace, code)) = key.split_once('.') else {
+            continue;
+        };
+        // `None` → namespace not registered → forward-compatible
+        // pass-through (the user may install the extension later).
+        let Some(declared) = registry.declared_diagnostic_codes(namespace) else {
+            continue;
+        };
+        if declared.iter().any(|d| d.code == code) {
+            continue;
+        }
+        findings.push(DiagnosticRuleFinding {
+            key: key.clone(),
+            message: format_finding(namespace, code, &declared),
+        });
+    }
+    findings
+}
+
+fn format_finding(namespace: &str, code: &str, declared: &[DiagnosticDecl]) -> String {
+    let mut msg = format!(
+        "`[diagnostics.rules]` entry `{namespace}.{code}`: namespace \
+         `{namespace}` declares no diagnostic code `{code}`"
+    );
+    if let Some(suggestion) = closest_code(code, declared) {
+        msg.push_str(&format!(" — did you mean `{namespace}.{suggestion}`?"));
+    }
+    if declared.is_empty() {
+        msg.push_str(&format!(
+            " (namespace `{namespace}` declares no diagnostic codes)"
+        ));
+    } else {
+        let list = declared
+            .iter()
+            .map(|d| d.code.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        msg.push_str(&format!(" (declared codes: {list})"));
+    }
+    msg
+}
+
+/// The declared code closest to `code` by edit distance, when it's a
+/// near miss. Threshold scales with the typo'd code's length so short
+/// codes need an exact-ish match while longer ones tolerate a couple of
+/// transpositions.
+fn closest_code<'a>(code: &str, declared: &'a [DiagnosticDecl]) -> Option<&'a str> {
+    let threshold = (code.len() / 3).max(2);
+    declared
+        .iter()
+        .map(|d| (levenshtein(code, &d.code), d.code.as_str()))
+        .filter(|(dist, _)| *dist <= threshold)
+        .min_by_key(|(dist, _)| *dist)
+        .map(|(_, c)| c)
+}
+
+/// Classic two-row Levenshtein edit distance over Unicode scalar values.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut curr = vec![0usize; b_chars.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b_chars.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b_chars.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_config::Severity;
+    use lex_extension::schema::{BodyShape, Capabilities, HookSet, Schema};
+    use lex_extension::DiagnosticSeverity;
+
+    fn schema_with_diagnostics(label: &str, codes: &[&str]) -> Schema {
+        Schema {
+            schema_version: 1,
+            label: label.into(),
+            description: None,
+            params: Default::default(),
+            attaches_to: vec!["annotation".into()],
+            body: BodyShape::default(),
+            verbatim_label: false,
+            capabilities: Capabilities::default(),
+            hooks: HookSet::default(),
+            handler: None,
+            diagnostics: codes
+                .iter()
+                .map(|c| DiagnosticDecl {
+                    code: (*c).into(),
+                    description: None,
+                    default_severity: DiagnosticSeverity::Warning,
+                })
+                .collect(),
+        }
+    }
+
+    fn registry_with_acme(codes: &[&str]) -> Registry {
+        let r = Registry::new();
+        r.register_namespace(
+            "acme",
+            vec![schema_with_diagnostics("acme.task", codes)],
+            Box::new(NoOp),
+        )
+        .unwrap();
+        r
+    }
+
+    struct NoOp;
+    impl lex_extension::LexHandler for NoOp {}
+
+    fn rules(keys: &[&str]) -> BTreeMap<String, RuleConfig> {
+        keys.iter()
+            .map(|k| ((*k).into(), RuleConfig::Bare(Severity::Warn)))
+            .collect()
+    }
+
+    #[test]
+    fn declared_code_passes() {
+        let reg = registry_with_acme(&["task-due-date-missing"]);
+        let found =
+            validate_extension_diagnostic_rules(&rules(&["acme.task-due-date-missing"]), &reg);
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn unregistered_namespace_passes() {
+        // `other` was never registered — staged ahead of install,
+        // pass-through per bounded-extensibility.
+        let reg = registry_with_acme(&["task-due-date-missing"]);
+        let found = validate_extension_diagnostic_rules(&rules(&["other.whatever"]), &reg);
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn undeclared_code_is_a_finding_with_suggestion() {
+        let reg = registry_with_acme(&["task-due-date-missing"]);
+        // Transposed `tsak`.
+        let found =
+            validate_extension_diagnostic_rules(&rules(&["acme.tsak-due-date-missing"]), &reg);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].key, "acme.tsak-due-date-missing");
+        assert!(
+            found[0]
+                .message
+                .contains("did you mean `acme.task-due-date-missing`?"),
+            "missing suggestion: {}",
+            found[0].message
+        );
+        assert!(found[0]
+            .message
+            .contains("declared codes: task-due-date-missing"));
+    }
+
+    #[test]
+    fn undeclared_code_far_from_any_declared_has_no_suggestion() {
+        let reg = registry_with_acme(&["task-due-date-missing"]);
+        let found =
+            validate_extension_diagnostic_rules(&rules(&["acme.completely-different"]), &reg);
+        assert_eq!(found.len(), 1);
+        assert!(!found[0].message.contains("did you mean"));
+        assert!(found[0]
+            .message
+            .contains("declared codes: task-due-date-missing"));
+    }
+
+    #[test]
+    fn registered_namespace_with_no_declared_codes_reports_so() {
+        let reg = registry_with_acme(&[]);
+        let found = validate_extension_diagnostic_rules(&rules(&["acme.anything"]), &reg);
+        assert_eq!(found.len(), 1);
+        assert!(
+            found[0].message.contains("declares no diagnostic codes"),
+            "{}",
+            found[0].message
+        );
+        assert!(!found[0].message.contains("did you mean"));
+    }
+
+    #[test]
+    fn multiple_keys_each_classified_independently() {
+        let reg = registry_with_acme(&["overdue"]);
+        let found = validate_extension_diagnostic_rules(
+            &rules(&["acme.overdue", "acme.overdew", "other.x"]),
+            &reg,
+        );
+        // `acme.overdue` ok, `other.x` unregistered → pass; only
+        // `acme.overdew` is a dead letter.
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].key, "acme.overdew");
+        assert!(found[0].message.contains("did you mean `acme.overdue`?"));
+    }
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("abc", "abd"), 1);
+        assert_eq!(levenshtein("tsak", "task"), 2);
+        assert_eq!(levenshtein("", "abc"), 3);
+    }
+}

--- a/crates/lex-fmt/src/lib.rs
+++ b/crates/lex-fmt/src/lib.rs
@@ -43,10 +43,12 @@
 //!
 //! [`TrustPromptHandler`]: lex_extension_host::TrustPromptHandler
 
+pub mod diag_rules;
 pub mod engine;
 pub mod prompts;
 pub mod setup;
 
+pub use diag_rules::{validate_extension_diagnostic_rules, DiagnosticRuleFinding};
 pub use engine::{BuildError, Engine, EngineBuilder, ParseError, RenderError, ResolveError};
 pub use prompts::{AutoDenyPrompt, AutoTrustPrompt};
 pub use setup::{

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -435,6 +435,26 @@ where
                 .await;
         }
 
+        // Cross-check `[diagnostics.rules]` extension entries against the
+        // freshly-booted registry. A `<namespace>.<code>` rule whose
+        // namespace is registered but doesn't declare the code is a dead
+        // letter — it retunes nothing. Surface each as a warning so the
+        // misspelling is visible; like boot diagnostics, it's session
+        // status with no document range to attach to. Unregistered
+        // namespaces pass silently (the user may install the extension
+        // later), so this never fires for staged-ahead rules.
+        {
+            let cfg = self.config.read().await;
+            for finding in lex_fmt::validate_extension_diagnostic_rules(
+                &cfg.extension_diagnostic_rules,
+                &outcome.registry,
+            ) {
+                self.client
+                    .show_message(MessageType::WARNING, finding.message)
+                    .await;
+            }
+        }
+
         let state = Arc::new(LspExtensionState::from(outcome));
         *self.extension.write().await = Some(state.clone());
         Some(state)

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -443,16 +443,20 @@ where
         // status with no document range to attach to. Unregistered
         // namespaces pass silently (the user may install the extension
         // later), so this never fires for staged-ahead rules.
-        {
+        // Collect findings under the lock, then drop it before awaiting
+        // any `show_message` — holding the config read lock across the
+        // network await could starve a concurrent config write.
+        let rule_findings = {
             let cfg = self.config.read().await;
-            for finding in lex_fmt::validate_extension_diagnostic_rules(
+            lex_fmt::validate_extension_diagnostic_rules(
                 &cfg.extension_diagnostic_rules,
                 &outcome.registry,
-            ) {
-                self.client
-                    .show_message(MessageType::WARNING, finding.message)
-                    .await;
-            }
+            )
+        };
+        for finding in rule_findings {
+            self.client
+                .show_message(MessageType::WARNING, finding.message)
+                .await;
         }
 
         let state = Arc::new(LspExtensionState::from(outcome));


### PR DESCRIPTION
## Summary

Closes the core of #659: extension-emitted `[diagnostics.rules]` entries (`<namespace>.<code>`) were accepted unchecked, so a misspelled or undeclared code silently matched nothing — the diagnostic it was meant to retune never got the rule, with no warning. This makes extensions declare their diagnostic codes in their schema and has the host validate config rules against the resolved registry.

Three pieces:

- **Schema declares codes.** `lex_extension::schema::Schema` gains an optional `diagnostics: Vec<DiagnosticDecl>` (`code` + optional `description` + `default_severity`, defaulting to `warning`). Additive and `deny_unknown_fields`-safe — schemas without it load with an empty vec. Built-in `lex.*` schemas declare none (they surface diagnostics through `lex-analysis`, not the extension code path).
- **Registry exposes them.** `Registry::declared_diagnostic_codes(ns)` aggregates + de-dupes codes across a namespace's schemas. Returns `None` for an unregistered namespace so callers can tell "unknown namespace" (pass-through) from "known namespace, undeclared code" (dead letter).
- **Host validates.** `lex_fmt::validate_extension_diagnostic_rules` classifies each rule key — unregistered namespace → pass (staged-ahead-of-install, per bounded extensibility); declared code → pass; undeclared code under a registered namespace → a finding with a Levenshtein "did you mean … ?" suggestion and the list of declared codes. The LSP runs it after registry boot and surfaces findings via `window/showMessage` (the surface that actually consumes these rules via `apply_rules`).

## Scope notes

- **Gap #1 in the issue (bare-typo built-in field names) is already handled** — the earlier `clapfig::Schema` migration rejects un-dotted unknown keys under `[diagnostics.rules]` at load, so they never reach the side-channel. That issue bullet is moot; this PR covers gap #2.
- **`config gen` enumeration (issue part 3 / "Discovery Channel") is deferred** — it needs a net-new subcommand and is orthogonal to the validation logic. Tracked as follow-up.
- **Spec doc** (`comms/specs/proposals/extending-lex.lex`) update for the new `diagnostics` schema field is a separate comms-repo change; not bundled here to avoid entangling the submodule pointer.

The bulk of the line count is the mechanical `diagnostics: Vec::new(),` addition to existing `Schema {}` literals (built-ins + tests) forced by the new field.

## Checklist

- [x] Changelog updated — `CHANGELOG/unreleased-pr-659.md`
- [x] Project umbrella check passes locally — `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, full `cargo test --workspace` (all green)
- [x] Tests added — schema field (default/explicit severity, unknown-field rejection, round-trip), registry accessor (unknown/empty/dedupe-sort), and validation (declared/unregistered/undeclared+suggestion/no-suggestion/empty-namespace/multi-key + Levenshtein)

## Notes for reviewers

The validation function lives in `lex-fmt` (the only crate that depends on both `lex-config` and `lex-extension-host`) and is wired into the LSP boot path in `server.rs`. The CLI deliberately discards extension diagnostic rules today (`make_builder`), so CLI surfacing is left for the `config gen` follow-up.
