### PR TITLE
docs(changelog): add missing #727 legacy-extinction fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## Unreleased
 
+### Fixed — whole-element reference-line anchors render on the default `lexd <file> --to <fmt>` path ([#722](https://github.com/lex-fmt/lex/issues/722))
+
+Whole-element reference-line anchors (the `[#id]`-on-its-own-line form) were silently dropped on the default file-convert path, which routes through the include resolver even when a file has no includes. The resolver used a hand-rolled copy of the source→AST front-end that never ran the reference-line pre-pass, so the list collapsed into a self-linking paragraph. The two front-ends are now unified into a single `parse_to_attached_root` stage that both the standard pipeline and the include resolver call, so the pre-pass (and any future front-end stage) lives in exactly one place. Entry-file reference lines now anchor correctly; reference lines authored inside included files are not yet propagated through the wire codec (dropped rather than emitted with a wrong range — a documented follow-up).
+### Removed — pre-1.0 legacy backward-compatibility scaffolding ([#727](https://github.com/lex-fmt/lex/issues/727))
+
+Lex is pre-1.0 with no install base, so the compatibility shims that existed only to ease migration from older formats are removed wholesale. Four user- and API-facing surfaces go away:
+
+- **`lexd migrate-labels` subcommand removed** ([#728](https://github.com/lex-fmt/lex/issues/728)). The standalone label-migration command and its `lex_core::lex::migrate` module (including `blessed_for_legacy`) are deleted. The LSP `forbidden-label-prefix` quickfix that previously rewrote a legacy label through the curated "blessed" table now simply strips the reserved `doc.` prefix, which covers the only case that arises in practice.
+- **`lexd format` no longer migrates legacy session-based footnotes** ([#729](https://github.com/lex-fmt/lex/issues/729)). The dual-format path that detected child sessions titled `1. Note` and converted them to list-based footnotes during formatting is gone (`normalize_footnotes`, `convert_session_notes_to_list`, `split_numbered_title`). List-based footnote formatting is unchanged; the legacy session form was documented as "should not occur in practice".
+- **Legacy detokenizer re-export shim removed** ([#730](https://github.com/lex-fmt/lex/issues/730)). The canonical detokenizer lives in `lex_core::lex::token::formatting`; the old `lex::formats::detokenizer` re-export that preserved historical import paths is deleted. Direct consumers import `{detokenize, ToLexString}` from `token::formatting`.
+- **Parser entry points consolidated** ([#731](https://github.com/lex-fmt/lex/issues/731)). Internal naming around the parser front-end is unified; no behavior change.
+### Changed — `process_full` collapsed into `parse_document`; `process_full_permissive` renamed to `parse_document_permissive` ([#737](https://github.com/lex-fmt/lex/pull/737))
+
+`lex-core`'s parsing entry points carried two public names for the same pipeline call — `parse_document` (documented as a backward-compatibility alias) and `process_full` — plus a matching `process_full_permissive`. Pre-1.0 there is no compatibility to keep, so the public surface is now a single canonical pair: `parse_document` (the standard strict parse) and `parse_document_permissive` (the LSP/diagnostics variant that lets policy-violating `doc.*` / unknown `lex.*` labels flow into the AST instead of failing the parse). `process_full` and `process_full_permissive` are removed. Direct `lex-core` consumers calling the old names must rename; `parse_document` itself is unchanged, so the overwhelming majority of call sites are unaffected.
+
 ## 0.15.0 - 2026-06-01
 
 ### Added — extensions declare diagnostic codes; the host validates `[diagnostics.rules]` against them ([#659](https://github.com/lex-fmt/lex/issues/659))

--- a/CHANGELOG/unreleased-pr-727.md
+++ b/CHANGELOG/unreleased-pr-727.md
@@ -1,0 +1,8 @@
+### Removed — pre-1.0 legacy backward-compatibility scaffolding ([#727](https://github.com/lex-fmt/lex/issues/727))
+
+Lex is pre-1.0 with no install base, so the compatibility shims that existed only to ease migration from older formats are removed wholesale. Four user- and API-facing surfaces go away:
+
+- **`lexd migrate-labels` subcommand removed** ([#728](https://github.com/lex-fmt/lex/issues/728)). The standalone label-migration command and its `lex_core::lex::migrate` module (including `blessed_for_legacy`) are deleted. The LSP `forbidden-label-prefix` quickfix that previously rewrote a legacy label through the curated "blessed" table now simply strips the reserved `doc.` prefix, which covers the only case that arises in practice.
+- **`lexd format` no longer migrates legacy session-based footnotes** ([#729](https://github.com/lex-fmt/lex/issues/729)). The dual-format path that detected child sessions titled `1. Note` and converted them to list-based footnotes during formatting is gone (`normalize_footnotes`, `convert_session_notes_to_list`, `split_numbered_title`). List-based footnote formatting is unchanged; the legacy session form was documented as "should not occur in practice".
+- **Legacy detokenizer re-export shim removed** ([#730](https://github.com/lex-fmt/lex/issues/730)). The canonical detokenizer lives in `lex_core::lex::token::formatting`; the old `lex::formats::detokenizer` re-export that preserved historical import paths is deleted. Direct consumers import `{detokenize, ToLexString}` from `token::formatting`.
+- **Parser entry points consolidated** ([#731](https://github.com/lex-fmt/lex/issues/731)). Internal naming around the parser front-end is unified; no behavior change.


### PR DESCRIPTION
## What

PR #727 (legacy extinction) merged without a `CHANGELOG/unreleased-*.md` fragment. This adds the missing **Removed** entry so the upcoming release changelog accurately reflects what #727 took out.

## Why it matters

#727 removed user- and API-facing surfaces that a release changelog must mention:
- `lexd migrate-labels` subcommand + `lex_core::lex::migrate` module — #728
- `lexd format`'s legacy session-based footnote migration — #729
- legacy detokenizer re-export shim — #730
- parser entry-point consolidation — #731

Combined with the already-present #737 `Changed` entry (public API rename), this release carries breaking crate-API changes → minor bump (0.15.0 → 0.16.0).

## Changes
- Add `CHANGELOG/unreleased-pr-727.md`
- Re-render `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)