### PR TITLE
docs(changelog): add smart-paste fragment for the v0.17.0 cut

### DIFF
--- a/CHANGELOG/unreleased-smart-paste.md
+++ b/CHANGELOG/unreleased-smart-paste.md
@@ -1,0 +1,3 @@
+### Added — smart paste: `lex/preparePaste` re-anchors pasted text to the caret's structural level ([#708](https://github.com/lex-fmt/lex/issues/708))
+
+The language server now implements a custom `lex/preparePaste` request. On paste, lex-lsp classifies the clipboard (verbatim / table / single-line / re-anchor) and, for the re-anchor case, shifts the pasted block's indentation to match the structural container enclosing the caret — so copy-paste between and into Lex documents lands at the right structural level instead of the source's original indentation. Advertised via a capability flag so editors enable interception only against a server that implements it. Editor glue that calls the request ships separately, one PR per editor.


### PR DESCRIPTION
Unblocks the v0.17.0 release. PR #740 landed `lex/preparePaste` but didn't add a changelog fragment, so `release / prepare` failed with *No CHANGELOG/unreleased-*.md fragments found* ([run](https://github.com/lex-fmt/lex/actions/runs/26846860642)). This adds the missing `Added` fragment. After merge, the release is re-cut.

Part of the smart-paste epic (#709).