### PR TITLE
feat(cli): `config gen` enumerates declared extension diagnostic codes (#707)

### DIFF
--- a/CHANGELOG/unreleased-config-gen-diagnostic-codes.md
+++ b/CHANGELOG/unreleased-config-gen-diagnostic-codes.md
@@ -1,0 +1,1 @@
+lexd config gen enumerates declared extension diagnostic codes as commented [diagnostics.rules] entries

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -813,6 +813,16 @@ fn handle_config_gen(
         surface_override: None,
     });
 
+    // Surface non-fatal boot problems (unresolvable namespaces, trust-gate
+    // denials, …) to stderr — otherwise a namespace that failed to register
+    // would silently drop its declared codes from the discovery section below.
+    for diag in &outcome.diagnostics {
+        match &diag.namespace {
+            Some(ns) => eprintln!("lexd config gen: {ns}: {}", diag.message),
+            None => eprintln!("lexd config gen: {}", diag.message),
+        }
+    }
+
     if let Some(section) = render_declared_diagnostics_section(&outcome) {
         if !rendered.ends_with('\n') {
             rendered.push('\n');
@@ -861,7 +871,12 @@ fn render_declared_diagnostics_section(
         let mut block = format!("# {} (declared diagnostic codes)\n", ns.name);
         for decl in &declared {
             if let Some(desc) = &decl.description {
-                block.push_str(&format!("# {desc}\n"));
+                // Comment EVERY line — a multi-line description (e.g. a YAML
+                // block scalar) would otherwise leave its continuation lines
+                // bare and produce invalid TOML once an entry is uncommented.
+                for line in desc.lines() {
+                    block.push_str(&format!("# {line}\n"));
+                }
             }
             block.push_str(&format!(
                 "# default severity: {}\n",
@@ -876,11 +891,15 @@ fn render_declared_diagnostics_section(
         return None;
     }
 
+    // The discovery section is fully COMMENTED and emits NO `[diagnostics.rules]`
+    // table header: the base clapfig template already defines that table, so a
+    // second header (or a top-level dotted key) would redefine it — invalid TOML.
+    // Users copy an entry up under the existing `[diagnostics.rules]` table.
     let mut section = String::from(
         "# Extension diagnostic rules\n\
-         # Uncomment an entry below to override an extension diagnostic's\n\
-         # severity. Allowed values: \"allow\", \"warn\", \"deny\".\n\
-         [diagnostics.rules]\n",
+         # The extension diagnostic codes below can be overridden under the\n\
+         # `[diagnostics.rules]` table above — copy an entry there and set its\n\
+         # severity. Allowed values: \"allow\", \"warn\", \"deny\".\n",
     );
     section.push_str(&blocks.join("#\n"));
     Some(section)

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -25,7 +25,7 @@
 use lexd::transforms;
 
 use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint};
-use clapfig::{Boundary, Clapfig, ConfigCommand, SchemaConfigBuilder, SearchPath};
+use clapfig::{Boundary, Clapfig, ConfigAction, ConfigCommand, SchemaConfigBuilder, SearchPath};
 use lex_analysis::semantic_tokens::collect_semantic_tokens;
 use lex_babel::{
     formats::lex::formatting_rules::FormattingRules, transforms::serialize_to_lex_with_rules,
@@ -540,10 +540,20 @@ fn main() {
                 eprintln!("Config error: {e}");
                 std::process::exit(1);
             });
-            builder.handle_and_print(&action).unwrap_or_else(|e| {
-                eprintln!("{e}");
-                std::process::exit(1);
-            });
+            // `config gen` is augmented over clapfig's static template:
+            // after the schema-derived sample, lexd boots the extension
+            // registry and appends a commented-out `[diagnostics.rules]`
+            // entry per declared extension diagnostic code (the
+            // "discovery channel" of #659 / #707). The other config
+            // actions (list/get/set/unset/schema) are plain clapfig.
+            if let ConfigAction::Gen { output } = &action {
+                handle_config_gen(builder, &matches, output.as_deref());
+            } else {
+                builder.handle_and_print(&action).unwrap_or_else(|e| {
+                    eprintln!("{e}");
+                    std::process::exit(1);
+                });
+            }
         }
         // `check-labels` doesn't need workspace config — only the
         // built-in `lex.*` canonical set, which the analysis pass
@@ -741,6 +751,152 @@ fn handle_check_labels_command(sub: &ArgMatches) -> i32 {
         label_diags.len()
     );
     1
+}
+
+/// Dispatch `lexd config gen`.
+///
+/// Augments clapfig's schema-derived template with a "discovery
+/// channel" (#659 / #707): after the static sample, lexd boots the
+/// extension registry from the workspace `[labels]` block (and any
+/// `--ext-schema` flags) and, for every registered namespace, appends
+/// a commented-out `[diagnostics.rules]` entry per *declared*
+/// diagnostic code. Each line is annotated with the code's declared
+/// `description` and `default_severity` so users see concrete lines to
+/// uncomment instead of guessing at what codes a namespace emits.
+///
+/// The rule *value* itself is the user-facing `[diagnostics.rules]`
+/// severity vocabulary (`allow` / `warn` / `deny`), defaulting to
+/// `warn`; the declared `default_severity` (an LSP-level
+/// `error`/`warning`/`info`/`hint`) is surfaced in the comment only,
+/// since it is declaration metadata, not a rule override value.
+fn handle_config_gen(
+    builder: SchemaConfigBuilder<LexConfig>,
+    matches: &ArgMatches,
+    output: Option<&Path>,
+) {
+    // Base template from clapfig (schema-derived commented sample).
+    let mut rendered = builder
+        .handle_to_string(&ConfigAction::Gen { output: None })
+        .unwrap_or_else(|e| {
+            eprintln!("{e}");
+            std::process::exit(1);
+        });
+
+    // Boot the registry the same way `lexd labels` does so the
+    // generated template reflects the namespaces actually visible to
+    // this workspace.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let workspace = find_nearest_lex_toml_dir(&cwd).unwrap_or_else(|| cwd.clone());
+    let labels_path = workspace.join(CONFIG_FILE_NAME);
+    let labels_config = match lex_config::load_labels_from_toml(&labels_path) {
+        Ok(c) => c,
+        Err(lex_config::LabelsConfigError::Io { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            lex_config::LabelsConfig::default()
+        }
+        Err(e) => {
+            eprintln!("lexd config gen: {e}");
+            std::process::exit(1);
+        }
+    };
+    let ext_schemas: Vec<PathBuf> = matches
+        .get_many::<PathBuf>("ext-schema")
+        .map(|values| values.cloned().collect())
+        .unwrap_or_default();
+    let enable_handlers = matches.get_flag("enable-handlers");
+    let outcome = lexd::extension_setup::boot_registry(lexd::extension_setup::ExtensionSetup {
+        workspace_root: &workspace,
+        labels_config: &labels_config,
+        ext_schemas: &ext_schemas,
+        enable_handlers,
+        surface_override: None,
+    });
+
+    if let Some(section) = render_declared_diagnostics_section(&outcome) {
+        if !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push('\n');
+        rendered.push_str(&section);
+    }
+
+    match output {
+        Some(path) => {
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        eprintln!("lexd config gen: {}: {e}", parent.display());
+                        std::process::exit(1);
+                    }
+                }
+            }
+            if let Err(e) = fs::write(path, &rendered) {
+                eprintln!("lexd config gen: {}: {e}", path.display());
+                std::process::exit(1);
+            }
+            println!("Wrote {}", path.display());
+        }
+        None => print!("{rendered}"),
+    }
+}
+
+/// Build the commented `[diagnostics.rules]` discovery section from a
+/// booted registry, or `None` when no registered namespace declares
+/// any diagnostic codes (so `config gen` output is unchanged for the
+/// common no-extension case).
+fn render_declared_diagnostics_section(
+    outcome: &lexd::extension_setup::BootOutcome,
+) -> Option<String> {
+    let mut blocks: Vec<String> = Vec::new();
+
+    for ns in &outcome.registered {
+        let Some(declared) = outcome.registry.declared_diagnostic_codes(&ns.name) else {
+            continue;
+        };
+        if declared.is_empty() {
+            continue;
+        }
+
+        let mut block = format!("# {} (declared diagnostic codes)\n", ns.name);
+        for decl in &declared {
+            if let Some(desc) = &decl.description {
+                block.push_str(&format!("# {desc}\n"));
+            }
+            block.push_str(&format!(
+                "# default severity: {}\n",
+                declared_severity_str(decl.default_severity)
+            ));
+            block.push_str(&format!("# \"{}.{}\" = \"warn\"\n", ns.name, decl.code));
+        }
+        blocks.push(block);
+    }
+
+    if blocks.is_empty() {
+        return None;
+    }
+
+    let mut section = String::from(
+        "# Extension diagnostic rules\n\
+         # Uncomment an entry below to override an extension diagnostic's\n\
+         # severity. Allowed values: \"allow\", \"warn\", \"deny\".\n\
+         [diagnostics.rules]\n",
+    );
+    section.push_str(&blocks.join("#\n"));
+    Some(section)
+}
+
+/// Render a declared (`DiagnosticDecl`) LSP-level severity as the
+/// lowercase string used in `config gen` annotations.
+fn declared_severity_str(severity: lex_extension::DiagnosticSeverity) -> &'static str {
+    use lex_extension::DiagnosticSeverity;
+    match severity {
+        DiagnosticSeverity::Error => "error",
+        DiagnosticSeverity::Warning => "warning",
+        DiagnosticSeverity::Info => "info",
+        DiagnosticSeverity::Hint => "hint",
+        _ => "info",
+    }
 }
 
 /// Dispatch `lexd labels {list,validate}`. Returns the exit code

--- a/crates/lex-cli/tests/integration/config_gen.rs
+++ b/crates/lex-cli/tests/integration/config_gen.rs
@@ -1,0 +1,88 @@
+//! End-to-end tests for `lexd config gen`'s extension-diagnostic
+//! "discovery channel" (#659 / #707): with a registered namespace that
+//! declares diagnostic codes, `config gen` appends a commented-out
+//! `[diagnostics.rules]` entry per declared code, annotated with its
+//! description and default severity.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a workspace whose `[labels]` block registers an `acme`
+/// namespace from a local `acme/` schema dir. The schema declares two
+/// diagnostic codes so `config gen` has something to enumerate.
+fn workspace_with_declared_diagnostics() -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(".lex.toml"),
+        "[labels]\nacme = \"path:acme\"\n",
+    )
+    .unwrap();
+
+    let acme_dir = dir.path().join("acme");
+    fs::create_dir(&acme_dir).unwrap();
+    fs::write(
+        acme_dir.join("task.yaml"),
+        "schema_version: 1\n\
+         label: acme.task\n\
+         attaches_to: [annotation, paragraph]\n\
+         diagnostics:\n  \
+         - code: task-due-date-missing\n    \
+         description: A task is missing its due date.\n    \
+         default_severity: warning\n  \
+         - code: task-overdue\n    \
+         description: A task's due date is in the past.\n    \
+         default_severity: error\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn config_gen_emits_commented_entry_per_declared_code() {
+    let dir = workspace_with_declared_diagnostics();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["config", "gen"])
+        .assert()
+        .success()
+        .stdout(
+            // The discovery section header + the rules table.
+            predicates::str::contains("[diagnostics.rules]")
+                // One commented entry per declared code, keyed by the
+                // on-the-wire `<namespace>.<code>`.
+                .and(predicates::str::contains(
+                    "# \"acme.task-due-date-missing\" = \"warn\"",
+                ))
+                .and(predicates::str::contains(
+                    "# \"acme.task-overdue\" = \"warn\"",
+                ))
+                // Each annotated with its declared description ...
+                .and(predicates::str::contains(
+                    "# A task is missing its due date.",
+                ))
+                .and(predicates::str::contains(
+                    "# A task's due date is in the past.",
+                ))
+                // ... and its declared default severity.
+                .and(predicates::str::contains("# default severity: warning"))
+                .and(predicates::str::contains("# default severity: error")),
+        );
+}
+
+#[test]
+fn config_gen_without_declared_diagnostics_omits_section() {
+    // A bare workspace (no `[labels]`, no extension schemas) has no
+    // declared diagnostic codes, so `config gen` emits the plain
+    // schema template with no discovery section.
+    let dir = TempDir::new().unwrap();
+    Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["config", "gen"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Extension diagnostic rules").not());
+}

--- a/crates/lex-cli/tests/integration/config_gen.rs
+++ b/crates/lex-cli/tests/integration/config_gen.rs
@@ -73,6 +73,58 @@ fn config_gen_emits_commented_entry_per_declared_code() {
 }
 
 #[test]
+fn config_gen_output_is_valid_toml_with_multiline_descriptions() {
+    // Regression (lex#750 review): a multi-line declared description must have
+    // EVERY line commented, and the discovery section must NOT emit a second
+    // `[diagnostics.rules]` table header (the base template already defines it) —
+    // either would yield invalid TOML.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(".lex.toml"),
+        "[labels]\nacme = \"path:acme\"\n",
+    )
+    .unwrap();
+    let acme_dir = dir.path().join("acme");
+    fs::create_dir(&acme_dir).unwrap();
+    fs::write(
+        acme_dir.join("task.yaml"),
+        "schema_version: 1\n\
+         label: acme.task\n\
+         attaches_to: [annotation, paragraph]\n\
+         diagnostics:\n  \
+         - code: task-overdue\n    \
+         description: |\n      \
+         First line of the description.\n      \
+         Second line that must also be commented.\n    \
+         default_severity: error\n",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("lexd")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["config", "gen"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+
+    // every line of the multi-line description is commented
+    assert!(stdout.contains("# First line of the description."));
+    assert!(stdout.contains("# Second line that must also be commented."));
+    // exactly one (base-template) `[diagnostics.rules]` table header — the
+    // discovery section adds none, so the TOML never redefines the table.
+    let headers = stdout
+        .lines()
+        .filter(|l| l.trim_start() == "[diagnostics.rules]")
+        .count();
+    assert_eq!(
+        headers, 1,
+        "expected exactly one [diagnostics.rules] header, got {headers}\n{stdout}"
+    );
+}
+
+#[test]
 fn config_gen_without_declared_diagnostics_omits_section() {
     // A bare workspace (no `[labels]`, no extension schemas) has no
     // declared diagnostic codes, so `config gen` emits the plain

--- a/crates/lex-cli/tests/integration/main.rs
+++ b/crates/lex-cli/tests/integration/main.rs
@@ -1,5 +1,6 @@
 //! Consolidated integration-test binary for lexd.
 
+mod config_gen;
 mod element_at;
 mod format_config;
 mod includes;


### PR DESCRIPTION
Closes #707 (the "discovery channel" deferred from #659; validation shipped in #706).

## What

`lexd config gen` now augments clapfig's static schema-derived template with a
**discovery section**: after the base sample, lexd boots the extension registry
(from the workspace `[labels]` block + any `--ext-schema` flags, the same path
`lexd labels` uses) and, for every registered namespace, appends a commented-out
`[diagnostics.rules]` entry per *declared* diagnostic code — annotated with its
declared `description` and `default_severity`. Users see concrete lines to
uncomment instead of guessing what codes a namespace emits.

Design note: the rule *value* uses the user-facing `[diagnostics.rules]` vocab
(`allow`/`warn`/`deny`, default `warn`); the declared `default_severity` (the
LSP-level `error`/`warning`/`info`/`hint`) is surfaced in the comment only — they
are different severity domains. Output is byte-identical for the common
no-extension workspace.

## Files
- `crates/lex-cli/src/main.rs` — intercept `ConfigAction::Gen` with `handle_config_gen` + `render_declared_diagnostics_section`.
- `crates/lex-cli/tests/integration/config_gen.rs` (new) — registered namespace with two declared codes → commented entry per code w/ description + severity; bare workspace → no section.

## Verification
- `release-core gate` green (fmt/clippy/lint).
- `cargo test -p lexd`: 57 integration tests pass (incl. the 2 new). Tests are a separate CI check from the lint gate.

Draft per the draft-first dev cycle; flips to ready when reviewed + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)