### PR TITLE
chore(ci): migrate release reusable-workflow callers @v2 → @v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v3
     with:
       binary-name: lexd
       submodules: 'recursive'

--- a/.github/workflows/on-upstream-released.yml
+++ b/.github/workflows/on-upstream-released.yml
@@ -1,6 +1,6 @@
 # Layer 2 handler: react to an upstream's release.
 #
-# Thin caller of arthur-debert/release's canonical `cascade-handler@v1`.
+# Thin caller of arthur-debert/release's canonical `cascade-handler@v3`.
 # The reusable workflow runs the 5 `scripts/release/` primitives in order:
 #   should-release → get-current-version → (compute new) → update-release
 #   → commit + branch + admin-merge PR → trigger-release
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   cascade:
-    uses: arthur-debert/release/.github/workflows/cascade-handler.yml@v2
+    uses: arthur-debert/release/.github/workflows/cascade-handler.yml@v3
     with:
       git-author-name: lex-fmt release-bot
       git-author-email: release-bot@lex-fmt.local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v3.
 # Bug fixes and improvements to the release pipeline come in via a
-# bump of the @v1 floating ref, no changes here.
+# bump of the @v3 floating ref, no changes here.
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v3
     with:
       version: ${{ inputs.version }}
       # Topological dep order. lex-extension publishes the public handler

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,0 +1,1 @@
+- ci: migrate release reusable-workflow callers from @v2 to @v3


### PR DESCRIPTION
Migrates lex's `arthur-debert/release` reusable-workflow callers from `@v2` to `@v3`.

## Why
`arthur-debert/release` cut **v3.0.0**. The major bump is **mechanical** — it only removed the unused `wasm-package` input (#634). No behavior change for this consumer; lex already uses `wasm-packages` (plural).

## Workflows bumped (uses: + version-referencing comments)
- `.github/workflows/ci.yml` — `rust-ci.yml@v2` → `@v3`
- `.github/workflows/release.yml` — `rust-cli.yml@v2` → `@v3` (uses + header comment + "floating ref" comment)
- `.github/workflows/on-upstream-released.yml` — `cascade-handler.yml@v2` → `@v3` (uses + header comment)

## Left untouched (intentional)
- `copilot-review.yml@v1` — pinned to v1 by design.
- `secrets:` blocks — this is a **cross-org** (lex-fmt → arthur-debert) consumer; `secrets: inherit` doesn't propagate, so the explicit secret mappings (incl. `CRATES_IO_KEY` ← `CARGO_REGISTRY_TOKEN`) stay as-is.
- Managed tree (`.release/**`, skills, etc.) — **NOT** in this PR; it arrives via the consumer's own wheel pull at the next SessionStart.

🤖 Generated with Claude Code