### PR TITLE
fix(core): route migrate-labels through the canonical parse pipeline (#724)

### DIFF
--- a/crates/lex-core/src/lex/migrate.rs
+++ b/crates/lex-core/src/lex/migrate.rs
@@ -28,17 +28,13 @@
 //! and rewrite the source in reverse byte order. No re-parsing, no
 //! regex heuristics, no ambiguity.
 
-use crate::lex::assembling::stages::{
-    ApplyTableConfig, AttachAnnotations, AttachRoot, NormalizeLabels,
-};
+use crate::lex::assembling::stages::normalize_labels::Mode;
 use crate::lex::ast::elements::annotation::Annotation;
 use crate::lex::ast::elements::content_item::ContentItem;
 use crate::lex::ast::elements::label::Label;
 use crate::lex::ast::elements::verbatim::Verbatim;
 use crate::lex::ast::Document;
-use crate::lex::transforms::stages::ParseInlines;
-use crate::lex::transforms::standard::LEXING;
-use crate::lex::transforms::Runnable;
+use crate::lex::transforms::standard::run_string_to_ast;
 
 /// Mapping of legacy label inputs to the canonical they migrate to.
 /// Local to the migration tool — the parse-time `NormalizeLabels` no
@@ -113,11 +109,16 @@ impl MigrationOutcome {
 /// from the parser are ignored; only hard parse errors abort.
 pub fn migrate_labels_in_source(src: &str) -> Result<MigrationOutcome, MigrationError> {
     // Strict-mode parse rejects legacy `doc.*` and bare non-shortcuts —
-    // exactly the inputs the migration tool needs to rewrite. Run a
-    // permissive pipeline so legacy spellings survive into the AST,
-    // then walk it to map source spans onto the rewrite table.
-    let doc = parse_permissive(src).map_err(|e| MigrationError::ParseFailed {
-        message: e.to_string(),
+    // exactly the inputs the migration tool needs to rewrite. Run the
+    // canonical pipeline in permissive mode so legacy spellings survive
+    // into the AST, then walk it to map source spans onto the rewrite
+    // table. Routing through `run_string_to_ast` (rather than a local
+    // copy of the stage sequence) keeps the migration parse in lockstep
+    // with every other parse path — see #724.
+    let doc = run_string_to_ast(src.to_string(), Mode::Permissive).map_err(|e| {
+        MigrationError::ParseFailed {
+            message: e.to_string(),
+        }
     })?;
 
     let mut sites = Vec::new();
@@ -128,35 +129,6 @@ pub fn migrate_labels_in_source(src: &str) -> Result<MigrationOutcome, Migration
         rewritten,
         migrations: sites,
     })
-}
-
-/// Run the parse + assembly stages with NormalizeLabels in permissive
-/// mode so legacy label spellings (`doc.*`, bare non-shortcut metadata)
-/// flow through unchanged. Mirrors `STRING_TO_AST` exactly except for
-/// the NormalizeLabels constructor.
-fn parse_permissive(src: &str) -> Result<Document, crate::lex::transforms::TransformError> {
-    let source = if !src.is_empty() && !src.ends_with('\n') {
-        format!("{src}\n")
-    } else {
-        src.to_string()
-    };
-    let tokens = LEXING.run(source.clone())?;
-    let mut output =
-        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).map_err(|e| {
-            crate::lex::transforms::TransformError::StageFailed {
-                stage: "Parser".to_string(),
-                message: e.to_string(),
-            }
-        })?;
-    output.root = ParseInlines::new().run(output.root)?;
-    if let Some(ref mut title) = output.title {
-        title.content.ensure_inline_parsed();
-    }
-    let mut doc = AttachRoot::new().run(output)?;
-    doc = AttachAnnotations::new().run(doc)?;
-    doc = NormalizeLabels::permissive().run(doc)?;
-    doc = ApplyTableConfig::new().run(doc)?;
-    Ok(doc)
 }
 
 /// Errors surfaced by [`migrate_labels_in_source`].
@@ -383,6 +355,37 @@ mod tests {
                 out.rewritten
             );
         }
+    }
+
+    #[test]
+    fn reference_line_document_migrates_through_canonical_pipeline() {
+        // Regression for #724 (follow-up to #722). `migrate-labels` used
+        // to run a hand-rolled copy of the parser front-end that lacked
+        // the reference-line pre-pass, so a whole-element reference line
+        // (`[#2]` on its own line) mis-parsed the surrounding structure
+        // — the list collapsed into a paragraph. The migration now
+        // routes through the canonical `run_string_to_ast(_, Permissive)`,
+        // so reference-line documents parse the same as every other path.
+        //
+        // The document combines a whole-element reference line with a
+        // legacy `:: doc.image ::` annotation. Migration must still find
+        // and rewrite the legacy label, and must leave the reference line
+        // untouched in the output.
+        let src = "- Apple\n[#2]\n- Banana\n\n:: doc.image :: photo.png\n";
+        let out = migrate_labels_in_source(src).expect("migrate ok");
+
+        assert!(out.is_modified(), "legacy doc.image must migrate");
+        assert_eq!(out.migrations.len(), 1);
+        assert_eq!(out.migrations[0].from, "doc.image");
+        assert_eq!(out.migrations[0].to, "image");
+        // Reference line preserved verbatim; label rewritten in place.
+        assert!(
+            out.rewritten.contains("[#2]"),
+            "reference line must survive migration verbatim, got: {}",
+            out.rewritten
+        );
+        assert!(out.rewritten.contains(":: image :: photo.png"));
+        assert!(!out.rewritten.contains(":: doc.image ::"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes Finding 1 of #724: removes the third hand-rolled copy of the source→`Document` parser front-end.

`crates/lex-core/src/lex/migrate.rs::parse_permissive` was a near-complete clone of the canonical `run_string_to_ast`. Its own doc comment claimed it *"mirrors `STRING_TO_AST` exactly except for the NormalizeLabels constructor"* — but it had **already drifted on two stages**:

| Stage | `run_string_to_ast` (canonical) | `parse_permissive` (deleted) |
|---|---|---|
| `extract_reference_lines` pre-pass | ✅ | ❌ missing |
| ref-line token filtering | ✅ | ❌ missing |
| title inlines | `ensure_inline_parsed_with_anchors()` | `ensure_inline_parsed()` ❌ |
| `doc.reference_lines` set | ✅ | ❌ |

This is the same anti-pattern as #722 (a later-added stage landed only in the canonical copy). Because `parse_permissive` fed `migrate_labels_in_source` ← the `lexd migrate-labels` CLI command, migrating a document containing a whole-element reference line mis-parsed its structure.

## How

`run_string_to_ast` already takes a `label_mode: Mode` parameter, so permissive normalization — `parse_permissive`'s only reason to exist — is a first-class parameter of the canonical function. The fix deletes `parse_permissive` outright and calls `run_string_to_ast(src, Mode::Permissive)` at the single call site. No new abstraction; just one fewer place the front-end stage sequence can drift.

Adds a `migrate-labels` regression test exercising a reference-line document alongside a legacy label.

## Scope

This PR is **only Finding 1** of #724 — the self-contained, independently-correct piece. The remaining findings are intentionally left out:
- **Findings 2 & 3** (relocating `parse_without_annotation_attachment` out of `testing`; lex-fmt / LSP includes-path regression tests) belong to #722's larger front-end de-dup, since they hinge on factoring `resolve_from_source` through the shared front-end.
- **Finding 4** (a unified `load_document` helper in lex-cli) is marked optional/separable in the issue.

## Test

- `cargo test -p lex-core --lib` → 874 passed (incl. new `reference_line_document_migrates_through_canonical_pipeline`)
- `cargo clippy -p lex-core` clean; `cargo check --workspace --exclude lex-wasm` clean

Refs #724, #722.

https://claude.ai/code/session_01DiVTYN5346CXhTkebSkE89

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiVTYN5346CXhTkebSkE89)_