### PR TITLE
refactor(babel): drop legacy session-based footnote migration (#729)

### DIFF
--- a/crates/lex-babel/src/transforms.rs
+++ b/crates/lex-babel/src/transforms.rs
@@ -7,8 +7,7 @@
 use crate::format::Format;
 use crate::formats::lex::formatting_rules::FormattingRules;
 use crate::formats::lex::LexFormat;
-use lex_core::lex::ast::elements::typed_content::ContentElement;
-use lex_core::lex::ast::{ContentItem, Document, List, ListItem, Session};
+use lex_core::lex::ast::Document;
 
 /// Serialize a Document to Lex format with default formatting rules
 ///
@@ -72,136 +71,17 @@ pub fn serialize_to_lex_with_rules(
 pub fn format_lex_source(source: &str) -> Result<String, String> {
     use lex_core::lex::transforms::standard::STRING_TO_AST;
 
-    let mut doc = STRING_TO_AST
+    let doc = STRING_TO_AST
         .run(source.to_string())
         .map_err(|e| e.to_string())?;
 
-    normalize_footnotes(&mut doc);
-
     serialize_to_lex(&doc)
-}
-
-/// Normalizes footnote definitions in a document from session-based format to list-based format.
-///
-/// Lex supports two formats for footnotes:
-/// 1. **Session-based** (legacy): Each note is a child session with title "1. Note content"
-/// 2. **List-based** (preferred): Notes are list items within a Notes/Footnotes session
-///
-/// This function converts session-based footnotes to list-based format during formatting,
-/// producing cleaner, more compact output.
-fn normalize_footnotes(doc: &mut Document) {
-    if let Some(ContentItem::Session(last_session)) = doc.root.children.as_mut_vec().last_mut() {
-        let title = last_session.title.as_string();
-        if title.trim().eq_ignore_ascii_case("Notes")
-            || title.trim().eq_ignore_ascii_case("Footnotes")
-        {
-            convert_session_notes_to_list(last_session);
-        }
-    }
-}
-
-/// Converts session-based footnote children to a single list.
-///
-/// Handles three content types within a Notes session:
-/// - **Numbered sessions** (e.g., "1. Note"): Converted to list items
-/// - **Existing lists**: Items are merged into the output list
-/// - **Blank lines**: Removed to compact the output
-fn convert_session_notes_to_list(session: &mut Session) {
-    let has_legacy_content = session.children.iter().any(|c| match c {
-        ContentItem::Session(s) => split_numbered_title(s.title.as_string()).is_some(),
-        ContentItem::List(_) | ContentItem::BlankLineGroup(_) => true,
-        _ => false,
-    });
-
-    if !has_legacy_content {
-        return;
-    }
-
-    let mut new_children = Vec::new();
-    let mut current_list_items = Vec::new();
-
-    // Drain children from the session
-    let children_vec = session.children.as_mut_vec();
-    let old_children = std::mem::take(children_vec);
-
-    for mut child in old_children {
-        // handle Session -> ListItem
-        let mut handled = false;
-
-        if let ContentItem::Session(inner_session) = &child {
-            let title = inner_session.title.as_string();
-            if let Some((number_part, content_part)) = split_numbered_title(title) {
-                handled = true;
-
-                let mut children_elements = Vec::new();
-                for inner_child in inner_session.children.iter().cloned() {
-                    if let Ok(el) = ContentElement::try_from(inner_child) {
-                        children_elements.push(el);
-                    }
-                }
-
-                let list_item = ListItem::with_content(
-                    number_part.to_string(),
-                    content_part.trim().to_string(),
-                    children_elements,
-                );
-                current_list_items.push(list_item);
-            }
-        } else if let ContentItem::List(l) = &mut child {
-            // Merge list items
-            handled = true;
-            // We need to extract items. ListContainer wraps generic content but typically ListContent::ListItem.
-            // We'll iterate and filter/map.
-            let items = std::mem::take(l.items.as_mut_vec());
-            for item in items {
-                if let ContentItem::ListItem(li) = item {
-                    current_list_items.push(li);
-                }
-                // If it's not a ListItem (e.g. comment), we drop it for now as per refactoring goal "Clean List".
-            }
-        } else if let ContentItem::BlankLineGroup(_) = child {
-            // Skip blank lines in Notes session to compact them
-            handled = true;
-        }
-
-        if !handled {
-            // If we encounter something else (e.g. Paragraph), we assume it breaks the list or is a preamble.
-            // Flush current items first.
-            if !current_list_items.is_empty() {
-                new_children.push(ContentItem::List(List::new(std::mem::take(
-                    &mut current_list_items,
-                ))));
-            }
-            new_children.push(child);
-        }
-    }
-
-    // Flush remaining
-    if !current_list_items.is_empty() {
-        new_children.push(ContentItem::List(List::new(current_list_items)));
-    }
-
-    *session.children.as_mut_vec() = new_children;
-}
-
-/// Splits a numbered title like "1. Note Title" into its marker and content parts.
-///
-/// Returns `Some(("1.", " Note Title"))` for valid numbered titles, `None` otherwise.
-/// The marker includes the trailing dot to preserve the original format for list item creation.
-fn split_numbered_title(title: &str) -> Option<(&str, &str)> {
-    let title = title.trim();
-    let number_len = title.chars().take_while(|c| c.is_ascii_digit()).count();
-    if number_len > 0 && title.chars().nth(number_len) == Some('.') {
-        let (num, rest) = title.split_at(number_len + 1);
-        return Some((num, rest));
-    }
-    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lex_core::lex::ast::Paragraph;
+    use lex_core::lex::ast::{ContentItem, Paragraph};
 
     #[test]
     fn test_serialize_to_lex() {
@@ -250,36 +130,5 @@ mod tests {
 
         // Both should parse successfully
         assert_eq!(doc1.root.children.len(), doc2.root.children.len());
-    }
-
-    #[test]
-    fn test_normalize_footnotes() {
-        let original = "Title\n\n    Content\n\nNotes\n\n    1. Note One\n\n    2. Note Two\n";
-        // This parses as Session("Notes") -> [Session("1. Note One"), Session("2. Note Two")]
-        // normally, but we want it to become a List.
-        let formatted = format_lex_source(original).unwrap();
-
-        // Verification
-        use lex_core::lex::transforms::standard::STRING_TO_AST;
-
-        let doc = STRING_TO_AST.run(formatted.clone()).unwrap();
-        let last_session = doc.root.children.last().unwrap();
-        if let ContentItem::Session(s) = last_session {
-            assert_eq!(s.title.as_string().trim(), "Notes");
-            assert_eq!(s.children.len(), 1);
-            if let ContentItem::List(l) = &s.children[0] {
-                assert_eq!(l.items.len(), 2);
-                if let ContentItem::ListItem(item) = &l.items[0] {
-                    assert_eq!(item.marker().trim(), "1.");
-                    assert_eq!(item.text().trim(), "Note One");
-                } else {
-                    panic!("Expected ListItem, found {:?}", l.items[0]);
-                }
-            } else {
-                panic!("Expected List, found {:?}", s.children[0]);
-            }
-        } else {
-            panic!("Expected Session");
-        }
     }
 }

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -25,12 +25,10 @@
 //!   - annotation label *spelling*        (canonical `.value` kept)
 //!   - table cell padding                 (cell text trimmed)
 //!
-//! Note on footnote normalization: `format` here is `format_lex_source`, which
-//! runs `normalize_footnotes` before serializing. That step rewrites a trailing
-//! legacy "Notes"/"Footnotes" *session* into a canonical `:: notes ::` *list*.
-//! The legacy session form is deprecated and should not occur in practice, so
-//! `canon` intentionally does not model the equivalence and no test input uses
-//! it — the canonical `:: notes ::` list form is the only one exercised.
+//! Note on footnotes: the only footnote form is the canonical `:: notes ::`
+//! *list*, which the formatter serializes as-is. (A legacy session→list
+//! migration once ran here as part of `format`; it has been removed, so `canon`
+//! does not model that equivalence and no test input uses the legacy form.)
 
 use lex_babel::transforms::format_lex_source;
 use lex_core::lex::ast::elements::inlines::{InlineNode, ReferenceType};
@@ -42,9 +40,9 @@ use lex_core::lex::parsing::parse_document;
 // format() — the function under test
 // -----------------------------------------------------------------------------
 
-/// `format(D)` = parse, `normalize_footnotes`, serialize (default rules) — the
-/// same path as `lexd format`. Returns the formatter error as `Err` rather than
-/// panicking, so proptest can shrink a formatting failure to a minimal input.
+/// `format(D)` = parse, serialize (default rules) — the same path as
+/// `lexd format`. Returns the formatter error as `Err` rather than panicking,
+/// so proptest can shrink a formatting failure to a minimal input.
 fn format(source: &str) -> Result<String, String> {
     format_lex_source(source).map_err(|e| format!("formatting failed: {e}"))
 }


### PR DESCRIPTION
Closes #729
Part of #727

## Summary

Removes the legacy session→list footnote migration in `lex-babel`. The formatter previously detected legacy session-based footnotes (a trailing `Notes`/`Footnotes` session whose children are sessions titled `1. Note`) and rewrote them into the preferred list-based form during `lexd format`. The code itself noted this "should not occur in practice."

## Changes

- Remove `normalize_footnotes()`, `convert_session_notes_to_list()`, and `split_numbered_title()` from `crates/lex-babel/src/transforms.rs` (grep-confirmed: no other callers).
- Remove the `normalize_footnotes(&mut doc)` call site in `format_lex_source`.
- Drop the now-obsolete `test_normalize_footnotes` unit test.
- Update the `format_invariants` module docs that described the legacy conversion as part of `format`.

List-based footnote formatting (the canonical `:: notes ::` list form) is unchanged.

## Verification

- `cargo build --workspace --exclude lex-wasm` — green
- `cargo clippy --workspace --exclude lex-wasm --all-targets -- -D warnings` — green
- `cargo test --workspace --exclude lex-wasm` — green (875 + others, 0 failures; format-invariant tests included)
- grep confirms no dangling references to the removed functions

This is a stacked sub-PR: base is `feat/legacy-extinction` (the epic integration branch), not `main`.

https://claude.ai/code/session_017VqMMAAM42r4pCurnx3JPU