### PR TITLE
docs(lsp): document Position.character == UTF-8 byte-offset at module level (#741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## Unreleased
 
-- docs(lsp): document the `Position.character` == UTF-8 byte-offset convention at lex-lsp module level, so feature authors find it before reaching for a char-based offset ([#741](https://github.com/lex-fmt/lex/issues/741))
-
 ## 0.17.0 - 2026-06-03
 
 ### Added — smart paste: `lex/preparePaste` re-anchors pasted text to the caret's structural level ([#708](https://github.com/lex-fmt/lex/issues/708))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- docs(lsp): document the `Position.character` == UTF-8 byte-offset convention at lex-lsp module level, so feature authors find it before reaching for a char-based offset ([#741](https://github.com/lex-fmt/lex/issues/741))
+
 ## 0.17.0 - 2026-06-03
 
 ### Added — smart paste: `lex/preparePaste` re-anchors pasted text to the caret's structural level ([#708](https://github.com/lex-fmt/lex/issues/708))

--- a/CHANGELOG/unreleased-pr-741.md
+++ b/CHANGELOG/unreleased-pr-741.md
@@ -1,0 +1,1 @@
+- docs(lsp): document the `Position.character` == UTF-8 byte-offset convention at lex-lsp module level, so feature authors find it before reaching for a char-based offset ([#741](https://github.com/lex-fmt/lex/issues/741))

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -9,17 +9,18 @@
 //!     line — NOT a UTF-16 code unit (the LSP default) nor a `char` count. This is the
 //!     single load-bearing convention for every position↔text conversion here.
 //!
-//!     It originates upstream: lex-core's `LineColumnLocator::byte_to_position` computes
+//!     It originates upstream: lex-core's `SourceLocation::byte_to_position` computes
 //!     `column = byte_offset - line_start`, and `to_lsp_position` forwards that value to
 //!     LSP unchanged. Every consumer of a `Position` in this crate must read `.character`
 //!     back as a byte offset to stay consistent.
 //!
 //!     Practical consequence: to take the text up to a caret, slice on the byte offset
-//!     (`&line[..pos.character as usize]`, guarding `is_char_boundary`) — never
-//!     `line.chars().take(pos.character)`. A `char`-based count silently over-reads past
-//!     the caret on any line containing multi-byte characters (this caused a real bug in
-//!     #740). See `slice_text_by_range` in `server.rs` for the canonical byte-offset
-//!     slicing routine, including the multi-byte-boundary guards.
+//!     (`line.get(..pos.character as usize)`, which returns `None` rather than panicking
+//!     on an out-of-bounds or mid-`char` index) — never `line.chars().take(pos.character)`.
+//!     A `char`-based count silently over-reads past the caret on any line containing
+//!     multi-byte characters (this caused a real bug in #740). See `slice_text_by_range`
+//!     in `server.rs` for the canonical byte-offset slicing routine, including the
+//!     multi-byte-boundary guards.
 //!
 //! Design Decision: tower-lsp
 //!

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -5,14 +5,14 @@
 //!
 //! Position Encoding — read before touching any `Position`
 //!
-//!     Throughout this server, `Position.character` is a **UTF-8 byte offset** into the
-//!     line — NOT a UTF-16 code unit (the LSP default) nor a `char` count. This is the
-//!     single load-bearing convention for every position↔text conversion here.
+//!     In this server, `Position.character` is a **UTF-8 byte offset** into the line —
+//!     NOT a UTF-16 code unit (the LSP default) nor a `char` count. This is the
+//!     load-bearing convention every position↔text conversion here must honor.
 //!
 //!     It originates upstream: lex-core's `SourceLocation::byte_to_position` computes
 //!     `column = byte_offset - line_start`, and `to_lsp_position` forwards that value to
-//!     LSP unchanged. Every consumer of a `Position` in this crate must read `.character`
-//!     back as a byte offset to stay consistent.
+//!     LSP unchanged. Every consumer of a `Position` in this crate must therefore read
+//!     `.character` back as a byte offset to stay consistent.
 //!
 //!     Practical consequence: to take the text up to a caret, slice on the byte offset
 //!     (`line.get(..pos.character as usize)`, which returns `None` rather than panicking
@@ -21,6 +21,11 @@
 //!     multi-byte characters (this caused a real bug in #740). See `slice_text_by_range`
 //!     in `server.rs` for the canonical byte-offset slicing routine, including the
 //!     multi-byte-boundary guards.
+//!
+//!     Caveat — not yet uniform: `indent_level_from_position` in `server.rs` still uses
+//!     the `chars().take()` form. It is currently harmless there (it only consumes leading
+//!     ASCII indentation, where byte and `char` counts coincide), but it does not yet
+//!     follow this convention and is a separate cleanup, not a reason to copy the pattern.
 //!
 //! Design Decision: tower-lsp
 //!

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -16,7 +16,8 @@
 //!
 //!     Practical consequence: to take the text up to a caret, slice on the byte offset
 //!     (`line.get(..pos.character as usize)`, which returns `None` rather than panicking
-//!     on an out-of-bounds or mid-`char` index) — never `line.chars().take(pos.character)`.
+//!     on an out-of-bounds or mid-`char` index) — never
+//!     `line.chars().take(pos.character as usize)`.
 //!     A `char`-based count silently over-reads past the caret on any line containing
 //!     multi-byte characters (this caused a real bug in #740). See `slice_text_by_range`
 //!     in `server.rs` for the canonical byte-offset slicing routine, including the

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -3,6 +3,24 @@
 //!     This crate provides language server capabilities for the Lex format, enabling rich editor
 //!     support in any LSP-compatible editor (VSCode, Neovim, Emacs, Sublime, etc.).
 //!
+//! Position Encoding — read before touching any `Position`
+//!
+//!     Throughout this server, `Position.character` is a **UTF-8 byte offset** into the
+//!     line — NOT a UTF-16 code unit (the LSP default) nor a `char` count. This is the
+//!     single load-bearing convention for every position↔text conversion here.
+//!
+//!     It originates upstream: lex-core's `LineColumnLocator::byte_to_position` computes
+//!     `column = byte_offset - line_start`, and `to_lsp_position` forwards that value to
+//!     LSP unchanged. Every consumer of a `Position` in this crate must read `.character`
+//!     back as a byte offset to stay consistent.
+//!
+//!     Practical consequence: to take the text up to a caret, slice on the byte offset
+//!     (`&line[..pos.character as usize]`, guarding `is_char_boundary`) — never
+//!     `line.chars().take(pos.character)`. A `char`-based count silently over-reads past
+//!     the caret on any line containing multi-byte characters (this caused a real bug in
+//!     #740). See `slice_text_by_range` in `server.rs` for the canonical byte-offset
+//!     slicing routine, including the multi-byte-boundary guards.
+//!
 //! Design Decision: tower-lsp
 //!
 //!     After evaluating the Rust LSP ecosystem, we chose tower-lsp as our framework:

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -3466,7 +3466,8 @@ mod tests {
         );
     }
 
-    /// `slice_text_by_range` treats `Range.character` as a UTF-8 byte
+    /// `slice_text_by_range` treats each endpoint's `Position.character`
+    /// (`range.start.character` / `range.end.character`) as a UTF-8 byte
     /// offset, matching lex-core's `SourceLocation::byte_to_position`
     /// (which sets `column = byte_offset - line_start`). Char-based
     /// slicing would mis-slice selections containing multi-byte chars;

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1813,12 +1813,14 @@ where
 /// Slice `text` by an LSP `Range`. Returns `None` when the range falls
 /// outside the document or splits a multi-byte character.
 ///
-/// `character` is treated as a **UTF-8 byte offset** to match the rest
-/// of the server: lex-core's `SourceLocation::byte_to_position`
-/// computes `column = byte_offset - line_start`, and `to_lsp_position`
-/// forwards that value to LSP as-is. Using char offsets here would
-/// mis-slice any selection containing multi-byte characters. See the
-/// crate-level "Position Encoding" docs for the full convention.
+/// `character` is treated as a **UTF-8 byte offset**, following the
+/// crate's position-encoding convention: lex-core's
+/// `SourceLocation::byte_to_position` computes
+/// `column = byte_offset - line_start`, and `to_lsp_position` forwards
+/// that value to LSP as-is. Using char offsets here would mis-slice any
+/// selection containing multi-byte characters. See the crate-level
+/// "Position Encoding" docs for the full convention (and its one known
+/// straggler).
 fn slice_text_by_range(text: &str, range: Range) -> Option<String> {
     let start_line = range.start.line as usize;
     let end_line = range.end.line as usize;

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1814,10 +1814,11 @@ where
 /// outside the document or splits a multi-byte character.
 ///
 /// `character` is treated as a **UTF-8 byte offset** to match the rest
-/// of the server: lex-core's `LineColumnLocator::byte_to_position`
+/// of the server: lex-core's `SourceLocation::byte_to_position`
 /// computes `column = byte_offset - line_start`, and `to_lsp_position`
 /// forwards that value to LSP as-is. Using char offsets here would
-/// mis-slice any selection containing multi-byte characters.
+/// mis-slice any selection containing multi-byte characters. See the
+/// crate-level "Position Encoding" docs for the full convention.
 fn slice_text_by_range(text: &str, range: Range) -> Option<String> {
     let start_line = range.start.line as usize;
     let end_line = range.end.line as usize;
@@ -3464,7 +3465,7 @@ mod tests {
     }
 
     /// `slice_text_by_range` treats `Range.character` as a UTF-8 byte
-    /// offset, matching lex-core's `LineColumnLocator::byte_to_position`
+    /// offset, matching lex-core's `SourceLocation::byte_to_position`
     /// (which sets `column = byte_offset - line_start`). Char-based
     /// slicing would mis-slice selections containing multi-byte chars;
     /// this test pins the byte semantics.


### PR DESCRIPTION
## Summary

`Position.character` is a **UTF-8 byte offset** throughout lex-lsp (not a UTF-16 code unit, not a `char` count). Until now that was documented only on `slice_text_by_range`'s docstring in `server.rs` — an LSP-feature author had no module-level signpost and was likely to reach for `chars().take(pos.character)` again (the trap that caused the #740 `is_fresh_line` over-read on multi-byte lines).

This adds a **"Position Encoding"** section to the `lex-lsp` crate's `lib.rs` `//!` docs, placed right under the crate's opening description so it's the first thing an author reads. It states the convention, its upstream origin (lex-core's `SourceLocation::byte_to_position` / `to_lsp_position`), the byte-slice-vs-char-take consequence, and points at `slice_text_by_range` as the canonical conversion routine. Review surfaced that the existing `slice_text_by_range` docstring (and its test) cited a non-existent `LineColumnLocator` type and that `indent_level_from_position` is a still-non-conforming straggler — both are now corrected/called out.

No behavior change — #740 already fixed the concrete bug and added regression tests. This is the documentation/discoverability follow-up.

## Checklist

- [x] Changelog updated — added the `CHANGELOG/unreleased-pr-741.md` fragment only. `CHANGELOG.md` is generated at release-cut and is intentionally **not** touched by this PR (matches repo convention; in-flight PRs ship only the fragment).
- [x] Project umbrella check passes locally — `lefthook run pre-commit` green (markdownlint + cargo-fmt + cargo-clippy); `lexd-lsp` builds and its byte-offset slice tests pass.
- [x] Tests added or updated for behavior changes — N/A (docs only; #740 already added the regression test).

## Notes for reviewers

Pure `//!` / `///` doc changes + a changelog fragment. Wording was cross-checked against `SourceLocation::byte_to_position` (crates/lex-core/src/lex/ast/range.rs) and `from_lsp_position` / `to_lsp_position` so the convention is stated exactly. The `indent_level_from_position` cleanup is deliberately deferred to its own PR (it needs a test and is a behavior-adjacent change; #741 is docs-only).

Closes #741