### PR TITLE
chore(release): re-seed managed tree from release v3.1.0

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v3
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/bin/pr-loop-guard
+++ b/bin/pr-loop-guard
@@ -133,16 +133,20 @@ def main():
         cwd = os.getcwd()
 
     # Candidate repos: the payload cwd PLUS any `cd <dir>` the command changes
-    # into before `gh pr create` (resolved relative to the payload cwd, with ~
-    # expansion). The sentinel armed in ANY of them counts — so a subagent that
-    # armed the target repo's .git is honoured even though the payload cwd is the
-    # session root.
+    # into before `gh pr create` (with ~ expansion). The sentinel armed in ANY
+    # of them counts — so a subagent that armed the target repo's .git is
+    # honoured even though the payload cwd is the session root. Sequential cds
+    # fold left: each relative target resolves against the previous resolved
+    # dir (`cd a && cd b` really lands in cwd/a/b), while an absolute or ~
+    # target resets the accumulator (release#632).
     candidate_cwds = [cwd]
+    acc = cwd
     for tgt in cd_targets(command):
         expanded = os.path.expanduser(tgt)
         if not os.path.isabs(expanded):
-            expanded = os.path.join(cwd, expanded)
+            expanded = os.path.join(acc, expanded)
         candidate_cwds.append(expanded)
+        acc = expanded
 
     # Collect each candidate's sentinel path; allow (consuming) on the first that
     # exists. The absolute paths feed the deny reason so the agent arms the right

--- a/bin/setup-dev-env.sh
+++ b/bin/setup-dev-env.sh
@@ -198,9 +198,7 @@ fi
 # Wiring `.git/hooks/pre-commit` is per-clone state — every fresh clone
 # (and cloud snapshot) starts without it, so we wire it on every session
 # and in both contexts. Runs ABOVE the cloud-only gate because skipping
-# it locally is what produces the "agents are still running husky"
-# symptom: lefthook never gets installed, husky's old wiring keeps
-# firing.
+# it locally leaves the session with no pre-commit hook wired at all.
 #
 # Runs AFTER the pull-model boot (§0.1) deliberately (release#567): on a
 # fresh clone/session the boot installs release-core and `release-core
@@ -214,13 +212,6 @@ fi
 # brew/cargo/npm locally). Fallback for repos that ship a hand-rolled
 # app-bin/pre-commit instead (zed-lex, tree-sitter-lex pattern): symlink
 # it into .git/hooks/.
-#
-# Husky migration: if a previous `husky install` set
-# `core.hooksPath=.husky`, git routes hooks to `.husky/pre-commit` and
-# ignores `.git/hooks/pre-commit` entirely — so `lefthook install`
-# silently no-ops. Clear that config first when migrating a repo to
-# lefthook. We do NOT delete `.husky/` itself; that's a consumer-side
-# cleanup (committed file, belongs in a PR).
 
 # Resolve lefthook binary. npm/pnpm consumers commonly have lefthook
 # installed at `node_modules/.bin/lefthook` (via `prepare: lefthook install`
@@ -253,25 +244,7 @@ if command -v release-core >/dev/null 2>&1 \
     echo "warning: release-core gate --install-hook failed — pre-commit hook NOT wired" >&2
   fi
 elif [ -f lefthook.yml ] && [ -n "${_lefthook}" ]; then
-  # `git config --get` returns 1 when unset. Command substitution exit
-  # codes don't propagate `set -e` from a conditional context, but the
-  # explicit `|| true` makes the empty-when-unset intent unambiguous.
-  _hooks_path="$(git config --get core.hooksPath 2>/dev/null || true)"
-  # Unset core.hooksPath if set to ANY value (not just .husky). Any
-  # custom hooksPath redirects git away from .git/hooks/, which is
-  # where `lefthook install` writes its pre-commit shim — so a leftover
-  # config from any prior hook manager (husky, pre-commit framework,
-  # custom) makes the install silently no-op.
-  if [ -n "${_hooks_path}" ]; then
-    # Don't suppress unset failures with `|| true` — if the unset
-    # fails (e.g. unwritable .git/config), the custom redirect stays
-    # in place and the subsequent `lefthook install` is effectively
-    # a no-op. The user needs to know that, not have it silently
-    # swallowed.
-    if ! git config --unset core.hooksPath; then
-      echo "warning: failed to unset core.hooksPath (=${_hooks_path}); custom redirect still active — lefthook install will not take effect" >&2
-    fi
-  fi
+  # Root-lefthook.yml branch — release's own repo (hand-authored root gate).
   if ! "${_lefthook}" install >/dev/null; then
     echo "warning: lefthook install failed — pre-commit hook NOT wired" >&2
   fi


### PR DESCRIPTION
Converge the managed tree to the published `release v3.1.0` wheel — the change a SessionStart pull would auto-commit, applied now to unblock fleet-wide v3 convergence (release Epic 3 / #652, §3.4 gated cleanups).

Pure managed-tree sync (`release-core init` output), 3 tracked files:
- `.github/workflows/copilot-review.yml` — caller `@v1 → @v3` (resolves the #569-B9 copilot-review re-sweep for this repo)
- `bin/pr-loop-guard` — upstream bugfix (release#632: sequential-cd folding)
- `bin/setup-dev-env.sh` — husky-migration logic simplified out upstream

No consumer-authored content touched; companion workflows (`test-rust.yml`/`sandbox-tests.yml`/`pages.yml`) untouched. Gate verified green locally.