### PR TITLE
feat(core): reference anchoring — parser + AST (PR A)

### DIFF
--- a/crates/lex-core/src/lex.rs
+++ b/crates/lex-core/src/lex.rs
@@ -65,6 +65,7 @@
 //!
 //!     For the complete end-to-end pipeline documentation, see [parsing](parsing) module.
 
+pub mod anchoring;
 pub mod annotation;
 pub mod assembling;
 pub mod ast;

--- a/crates/lex-core/src/lex/anchoring.rs
+++ b/crates/lex-core/src/lex/anchoring.rs
@@ -18,10 +18,10 @@
 //! # Why this is a pre-pass
 //!
 //! A reference line is *transparent* to structural parsing (§2.3.3): it is
-//! neither a content line nor a blank line. It is removed from the line stream
-//! **before** structure is resolved, so the lines around it keep their original
-//! adjacency. This matters because a blank line after a subject is exactly what
-//! separates a *definition* from a *session*:
+//! neither a content line nor a blank line. Its tokens are removed from the
+//! token stream **before** structure is resolved, so the lines around it keep
+//! their original adjacency. This matters because a blank line after a subject
+//! is exactly what separates a *definition* from a *session*:
 //!
 //! ```text
 //! API Endpoint:
@@ -34,30 +34,74 @@
 //! reference line anchors the term "API Endpoint". Blanking it would wrongly
 //! turn it into a session.
 //!
+//! To make removal a token-stream operation (rather than a source-string edit
+//! that would shift every downstream byte offset), the pre-pass reports the
+//! **byte range of each removed reference line** — the line plus its terminating
+//! newline. The caller lexes the *original* source and drops every token whose
+//! range falls inside a removed line before parsing. The newline is included so
+//! the content line above and the line below become directly adjacent.
+//!
 //! # Coordinates
 //!
-//! Resolution runs against the *original* source, before removal, so every
-//! [`Range`] produced here is in original-source coordinates. That is what the
-//! document the user edits still contains, which is what editors (LSP
-//! `documentLink`) and serializers need.
+//! Nothing here edits the source string, and the caller parses the original
+//! source with token ranges intact, so **every AST range stays in
+//! original-source coordinates** — including elements that appear *after* a
+//! reference line. Every [`Range`] this module produces is likewise in
+//! original-source coordinates. That is what the document the user edits still
+//! contains, which is what editors (LSP `documentLink`) and serializers need.
 
 use crate::lex::ast::anchoring::{AnchoredElement, ReferenceAnchor, ReferenceLine};
 use crate::lex::ast::diagnostics::{Diagnostic, DiagnosticSeverity};
 use crate::lex::ast::range::SourceLocation;
 use crate::lex::inlines::{
-    determine_reference_type, AnchorDirection, AnchorKind, ReferenceInline, WordAnchor,
+    determine_reference_type, parse_inlines, AnchorDirection, AnchorKind, InlineNode,
+    ReferenceInline, WordAnchor,
 };
+use std::ops::Range;
 
 /// Result of the reference-line pre-pass.
 pub struct AnchoringPrepass {
-    /// Source with every reference line removed (the line plus its trailing
-    /// newline), ready to feed the structural parser. Other lines keep their
-    /// original byte content.
-    pub cleaned_source: String,
+    /// Byte ranges (in original-source coordinates) of every removed reference
+    /// line — each covers the line *plus its terminating newline*. The caller
+    /// drops every token whose range falls inside one of these ranges from the
+    /// token stream before parsing, which keeps all surviving tokens (and thus
+    /// all AST node ranges) in original-source coordinates.
+    pub removed_line_ranges: Vec<Range<usize>>,
     /// Resolved reference lines, in source order.
     pub reference_lines: Vec<ReferenceLine>,
     /// Overlap / stacking warnings (§2.3.3).
     pub diagnostics: Vec<Diagnostic>,
+}
+
+impl AnchoringPrepass {
+    /// True when no reference line was found, so the caller can skip the
+    /// token-filtering work entirely.
+    pub fn is_empty(&self) -> bool {
+        self.removed_line_ranges.is_empty()
+    }
+
+    /// Drop every token whose range starts inside a removed reference line.
+    ///
+    /// A token belongs to a removed line when its start offset lies within that
+    /// line's `[start, end)` byte range (the range includes the terminating
+    /// newline, so the line's `BlankLine`/newline token is dropped too — that is
+    /// what makes the surrounding content lines directly adjacent rather than
+    /// separated by a blank line). Tokens keep their original ranges, so the
+    /// survivors stay in original-source coordinates.
+    pub fn filter_tokens<T>(&self, tokens: Vec<(T, Range<usize>)>) -> Vec<(T, Range<usize>)> {
+        if self.removed_line_ranges.is_empty() {
+            return tokens;
+        }
+        tokens
+            .into_iter()
+            .filter(|(_, range)| {
+                !self
+                    .removed_line_ranges
+                    .iter()
+                    .any(|removed| removed.contains(&range.start))
+            })
+            .collect()
+    }
 }
 
 /// A single physical source line with its byte bounds.
@@ -317,7 +361,7 @@ pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
                         )
                         .with_code("stacked-reference-line"),
                     );
-                } else if head_line_has_inline_reference(lines[above_idx].text) {
+                } else if head_line_has_inline_reference(&lines[above_idx]) {
                     diagnostics.push(
                         Diagnostic::new(
                             reference_range.clone(),
@@ -350,27 +394,23 @@ pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
         });
     }
 
-    // Build cleaned source: keep every non-removed line verbatim, drop removed
-    // ones entirely (line + trailing newline). A reference line that self-links
-    // is *also* removed from structure (it is transparent either way); its
-    // standalone rendering is reconstructed by consumers from the collected
-    // `reference_lines` entry. This keeps the structural parser unaware of
-    // reference lines, which is the whole point of §2.3.3.
-    let cleaned_source = if reference_lines.is_empty() {
-        source.to_string()
-    } else {
-        let mut out = String::with_capacity(source.len());
-        for (idx, line) in lines.iter().enumerate() {
-            if removed[idx] {
-                continue;
-            }
-            out.push_str(&source[line.start..line.end]);
-        }
-        out
-    };
+    // Report the byte range of every removed reference line — the line *plus*
+    // its terminating newline (`line.end` already points just past the `\n`).
+    // The caller drops the tokens inside these ranges from the token stream, so
+    // a reference line that self-links is *also* removed from structure (it is
+    // transparent either way); its standalone rendering is reconstructed by
+    // consumers from the collected `reference_lines` entry. This keeps the
+    // structural parser unaware of reference lines (§2.3.3) without editing the
+    // source string, so all surviving tokens keep original-source coordinates.
+    let removed_line_ranges: Vec<Range<usize>> = lines
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| removed[*idx])
+        .map(|(_, line)| line.start..line.end)
+        .collect();
 
     AnchoringPrepass {
-        cleaned_source,
+        removed_line_ranges,
         reference_lines,
         diagnostics,
     }
@@ -394,6 +434,16 @@ pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
 pub(crate) fn resolve_word_anchors(nodes: &mut [crate::lex::inlines::InlineNode]) {
     use crate::lex::inlines::InlineNode;
 
+    // Fast path: nothing to anchor if the line carries no reference. This avoids
+    // the flatten/allocate work on the overwhelmingly common reference-free line
+    // (this runs for every `TextContent`).
+    if !nodes
+        .iter()
+        .any(|n| matches!(n, InlineNode::Reference { .. }))
+    {
+        return;
+    }
+
     // Flatten each top-level node to its plain text so word boundaries can be
     // computed across formatting spans.
     let texts: Vec<String> = nodes.iter().map(flatten_inline_text).collect();
@@ -410,21 +460,45 @@ pub(crate) fn resolve_word_anchors(nodes: &mut [crate::lex::inlines::InlineNode]
         let first_on_line = before.trim().is_empty();
         let anchor = if first_on_line {
             // Following word (only when text actually follows).
-            after.split_whitespace().next().map(|w| WordAnchor {
-                word: w.to_string(),
-                direction: AnchorDirection::Following,
-            })
+            after
+                .split_whitespace()
+                .next()
+                .and_then(clean_anchor_word)
+                .map(|word| WordAnchor {
+                    word,
+                    direction: AnchorDirection::Following,
+                })
         } else {
             // Preceding word: the last whitespace-delimited token of `before`.
-            before.split_whitespace().next_back().map(|w| WordAnchor {
-                word: w.to_string(),
-                direction: AnchorDirection::Preceding,
-            })
+            before
+                .split_whitespace()
+                .next_back()
+                .and_then(clean_anchor_word)
+                .map(|word| WordAnchor {
+                    word,
+                    direction: AnchorDirection::Preceding,
+                })
         };
 
         if let InlineNode::Reference { data, .. } = &mut nodes[i] {
             data.word_anchor = anchor;
         }
+    }
+}
+
+/// Strip surrounding punctuation from a candidate anchor word, honoring
+/// [`WordAnchor::word`]'s contract that the stored word carries no surrounding
+/// punctuation (`website, [url]` anchors `"website"`, not `"website,"`).
+///
+/// Leading and trailing non-alphanumeric characters are removed; interior
+/// punctuation (e.g. `lex.ing`, `can't`) is preserved. Returns `None` when
+/// nothing alphanumeric remains, so a punctuation-only token produces no anchor.
+fn clean_anchor_word(word: &str) -> Option<String> {
+    let cleaned = word.trim_matches(|c: char| !c.is_alphanumeric());
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned.to_string())
     }
 }
 
@@ -444,19 +518,17 @@ fn flatten_inline_text(node: &crate::lex::inlines::InlineNode) -> String {
     }
 }
 
-/// Cheap check: does a head line contain an inline `[...]` reference (something
-/// other than being a bare reference line)? Used only for the overlap warning.
-fn head_line_has_inline_reference(text: &str) -> bool {
-    // A bracketed token somewhere in the line that is *not* the whole line.
-    if let Some(open) = text.find('[') {
-        if let Some(rel_close) = text[open + 1..].find(']') {
-            let inner = &text[open + 1..open + 1 + rel_close];
-            if !inner.is_empty() && !inner.contains('[') {
-                return true;
-            }
-        }
-    }
-    false
+/// Does a head line carry a genuine inline reference? Used only for the overlap
+/// warning (§2.3.3).
+///
+/// This parses the line's inline content and inspects the resulting
+/// [`InlineNode::Reference`] nodes rather than matching brackets textually, so
+/// it does not false-positive on stray `[` characters (e.g. a verbatim subject
+/// or prose that merely contains a bracket but no real reference).
+fn head_line_has_inline_reference(line: &PhysicalLine<'_>) -> bool {
+    parse_inlines(line.text.trim())
+        .iter()
+        .any(|node| matches!(node, InlineNode::Reference { .. }))
 }
 
 #[cfg(test)]
@@ -523,6 +595,48 @@ mod tests {
         let wa = word_anchor("Hello[./file.txt] World\n\n");
         assert_eq!(wa.word, "Hello");
         assert_eq!(wa.direction, AnchorDirection::Preceding);
+    }
+
+    #[test]
+    fn inline_preceding_word_anchor_trims_trailing_punctuation() {
+        // "website, [https://x]" — the preceding token is "website," but the
+        // stored word must carry no surrounding punctuation (per the
+        // `WordAnchor::word` contract): "website".
+        let wa = word_anchor("the project website, [https://x] is fast.\n\n");
+        assert_eq!(wa.word, "website");
+        assert_eq!(wa.direction, AnchorDirection::Preceding);
+    }
+
+    #[test]
+    fn inline_following_word_anchor_trims_punctuation() {
+        // First-on-line reference, following token has trailing punctuation.
+        let wa = word_anchor("[https://x] (home) page.\n\n");
+        assert_eq!(wa.word, "home");
+        assert_eq!(wa.direction, AnchorDirection::Following);
+    }
+
+    #[test]
+    fn inline_word_anchor_preserves_interior_punctuation() {
+        // Interior dots/apostrophes are part of the word, not surrounding it.
+        let wa = word_anchor("visit lex.ing [https://lex.ing] now.\n\n");
+        assert_eq!(wa.word, "lex.ing");
+        assert_eq!(wa.direction, AnchorDirection::Preceding);
+    }
+
+    #[test]
+    fn inline_punctuation_only_neighbor_yields_no_anchor() {
+        // The token preceding the reference is punctuation-only; after trimming
+        // nothing alphanumeric remains, so no word anchor is produced.
+        let doc = parse_document("word -- [https://x] end.\n\n").unwrap();
+        let r = doc
+            .iter_all_references()
+            .find(|r| matches!(r.reference_type, ReferenceType::Url { .. }))
+            .expect("the url reference");
+        assert!(
+            r.word_anchor.is_none(),
+            "punctuation-only neighbor must not produce an anchor: {:?}",
+            r.word_anchor
+        );
     }
 
     // -- Fixture §2: reference line on a session title ---------------------
@@ -686,6 +800,27 @@ mod tests {
         assert!(doc.reference_lines[0].anchor.is_whole_element());
     }
 
+    #[test]
+    fn head_line_with_stray_bracket_does_not_warn() {
+        // The head line contains a `[` but no genuine inline reference (it is a
+        // code span, not a reference). The string/bracket heuristic used to
+        // false-positive here; the AST-based check must not fire the overlap
+        // warning.
+        let src = "Intro.\nThe array index `a[0]` matters.\n[./b.txt]\n\n";
+        let doc = parse_document(src).unwrap();
+        let warns: Vec<_> = doc
+            .diagnostics()
+            .into_iter()
+            .filter(|d| d.code.as_deref() == Some("overlapping-reference-line"))
+            .collect();
+        assert!(
+            warns.is_empty(),
+            "a stray bracket is not an inline reference: {warns:?}"
+        );
+        // The whole-line anchor is still resolved.
+        assert!(doc.reference_lines[0].anchor.is_whole_element());
+    }
+
     // -- Type-level anchoring split (§2.3.4) -----------------------------
 
     #[test]
@@ -737,6 +872,60 @@ mod tests {
         let doc = parse_document(src).unwrap();
         let range = &doc.reference_lines[0].reference_range;
         assert_eq!(&src[range.span.clone()], "[./readme.txt]");
+    }
+
+    // -- Original-coordinate invariant (regression for the cleaned-source
+    //    coordinate bug) --------------------------------------------------
+
+    /// Removing a reference line by *editing the source string* used to shift
+    /// every byte offset after it, so parsed AST nodes that followed a reference
+    /// line carried "cleaned-source" coordinates instead of original-source
+    /// ones. The token-filtering pre-pass keeps tokens at their original ranges,
+    /// so every node after a reference line must still report its position in
+    /// the ORIGINAL source.
+    ///
+    /// This asserts a later element's parsed range start equals the byte offset
+    /// of its text in the original source. It fails against the old
+    /// cleaned-source approach (the offset is short by the removed line's
+    /// length) and passes with token filtering.
+    #[test]
+    fn later_element_keeps_original_source_coordinates() {
+        // A reference line near the top, then a clearly later paragraph. The
+        // removed `[./top.txt]\n` line is 12 bytes; under the old cleaned-source
+        // approach every node after it was shifted left by 12.
+        let original =
+            "Intro paragraph here.\n[./top.txt]\n\nLater Section paragraph text.\n\n".to_string();
+
+        let doc = parse_document(&original).unwrap();
+
+        // Find the parsed paragraph whose text starts with "Later Section".
+        let later = doc
+            .root
+            .children
+            .iter()
+            .find(|c| {
+                c.text()
+                    .map(|t| t.contains("Later Section"))
+                    .unwrap_or(false)
+            })
+            .expect("a 'Later Section' element after the reference line");
+
+        let expected_start = original
+            .find("Later Section")
+            .expect("the literal text in the original source");
+
+        assert_eq!(
+            later.range().span.start,
+            expected_start,
+            "node after a reference line must carry an ORIGINAL-source offset \
+             (got {}, expected {}); a mismatch means a cleaned-source coordinate \
+             leaked into the AST",
+            later.range().span.start,
+            expected_start,
+        );
+
+        // And the slice at that range is the actual original text.
+        assert!(original[later.range().span.clone()].starts_with("Later Section"));
     }
 
     // -- Cleaned-source / no-reference-line passthrough ------------------

--- a/crates/lex-core/src/lex/anchoring.rs
+++ b/crates/lex-core/src/lex/anchoring.rs
@@ -1,0 +1,758 @@
+//! Reference-line extraction and whole-element anchor resolution.
+//!
+//! Implements §2.3.2–§2.3.4 of the references spec
+//! (`comms/specs/elements/inlines.docs/specs/references/references-general.lex`).
+//!
+//! # What a reference line is
+//!
+//! A *reference line* is a physical source line whose only content, after
+//! stripping leading indentation, is a single bracketed reference — the line is
+//! exactly `[<inner>]` with nothing else. When `<inner>` classifies to a
+//! *link-like* reference type (`Url`, `File`, `Session`, `General`; see
+//! [`ReferenceType::anchoring`]) the line takes a **whole-element anchor**: it
+//! anchors the entire head line of the element directly above it. A
+//! marker-style reference (`[1]`, `[@key]`, `[::label]`) on its own line is
+//! *not* a reference line for anchoring purposes — it self-links / resolves as
+//! usual, exactly like an inline marker.
+//!
+//! # Why this is a pre-pass
+//!
+//! A reference line is *transparent* to structural parsing (§2.3.3): it is
+//! neither a content line nor a blank line. It is removed from the line stream
+//! **before** structure is resolved, so the lines around it keep their original
+//! adjacency. This matters because a blank line after a subject is exactly what
+//! separates a *definition* from a *session*:
+//!
+//! ```text
+//! API Endpoint:
+//! [./endpoint.txt]
+//!     A URL that provides access to a resource.
+//! ```
+//!
+//! Removing (not blanking) the reference line keeps `API Endpoint:` immediately
+//! adjacent to its indented body, so it stays a **definition** and the
+//! reference line anchors the term "API Endpoint". Blanking it would wrongly
+//! turn it into a session.
+//!
+//! # Coordinates
+//!
+//! Resolution runs against the *original* source, before removal, so every
+//! [`Range`] produced here is in original-source coordinates. That is what the
+//! document the user edits still contains, which is what editors (LSP
+//! `documentLink`) and serializers need.
+
+use crate::lex::ast::anchoring::{AnchoredElement, ReferenceAnchor, ReferenceLine};
+use crate::lex::ast::diagnostics::{Diagnostic, DiagnosticSeverity};
+use crate::lex::ast::range::SourceLocation;
+use crate::lex::inlines::{
+    determine_reference_type, AnchorDirection, AnchorKind, ReferenceInline, WordAnchor,
+};
+
+/// Result of the reference-line pre-pass.
+pub struct AnchoringPrepass {
+    /// Source with every reference line removed (the line plus its trailing
+    /// newline), ready to feed the structural parser. Other lines keep their
+    /// original byte content.
+    pub cleaned_source: String,
+    /// Resolved reference lines, in source order.
+    pub reference_lines: Vec<ReferenceLine>,
+    /// Overlap / stacking warnings (§2.3.3).
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// A single physical source line with its byte bounds.
+struct PhysicalLine<'a> {
+    /// Byte offset of the first character of the line (after the previous `\n`).
+    start: usize,
+    /// Byte offset just past the line's terminating `\n` (== the line's content
+    /// end when the final line has no trailing newline).
+    end: usize,
+    /// The line's text, excluding the trailing newline.
+    text: &'a str,
+}
+
+impl PhysicalLine<'_> {
+    /// The line trimmed of surrounding whitespace.
+    fn trimmed(&self) -> &str {
+        self.text.trim()
+    }
+
+    /// True when the line has no non-whitespace content.
+    fn is_blank(&self) -> bool {
+        self.trimmed().is_empty()
+    }
+}
+
+/// Split `source` into physical lines, preserving byte bounds.
+fn physical_lines(source: &str) -> Vec<PhysicalLine<'_>> {
+    let mut lines = Vec::new();
+    let mut start = 0;
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\n' {
+            lines.push(PhysicalLine {
+                start,
+                end: i + 1,
+                text: &source[start..i],
+            });
+            start = i + 1;
+        }
+        i += 1;
+    }
+    if start < source.len() {
+        lines.push(PhysicalLine {
+            start,
+            end: source.len(),
+            text: &source[start..],
+        });
+    }
+    lines
+}
+
+/// If `trimmed` is exactly a single bracketed reference (`[<inner>]` with no
+/// other `[`/`]` and a non-empty inner), return the inner content. Otherwise
+/// `None`. The inner is returned verbatim (not trimmed) so byte math lines up.
+fn bracketed_inner(trimmed: &str) -> Option<&str> {
+    let inner = trimmed.strip_prefix('[')?.strip_suffix(']')?;
+    if inner.is_empty() || inner.contains('[') || inner.contains(']') {
+        return None;
+    }
+    Some(inner)
+}
+
+/// Derive the anchor head-line text for a content line, applying the
+/// element-specific head-line rules (§2.3.2):
+/// - list item: drop the leading list marker (`- `, `1. `, `a) `, …).
+/// - definition / session subject: drop the trailing `:` marker.
+///
+/// Returns `(anchor_text, byte_start, byte_end)` where the byte range is into
+/// the original source and covers exactly `anchor_text`.
+fn head_line_anchor(line: &PhysicalLine<'_>) -> HeadLine {
+    let text = line.text;
+    // Byte offset of the first non-indentation, non-leading-whitespace char.
+    let content_offset = text.len() - text.trim_start().len();
+    // Trimmed body (both ends) and its start offset in the original source.
+    let mut start = line.start + content_offset;
+    let mut body = text.trim();
+    let mut end = start + body.len();
+
+    let mut element = AnchoredElement::WholeLine;
+
+    // List marker: `-`, `*`, `+`, or an ordered marker like `1.` / `a)` /
+    // `I.`. We only need to strip the marker + following whitespace.
+    if let Some(marker_len) = list_marker_len(body) {
+        let after = &body[marker_len..];
+        let ws = after.len() - after.trim_start().len();
+        start += marker_len + ws;
+        body = after.trim_start();
+        end = start + body.len();
+        element = AnchoredElement::ListItem;
+    }
+
+    // Trailing `:` subject marker (definition term / session title written with
+    // a colon, verbatim subject). Strip a single trailing colon (and the
+    // whitespace before it, if any).
+    if let Some(stripped) = body.strip_suffix(':') {
+        body = stripped.trim_end();
+        end = start + body.len();
+        if element == AnchoredElement::WholeLine {
+            element = AnchoredElement::Subject;
+        }
+    }
+
+    HeadLine {
+        text: body.to_string(),
+        start,
+        end,
+        element,
+    }
+}
+
+struct HeadLine {
+    text: String,
+    start: usize,
+    end: usize,
+    element: AnchoredElement,
+}
+
+/// Length in bytes of a leading list marker on `body`, if present.
+///
+/// Recognises the unordered markers `-`, `*`, `+` and ordered markers of the
+/// form `<seq><.|)>` where `<seq>` is digits or ASCII letters (covers `1.`,
+/// `a)`, `IV.`) — matching the markers the structural parser accepts. The
+/// returned length covers the marker punctuation only (not trailing
+/// whitespace), and a marker must be followed by whitespace (so `-5` and
+/// `note:` are not markers).
+fn list_marker_len(body: &str) -> Option<usize> {
+    let first = body.chars().next()?;
+
+    // Unordered: a single bullet char followed by whitespace.
+    if matches!(first, '-' | '*' | '+') {
+        if body[first.len_utf8()..].starts_with(char::is_whitespace) {
+            return Some(first.len_utf8());
+        }
+        return None;
+    }
+
+    // Ordered: a run of alphanumerics terminated by `.` or `)`.
+    let mut seq_end = 0;
+    for (i, c) in body.char_indices() {
+        if c.is_ascii_alphanumeric() {
+            seq_end = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if seq_end == 0 {
+        return None;
+    }
+    let term = body[seq_end..].chars().next()?;
+    if matches!(term, '.' | ')') {
+        let marker_len = seq_end + term.len_utf8();
+        if marker_len == body.len() || body[marker_len..].starts_with(char::is_whitespace) {
+            return Some(marker_len);
+        }
+    }
+    None
+}
+
+/// Run the reference-line pre-pass over `source`.
+pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
+    let lines = physical_lines(source);
+    let loc = SourceLocation::new(source);
+
+    let mut reference_lines: Vec<ReferenceLine> = Vec::new();
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+    // Which line indices are reference lines, so we skip them when building the
+    // cleaned source.
+    let mut removed: Vec<bool> = vec![false; lines.len()];
+
+    // Track, per source line index, whether an element head line at that index
+    // has already been claimed by a reference line — so a second (stacked)
+    // reference line over the same element is flagged.
+    let mut anchored_line: Vec<bool> = vec![false; lines.len()];
+
+    for idx in 0..lines.len() {
+        let line = &lines[idx];
+        let trimmed = line.trimmed();
+        let Some(inner) = bracketed_inner(trimmed) else {
+            continue;
+        };
+        let reference_type = determine_reference_type(inner);
+
+        // Build the reference's range (brackets inclusive) in original coords.
+        let bracket_start = line.start + (line.text.len() - line.text.trim_start().len());
+        let bracket_end = bracket_start + trimmed.len();
+        let reference_range = loc.byte_range_to_ast_range(&(bracket_start..bracket_end));
+
+        let reference = {
+            let mut r = ReferenceInline::new(inner.to_string());
+            r.reference_type = reference_type.clone();
+            r
+        };
+
+        // Marker-style references on their own line are not reference lines for
+        // anchoring: they remain in the stream and self-link / resolve as usual.
+        if reference_type.anchoring() != AnchorKind::WholeLineCapable {
+            continue;
+        }
+
+        // This is a reference line: it is removed from the structural stream.
+        removed[idx] = true;
+
+        // Find the content line directly above (upward-only). Skipping is *not*
+        // allowed: a blank line directly above means self-link. But preceding
+        // reference lines have already been removed from the logical stream, so
+        // we look past lines we have already marked `removed` to find the
+        // nearest physical predecessor — and if that predecessor is itself a
+        // reference line we just removed, the *element* it anchored is the head
+        // line, which would now be double-anchored (stacked): flag it.
+        let mut above: Option<usize> = None;
+        let mut stacked_over: Option<usize> = None;
+        if idx > 0 {
+            let mut j = idx - 1;
+            loop {
+                if removed[j] {
+                    // A reference line directly above us: stacking. Its own
+                    // anchor target (if any) is what we'd collide on.
+                    stacked_over = Some(j);
+                    if j == 0 {
+                        break;
+                    }
+                    j -= 1;
+                    continue;
+                }
+                if lines[j].is_blank() {
+                    above = None;
+                } else {
+                    above = Some(j);
+                }
+                break;
+            }
+        }
+
+        let anchor = match above {
+            Some(above_idx) => {
+                let head = head_line_anchor(&lines[above_idx]);
+                let anchor_range = loc.byte_range_to_ast_range(&(head.start..head.end));
+
+                // Overlap diagnostics (§2.3.3): at most one reference line may
+                // anchor a given element. Two situations are illegal:
+                //  (a) the head line is already claimed by an earlier
+                //      reference line (stacked), or
+                //  (b) the head line itself carries an inline reference (a
+                //      nested link over the same text).
+                if anchored_line[above_idx] || stacked_over.is_some() {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            reference_range.clone(),
+                            DiagnosticSeverity::Warning,
+                            format!(
+                                "Multiple reference lines anchor the same element \
+                                 ('{}'); only the first is honored",
+                                head.text
+                            ),
+                        )
+                        .with_code("stacked-reference-line"),
+                    );
+                } else if head_line_has_inline_reference(lines[above_idx].text) {
+                    diagnostics.push(
+                        Diagnostic::new(
+                            reference_range.clone(),
+                            DiagnosticSeverity::Warning,
+                            format!(
+                                "Reference line anchors an element whose head line \
+                                 ('{}') already carries an inline reference; the \
+                                 whole-line anchor is honored",
+                                head.text
+                            ),
+                        )
+                        .with_code("overlapping-reference-line"),
+                    );
+                }
+
+                anchored_line[above_idx] = true;
+                ReferenceAnchor::WholeElement {
+                    anchor_text: head.text,
+                    anchor_range,
+                    element: head.element,
+                }
+            }
+            None => ReferenceAnchor::SelfLink,
+        };
+
+        reference_lines.push(ReferenceLine {
+            reference,
+            reference_range,
+            anchor,
+        });
+    }
+
+    // Build cleaned source: keep every non-removed line verbatim, drop removed
+    // ones entirely (line + trailing newline). A reference line that self-links
+    // is *also* removed from structure (it is transparent either way); its
+    // standalone rendering is reconstructed by consumers from the collected
+    // `reference_lines` entry. This keeps the structural parser unaware of
+    // reference lines, which is the whole point of §2.3.3.
+    let cleaned_source = if reference_lines.is_empty() {
+        source.to_string()
+    } else {
+        let mut out = String::with_capacity(source.len());
+        for (idx, line) in lines.iter().enumerate() {
+            if removed[idx] {
+                continue;
+            }
+            out.push_str(&source[line.start..line.end]);
+        }
+        out
+    };
+
+    AnchoringPrepass {
+        cleaned_source,
+        reference_lines,
+        diagnostics,
+    }
+}
+
+/// Resolve word anchors (§2.3.1) for every top-level inline reference in a
+/// single line's inline node sequence, mutating each `Reference` node's
+/// `word_anchor` in place.
+///
+/// Rules:
+/// - Default: the word immediately *preceding* the reference.
+/// - If the reference is the first token on the line (only whitespace before
+///   it) and text follows on the same line, the word immediately *following*.
+/// - A reference directly abutting a preceding word counts as that word
+///   (`Hello[./f] World` → "Hello") — the preceding-word logic already does
+///   this because abutting text has no whitespace before the word boundary.
+///
+/// A reference that is the only token on its line gets no word anchor (it would
+/// have been a reference line if link-like; a lone marker reference simply has
+/// no word to anchor). Whitespace-only text on one side is treated as empty.
+pub(crate) fn resolve_word_anchors(nodes: &mut [crate::lex::inlines::InlineNode]) {
+    use crate::lex::inlines::InlineNode;
+
+    // Flatten each top-level node to its plain text so word boundaries can be
+    // computed across formatting spans.
+    let texts: Vec<String> = nodes.iter().map(flatten_inline_text).collect();
+
+    let n = nodes.len();
+    for i in 0..n {
+        if !matches!(nodes[i], InlineNode::Reference { .. }) {
+            continue;
+        }
+
+        let before: String = texts[..i].concat();
+        let after: String = texts[i + 1..].concat();
+
+        let first_on_line = before.trim().is_empty();
+        let anchor = if first_on_line {
+            // Following word (only when text actually follows).
+            after.split_whitespace().next().map(|w| WordAnchor {
+                word: w.to_string(),
+                direction: AnchorDirection::Following,
+            })
+        } else {
+            // Preceding word: the last whitespace-delimited token of `before`.
+            before.split_whitespace().next_back().map(|w| WordAnchor {
+                word: w.to_string(),
+                direction: AnchorDirection::Preceding,
+            })
+        };
+
+        if let InlineNode::Reference { data, .. } = &mut nodes[i] {
+            data.word_anchor = anchor;
+        }
+    }
+}
+
+/// Flatten an inline node to its plain text content (recursing into formatting
+/// spans). References contribute no text (their bracketed content is not part
+/// of the surrounding word stream).
+fn flatten_inline_text(node: &crate::lex::inlines::InlineNode) -> String {
+    use crate::lex::inlines::InlineNode;
+    match node {
+        InlineNode::Plain { text, .. }
+        | InlineNode::Code { text, .. }
+        | InlineNode::Math { text, .. } => text.clone(),
+        InlineNode::Strong { content, .. } | InlineNode::Emphasis { content, .. } => {
+            content.iter().map(flatten_inline_text).collect()
+        }
+        InlineNode::Reference { .. } => String::new(),
+    }
+}
+
+/// Cheap check: does a head line contain an inline `[...]` reference (something
+/// other than being a bare reference line)? Used only for the overlap warning.
+fn head_line_has_inline_reference(text: &str) -> bool {
+    // A bracketed token somewhere in the line that is *not* the whole line.
+    if let Some(open) = text.find('[') {
+        if let Some(rel_close) = text[open + 1..].find(']') {
+            let inner = &text[open + 1..open + 1 + rel_close];
+            if !inner.is_empty() && !inner.contains('[') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lex::ast::traits::AstNode;
+    use crate::lex::inlines::{AnchorDirection, ReferenceType};
+    use crate::lex::parsing::parse_document;
+
+    /// Helper: resolved reference lines for a source.
+    fn ref_lines(src: &str) -> Vec<ReferenceLine> {
+        parse_document(src).unwrap().reference_lines
+    }
+
+    /// Helper: the single whole-element anchor text for a one-reference-line
+    /// source. Panics if there isn't exactly one whole-element anchor.
+    fn sole_whole_anchor(src: &str) -> (String, AnchoredElement) {
+        let lines = ref_lines(src);
+        assert_eq!(
+            lines.len(),
+            1,
+            "expected exactly one reference line: {lines:?}"
+        );
+        match &lines[0].anchor {
+            ReferenceAnchor::WholeElement {
+                anchor_text,
+                element,
+                ..
+            } => (anchor_text.clone(), *element),
+            other => panic!("expected whole-element anchor, got {other:?}"),
+        }
+    }
+
+    // -- Fixture §1: inline word anchors -----------------------------------
+
+    fn word_anchor(src: &str) -> WordAnchor {
+        let doc = parse_document(src).unwrap();
+        let r = doc
+            .iter_all_references()
+            .find(|r| r.word_anchor.is_some())
+            .expect("a reference with a word anchor");
+        r.word_anchor.clone().unwrap()
+    }
+
+    #[test]
+    fn inline_preceding_word_anchor() {
+        // "the project website [https://lex.ing] is fast."
+        let wa = word_anchor("the project website [https://lex.ing] is fast.\n\n");
+        assert_eq!(wa.word, "website");
+        assert_eq!(wa.direction, AnchorDirection::Preceding);
+    }
+
+    #[test]
+    fn inline_following_word_anchor() {
+        // "[https://lex.ing] is the home page." — first on line → following.
+        let wa = word_anchor("[https://lex.ing] is the home page.\n\n");
+        assert_eq!(wa.word, "is");
+        assert_eq!(wa.direction, AnchorDirection::Following);
+    }
+
+    #[test]
+    fn inline_abutting_word_anchor() {
+        // "Hello[./file.txt] World" — abutting → preceding "Hello".
+        let wa = word_anchor("Hello[./file.txt] World\n\n");
+        assert_eq!(wa.word, "Hello");
+        assert_eq!(wa.direction, AnchorDirection::Preceding);
+    }
+
+    // -- Fixture §2: reference line on a session title ---------------------
+
+    #[test]
+    fn reference_line_anchors_session_title() {
+        let src = "Getting Started\n[./readme.txt]\n\n    Welcome to the docs.\n\n";
+        let (anchor, _kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "Getting Started");
+        // The reference line is removed; structure is a session with a body.
+        let doc = parse_document(src).unwrap();
+        assert_eq!(doc.root.children[0].node_type(), "Session");
+    }
+
+    // -- Fixture §3: reference line on a list item ------------------------
+
+    #[test]
+    fn reference_line_anchors_list_item() {
+        let src = "- Food\n- Water\n[https://water.example]\n- Bread\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "Water");
+        assert_eq!(kind, AnchoredElement::ListItem);
+        // List structure is preserved (3 items, the reference line removed).
+        let doc = parse_document(src).unwrap();
+        assert_eq!(doc.root.children[0].node_type(), "List");
+    }
+
+    // -- Fixture §4: reference line on a definition term (transparency) ----
+
+    #[test]
+    fn reference_line_keeps_definition_a_definition() {
+        // The critical transparency case: with the reference line *removed*
+        // (not blanked), `API Endpoint:` stays adjacent to its indented body,
+        // so it remains a definition — not a session.
+        let src =
+            "API Endpoint:\n[./endpoint.txt]\n    A URL that provides access to a resource.\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "API Endpoint");
+        assert_eq!(kind, AnchoredElement::Subject);
+
+        let doc = parse_document(src).unwrap();
+        assert_eq!(
+            doc.root.children[0].node_type(),
+            "Definition",
+            "reference line must be transparent: blanking it would wrongly \
+             turn the definition into a session"
+        );
+    }
+
+    #[test]
+    fn reference_line_as_blank_would_make_a_session() {
+        // Control: the *same* source but with a genuine blank line in place of
+        // the reference line parses as a session. This pins down exactly what
+        // the transparency rule prevents.
+        let src = "API Endpoint:\n\n    A URL that provides access to a resource.\n\n";
+        let doc = parse_document(src).unwrap();
+        assert_eq!(doc.root.children[0].node_type(), "Session");
+    }
+
+    // -- Fixture §5: reference line on a verbatim subject -----------------
+
+    #[test]
+    fn reference_line_anchors_verbatim_subject() {
+        let src = "Example Source:\n[./example.rs]\n    fn main() {}\n:: rust ::\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "Example Source");
+        assert_eq!(kind, AnchoredElement::Subject);
+
+        let doc = parse_document(src).unwrap();
+        assert_eq!(doc.root.children[0].node_type(), "VerbatimBlock");
+    }
+
+    // -- Fixture §6: reference line on a paragraph -----------------------
+
+    #[test]
+    fn reference_line_anchors_paragraph_line() {
+        // A multi-line paragraph above so the line above the reference is a
+        // genuine paragraph line (not promoted to a document title).
+        let src =
+            "First paragraph line.\nThe release notes cover every change.\n[./CHANGELOG.md]\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "The release notes cover every change.");
+        assert_eq!(kind, AnchoredElement::WholeLine);
+    }
+
+    // -- Fixture §7: self-link fallback ----------------------------------
+
+    #[test]
+    fn reference_line_self_links_when_blank_above() {
+        let src = "See the upstream project:\n\n[https://github.com/lex-fmt/lex]\n\n";
+        let lines = ref_lines(src);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].anchor, ReferenceAnchor::SelfLink);
+    }
+
+    #[test]
+    fn reference_line_self_links_at_start_of_container() {
+        // First line of the document → no content above → self-link.
+        let src = "[https://lex.ing]\n\n";
+        let lines = ref_lines(src);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].anchor, ReferenceAnchor::SelfLink);
+    }
+
+    // -- Fixture §8: marker-style references on a reference line ----------
+
+    #[test]
+    fn marker_reference_on_its_own_line_is_not_a_reference_line() {
+        // `[::summary-note]` is marker-style: it does NOT take a whole-element
+        // anchor; it stays in the stream and resolves as usual.
+        let src = "Closing remarks.\n[::summary-note]\n\n:: summary-note ::\n    Resolved.\n\n";
+        let lines = ref_lines(src);
+        assert!(
+            lines.is_empty(),
+            "marker-style reference must not become a whole-element anchor: {lines:?}"
+        );
+        // It remains an inline reference in the document.
+        let doc = parse_document(src).unwrap();
+        assert!(doc
+            .iter_all_references()
+            .any(|r| matches!(r.reference_type, ReferenceType::AnnotationReference { .. })));
+    }
+
+    #[test]
+    fn footnote_on_its_own_line_is_not_a_reference_line() {
+        let src = "Some claim.\n[42]\n\n:: 42 :: A footnote.\n\n";
+        assert!(ref_lines(src).is_empty());
+    }
+
+    // -- §2.3.3: overlap / stacking diagnostics --------------------------
+
+    #[test]
+    fn stacked_reference_lines_warn_and_keep_first() {
+        // Two reference lines over the same paragraph line.
+        let src = "First line.\nClaim line here.\n[./a.txt]\n[./b.txt]\n\n";
+        let doc = parse_document(src).unwrap();
+        let lines = &doc.reference_lines;
+        assert_eq!(lines.len(), 2, "both reference lines are collected");
+        // Exactly one stacked-reference-line warning is emitted.
+        let warns: Vec<_> = doc
+            .diagnostics()
+            .into_iter()
+            .filter(|d| d.code.as_deref() == Some("stacked-reference-line"))
+            .collect();
+        assert_eq!(warns.len(), 1, "one stacking warning: {warns:?}");
+    }
+
+    #[test]
+    fn reference_line_over_head_line_with_inline_reference_warns() {
+        // The head line already carries an inline reference, so the
+        // whole-element anchor would nest two links over the same text.
+        let src = "See more here.\nVisit [https://a.example] now.\n[./b.txt]\n\n";
+        let doc = parse_document(src).unwrap();
+        let warns: Vec<_> = doc
+            .diagnostics()
+            .into_iter()
+            .filter(|d| d.code.as_deref() == Some("overlapping-reference-line"))
+            .collect();
+        assert_eq!(warns.len(), 1, "one overlap warning: {warns:?}");
+        // The whole-line anchor is still honored (§2.3.3).
+        assert!(doc.reference_lines[0].anchor.is_whole_element());
+    }
+
+    // -- Type-level anchoring split (§2.3.4) -----------------------------
+
+    #[test]
+    fn anchor_kind_split_matches_spec() {
+        use crate::lex::inlines::AnchorKind;
+        assert_eq!(
+            ReferenceType::Url { target: "x".into() }.anchoring(),
+            AnchorKind::WholeLineCapable
+        );
+        assert_eq!(
+            ReferenceType::File { target: "x".into() }.anchoring(),
+            AnchorKind::WholeLineCapable
+        );
+        assert_eq!(
+            ReferenceType::Session { target: "1".into() }.anchoring(),
+            AnchorKind::WholeLineCapable
+        );
+        assert_eq!(
+            ReferenceType::General { target: "x".into() }.anchoring(),
+            AnchorKind::WholeLineCapable
+        );
+        assert_eq!(
+            ReferenceType::FootnoteNumber { number: 1 }.anchoring(),
+            AnchorKind::MarkerOnly
+        );
+        assert_eq!(
+            ReferenceType::AnnotationReference { label: "n".into() }.anchoring(),
+            AnchorKind::MarkerOnly
+        );
+        assert_eq!(ReferenceType::NotSure.anchoring(), AnchorKind::MarkerOnly);
+    }
+
+    // -- Range fidelity ---------------------------------------------------
+
+    #[test]
+    fn anchor_range_covers_the_head_line_text() {
+        let src = "Getting Started\n[./readme.txt]\n\n    Body.\n\n";
+        let doc = parse_document(src).unwrap();
+        let ReferenceAnchor::WholeElement { anchor_range, .. } = &doc.reference_lines[0].anchor
+        else {
+            panic!("expected whole-element anchor");
+        };
+        assert_eq!(&src[anchor_range.span.clone()], "Getting Started");
+    }
+
+    #[test]
+    fn reference_range_covers_brackets_inclusive() {
+        let src = "Getting Started\n[./readme.txt]\n\n    Body.\n\n";
+        let doc = parse_document(src).unwrap();
+        let range = &doc.reference_lines[0].reference_range;
+        assert_eq!(&src[range.span.clone()], "[./readme.txt]");
+    }
+
+    // -- Cleaned-source / no-reference-line passthrough ------------------
+
+    #[test]
+    fn documents_without_reference_lines_have_empty_collection() {
+        let doc = parse_document("Just a paragraph.\n\n").unwrap();
+        assert!(doc.reference_lines.is_empty());
+        assert!(doc.reference_line_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn list_marker_stripping_handles_ordered_markers() {
+        let src = "1. First item\n[./x.txt]\n2. Second item\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "First item");
+        assert_eq!(kind, AnchoredElement::ListItem);
+    }
+}

--- a/crates/lex-core/src/lex/ast.rs
+++ b/crates/lex-core/src/lex/ast.rs
@@ -102,6 +102,7 @@
 //! out at compile time. See `docs/architecture/type-safe-containers.md` for
 //! details and compile-fail examples.
 
+pub mod anchoring;
 pub mod diagnostics;
 pub mod elements;
 pub mod error;
@@ -114,6 +115,7 @@ pub mod trait_helpers;
 pub mod traits;
 
 // Re-export commonly used types at module root
+pub use anchoring::{AnchoredElement, ReferenceAnchor, ReferenceLine};
 pub use diagnostics::{validate_references, validate_structure, Diagnostic, DiagnosticSeverity};
 pub use elements::{
     Annotation, ContentItem, Data, Definition, Document, DocumentTitle, Label, List, ListItem,

--- a/crates/lex-core/src/lex/ast/anchoring.rs
+++ b/crates/lex-core/src/lex/ast/anchoring.rs
@@ -1,0 +1,93 @@
+//! Whole-element anchoring: reference lines and their resolved anchors.
+//!
+//! A *reference line* is a line whose only content (after indentation) is a
+//! single bracketed reference, e.g. a line that is exactly `[./readme.txt]`.
+//! Per `specs/.../references-general.lex` §2.3.2–§2.3.4 such a line anchors the
+//! *entire head line of the element directly above it* (a session title, a list
+//! item's own line, a definition's subject term, a verbatim subject, or a
+//! paragraph line). It never attaches downward, and when there is no content
+//! line directly above it (first line of its container, or preceded by a blank
+//! line) it *self-links* — it stands alone and links its own text, exactly like
+//! a lone inline reference.
+//!
+//! Reference lines are removed from the line stream *before* structural parsing
+//! (see [`crate::lex::anchoring`]), so they are transparent to the
+//! definition-vs-session decision. The removal pass also resolves each line's
+//! anchor here, against the original (pre-removal) source, so every range below
+//! is in original-source coordinates — which is what editors and serializers
+//! need, since the document the user sees still contains the reference lines.
+
+use super::range::Range;
+use crate::lex::inlines::ReferenceInline;
+
+/// A reference line and its resolved anchor.
+///
+/// Collected on [`crate::lex::ast::Document`] as a queryable, document-level
+/// list (`Document::reference_lines()`), so downstream consumers — the babel
+/// serializers and the LSP `documentLink` provider — can read the anchor
+/// without re-deriving the line-adjacency rules.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReferenceLine {
+    /// The bracketed reference itself (raw text + classified type).
+    pub reference: ReferenceInline,
+    /// Source range covering the `[bracketed]` reference, in original-source
+    /// coordinates (brackets inclusive).
+    pub reference_range: Range,
+    /// The resolved anchor for this reference line.
+    pub anchor: ReferenceAnchor,
+}
+
+/// The resolved anchor of a reference line.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReferenceAnchor {
+    /// Anchors the whole head line of the element directly above.
+    WholeElement {
+        /// The element's head-line text the link wraps (list marker and the
+        /// definition's trailing `:` excluded — the head line *only*).
+        anchor_text: String,
+        /// Source range of `anchor_text`, in original-source coordinates.
+        anchor_range: Range,
+        /// What kind of element head line was anchored.
+        element: AnchoredElement,
+    },
+    /// No content line directly above: the reference line links its own text,
+    /// exactly like a lone inline reference (§2.3.2).
+    SelfLink,
+}
+
+impl ReferenceAnchor {
+    /// True when this reference line took a whole-element anchor.
+    pub fn is_whole_element(&self) -> bool {
+        matches!(self, ReferenceAnchor::WholeElement { .. })
+    }
+}
+
+/// The head-line shape a reference line anchored.
+///
+/// The anchor is resolved against the original source line directly above the
+/// reference line, so the classification reflects what that line *looks like*,
+/// which is also exactly what determines how much of it the anchor covers:
+///
+/// - [`AnchoredElement::ListItem`] — the line opens with a list marker (`- `,
+///   `1. `, `a) `, …); the marker is excluded from the anchor.
+/// - [`AnchoredElement::Subject`] — the line ends with a `:` subject marker (a
+///   definition term, a colon-style session title, or a verbatim subject); the
+///   trailing colon is excluded from the anchor.
+/// - [`AnchoredElement::WholeLine`] — any other head line (a plain paragraph
+///   line, or a session title written without a colon); the whole line is the
+///   anchor.
+///
+/// Session title vs. paragraph vs. verbatim subject are *not* distinguished
+/// here because they are indistinguishable from the head line alone and, more
+/// importantly, anchor identically (the whole line, modulo the colon rule). The
+/// behaviorally-meaningful distinctions — marker stripping and colon stripping
+/// — are the ones captured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchoredElement {
+    /// The head line opens with a list marker, excluded from the anchor.
+    ListItem,
+    /// The head line ends with a `:` subject marker, excluded from the anchor.
+    Subject,
+    /// A plain head line; the whole line is the anchor.
+    WholeLine,
+}

--- a/crates/lex-core/src/lex/ast/diagnostics.rs
+++ b/crates/lex-core/src/lex/ast/diagnostics.rs
@@ -118,6 +118,10 @@ impl Document {
         // Collect structure validation errors
         diagnostics.extend(validate_structure(self));
 
+        // Reference-line anchoring warnings (overlap / stacking, §2.3.3) are
+        // computed during parsing and stored on the document.
+        diagnostics.extend(self.reference_line_diagnostics.iter().cloned());
+
         diagnostics
     }
 }

--- a/crates/lex-core/src/lex/ast/elements/document.rs
+++ b/crates/lex-core/src/lex/ast/elements/document.rs
@@ -128,6 +128,16 @@ pub struct Document {
     pub title: Option<DocumentTitle>,
     // all content is attached to the root node
     pub root: Session,
+    /// Reference lines (whole-element anchors) extracted before structural
+    /// parsing and resolved against the original source. See
+    /// [`crate::lex::ast::anchoring`] and [`crate::lex::anchoring`].
+    ///
+    /// Empty for documents that contained no reference lines and for any
+    /// document built programmatically rather than parsed.
+    pub reference_lines: Vec<super::super::anchoring::ReferenceLine>,
+    /// Warnings produced while resolving reference-line anchors (overlap /
+    /// stacking, per §2.3.3). Surfaced through [`Document::diagnostics`].
+    pub reference_line_diagnostics: Vec<super::super::diagnostics::Diagnostic>,
 }
 
 impl Document {
@@ -136,6 +146,8 @@ impl Document {
             annotations: Vec::new(),
             title: None,
             root: Session::with_title(String::new()),
+            reference_lines: Vec::new(),
+            reference_line_diagnostics: Vec::new(),
         }
     }
 
@@ -147,6 +159,8 @@ impl Document {
             annotations: Vec::new(),
             title: None,
             root,
+            reference_lines: Vec::new(),
+            reference_line_diagnostics: Vec::new(),
         }
     }
 
@@ -156,6 +170,8 @@ impl Document {
             annotations: Vec::new(),
             title: None,
             root,
+            reference_lines: Vec::new(),
+            reference_line_diagnostics: Vec::new(),
         }
     }
 
@@ -165,6 +181,8 @@ impl Document {
             annotations: Vec::new(),
             title,
             root,
+            reference_lines: Vec::new(),
+            reference_line_diagnostics: Vec::new(),
         }
     }
 
@@ -179,12 +197,22 @@ impl Document {
             annotations,
             title: None,
             root,
+            reference_lines: Vec::new(),
+            reference_line_diagnostics: Vec::new(),
         }
     }
 
     pub fn with_root_location(mut self, location: Range) -> Self {
         self.root.location = location;
         self
+    }
+
+    /// Reference lines (whole-element anchors) resolved for this document.
+    ///
+    /// Consumed by the babel serializers and the LSP `documentLink` provider so
+    /// they can wrap the anchored head line without re-deriving §2.3 adjacency.
+    pub fn reference_lines(&self) -> &[super::super::anchoring::ReferenceLine] {
+        &self.reference_lines
     }
 
     pub fn root_session(&self) -> &Session {

--- a/crates/lex-core/src/lex/ast/elements/inlines.rs
+++ b/crates/lex-core/src/lex/ast/elements/inlines.rs
@@ -8,5 +8,6 @@ mod references;
 
 pub use base::{InlineContent, InlineNode};
 pub use references::{
-    CitationData, CitationLocator, PageFormat, PageRange, ReferenceInline, ReferenceType,
+    AnchorDirection, AnchorKind, CitationData, CitationLocator, PageFormat, PageRange,
+    ReferenceInline, ReferenceType, WordAnchor,
 };

--- a/crates/lex-core/src/lex/ast/elements/inlines/references.rs
+++ b/crates/lex-core/src/lex/ast/elements/inlines/references.rs
@@ -9,6 +9,13 @@
 pub struct ReferenceInline {
     pub raw: String,
     pub reference_type: ReferenceType,
+    /// Resolved word anchor for an inline reference (one that shares its line
+    /// with other text). Populated by the anchor-resolution pass after inline
+    /// parsing; `None` for a freshly built node, for a reference that is the
+    /// only token on its line (those are handled as reference lines), or for a
+    /// reference with no word to anchor (an empty line). See
+    /// `specs/.../references-general.lex` §2.3.1.
+    pub word_anchor: Option<WordAnchor>,
 }
 
 impl ReferenceInline {
@@ -16,8 +23,51 @@ impl ReferenceInline {
         Self {
             raw,
             reference_type: ReferenceType::NotSure,
+            word_anchor: None,
         }
     }
+}
+
+/// The word a single inline reference anchors, per §2.3.1.
+///
+/// The anchor is a single word taken from the same line as the reference:
+/// the word immediately *preceding* it (default), or — when the reference is
+/// the first token on the line and text follows — the word immediately
+/// *following* it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WordAnchor {
+    /// The anchored word text (no surrounding whitespace or punctuation kept
+    /// beyond the word itself).
+    pub word: String,
+    /// Which side of the reference the word was taken from.
+    pub direction: AnchorDirection,
+}
+
+/// Side of an inline reference its word anchor was taken from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorDirection {
+    /// The word immediately before the reference (default).
+    Preceding,
+    /// The word immediately after the reference (reference is first on line).
+    Following,
+}
+
+/// Anchor capability of a reference type, per §2.3.4.
+///
+/// Whole-element anchoring (reference lines) applies only to *link-like*
+/// references — those that render as a span of linked text. Marker-style
+/// references render as markers/superscripts, so a whole-element anchor has no
+/// visual meaning for them; on a reference line they self-link or resolve as
+/// usual. This split is a property of the reference *type*, not of position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorKind {
+    /// Renders as a span of linked text: may take a whole-element anchor when
+    /// it appears as a reference line. (Url, File, Session, General.)
+    WholeLineCapable,
+    /// Renders as a marker/superscript: never takes a whole-element anchor.
+    /// (FootnoteNumber, Citation, AnnotationReference, and the unclassified
+    /// ToCome / NotSure placeholders.)
+    MarkerOnly,
 }
 
 /// Reference type classification derived from its content.
@@ -41,6 +91,31 @@ pub enum ReferenceType {
     General { target: String },
     /// Unable to classify.
     NotSure,
+}
+
+impl ReferenceType {
+    /// Classify this reference type's anchoring capability, per §2.3.4.
+    ///
+    /// Link-like types (`Url`, `File`, `Session`, `General`) render as a span
+    /// of linked text and are therefore [`AnchorKind::WholeLineCapable`].
+    /// Marker-style types (`FootnoteNumber`, `Citation`, `AnnotationReference`)
+    /// render as markers/superscripts and are [`AnchorKind::MarkerOnly`]. The
+    /// unclassified placeholders (`ToCome`, `NotSure`) are treated as
+    /// `MarkerOnly`: a `[TK]` placeholder has no destination to link and an
+    /// unclassifiable reference must not silently consume a whole element.
+    pub fn anchoring(&self) -> AnchorKind {
+        match self {
+            ReferenceType::Url { .. }
+            | ReferenceType::File { .. }
+            | ReferenceType::Session { .. }
+            | ReferenceType::General { .. } => AnchorKind::WholeLineCapable,
+            ReferenceType::FootnoteNumber { .. }
+            | ReferenceType::Citation(_)
+            | ReferenceType::AnnotationReference { .. }
+            | ReferenceType::ToCome { .. }
+            | ReferenceType::NotSure => AnchorKind::MarkerOnly,
+        }
+    }
 }
 
 /// Structured citation payload capturing parsed information.

--- a/crates/lex-core/src/lex/ast/text_content.rs
+++ b/crates/lex-core/src/lex/ast/text_content.rs
@@ -140,6 +140,17 @@ impl TextContent {
         self.inner = TextRepresentation::Inlines { raw, nodes };
     }
 
+    /// Ensure inlines are parsed, then resolve inline word anchors (§2.3.1) on
+    /// the stored reference nodes. A `TextContent` is a single logical line, so
+    /// the surrounding-word rules apply within this run. Idempotent given the
+    /// same content.
+    pub fn ensure_inline_parsed_with_anchors(&mut self) {
+        self.ensure_inline_parsed();
+        if let TextRepresentation::Inlines { nodes, .. } = &mut self.inner {
+            crate::lex::anchoring::resolve_word_anchors(nodes);
+        }
+    }
+
     // ============================================================================
     // LSP-FRIENDLY APIS (Issue #290)
     // ============================================================================

--- a/crates/lex-core/src/lex/inlines.rs
+++ b/crates/lex-core/src/lex/inlines.rs
@@ -24,9 +24,11 @@ mod parser;
 mod references;
 
 pub use crate::lex::ast::elements::inlines::{
-    InlineContent, InlineNode, PageFormat, ReferenceInline, ReferenceType,
+    AnchorDirection, AnchorKind, InlineContent, InlineNode, PageFormat, ReferenceInline,
+    ReferenceType, WordAnchor,
 };
 pub use crate::lex::token::InlineKind;
 pub use parser::{
     parse_inlines, parse_inlines_with_parser, InlineParser, InlinePostProcessor, InlineSpec,
 };
+pub(crate) use references::determine_reference_type;

--- a/crates/lex-core/src/lex/inlines/parser.rs
+++ b/crates/lex-core/src/lex/inlines/parser.rs
@@ -456,8 +456,15 @@ fn is_valid_start(
     spec: &InlineSpec,
     parser: &InlineParser,
 ) -> bool {
-    if spec.literal {
-        // Literal elements (code, math, reference) accept any non-whitespace content.
+    if matches!(spec.kind, InlineKind::Reference) {
+        // References may abut a preceding word: `Hello[./file.txt]` anchors the
+        // word "Hello" (references-general.lex §2.3.1, "no surrounding space is
+        // required"). So unlike code/math, a reference start is allowed even
+        // when the previous char is a word char. The opening still requires
+        // non-whitespace content immediately after `[`.
+        next.is_some_and(|c| !c.is_whitespace())
+    } else if spec.literal {
+        // Literal elements (code, math) accept any non-whitespace content.
         // This allows code/math to start with \, {, (, *, etc.
         !is_word(prev) && next.is_some_and(|c| !c.is_whitespace())
     } else {

--- a/crates/lex-core/src/lex/inlines/references.rs
+++ b/crates/lex-core/src/lex/inlines/references.rs
@@ -28,7 +28,12 @@ pub(super) fn classify_reference_node(node: InlineNode) -> InlineNode {
 }
 
 /// Determine the reference type from raw content.
-fn determine_reference_type(raw: &str) -> ReferenceType {
+///
+/// Exposed to the crate so the reference-line pre-pass
+/// ([`crate::lex::anchoring`]) classifies a bracketed reference identically to
+/// the inline parser — the link-like vs marker-only split (§2.3.4) must agree
+/// between an inline `[...]` and a standalone reference line.
+pub(crate) fn determine_reference_type(raw: &str) -> ReferenceType {
     let trimmed = raw.trim();
     if trimmed.is_empty() || !trimmed.chars().any(|ch| ch.is_alphanumeric()) {
         return ReferenceType::NotSure;

--- a/crates/lex-core/src/lex/testing/ast_assertions.rs
+++ b/crates/lex-core/src/lex/testing/ast_assertions.rs
@@ -236,6 +236,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_starts_at(0, 0);
@@ -251,6 +252,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_starts_at(5, 0);
@@ -265,6 +267,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_ends_at(2, 15);
@@ -280,6 +283,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_ends_at(2, 10);
@@ -294,6 +298,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_contains(2, 5);
@@ -309,6 +314,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_contains(5, 5);
@@ -323,6 +329,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_excludes(5, 5);
@@ -338,6 +345,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc).root_location_excludes(2, 5);
@@ -352,6 +360,7 @@ mod tests {
             annotations: Vec::new(),
             title: None,
             root: session,
+            ..Document::new()
         };
 
         assert_ast(&doc)

--- a/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
+++ b/crates/lex-core/src/lex/transforms/stages/inline_parsing.rs
@@ -140,6 +140,6 @@ impl InlineProcessor {
     }
 
     fn process_text_content(&self, content: &mut TextContent) {
-        content.ensure_inline_parsed();
+        content.ensure_inline_parsed_with_anchors();
     }
 }

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -135,24 +135,31 @@ pub fn run_string_to_ast(
         s
     };
 
-    // Run lexing
-    let tokens = LEXING.run(source.clone())?;
+    // Reference-line pre-pass (§2.3): extract whole-element-anchoring reference
+    // lines and remove them from the line stream *before* structural parsing,
+    // so the surrounding lines keep their original adjacency (a reference line
+    // must not be mistaken for the blank line that separates a definition from
+    // a session). Resolution runs against the original source, so the collected
+    // ranges stay in original-source coordinates. See `crate::lex::anchoring`.
+    let prepass = crate::lex::anchoring::extract_reference_lines(&source);
+
+    // Run lexing on the cleaned source (reference lines removed).
+    let tokens = LEXING.run(prepass.cleaned_source.clone())?;
 
     // Parse to AST
     let mut output =
-        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).map_err(|e| {
-            crate::lex::transforms::TransformError::StageFailed {
+        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &prepass.cleaned_source)
+            .map_err(|e| crate::lex::transforms::TransformError::StageFailed {
                 stage: "Parser".to_string(),
                 message: e.to_string(),
-            }
-        })?;
+            })?;
 
     // Parse inline elements in root session before assembly
     output.root = ParseInlines::new().run(output.root)?;
 
     // Parse inlines in document title if present
     if let Some(ref mut title) = output.title {
-        title.content.ensure_inline_parsed();
+        title.content.ensure_inline_parsed_with_anchors();
     }
 
     // Attach root session and title to a document
@@ -170,6 +177,11 @@ pub fn run_string_to_ast(
 
     // Apply table config from :: table :: annotations (header, align)
     doc = crate::lex::assembling::stages::ApplyTableConfig::new().run(doc)?;
+
+    // Attach the reference-line pre-pass results to the document so consumers
+    // (babel serializers, LSP documentLink) can read the resolved anchors.
+    doc.reference_lines = prepass.reference_lines;
+    doc.reference_line_diagnostics = prepass.diagnostics;
 
     Ok(doc)
 }

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -135,24 +135,38 @@ pub fn run_string_to_ast(
         s
     };
 
-    // Reference-line pre-pass (§2.3): extract whole-element-anchoring reference
-    // lines and remove them from the line stream *before* structural parsing,
-    // so the surrounding lines keep their original adjacency (a reference line
-    // must not be mistaken for the blank line that separates a definition from
-    // a session). Resolution runs against the original source, so the collected
-    // ranges stay in original-source coordinates. See `crate::lex::anchoring`.
+    // Reference-line pre-pass (§2.3): identify whole-element-anchoring reference
+    // lines so their tokens can be removed from the stream *before* structural
+    // parsing — the surrounding lines then keep their original adjacency (a
+    // reference line must not be mistaken for the blank line that separates a
+    // definition from a session). See `crate::lex::anchoring`.
+    //
+    // Critically, we do *not* edit the source string. We tokenize the ORIGINAL
+    // source (so every token keeps its original byte range), drop the tokens
+    // belonging to each reference line — including each line's terminating
+    // newline, so the lines above and below become directly adjacent — and then
+    // run semantic indentation and parse against the original source. The result
+    // is that every AST node range stays in original-source coordinates, even
+    // for elements that appear *after* a reference line. (Editing the source
+    // string instead would shift every downstream offset into a "cleaned-source"
+    // coordinate system that no longer matches what the editor holds.)
     let prepass = crate::lex::anchoring::extract_reference_lines(&source);
 
-    // Run lexing on the cleaned source (reference lines removed).
-    let tokens = LEXING.run(prepass.cleaned_source.clone())?;
+    // Core tokenization on the original source (flat tokens, original ranges),
+    // then drop the reference-line tokens, then semantic indentation.
+    let core_tokens = CoreTokenization::new().run(source.clone())?;
+    let core_tokens = prepass.filter_tokens(core_tokens);
+    let tokens = SemanticIndentation::new().run(core_tokens)?;
 
-    // Parse to AST
+    // Parse to AST against the original source (keeps location tracking in
+    // original-source coordinates).
     let mut output =
-        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &prepass.cleaned_source)
-            .map_err(|e| crate::lex::transforms::TransformError::StageFailed {
+        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).map_err(|e| {
+            crate::lex::transforms::TransformError::StageFailed {
                 stage: "Parser".to_string(),
                 message: e.to_string(),
-            })?;
+            }
+        })?;
 
     // Parse inline elements in root session before assembly
     output.root = ParseInlines::new().run(output.root)?;

--- a/crates/lex-core/tests/integration/main.rs
+++ b/crates/lex-core/tests/integration/main.rs
@@ -18,6 +18,7 @@ mod location_integrity;
 mod parser;
 mod parser_kitchensink;
 mod parser_regression;
+mod reference_anchoring;
 mod runtime_type_safety;
 mod spec_documents;
 mod spec_validation;

--- a/crates/lex-core/tests/integration/reference_anchoring.rs
+++ b/crates/lex-core/tests/integration/reference_anchoring.rs
@@ -1,0 +1,163 @@
+//! Integration tests for whole-element / word anchoring of references.
+//!
+//! Pins the resolved anchor for every case in the canonical comms fixture
+//! `comms/specs/elements/inlines.docs/specs/references/reference-anchoring.lex`
+//! (the authoritative behavior spec is §2.3 of `references-general.lex`).
+//!
+//! The fixture is a *documentation* `.lex` file: each example is shown inside a
+//! 4-space-indented illustration block, so parsing the whole file does not
+//! surface the examples as top-level reference lines. These tests therefore
+//! exercise the canonical snippets directly through the parser (the same text
+//! that appears in the fixture), and additionally assert that the fixture file
+//! itself parses cleanly.
+
+use lex_core::lex::ast::anchoring::{AnchoredElement, ReferenceAnchor};
+use lex_core::lex::ast::traits::AstNode;
+use lex_core::lex::inlines::AnchorDirection;
+use lex_core::lex::parsing::parse_document;
+use lex_core::lex::testing::workspace_path;
+
+const FIXTURE: &str = "comms/specs/elements/inlines.docs/specs/references/reference-anchoring.lex";
+
+fn whole_anchor(src: &str) -> (String, AnchoredElement) {
+    let doc = parse_document(src).unwrap();
+    assert_eq!(
+        doc.reference_lines.len(),
+        1,
+        "expected one reference line in {src:?}, got {:?}",
+        doc.reference_lines
+    );
+    match &doc.reference_lines[0].anchor {
+        ReferenceAnchor::WholeElement {
+            anchor_text,
+            element,
+            ..
+        } => (anchor_text.clone(), *element),
+        other => panic!("expected whole-element anchor, got {other:?}"),
+    }
+}
+
+#[test]
+fn fixture_file_exists_and_parses() {
+    let path = workspace_path(FIXTURE);
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    assert!(source.contains("Reference Anchoring Fixture"));
+    parse_document(&source).expect("fixture parses");
+}
+
+// Fixture §1 — inline word anchors.
+
+#[test]
+fn fixture_1_preceding_word() {
+    let doc = parse_document("the project website [https://lex.ing] is fast.\n\n").unwrap();
+    let wa = doc
+        .iter_all_references()
+        .find_map(|r| r.word_anchor.clone())
+        .unwrap();
+    assert_eq!(wa.word, "website");
+    assert_eq!(wa.direction, AnchorDirection::Preceding);
+}
+
+#[test]
+fn fixture_1_following_word() {
+    let doc = parse_document("[https://lex.ing] is the home page.\n\n").unwrap();
+    let wa = doc
+        .iter_all_references()
+        .find_map(|r| r.word_anchor.clone())
+        .unwrap();
+    assert_eq!(wa.word, "is");
+    assert_eq!(wa.direction, AnchorDirection::Following);
+}
+
+#[test]
+fn fixture_1_explicit_single_word() {
+    let doc = parse_document("Hello[./file.txt] World\n\n").unwrap();
+    let wa = doc
+        .iter_all_references()
+        .find_map(|r| r.word_anchor.clone())
+        .unwrap();
+    assert_eq!(wa.word, "Hello");
+    assert_eq!(wa.direction, AnchorDirection::Preceding);
+}
+
+// Fixture §2 — reference line on a session title.
+
+#[test]
+fn fixture_2_session_title() {
+    let (anchor, _) =
+        whole_anchor("Getting Started\n[./readme.txt]\n\n    Welcome to the docs.\n\n");
+    assert_eq!(anchor, "Getting Started");
+}
+
+// Fixture §3 — reference line on a list item.
+
+#[test]
+fn fixture_3_list_item() {
+    let (anchor, kind) = whole_anchor("- Food\n- Water\n[https://water.example]\n- Bread\n\n");
+    assert_eq!(anchor, "Water");
+    assert_eq!(kind, AnchoredElement::ListItem);
+}
+
+// Fixture §4 — reference line on a definition term (transparency).
+
+#[test]
+fn fixture_4_definition_term_transparent() {
+    let src = "API Endpoint:\n[./endpoint.txt]\n    A URL that provides access to a resource.\n\n";
+    let (anchor, kind) = whole_anchor(src);
+    assert_eq!(anchor, "API Endpoint");
+    assert_eq!(kind, AnchoredElement::Subject);
+    let doc = parse_document(src).unwrap();
+    assert_eq!(doc.root.children[0].node_type(), "Definition");
+}
+
+// Fixture §5 — reference line on a verbatim subject.
+
+#[test]
+fn fixture_5_verbatim_subject() {
+    let src =
+        "Example Source:\n[./example.rs]\n    fn main() {\n        ok();\n    }\n:: rust ::\n\n";
+    let (anchor, kind) = whole_anchor(src);
+    assert_eq!(anchor, "Example Source");
+    assert_eq!(kind, AnchoredElement::Subject);
+    let doc = parse_document(src).unwrap();
+    assert_eq!(doc.root.children[0].node_type(), "VerbatimBlock");
+}
+
+// Fixture §6 — reference line on a paragraph.
+
+#[test]
+fn fixture_6_paragraph_line() {
+    let src =
+        "First line of notes.\nThe release notes cover every change in this cycle.\n[./CHANGELOG.md]\n\n";
+    let (anchor, kind) = whole_anchor(src);
+    assert_eq!(
+        anchor,
+        "The release notes cover every change in this cycle."
+    );
+    assert_eq!(kind, AnchoredElement::WholeLine);
+}
+
+// Fixture §7 — self-link fallback.
+
+#[test]
+fn fixture_7_self_link() {
+    let src = "There is no content line directly above:\n\n[https://github.com/lex-fmt/lex]\n\n";
+    let doc = parse_document(src).unwrap();
+    assert_eq!(doc.reference_lines.len(), 1);
+    assert_eq!(doc.reference_lines[0].anchor, ReferenceAnchor::SelfLink);
+}
+
+// Fixture §8 — marker-style references on a reference line.
+
+#[test]
+fn fixture_8_marker_style_not_a_reference_line() {
+    let src =
+        "Closing remarks.\n[::summary-note]\n\n:: summary-note ::\n    Resolved by label.\n\n";
+    let doc = parse_document(src).unwrap();
+    assert!(
+        doc.reference_lines.is_empty(),
+        "marker-style reference must not take a whole-element anchor: {:?}",
+        doc.reference_lines
+    );
+}


### PR DESCRIPTION
PR A of the 3-PR reference-anchoring feature: the **parser + AST** changes only. Babel (HTML/MD serializers) and LSP (documentLink) are PRs B and C and are untouched here beyond keeping the workspace compiling.

Implements `references-general.lex` §2.3 (whole-element anchors via reference lines, and inline word anchors).

## Architecture

**Two pieces, exactly as the spec frames it.**

1. **Pre-structural pre-pass** (`crate::lex::anchoring::extract_reference_lines`, run before `LEXING` in `run_string_to_ast`): operates on the *original* source. Detects reference lines (a physical line whose entire trimmed content is a single link-like `[...]`), resolves each one's anchor against the **content line directly above** (upward-only; self-link when that line is blank or absent), and removes the reference lines from the source handed to the structural parser. **Removal, not blanking** — this is what preserves the no-blank-line adjacency that distinguishes a definition from a session (§2.3.3). The `API Endpoint:` case stays a `Definition`; a test pins this, with a control asserting that a *real* blank line in the same spot yields a `Session`.

2. **Resolution** happens in that same pre-pass (against original source, so all ranges are original-source coordinates — what editors/serializers consume). Word anchors (§2.3.1) are resolved separately, per line, right after inline parsing.

## AST shape

- `ReferenceType::anchoring() -> AnchorKind` — the **type-level** link-like vs marker-like split (§2.3.4): `Url`/`File`/`Session`/`General` are `WholeLineCapable`; `FootnoteNumber`/`Citation`/`AnnotationReference` plus the `ToCome`/`NotSure` placeholders are `MarkerOnly`. No ad-hoc string matching.
- `ReferenceInline.word_anchor: Option<WordAnchor>` — the resolved inline word anchor (`{ word, direction: Preceding | Following }`), populated by the inline pass.
- `ast::anchoring`: `ReferenceLine { reference, reference_range, anchor }` and `ReferenceAnchor { WholeElement { anchor_text, anchor_range, element } | SelfLink }`, with `AnchoredElement` (`ListItem` | `Subject` | `WholeLine`) capturing the behaviorally-meaningful head-line shape (marker stripped / trailing-colon stripped / whole line).
- `Document.reference_lines` + `Document.reference_line_diagnostics`, exposed via `Document::reference_lines()`; `Document::diagnostics()` now includes the anchoring warnings.

This is how PR B/C consume the data: `doc.reference_lines()` gives them the anchor text + original-source range per reference line without re-deriving the §2.3 adjacency rules, and each inline `ReferenceInline` carries its `word_anchor`.

## Diagnostics

Stacked reference lines, and a reference line whose anchored head line already carries an inline reference, emit a **warning** (`stacked-reference-line` / `overlapping-reference-line`) while still honoring the whole-line anchor — no hard error, no panic.

## Inline-parser change

A reference may now abut a preceding word (`Hello[./file.txt]` → anchors "Hello"), per §2.3.1 "no surrounding space is required". Scoped to `[` references only — code/math start rules are unchanged. No existing tests regressed.

## Tests

- Unit tests in `crate::lex::anchoring` (20) covering all 8 fixture sections, the transparency case + control, self-link fallback, overlap/stacked warnings, range fidelity, and the `AnchorKind` split.
- Integration tests in `reference_anchoring.rs` (11) pinning the §1–§8 cases through the full parser and asserting the canonical comms fixture parses.
- Full workspace: **2444 passed, 0 failed**. `cargo fmt` + `cargo clippy` clean.

## Out of scope (PR B/C)

No changes to babel serializers' anchoring output or the LSP `documentLink` range logic — only the anchor data they will read is exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)