### PR TITLE
fix(lsp): smart-paste single-line fresh-line re-anchor + merge strip-to-baseline (#743)

### DIFF
--- a/CHANGELOG/unreleased-pr-743.md
+++ b/CHANGELOG/unreleased-pr-743.md
@@ -1,0 +1,6 @@
+### Changed — smart paste: single-line fresh-line re-anchor + merge first-line strip-to-baseline ([#743](https://github.com/lex-fmt/lex/issues/743))
+
+Two refinements to the `lex/preparePaste` re-anchor transform, from the comms#73 spec review:
+
+- **Single-line paste on a fresh line now re-anchors.** A single clipboard line dropped onto a blank/whitespace-only caret position is a new block, so it is re-anchored to the caret's structural level instead of inserted verbatim (a deep-indented line lifted from a nesting no longer lands over-indented). Single-line pastes that *merge* into existing content still pass through unchanged.
+- **Merge-case first line strips only to the clipboard baseline.** Previously the first line of a merge paste had its leading whitespace stripped entirely; if that line was indented deeper than the block baseline, the extra relative indentation was lost. It is now stripped only down to the baseline, preserving `max(0, original_indent - baseline)`.

--- a/crates/lex-lsp-core/src/prepare_paste.rs
+++ b/crates/lex-lsp-core/src/prepare_paste.rs
@@ -109,7 +109,8 @@ pub fn prepare_paste(
         };
     }
 
-    let mode = classify(document, source, range.start, pasted_text);
+    let fresh_line = is_fresh_line(source, range.start);
+    let mode = classify(document, source, range.start, pasted_text, fresh_line);
 
     let text = match mode {
         PasteMode::PassthroughVerbatim
@@ -117,7 +118,6 @@ pub fn prepare_paste(
         | PasteMode::PassthroughSingleLine => pasted_text.to_string(),
         PasteMode::Reanchor => {
             let anchor = resolve_anchor(document, source, range.start);
-            let fresh_line = is_fresh_line(source, range.start);
             reanchor(pasted_text, anchor, fresh_line)
         }
     };
@@ -126,11 +126,16 @@ pub fn prepare_paste(
 }
 
 /// §3: classify the paste by the caret's structural context, innermost-first.
+///
+/// `fresh_line` (§4.4) is the caret-position signal computed by [`is_fresh_line`]:
+/// `true` when everything before the caret on its source line is whitespace (the
+/// paste starts a new block), `false` when the paste merges into existing content.
 fn classify(
     document: &Document,
     source: &str,
     anchor_pos: Position,
     pasted_text: &str,
+    fresh_line: bool,
 ) -> PasteMode {
     let ast_pos = to_ast_position(anchor_pos);
 
@@ -147,8 +152,14 @@ fn classify(
         return PasteMode::PassthroughTable;
     }
 
-    // Single-line clipboard: no inter-line structure to re-anchor.
-    if is_single_line(pasted_text) {
+    // Single-line clipboard: split on caret context (§3, gemini refinement).
+    //   - Merge (caret follows existing content): no structural block is being
+    //     placed — the line continues the current one, so it stays passthrough.
+    //   - Fresh line (caret on a blank/whitespace-only prefix): the single line
+    //     IS a new block being dropped at this structural level, so it is
+    //     re-anchored just like a multi-line fresh paste. A line carrying the
+    //     source's absolute indentation would otherwise land at the wrong level.
+    if is_single_line(pasted_text) && !fresh_line {
         return PasteMode::PassthroughSingleLine;
     }
 
@@ -310,7 +321,8 @@ pub fn is_fresh_line(source: &str, pos: Position) -> bool {
 ///
 /// - `anchor`: target content indentation (display columns).
 /// - `fresh_line`: §4.4 — `true` re-anchors every line; `false` (merge) strips
-///   line 1's whitespace with no anchor and re-anchors lines 2..n.
+///   line 1 down to the clipboard baseline (preserving any relative indentation
+///   it carried *beyond* the baseline) with no anchor, and re-anchors lines 2..n.
 ///
 /// The clipboard's trailing newline (and internal blank lines) are preserved.
 pub fn reanchor(pasted_text: &str, anchor: usize, fresh_line: bool) -> String {
@@ -349,8 +361,15 @@ pub fn reanchor(pasted_text: &str, anchor: usize, fresh_line: bool) -> String {
         let (orig_indent, content) = split_leading(line);
 
         if idx == 0 && !fresh_line {
-            // §4.4 merge: the first pasted line continues existing content —
-            // strip its whitespace entirely, apply no anchor.
+            // §4.4 merge: the first pasted line continues existing content, so
+            // it gets no anchor. But strip only down to the clipboard *baseline*,
+            // not to bare content: if line 1 was indented deeper than the block
+            // baseline, that extra relative indentation is part of the copied
+            // structure and is preserved (gemini refinement). `orig_indent` is
+            // never below `baseline` (baseline is the per-line min), so the
+            // subtraction is non-negative; `max(0, …)` keeps it total.
+            let rel_indent = orig_indent.saturating_sub(baseline);
+            out.extend(std::iter::repeat_n(' ', rel_indent));
             out.push_str(content);
             continue;
         }

--- a/crates/lex-lsp-core/src/prepare_paste/tests.rs
+++ b/crates/lex-lsp-core/src/prepare_paste/tests.rs
@@ -218,8 +218,8 @@ fn classify_single_line_merge_passthrough() {
     // current line, so it stays passthrough — there is no new block to anchor.
     let source = "Top\n\n    body line\n";
     let doc = parse_document(source).expect("parse");
-    // Caret at byte 12 — past "    body line" content, a merge position.
-    let result = prepare_paste(&doc, source, empty_range(2, 12), "just one line");
+    // Caret at byte 13 — end of "    body line" (4 + 9), a merge position.
+    let result = prepare_paste(&doc, source, empty_range(2, 13), "just one line");
     assert_eq!(result.mode, PasteMode::PassthroughSingleLine);
     assert_eq!(result.text, "just one line");
 }
@@ -482,7 +482,7 @@ fn partial_indentation_carried_through_end_to_end() {
 fn single_line_clipboard_merge_inside_session_passes_through() {
     let source = "Top\n\n    existing\n";
     let doc = parse_document(source).expect("parse");
-    // Caret at byte 12 — past "    existing", a merge position.
+    // Caret at byte 12 — end of "    existing" (4 + 8), a merge position.
     let result = prepare_paste(&doc, source, empty_range(2, 12), "one liner");
     assert_eq!(result.mode, PasteMode::PassthroughSingleLine);
     assert_eq!(result.text, "one liner");

--- a/crates/lex-lsp-core/src/prepare_paste/tests.rs
+++ b/crates/lex-lsp-core/src/prepare_paste/tests.rs
@@ -87,8 +87,28 @@ fn reanchor_table() {
             pasted: "    joined\n        second\n",
             anchor: 4,
             fresh_line: false,
-            // baseline = 4, delta = 0. line1 merge -> "joined"; line2 (8) -> 8.
+            // baseline = 4, delta = 0. line1 at baseline -> "joined"; line2 (8) -> 8.
             expected: "joined\n        second\n",
+        },
+        ReanchorCase {
+            name: "merge first line deeper than baseline preserves relative indent",
+            // gemini refinement (#2): baseline = min(8, 4) = 4. delta = anchor(8)
+            // - baseline(4) = +4. line1 (8) merges -> strip only to baseline,
+            // keep 8-4=4 relative spaces ("    joined"); line2 (4) re-anchors:
+            // 4 + delta(4) = 8.
+            pasted: "        joined\n    second\n",
+            anchor: 8,
+            fresh_line: false,
+            expected: "    joined\n        second\n",
+        },
+        ReanchorCase {
+            name: "merge single deeper-than-baseline line keeps relative indent",
+            // A one-line merge whose sole line is indented: baseline equals that
+            // indent, so relative indent is zero — strips entirely, as before.
+            pasted: "        only\n",
+            anchor: 4,
+            fresh_line: false,
+            expected: "only\n",
         },
         ReanchorCase {
             name: "trailing newline preserved",
@@ -193,12 +213,41 @@ fn is_fresh_line_whitespace_only_prefix_with_later_multibyte_is_fresh() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn classify_single_line_passthrough() {
+fn classify_single_line_merge_passthrough() {
+    // Merge case (caret follows existing content): a single line continues the
+    // current line, so it stays passthrough — there is no new block to anchor.
     let source = "Top\n\n    body line\n";
     let doc = parse_document(source).expect("parse");
-    let result = prepare_paste(&doc, source, empty_range(2, 4), "just one line");
+    // Caret at byte 12 — past "    body line" content, a merge position.
+    let result = prepare_paste(&doc, source, empty_range(2, 12), "just one line");
     assert_eq!(result.mode, PasteMode::PassthroughSingleLine);
     assert_eq!(result.text, "just one line");
+}
+
+#[test]
+fn classify_single_line_fresh_reanchors() {
+    // Fresh-line case (gemini refinement): a single line dropped onto a
+    // blank/whitespace-only prefix IS a new block, so it re-anchors to the
+    // caret's structural level rather than passing through verbatim.
+    let source = "Top\n\n    existing\n\n";
+    let doc = parse_document(source).expect("parse");
+    // Blank line 4, inside the session (content indent 4). A column-zero single
+    // line re-anchors to 4.
+    let result = prepare_paste(&doc, source, empty_range(4, 0), "just one line");
+    assert_eq!(result.mode, PasteMode::Reanchor);
+    assert_eq!(result.text, "    just one line");
+}
+
+#[test]
+fn classify_single_line_fresh_dedents_overindented_clipboard() {
+    // A single line lifted from deep nesting (absolute indent 8) dropped on a
+    // fresh line at a shallower level (anchor 4) is re-anchored down to 4 —
+    // exactly the bug smart paste exists to fix, now reached for single lines.
+    let source = "Top\n\n    existing\n\n";
+    let doc = parse_document(source).expect("parse");
+    let result = prepare_paste(&doc, source, empty_range(4, 0), "        deep line");
+    assert_eq!(result.mode, PasteMode::Reanchor);
+    assert_eq!(result.text, "    deep line");
 }
 
 #[test]
@@ -320,6 +369,27 @@ fn merge_first_line_joins_existing_content() {
 }
 
 #[test]
+fn merge_first_line_deeper_than_baseline_preserves_relative_indent() {
+    // gemini refinement (#2), end-to-end: the first clipboard line is indented
+    // deeper than the block baseline. On a merge it must NOT be stripped to bare
+    // content — the extra relative indentation (orig - baseline) is preserved.
+    let source = "Top\n\n    existing text\n";
+    let doc = parse_document(source).expect("parse");
+    // Merge caret mid-content on line 2 (byte 13, after "    existing ").
+    // Clipboard baseline = min(8, 4) = 4; first line at 8 keeps 8-4 = 4 spaces.
+    let result = prepare_paste(
+        &doc,
+        source,
+        empty_range(2, 13),
+        "        joined\n    tail\n",
+    );
+    assert_eq!(result.mode, PasteMode::Reanchor);
+    // line1 merge: keep relative indent 4 -> "    joined".
+    // line2: anchor 4, baseline 4, delta 0; tail (4) -> 4.
+    assert_eq!(result.text, "    joined\n    tail\n");
+}
+
+#[test]
 fn selection_replace_anchor_from_selection_start() {
     let source = "Top\n\n    Nested\n\n        deep one\n        deep two\n";
     let doc = parse_document(source).expect("parse");
@@ -409,10 +479,11 @@ fn partial_indentation_carried_through_end_to_end() {
 }
 
 #[test]
-fn single_line_clipboard_inside_session_passes_through() {
+fn single_line_clipboard_merge_inside_session_passes_through() {
     let source = "Top\n\n    existing\n";
     let doc = parse_document(source).expect("parse");
-    let result = prepare_paste(&doc, source, empty_range(2, 4), "one liner");
+    // Caret at byte 12 — past "    existing", a merge position.
+    let result = prepare_paste(&doc, source, empty_range(2, 12), "one liner");
     assert_eq!(result.mode, PasteMode::PassthroughSingleLine);
     assert_eq!(result.text, "one liner");
 }


### PR DESCRIPTION
## What

Two of the three smart-paste refinements tracked in #743 (from the comms#73 spec review), to the `lex/preparePaste` re-anchor transform in `lex-lsp-core`.

### #2 — Merge-case first line: strip to baseline, not entirely (implemented)
The most concrete suggestion. `reanchor(..., fresh_line=false)` previously stripped the first line's leading whitespace **entirely**. If the first clipboard line was indented deeper than the block baseline, that extra relative indentation was lost. Now the first line of a merge is stripped only down to the clipboard `baseline`, preserving `max(0, original_indent - baseline)`.

### #1 — Single-line paste on a fresh line → re-anchor (implemented)
`classify` returned `passthrough-single-line` for **any** single-line clipboard regardless of caret context. It now splits on fresh-vs-merge (the `is_fresh_line` signal already computed by the transform, now threaded into `classify`):

- **Fresh line** (caret on a blank/whitespace-only prefix): the single line is a new block, so it **re-anchors** to the caret's structural level. A deep-indented line lifted from a nesting no longer lands over-indented.
- **Merge** (caret follows existing content): stays `passthrough-single-line` — the line continues the current one, there is no block to anchor.

**Design decision flagged:** the issue calls this "arguably should." I implemented the default the issue describes (fresh → re-anchor, merge → passthrough) because it makes single-line paste consistent with the existing multi-line fresh-line behavior and is the whole point of smart paste (kill the source's absolute indent). It is fully covered by tests. Two pre-existing tests asserted single-line passthrough at what were actually *fresh-line* caret positions (caret sitting just after the leading whitespace); they were re-pointed to genuine merge positions and complemented with fresh-line re-anchor tests. If the product preference is "single-line is always passthrough," reverting is a one-line change to `classify` — call it out in review.

### #3 — Fresh-line collapsed-caret range contract (DEFERRED, by design)
This is a spec + editor-shim contract question, not a self-contained code change, so I did **not** force it. Precise statement and rationale:

- For a collapsed caret the request `range` is empty (§2). §4.4 assumes the line's pre-existing (auto-indent) whitespace is part of the replaced range and gets overwritten by the re-anchored first line. An empty range covers none of that whitespace, so on an editor that auto-indents a fresh line, the anchor can be **duplicated** (editor's auto-indent + the transform's re-anchored indent).
- The server transform here is **pure over `(range, pasted_text)`** and has no knowledge of whatever whitespace the client leaves *outside* the edit range. Resolving this correctly requires a decision that lives in two other repos:
  1. **comms#73 §2/§4.4** must state the client contract — either "client must expand the range to cover the fresh line's leading whitespace before issuing `preparePaste`," or "transform must account for whitespace outside the edit range."
  2. The **editor shim** (ships separately, one PR per editor) must implement whichever side the spec picks.
- Picking unilaterally here risks shipping a half-broken behavior change that's wrong against whatever the spec ultimately says. Recommended next step: land the §2/§4.4 contract clarification in comms#73 (favor "client expands the range" — it keeps the server transform pure and range-driven), then the shim PRs conform. Tracked back to #743; this PR uses `Refs`, not `Closes`.

## Tests
- `reanchor_table`: added merge deeper-than-baseline relative-indent case + a single-line merge case.
- Classification: split `classify_single_line_*` into merge-passthrough vs fresh-reanchor (+ an over-indented fresh dedent case).
- End-to-end: `merge_first_line_deeper_than_baseline_preserves_relative_indent`.
- `cargo nextest run -p lex-lsp-core -p lexd-lsp` → all green (81 + 92).
- lefthook pre-commit gate green (markdownlint / cargo-fmt / cargo-clippy).
- Changelog fragment added (`CHANGELOG/unreleased-pr-743.md`); `CHANGELOG.md` not regenerated.

Refs #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)