### PR TITLE
refactor(core): consolidate parser entry points + clarity renames (#731)

### DIFF
--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -717,8 +717,11 @@ mod tests {
         use crate::lex::transforms::standard::LEXING;
         let source = format!("{src}\n");
         let tokens = LEXING.run(source.clone()).expect("tokens");
+        let grouped_tokens =
+            crate::lex::lexing::transformations::LineTokenGroupingMapper::new().map(tokens);
         let mut output =
-            crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).expect("parse");
+            crate::lex::parsing::engine::parse_from_grouped_stream(grouped_tokens, &source)
+                .expect("parse");
         output.root = ParseInlines::new().run(output.root).expect("inlines");
         let mut doc = AttachRoot::new().run(output).expect("attach root");
         doc = AttachAnnotations::new().run(doc).expect("attach anns");

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -717,8 +717,8 @@ mod tests {
         use crate::lex::transforms::standard::LEXING;
         let source = format!("{src}\n");
         let tokens = LEXING.run(source.clone()).expect("tokens");
-        let grouped_tokens =
-            crate::lex::lexing::transformations::LineTokenGroupingMapper::new().map(tokens);
+        let mut mapper = crate::lex::lexing::transformations::LineTokenGroupingMapper::new();
+        let grouped_tokens = mapper.map(tokens);
         let mut output =
             crate::lex::parsing::engine::parse_from_grouped_stream(grouped_tokens, &source)
                 .expect("parse");

--- a/crates/lex-core/src/lex/parsing/engine.rs
+++ b/crates/lex-core/src/lex/parsing/engine.rs
@@ -25,8 +25,7 @@
 use super::parser;
 use crate::lex::building::ast_tree::{AstTreeBuilder, BuildOutput};
 use crate::lex::parsing::ir::{NodeType, ParseNode};
-use crate::lex::token::{to_line_container, LineContainer, Token};
-use std::ops::Range as ByteRange;
+use crate::lex::token::{to_line_container, LineContainer};
 
 /// Parse from grouped token stream (main entry point).
 ///
@@ -60,37 +59,14 @@ pub fn parse_from_grouped_stream(
     let tree = to_line_container::build_line_container(line_tokens);
 
     // Parse using existing logic
-    parse_experimental_v2(tree, source)
+    parse_grammar_tree(tree, source)
 }
 
-/// Parse from flat token stream (legacy/test entry point).
+/// Parse a LineContainer tree into the AST using the declarative grammar engine.
 ///
-/// This entry point is kept for backward compatibility with existing tests.
-/// Production code should use parse_from_grouped_stream instead.
-///
-/// # Arguments
-/// * `tokens` - Flat vector of (Token, Range) pairs
-/// * `source` - The original source text (for location tracking)
-///
-/// # Returns
-/// The root session tree if successful
-pub fn parse_from_flat_tokens(
-    tokens: Vec<(Token, ByteRange<usize>)>,
-    source: &str,
-) -> Result<BuildOutput, String> {
-    // Apply grouping transformation inline for tests/legacy code
-    use crate::lex::lexing::transformations::LineTokenGroupingMapper;
-
-    let mut mapper = LineTokenGroupingMapper::new();
-    let grouped_tokens = mapper.map(tokens);
-
-    parse_from_grouped_stream(grouped_tokens, source)
-}
-
-/// Parse using the new declarative grammar engine (Delivery 2).
-///
-/// This is the main entry point for the parser using LineContainerToken.
-/// It uses the declarative grammar matcher and recursive descent parser.
+/// This is the production parser core: given the LineContainer tree produced by
+/// the lexing/grouping pipeline, it runs the declarative grammar matcher and
+/// recursive-descent parser, then builds the AST.
 ///
 /// # Arguments
 /// * `tree` - The token tree from the lexer (LineContainerToken)
@@ -98,7 +74,7 @@ pub fn parse_from_flat_tokens(
 ///
 /// # Returns
 /// The root session tree if successful
-pub fn parse_experimental_v2(tree: LineContainer, source: &str) -> Result<BuildOutput, String> {
+pub fn parse_grammar_tree(tree: LineContainer, source: &str) -> Result<BuildOutput, String> {
     // Extract children from root container
     let children = match tree {
         LineContainer::Container { children, .. } => children,
@@ -127,13 +103,27 @@ mod tests {
         Ok(crate::lex::lexing::lex(tokens)?)
     }
 
+    // Test helper: group a flat token stream and run the main parser. Applies the
+    // same LineTokenGroupingMapper step the lexing pipeline performs before
+    // `parse_from_grouped_stream`.
+    fn parse_flat(
+        tokens: Vec<(crate::lex::token::Token, std::ops::Range<usize>)>,
+        source: &str,
+    ) -> Result<BuildOutput, String> {
+        use crate::lex::lexing::transformations::LineTokenGroupingMapper;
+
+        let mut mapper = LineTokenGroupingMapper::new();
+        let grouped_tokens = mapper.map(tokens);
+        parse_from_grouped_stream(grouped_tokens, source)
+    }
+
     #[test]
     fn test_parse_simple_paragraphs() {
         // Use tokens from the lexer pipeline
         let source = "Simple paragraph\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
         assert!(result.is_ok(), "Parser should succeed");
 
         let root = result.unwrap().root;
@@ -148,7 +138,7 @@ mod tests {
         let source = "Definition:\n    This is the definition content\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
         assert!(result.is_ok(), "Parser should succeed");
 
         let root = result.unwrap().root;
@@ -166,7 +156,7 @@ mod tests {
         let source = "Session:\n\n    Session content here\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
         assert!(result.is_ok(), "Parser should succeed");
 
         let root = result.unwrap().root;
@@ -184,7 +174,7 @@ mod tests {
         let source = "Title Two\n\n\n    Content with two blank lines.\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
         assert!(result.is_ok(), "Parser should succeed");
 
         let root = result.unwrap().root;
@@ -212,7 +202,7 @@ mod tests {
         let source = "Title Three\n\n\n\n    Content with three blank lines.\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
         assert!(result.is_ok(), "Parser should succeed");
 
         let root = result.unwrap().root;
@@ -229,9 +219,7 @@ mod tests {
             "Code Example:\n\n    function hello() {\n        return \"world\";\n    }\n\n:: javascript ::\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let root = parse_from_flat_tokens(tokens, source)
-            .expect("Parser failed")
-            .root;
+        let root = parse_flat(tokens, source).expect("Parser failed").root;
 
         let has_verbatim = root
             .children
@@ -259,9 +247,7 @@ mod tests {
         let source = "1. Session\n\n    Some content.\n\n    :: note-editor :: Maybe this could be better rephrased?\n    :: note.author :: Done keeping it simple\n\n    More content.\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let root = parse_from_flat_tokens(tokens, source)
-            .expect("Parser failed")
-            .root;
+        let root = parse_flat(tokens, source).expect("Parser failed").root;
 
         // Should have a session
         let session = root
@@ -301,7 +287,7 @@ mod tests {
         let source = ":: test.note ::\n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
         assert!(result.is_ok(), "Parser should succeed");
 
         let root = result.unwrap().root;
@@ -341,9 +327,7 @@ Final paragraph.
 
         let tokens = lex_helper(source).expect("Failed to tokenize");
 
-        let root = parse_from_flat_tokens(tokens, source)
-            .expect("Parser failed")
-            .root;
+        let root = parse_flat(tokens, source).expect("Parser failed").root;
 
         eprintln!("\n=== ANNOTATIONS + TRIFECTA COMBINED ===");
         eprintln!("Root items count: {}", root.children.len());
@@ -391,7 +375,7 @@ Final paragraph.
     fn test_parse_empty_input() {
         let source = "";
         let tokens = lex_helper(source).expect("Failed to tokenize");
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
 
         assert!(result.is_ok(), "Empty input should parse successfully");
         let root = result.unwrap().root;
@@ -406,7 +390,7 @@ Final paragraph.
     fn test_parse_only_whitespace() {
         let source = "   \n\n   \n";
         let tokens = lex_helper(source).expect("Failed to tokenize");
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
 
         assert!(
             result.is_ok(),
@@ -423,7 +407,7 @@ Final paragraph.
 No closing marker
 "#;
         let tokens = lex_helper(source).expect("Failed to tokenize");
-        let result = parse_from_flat_tokens(tokens, source);
+        let result = parse_flat(tokens, source);
 
         assert!(
             result.is_ok(),

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -176,14 +176,17 @@ pub(crate) fn parse_to_attached_root(
     let tokens = SemanticIndentation::new().run(core_tokens)?;
 
     // Parse to AST against the original source (keeps location tracking in
-    // original-source coordinates).
+    // original-source coordinates). Group the flat tokens into lines before
+    // handing them to the main grouped-stream entry point.
+    let grouped_tokens =
+        crate::lex::lexing::transformations::LineTokenGroupingMapper::new().map(tokens);
     let mut output =
-        crate::lex::parsing::engine::parse_from_flat_tokens(tokens, &source).map_err(|e| {
-            crate::lex::transforms::TransformError::StageFailed {
+        crate::lex::parsing::engine::parse_from_grouped_stream(grouped_tokens, &source).map_err(
+            |e| crate::lex::transforms::TransformError::StageFailed {
                 stage: "Parser".to_string(),
                 message: e.to_string(),
-            }
-        })?;
+            },
+        )?;
 
     // Parse inline elements in root session before assembly
     output.root = ParseInlines::new().run(output.root)?;

--- a/crates/lex-core/src/lex/transforms/standard.rs
+++ b/crates/lex-core/src/lex/transforms/standard.rs
@@ -178,8 +178,8 @@ pub(crate) fn parse_to_attached_root(
     // Parse to AST against the original source (keeps location tracking in
     // original-source coordinates). Group the flat tokens into lines before
     // handing them to the main grouped-stream entry point.
-    let grouped_tokens =
-        crate::lex::lexing::transformations::LineTokenGroupingMapper::new().map(tokens);
+    let mut mapper = crate::lex::lexing::transformations::LineTokenGroupingMapper::new();
+    let grouped_tokens = mapper.map(tokens);
     let mut output =
         crate::lex::parsing::engine::parse_from_grouped_stream(grouped_tokens, &source).map_err(
             |e| crate::lex::transforms::TransformError::StageFailed {

--- a/crates/lex-core/tests/proptests/parameter_proptest.rs
+++ b/crates/lex-core/tests/proptests/parameter_proptest.rs
@@ -8,7 +8,8 @@
 
 use lex_core::lex::assembling::AttachRoot;
 use lex_core::lex::escape::escape_quoted;
-use lex_core::lex::parsing::engine::parse_from_flat_tokens;
+use lex_core::lex::lexing::transformations::LineTokenGroupingMapper;
+use lex_core::lex::parsing::engine::parse_from_grouped_stream;
 use lex_core::lex::parsing::{parse_document, ContentItem, Document};
 use lex_core::lex::testing::assert_ast;
 use lex_core::lex::transforms::standard::LEXING;
@@ -22,7 +23,8 @@ fn parse_annotation_without_attachment(source: &str) -> Result<Document, String>
         source.to_string()
     };
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
-    let root = parse_from_flat_tokens(tokens, &source)?;
+    let grouped_tokens = LineTokenGroupingMapper::new().map(tokens);
+    let root = parse_from_grouped_stream(grouped_tokens, &source)?;
     AttachRoot::new().run(root).map_err(|e| e.to_string())
 }
 

--- a/crates/lex-core/tests/proptests/parameter_proptest.rs
+++ b/crates/lex-core/tests/proptests/parameter_proptest.rs
@@ -23,7 +23,8 @@ fn parse_annotation_without_attachment(source: &str) -> Result<Document, String>
         source.to_string()
     };
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
-    let grouped_tokens = LineTokenGroupingMapper::new().map(tokens);
+    let mut mapper = LineTokenGroupingMapper::new();
+    let grouped_tokens = mapper.map(tokens);
     let root = parse_from_grouped_stream(grouped_tokens, &source)?;
     AttachRoot::new().run(root).map_err(|e| e.to_string())
 }

--- a/crates/lex-core/tests/proptests/parser_correctness_proptest.rs
+++ b/crates/lex-core/tests/proptests/parser_correctness_proptest.rs
@@ -8,7 +8,8 @@
 use lex_core::lex::assembling::AttachRoot;
 use lex_core::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
 use lex_core::lex::ast::ContentItem;
-use lex_core::lex::parsing::engine::parse_from_flat_tokens;
+use lex_core::lex::lexing::transformations::LineTokenGroupingMapper;
+use lex_core::lex::parsing::engine::parse_from_grouped_stream;
 use lex_core::lex::parsing::{parse_document, Document};
 use lex_core::lex::testing::{assert_ast, InlineAssertion, InlineExpectation};
 use lex_core::lex::transforms::standard::LEXING;
@@ -30,7 +31,8 @@ fn ensure_trailing_newline(source: &str) -> String {
 fn parse_annotation_without_attachment(source: &str) -> Result<Document, String> {
     let source = ensure_trailing_newline(source);
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
-    let root = parse_from_flat_tokens(tokens, &source)?;
+    let grouped_tokens = LineTokenGroupingMapper::new().map(tokens);
+    let root = parse_from_grouped_stream(grouped_tokens, &source)?;
     AttachRoot::new().run(root).map_err(|e| e.to_string())
 }
 

--- a/crates/lex-core/tests/proptests/parser_correctness_proptest.rs
+++ b/crates/lex-core/tests/proptests/parser_correctness_proptest.rs
@@ -31,7 +31,8 @@ fn ensure_trailing_newline(source: &str) -> String {
 fn parse_annotation_without_attachment(source: &str) -> Result<Document, String> {
     let source = ensure_trailing_newline(source);
     let tokens = LEXING.run(source.clone()).map_err(|e| e.to_string())?;
-    let grouped_tokens = LineTokenGroupingMapper::new().map(tokens);
+    let mut mapper = LineTokenGroupingMapper::new();
+    let grouped_tokens = mapper.map(tokens);
     let root = parse_from_grouped_stream(grouped_tokens, &source)?;
     AttachRoot::new().run(root).map_err(|e| e.to_string())
 }


### PR DESCRIPTION
Closes #731
Part of #727

This is a sub-PR of the **Legacy extinction** epic, targeting the integration branch `feat/legacy-extinction` (not `main`). It will be squash-merged into the feature branch; the human reviews only the final `feat/legacy-extinction → main` PR.

## What

Two clarity cleanups in the parser, both confined to parser internals.

**Scope A — remove the legacy flat-token entry point.**
`parse_from_flat_tokens()` was documented as a "legacy/test entry point"; production code uses `parse_from_grouped_stream`. The legacy fn merely ran `LineTokenGroupingMapper` over the flat tokens and delegated. Removed it and migrated all callers to call `parse_from_grouped_stream` directly, applying that same grouping inline:
- `crates/lex-core/src/lex/transforms/standard.rs` (production caller)
- `crates/lex-core/src/lex/assembling/stages/normalize_labels.rs` (test call site)
- `crates/lex-core/tests/proptests/parameter_proptest.rs`
- `crates/lex-core/tests/proptests/parser_correctness_proptest.rs`
- the engine's own `#[cfg(test)]` module gains a small `parse_flat` test helper that does the grouping, so the existing unit tests stay readable.

**Scope B — rename the misleading `parse_experimental_v2`.**
It is the **main production parser**, not experimental. Renamed to `parse_grammar_tree` and updated the single internal reference. Not a broader public-API rename.

## Out of scope (per #727)
- The `parse_document()` alias (325 sites) — explicitly out of scope.
- `Mode::Permissive` semantics — untouched.

## Verification
- `grep -rn "parse_from_flat_tokens\|parse_experimental_v2" crates` → clean.
- `cargo fmt` — clean.
- `cargo build --workspace --exclude lex-wasm` — green.
- `cargo clippy --workspace --exclude lex-wasm --all-targets -- -D warnings` — green.
- `cargo test --workspace --exclude lex-wasm` — green (proptests: 215 passed; lex-core lib: 875 passed). Note: requires the `comms` submodule initialized for fixture-backed tests.

https://claude.ai/code/session_017VqMMAAM42r4pCurnx3JPU