### PR TITLE
test(wire): cover inline codec helpers and FromWireError surface

### DIFF
--- a/CHANGELOG/unreleased-wire-codec-tests.md
+++ b/CHANGELOG/unreleased-wire-codec-tests.md
@@ -1,0 +1,1 @@
+- Add direct unit tests for the wire/inline codec helpers and the FromWireError Display surface (covers each WireInline arm forward+reverse, raises wire/inline.rs line coverage 35% → 94% and wire/error.rs 0% → 100%).

--- a/crates/lex-core/src/lex/wire/error.rs
+++ b/crates/lex-core/src/lex/wire/error.rs
@@ -38,3 +38,69 @@ impl std::fmt::Display for FromWireError {
 }
 
 impl std::error::Error for FromWireError {}
+
+#[cfg(test)]
+mod tests {
+    //! `FromWireError` is what propagates out of the reverse codec
+    //! when the wire input is malformed; its `Display` impl is what
+    //! callers (handler dispatch, debug logs, panics in tests) end
+    //! up showing humans, so pin the surface text down.
+    use super::*;
+
+    #[test]
+    fn display_unsupported_kind_includes_kind_string() {
+        let err = FromWireError::UnsupportedKind {
+            kind: "lex.future.shape".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("unsupported kind"), "got: {msg}");
+        assert!(msg.contains("lex.future.shape"), "got: {msg}");
+    }
+
+    #[test]
+    fn display_malformed_field_includes_field_and_detail() {
+        let err = FromWireError::MalformedField {
+            field: "params",
+            detail: "expected object".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("malformed field"), "got: {msg}");
+        assert!(msg.contains("params"), "got: {msg}");
+        assert!(msg.contains("expected object"), "got: {msg}");
+    }
+
+    #[test]
+    fn display_deserialisation_failed_includes_detail() {
+        let err = FromWireError::DeserialisationFailed("invalid type: integer `1`".into());
+        let msg = err.to_string();
+        assert!(msg.contains("deserialisation failed"), "got: {msg}");
+        assert!(msg.contains("invalid type"), "got: {msg}");
+    }
+
+    /// `FromWireError` participates in `std::error::Error`. Confirm it
+    /// can be boxed and re-formatted through that trait — the path
+    /// dispatch code uses when bubbling up handler errors.
+    #[test]
+    fn implements_std_error_and_round_trips_via_dyn() {
+        let err: Box<dyn std::error::Error> =
+            Box::new(FromWireError::UnsupportedKind { kind: "x".into() });
+        assert!(err.to_string().contains("unsupported kind"));
+    }
+
+    /// `Clone` and `PartialEq` are part of the public surface — tests
+    /// that triage error-bearing return paths rely on them.
+    #[test]
+    fn clone_and_equality_hold() {
+        let a = FromWireError::MalformedField {
+            field: "f",
+            detail: "d".into(),
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+        let c = FromWireError::MalformedField {
+            field: "f",
+            detail: "other".into(),
+        };
+        assert_ne!(a, c);
+    }
+}

--- a/crates/lex-core/src/lex/wire/inline.rs
+++ b/crates/lex-core/src/lex/wire/inline.rs
@@ -128,3 +128,238 @@ fn write_inline_source(inline: &WireInline, buf: &mut String) {
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Direct unit tests for the inline codec helpers.
+    //!
+    //! These complement the higher-level wire round-trip tests in
+    //! `wire::tests` by exercising each `WireInline` arm explicitly —
+    //! the round-trip suite currently focuses on block-level nodes and
+    //! only touches inlines through plain `Text`, which leaves
+    //! `Bold`/`Italic`/`Code`/`Math`/`Reference` and the empty-text
+    //! short-circuit uncovered.
+    use super::*;
+    use crate::lex::ast::elements::inlines::ReferenceInline;
+    use crate::lex::ast::TextContent;
+    use crate::lex::inlines::parse_inlines;
+    use lex_extension::wire::{RefKind, WireInline};
+
+    /// Empty `TextContent` must yield an empty wire vector — not a
+    /// single empty `Text` inline, which would be a wasteful (and
+    /// semantically distinct) round-trip artefact.
+    #[test]
+    fn text_content_to_wire_empty_yields_empty_vec() {
+        let tc = TextContent::empty();
+        assert!(text_content_to_wire(&tc).is_empty());
+    }
+
+    /// Raw text without parsed inlines (the Phase-1 representation)
+    /// emits a single `WireInline::Text` carrying the original string
+    /// verbatim. Re-parsing on the far side restores any formatting
+    /// markers.
+    #[test]
+    fn text_content_to_wire_raw_emits_single_text_inline() {
+        let tc = TextContent::from_string("plain *bold* text".into(), None);
+        let wire = text_content_to_wire(&tc);
+        assert_eq!(wire.len(), 1);
+        match &wire[0] {
+            WireInline::Text { text } => assert_eq!(text, "plain *bold* text"),
+            other => panic!("expected Text inline carrying the raw string, got {other:?}"),
+        }
+    }
+
+    /// Once inlines are parsed, the codec walks the tree and emits
+    /// matching wire variants rather than collapsing to raw text.
+    #[test]
+    fn text_content_to_wire_walks_parsed_inlines() {
+        let mut tc = TextContent::from_string("hello *loud* world".into(), None);
+        tc.ensure_inline_parsed();
+        let wire = text_content_to_wire(&tc);
+        // Expect: Text("hello "), Bold([Text("loud")]), Text(" world").
+        assert_eq!(wire.len(), 3);
+        assert!(matches!(&wire[0], WireInline::Text { text } if text == "hello "));
+        match &wire[1] {
+            WireInline::Bold { children } => {
+                assert_eq!(children.len(), 1);
+                assert!(matches!(&children[0], WireInline::Text { text } if text == "loud"));
+            }
+            other => panic!("expected Bold inline, got {other:?}"),
+        }
+        assert!(matches!(&wire[2], WireInline::Text { text } if text == " world"));
+    }
+
+    /// Each `InlineNode` variant has a matching `WireInline` arm —
+    /// pin them down individually so a future refactor that drops or
+    /// re-maps one arm fails loudly.
+    #[test]
+    fn each_inline_node_variant_maps_to_its_wire_arm() {
+        let plain = InlineNode::plain("p".into());
+        assert!(matches!(inline_nodes_to_wire(&vec![plain])[0],
+            WireInline::Text { ref text } if text == "p"));
+
+        let strong = InlineNode::strong(vec![InlineNode::plain("s".into())]);
+        match &inline_nodes_to_wire(&vec![strong])[0] {
+            WireInline::Bold { children } => {
+                assert!(matches!(&children[0], WireInline::Text { text } if text == "s"));
+            }
+            other => panic!("Strong → Bold expected, got {other:?}"),
+        }
+
+        let emphasis = InlineNode::emphasis(vec![InlineNode::plain("e".into())]);
+        match &inline_nodes_to_wire(&vec![emphasis])[0] {
+            WireInline::Italic { children } => {
+                assert!(matches!(&children[0], WireInline::Text { text } if text == "e"));
+            }
+            other => panic!("Emphasis → Italic expected, got {other:?}"),
+        }
+
+        let code = InlineNode::code("x".into());
+        assert!(matches!(inline_nodes_to_wire(&vec![code])[0],
+            WireInline::Code { ref text } if text == "x"));
+
+        let math = InlineNode::math("y".into());
+        assert!(matches!(inline_nodes_to_wire(&vec![math])[0],
+            WireInline::Math { ref text } if text == "y"));
+
+        let reference = InlineNode::reference(ReferenceInline::new("ref".into()));
+        match &inline_nodes_to_wire(&vec![reference])[0] {
+            WireInline::Reference {
+                ref_kind,
+                target,
+                label,
+            } => {
+                // The forward codec emits `RefKind::General` and no label —
+                // detail-level fidelity is documented as a future
+                // improvement, so pin the current behaviour explicitly.
+                assert_eq!(*ref_kind, RefKind::General);
+                assert_eq!(target, "ref");
+                assert!(label.is_none());
+            }
+            other => panic!("Reference → Reference expected, got {other:?}"),
+        }
+    }
+
+    /// Nested formatting (`*outer _inner_*`) preserves structure: the
+    /// inner emphasis appears under the outer bold's children, not
+    /// flattened.
+    #[test]
+    fn nested_strong_with_inner_emphasis_preserves_structure() {
+        let node = InlineNode::strong(vec![
+            InlineNode::plain("o ".into()),
+            InlineNode::emphasis(vec![InlineNode::plain("i".into())]),
+        ]);
+        let wire = inline_nodes_to_wire(&vec![node]);
+        let WireInline::Bold { children } = &wire[0] else {
+            panic!("expected Bold");
+        };
+        assert_eq!(children.len(), 2);
+        assert!(matches!(&children[0], WireInline::Text { text } if text == "o "));
+        let WireInline::Italic { children: inner } = &children[1] else {
+            panic!("expected nested Italic");
+        };
+        assert!(matches!(&inner[0], WireInline::Text { text } if text == "i"));
+    }
+
+    /// Reverse path: each `WireInline` arm re-serialises to a `.lex`
+    /// source-form string that the inline parser re-reads identically.
+    /// This is the contract `from_wire_*` relies on.
+    #[test]
+    fn from_wire_emits_source_form_per_variant() {
+        let cases: &[(&[WireInline], &str)] = &[
+            (&[WireInline::Text { text: "raw".into() }], "raw"),
+            (
+                &[WireInline::Bold {
+                    children: vec![WireInline::Text { text: "b".into() }],
+                }],
+                "*b*",
+            ),
+            (
+                &[WireInline::Italic {
+                    children: vec![WireInline::Text { text: "i".into() }],
+                }],
+                "_i_",
+            ),
+            (&[WireInline::Code { text: "c".into() }], "`c`"),
+            (&[WireInline::Math { text: "m".into() }], "#m#"),
+            (
+                &[WireInline::Reference {
+                    ref_kind: RefKind::General,
+                    target: "target".into(),
+                    label: None,
+                }],
+                "[target]",
+            ),
+            (
+                &[WireInline::Reference {
+                    ref_kind: RefKind::General,
+                    target: "url".into(),
+                    label: Some("see".into()),
+                }],
+                "[see]",
+            ),
+        ];
+        for (inlines, expected) in cases {
+            let tc = text_content_from_wire(inlines);
+            assert_eq!(
+                tc.as_string(),
+                *expected,
+                "reverse codec emitted unexpected source for {inlines:?}"
+            );
+        }
+    }
+
+    /// Reverse with multiple inlines concatenates their source forms
+    /// in order — no separator, matching how the inline parser will
+    /// re-tokenise them.
+    #[test]
+    fn from_wire_concatenates_multiple_inlines() {
+        let inlines = vec![
+            WireInline::Text { text: "a ".into() },
+            WireInline::Bold {
+                children: vec![WireInline::Text { text: "b".into() }],
+            },
+            WireInline::Text { text: " c".into() },
+        ];
+        let tc = text_content_from_wire(&inlines);
+        assert_eq!(tc.as_string(), "a *b* c");
+    }
+
+    /// End-to-end identity for `.lex` source containing every
+    /// supported inline kind: parse → forward → reverse should
+    /// reproduce the original source character-for-character.
+    /// This is the property the codec exists to guarantee for the
+    /// `lex.include` splicing path.
+    #[test]
+    fn round_trip_preserves_source_for_each_inline_kind() {
+        let source = "plain *bold* _italic_ `code` #math# [ref]";
+        let mut tc = TextContent::from_string(source.into(), None);
+        tc.ensure_inline_parsed();
+        let wire = text_content_to_wire(&tc);
+        let back = text_content_from_wire(&wire);
+        assert_eq!(back.as_string(), source);
+    }
+
+    /// `parse_inlines` is the source of truth for what the codec sees
+    /// — use it directly to confirm the forward path doesn't depend
+    /// on any TextContent caching subtlety.
+    #[test]
+    fn inline_nodes_to_wire_handles_parser_output_directly() {
+        let nodes = parse_inlines("a `code` b");
+        let wire = inline_nodes_to_wire(&nodes);
+        // Whatever the parser produced, the wire form must end with a
+        // Text("b") inline (the trailing plain segment) — a sanity
+        // check that the codec doesn't drop trailing nodes.
+        assert!(
+            matches!(wire.last(), Some(WireInline::Text { text }) if text == " b"),
+            "expected trailing Text inline, got {:?}",
+            wire.last()
+        );
+        // And a Code inline must appear somewhere in the middle.
+        assert!(
+            wire.iter()
+                .any(|w| matches!(w, WireInline::Code { text } if text == "code")),
+            "Code inline missing from wire output: {wire:?}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds direct unit tests for the `lex::wire::inline` codec helpers — every `InlineNode` → `WireInline` arm in the forward direction, every `WireInline` → source-form arm in the reverse direction, the empty-text short-circuit, nested formatting, and an end-to-end source-identity round-trip across all supported inline kinds.
- Pins the `FromWireError` Display surface and trait conformance (Clone / PartialEq / round-tripping through `Box<dyn std::error::Error>`), which had no direct tests.

## Coverage delta

| File | Lines before | Lines after |
|---|---|---|
| `crates/lex-core/src/lex/wire/inline.rs` | 35.06% | 94.44% |
| `crates/lex-core/src/lex/wire/error.rs`  |  0.00% | 100.00% |

Test count: 2521 → 2535 (+14, all passing).

## Context

- `wire/inline.rs` was indirectly exercised through higher-level wire round-trip tests, but those tests only carried plain-text inlines, leaving `Bold` / `Italic` / `Code` / `Math` / `Reference` arms uncovered in both directions and the `text_content_to_wire` empty-string short-circuit untested.
- The helpers are `pub(crate)`, so tests live in `#[cfg(test)] mod tests` blocks inside each source file (same crate visibility as the higher-level `wire::tests` module).
- The reverse codec contract is "re-serialise to `.lex` source the inline parser re-reads identically" — the round-trip test pins that contract end-to-end against a string containing one of every supported kind.
- Reference forward mapping is currently lossy (always emits `RefKind::General`, drops the label). The test pins that current behaviour explicitly with a comment so a future fidelity improvement updates this test alongside the codec change.
- The `_ => {}` arm in `write_inline_source` (defensive against future `WireInline` variants, which is `#[non_exhaustive]`) is deliberately not exercised — there is no public way to construct an unknown variant from inside the crate, and synthesising one would require either an extension-crate change or an `unsafe` transmute. Leaving it as the only uncovered branch is intentional.

Tests-only — no production behaviour change.

## Test plan

- [x] `cargo test -p lex-core --lib lex::wire::inline::tests` — 9 pass
- [x] `cargo test -p lex-core --lib lex::wire::error::tests` — 5 pass
- [x] `release-core test-unit` — 2535 pass, 1 skipped
- [x] `release-core gate` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)