### PR TITLE
feat(cli): lexd check --references — internal cross-reference validation

### DIFF
--- a/CHANGELOG/unreleased-lexd-check-references.md
+++ b/CHANGELOG/unreleased-lexd-check-references.md
@@ -1,0 +1,1 @@
+- lexd check --references: internal cross-reference validation (session/definition/annotation/citation) over the merged document; fixes reference diagnostics inside included fragments

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -1426,15 +1426,17 @@ mod tests {
 
     #[test]
     fn each_unresolved_citation_key_is_flagged() {
-        // A multi-key citation flags each unresolved key independently.
+        // A multi-key citation flags each unresolved key independently —
+        // both `@a` and `@b`, not just the first. Exactly two pins the
+        // per-key behaviour against a regression that reports only one.
         let diags = reference_diags("1. Intro\n\n    See [@a; @b].\n");
         let citation = diags
             .iter()
             .filter(|d| d.kind == DiagnosticKind::MissingCitationTarget)
             .count();
-        assert!(
-            citation >= 1,
-            "expected at least one citation finding: {diags:?}"
+        assert_eq!(
+            citation, 2,
+            "both unresolved keys must be flagged: {diags:?}"
         );
     }
 

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -53,6 +53,21 @@ pub enum DiagnosticKind {
     /// warns the author that what looks like metadata is being treated as
     /// content. The fix is to close the marker: `:: label ::`.
     UnclosedAnnotation,
+    /// A session reference (`[#2.1]`) whose identifier matches no session
+    /// in the merged document. Emitted only by the opt-in
+    /// [`analyze_references`] pass (`check --references`), never by the
+    /// always-on analyser.
+    MissingSessionTarget,
+    /// A definition reference (`[Title]`) whose subject matches no
+    /// definition in the merged document. Opt-in (`check --references`).
+    MissingDefinitionTarget,
+    /// An annotation reference (`[::label]`) whose label matches no
+    /// annotation in the merged document. Opt-in (`check --references`).
+    MissingAnnotationTarget,
+    /// A citation reference (`[@key]`) whose key matches no annotation
+    /// label or definition subject in the merged document. Opt-in
+    /// (`check --references`).
+    MissingCitationTarget,
 }
 
 /// Severity for analysis-emitted diagnostics. The analyser populates
@@ -134,6 +149,10 @@ impl DiagnosticKind {
             DiagnosticKind::ForbiddenLabelPrefix => "forbidden-label-prefix".into(),
             DiagnosticKind::UnknownLexCanonical => "unknown-lex-canonical".into(),
             DiagnosticKind::UnclosedAnnotation => "unclosed-annotation".into(),
+            DiagnosticKind::MissingSessionTarget => "missing-session-target".into(),
+            DiagnosticKind::MissingDefinitionTarget => "missing-definition-target".into(),
+            DiagnosticKind::MissingAnnotationTarget => "missing-annotation-target".into(),
+            DiagnosticKind::MissingCitationTarget => "missing-citation-target".into(),
         }
     }
 }
@@ -288,6 +307,106 @@ pub fn analyze_with_rules(
 ) -> Vec<AnalysisDiagnostic> {
     let mut diagnostics = analyze_with_registry(document, registry);
     apply_rules(&mut diagnostics, |code| rules.lookup_by_code(code).cloned());
+    diagnostics
+}
+
+/// Opt-in pass: validate internal cross-references over the (merged)
+/// document and emit a `missing-*-target` diagnostic for each dangling
+/// in-document reference.
+///
+/// **Deliberately separate from [`analyze_with_registry`]** so the
+/// always-on analyser (and thus the LSP, which calls
+/// [`analyze_with_rules`] on every keystroke) does *not* emit these.
+/// `check --references` calls this explicitly; the LSP can opt in later.
+///
+/// Resolution runs over the single merged tree, so it is bidirectional:
+/// a reference resolves against targets defined anywhere in the document
+/// — any included fragment or the master — and a `missing-*` fires only
+/// when the target is absent from the *whole* tree. Each finding's range
+/// carries the reference's origin (via [`extract_references`]), so the
+/// caller blames it on the file the reference was authored in.
+///
+/// Checked kinds and their codes:
+///
+/// - [`ReferenceType::Session`] → `missing-session-target`
+/// - [`ReferenceType::General`] → `missing-definition-target`
+/// - [`ReferenceType::AnnotationReference`] → `missing-annotation-target`
+/// - [`ReferenceType::Citation`] → `missing-citation-target`
+///
+/// `ToCome` / `NotSure` are intentional placeholders and never flagged;
+/// `FootnoteNumber` is validated by the always-on analyser
+/// ([`check_footnotes`]); `Url` / `File` are out of scope here (epic
+/// #758, issues #761–#762). All emitted diagnostics default to
+/// [`DiagnosticSeverity::Warning`] — callers apply
+/// `[diagnostics.rules]` via [`apply_rules`] for per-kind overrides.
+pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
+    use crate::reference_targets::{targets_from_reference_type, ReferenceTarget};
+    use crate::references::target_resolves;
+
+    let mut diagnostics = Vec::new();
+    crate::utils::for_each_text_content(document, &mut |text| {
+        for reference in extract_references(text) {
+            let (kind, render): (DiagnosticKind, String) = match &reference.reference_type {
+                ReferenceType::Session { target } if !target.trim().is_empty() => (
+                    DiagnosticKind::MissingSessionTarget,
+                    format!(
+                        "Session reference [#{}] has no matching session",
+                        target.trim()
+                    ),
+                ),
+                ReferenceType::General { target } if !target.trim().is_empty() => (
+                    DiagnosticKind::MissingDefinitionTarget,
+                    format!("Reference [{}] has no matching definition", target.trim()),
+                ),
+                ReferenceType::AnnotationReference { label } if !label.trim().is_empty() => (
+                    DiagnosticKind::MissingAnnotationTarget,
+                    format!(
+                        "Annotation reference [::{}] has no matching annotation",
+                        label.trim()
+                    ),
+                ),
+                ReferenceType::Citation(data) => {
+                    // A citation may carry multiple keys; each is its own
+                    // potential dangling target. Emit per unresolved key.
+                    for key in &data.keys {
+                        if key.trim().is_empty() {
+                            continue;
+                        }
+                        let target = ReferenceTarget::CitationKey(key.trim().to_string());
+                        if !target_resolves(document, &target) {
+                            diagnostics.push(AnalysisDiagnostic {
+                                range: reference.range.clone(),
+                                severity: DiagnosticSeverity::Warning,
+                                kind: DiagnosticKind::MissingCitationTarget,
+                                message: format!(
+                                    "Citation [@{}] has no matching annotation or definition",
+                                    key.trim()
+                                ),
+                            });
+                        }
+                    }
+                    continue;
+                }
+                // Placeholders, footnotes (always-on), URL/File (out of
+                // scope), and empty-target references: skip.
+                _ => continue,
+            };
+
+            // Non-citation kinds: resolve via the reference's targets and
+            // emit when none match anywhere in the merged tree.
+            let resolves = targets_from_reference_type(&reference.reference_type)
+                .iter()
+                .any(|t| target_resolves(document, t));
+            if !resolves {
+                diagnostics.push(AnalysisDiagnostic {
+                    range: reference.range.clone(),
+                    severity: DiagnosticSeverity::Warning,
+                    kind,
+                    message: render,
+                });
+            }
+        }
+    });
     diagnostics
 }
 
@@ -1201,5 +1320,128 @@ mod tests {
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
         assert_eq!(diags[1].kind, DiagnosticKind::TableInconsistentColumns);
         assert_eq!(diags[1].severity, DiagnosticSeverity::Error);
+    }
+
+    // ========================================================================
+    // analyze_references (opt-in `check --references`) unit tests
+    // ========================================================================
+
+    fn reference_diags(source: &str) -> Vec<AnalysisDiagnostic> {
+        let doc = parse_document_permissive(source).expect("permissive parse");
+        analyze_references(&doc)
+    }
+
+    fn ref_codes(source: &str) -> Vec<String> {
+        let mut codes: Vec<String> = reference_diags(source)
+            .into_iter()
+            .map(|d| d.kind.code().into_owned())
+            .collect();
+        codes.sort();
+        codes
+    }
+
+    #[test]
+    fn references_pass_is_not_run_by_the_always_on_analyser() {
+        // A dangling definition reference produces nothing from `analyze`
+        // (the always-on path) — only the opt-in pass flags it. This pins
+        // the separation that keeps the LSP from emitting these unasked.
+        let doc = parse_document_permissive("Body with a [Dangling] reference.\n")
+            .expect("permissive parse");
+        let always_on = analyze(&doc);
+        assert!(
+            always_on
+                .iter()
+                .all(|d| !d.kind.code().starts_with("missing-")
+                    || d.kind == DiagnosticKind::MissingFootnoteDefinition),
+            "always-on analyser must not emit reference-target diagnostics"
+        );
+    }
+
+    #[test]
+    fn dangling_definition_reference_flagged() {
+        let codes = ref_codes("1. Intro\n\n    See [Nope].\n");
+        assert_eq!(codes, vec!["missing-definition-target"]);
+    }
+
+    #[test]
+    fn dangling_session_reference_flagged() {
+        let codes = ref_codes("1. Intro\n\n    See [#9.9].\n");
+        assert_eq!(codes, vec!["missing-session-target"]);
+    }
+
+    #[test]
+    fn dangling_annotation_reference_flagged() {
+        let codes = ref_codes("1. Intro\n\n    See [::ghost].\n");
+        assert_eq!(codes, vec!["missing-annotation-target"]);
+    }
+
+    #[test]
+    fn dangling_citation_flagged() {
+        let codes = ref_codes("1. Intro\n\n    See [@missing2024].\n");
+        assert_eq!(codes, vec!["missing-citation-target"]);
+    }
+
+    #[test]
+    fn resolved_references_are_clean() {
+        // Definition + annotation + session all defined; references to
+        // each resolve and produce no findings.
+        let source = ":: mynote ::\n\
+             \x20   Note body.\n\
+             \n\
+             Cache:\n\
+             \x20   Definition body.\n\
+             \n\
+             2. Topic\n\
+             \n\
+             \x20   See [Cache] and [::mynote] and [#2].\n";
+        assert!(
+            reference_diags(source).is_empty(),
+            "resolved references must be clean: {:?}",
+            reference_diags(source)
+        );
+    }
+
+    #[test]
+    fn citation_resolves_via_annotation_label() {
+        // `[@spec]` resolves to a `:: spec ::` annotation (its label is a
+        // citation key too).
+        let source = ":: spec ::\n    Body.\n\n1. Intro\n\n    See [@spec].\n";
+        assert!(reference_diags(source).is_empty());
+    }
+
+    #[test]
+    fn annotation_matching_is_case_insensitive() {
+        // `[::MyNote]` resolves to `:: mynote ::` — resolution is
+        // case-insensitive, mirroring `references::reference_matches`.
+        let source = ":: mynote ::\n    Body.\n\n1. Intro\n\n    See [::MyNote].\n";
+        assert!(reference_diags(source).is_empty());
+    }
+
+    #[test]
+    fn placeholders_never_flagged() {
+        // `[TK]` / `[TK-id]` and an unclassifiable reference are
+        // intentional placeholders — never flagged.
+        assert!(reference_diags("1. Intro\n\n    A [TK] and [TK-later].\n").is_empty());
+    }
+
+    #[test]
+    fn each_unresolved_citation_key_is_flagged() {
+        // A multi-key citation flags each unresolved key independently.
+        let diags = reference_diags("1. Intro\n\n    See [@a; @b].\n");
+        let citation = diags
+            .iter()
+            .filter(|d| d.kind == DiagnosticKind::MissingCitationTarget)
+            .count();
+        assert!(
+            citation >= 1,
+            "expected at least one citation finding: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn reference_findings_default_to_warning() {
+        let diags = reference_diags("1. Intro\n\n    See [Nope].\n");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
     }
 }

--- a/crates/lex-analysis/src/inline.rs
+++ b/crates/lex-analysis/src/inline.rs
@@ -130,11 +130,16 @@ impl<'a> ReferenceWalker<'a> {
     fn make_range(&self, start: usize, end: usize) -> Range {
         let start_pos = self.position_at(start);
         let end_pos = self.position_at(end);
-        Range::new(
+        let mut range = Range::new(
             (self.base_range.span.start + start)..(self.base_range.span.start + end),
             start_pos,
             end_pos,
-        )
+        );
+        // Carry the text's origin so reference diagnostics built from
+        // this range are blamed on the file the text came from (e.g. an
+        // included fragment), not the entry document.
+        range.origin_path = self.base_range.origin_path.clone();
+        range
     }
 
     fn position_at(&self, offset: usize) -> Position {

--- a/crates/lex-analysis/src/references.rs
+++ b/crates/lex-analysis/src/references.rs
@@ -119,17 +119,23 @@ fn definition_ranges(document: &Document, subject: &str) -> Vec<Range> {
 /// bidirectionally: the target may live in any included fragment or in
 /// the master, regardless of where the reference sits.
 pub fn target_resolves(document: &Document, target: &ReferenceTarget) -> bool {
+    // Trim each query so resolution matches `reference_matches`'
+    // trimmed, case-insensitive comparison and never false-positives on
+    // an untrimmed target. (The `find_*` helpers normalize internally
+    // via `normalize_key`; trimming here makes the contract explicit and
+    // self-contained rather than relying on the callee.)
     match target {
-        ReferenceTarget::AnnotationLabel(label) => annotation_label_exists(document, label),
+        ReferenceTarget::AnnotationLabel(label) => annotation_label_exists(document, label.trim()),
         ReferenceTarget::CitationKey(key) => {
-            annotation_label_exists(document, key)
-                || !find_definitions_by_subject(document, key).is_empty()
+            let trimmed = key.trim();
+            annotation_label_exists(document, trimmed)
+                || !find_definitions_by_subject(document, trimmed).is_empty()
         }
         ReferenceTarget::DefinitionSubject(subject) => {
-            !find_definitions_by_subject(document, subject).is_empty()
+            !find_definitions_by_subject(document, subject.trim()).is_empty()
         }
         ReferenceTarget::Session(identifier) => {
-            !find_sessions_by_identifier(document, identifier).is_empty()
+            !find_sessions_by_identifier(document, identifier.trim()).is_empty()
         }
     }
 }

--- a/crates/lex-analysis/src/references.rs
+++ b/crates/lex-analysis/src/references.rs
@@ -110,6 +110,44 @@ fn definition_ranges(document: &Document, subject: &str) -> Vec<Range> {
         .collect()
 }
 
+/// Does `target` resolve to at least one declaration anywhere in
+/// `document`? This is the boolean form of [`declaration_ranges`] — same
+/// resolution rules (case-insensitive throughout, citation keys fall
+/// back from annotation labels to definition subjects) — used by the
+/// opt-in `check --references` pass to decide whether a reference is
+/// dangling. Because it runs over the merged tree it resolves
+/// bidirectionally: the target may live in any included fragment or in
+/// the master, regardless of where the reference sits.
+pub fn target_resolves(document: &Document, target: &ReferenceTarget) -> bool {
+    match target {
+        ReferenceTarget::AnnotationLabel(label) => annotation_label_exists(document, label),
+        ReferenceTarget::CitationKey(key) => {
+            annotation_label_exists(document, key)
+                || !find_definitions_by_subject(document, key).is_empty()
+        }
+        ReferenceTarget::DefinitionSubject(subject) => {
+            !find_definitions_by_subject(document, subject).is_empty()
+        }
+        ReferenceTarget::Session(identifier) => {
+            !find_sessions_by_identifier(document, identifier).is_empty()
+        }
+    }
+}
+
+/// Case-insensitive existence check for an annotation label anywhere in
+/// the document (document-level annotations plus every annotation nested
+/// in the root session). `find_annotations_by_label` matches exactly;
+/// reference resolution is case-insensitive (see [`reference_matches`]),
+/// so this scans rather than delegating.
+fn annotation_label_exists(document: &Document, label: &str) -> bool {
+    let needle = label.trim();
+    document
+        .annotations()
+        .iter()
+        .chain(document.root.iter_annotations_recursive())
+        .any(|ann| ann.data.label.value.trim().eq_ignore_ascii_case(needle))
+}
+
 pub fn reference_occurrences(document: &Document, targets: &[ReferenceTarget]) -> Vec<Range> {
     let mut matches = Vec::new();
     for_each_text_content(document, &mut |text| {

--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -30,17 +30,20 @@
 //! ## Extension seam
 //!
 //! [`collect_file_diagnostics`] returns the full finding set for one
-//! file as a flat `Vec<CheckFinding>`. A future `--references` pass
-//! (epic #758, issues #760–#762) appends its post-merge reference
-//! diagnostics to that same vector before reporting — the reporting and
-//! exit-code layers operate on `CheckFinding`, not on any analysis-
-//! specific type, so they need no change to absorb new finding sources.
+//! file as a flat `Vec<CheckFinding>`. The opt-in `--references` pass
+//! (epic #758, issue #760 — internal cross-references; #761–#762 to
+//! come) appends its post-merge reference diagnostics
+//! ([`lex_analysis::diagnostics::analyze_references`]) to that same
+//! vector before reporting — the reporting and exit-code layers operate
+//! on `CheckFinding`, not on any analysis-specific type, so they absorb
+//! the new finding source unchanged.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use lex_analysis::diagnostics::{
-    analyze_with_rules, AnalysisDiagnostic, DiagnosticSeverity as AnalysisSeverity,
+    analyze_references, analyze_with_rules, apply_rules, AnalysisDiagnostic,
+    DiagnosticSeverity as AnalysisSeverity,
 };
 use lex_config::{DiagnosticsRulesConfig, LabelsConfig, CONFIG_FILE_NAME};
 use lex_core::lex::ast::{Position, Range};
@@ -207,6 +210,10 @@ pub struct CheckOptions<'a> {
     pub ext_schemas: &'a [PathBuf],
     /// Whether subprocess handlers are permitted (`--enable-handlers`).
     pub enable_handlers: bool,
+    /// Run the opt-in internal cross-reference validation pass
+    /// (`--references`) over the merged document, appending its findings
+    /// to the base diagnostics.
+    pub check_references: bool,
 }
 
 /// Load the workspace `[labels]` block for an entry from `workspace`'s
@@ -407,6 +414,24 @@ pub fn collect_file_diagnostics(
 
     for diag in diagnostics {
         findings.push(analysis_finding(diag, entry));
+    }
+
+    // Opt-in `--references` pass. Runs over the same (merged) `document`
+    // as the base analysis, so reference resolution is bidirectional
+    // across the include merge: a reference resolves against targets
+    // defined in any fragment or the master. Kept out of
+    // `analyze_with_rules` so the always-on analyser (and the LSP) never
+    // emits these unless asked. `[diagnostics.rules]` overrides are
+    // applied via the same `apply_rules` path the base command uses, so
+    // a `.lex.toml` downgrade silences a kind identically.
+    if opts.check_references {
+        let mut reference_diagnostics = analyze_references(&document);
+        apply_rules(&mut reference_diagnostics, |code| {
+            opts.rules.lookup_by_code(code).cloned()
+        });
+        for diag in reference_diagnostics {
+            findings.push(analysis_finding(diag, entry));
+        }
     }
 
     Ok(findings)

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -467,6 +467,13 @@ fn build_cli() -> Command {
                      Include-assembly failures (missing/cyclic/oversize includes) surface \
                      here as diagnostics blamed on the include site. Findings originating \
                      inside an included file are reported against that file's path.\n\n\
+                     Pass --references to also validate internal cross-references \
+                     (session / definition / annotation / citation) over the merged \
+                     document: a reference is flagged when its target is absent from the \
+                     whole tree. Resolution is bidirectional across includes (a fragment \
+                     may reference targets in its master and vice-versa). These findings \
+                     default to warning severity, configurable per-rule via \
+                     `[diagnostics.rules]`.\n\n\
                      Exit codes:\n  \
                      0: clean (no finding at/above the --fail-on threshold)\n  \
                      1: at least one finding met the threshold\n  \
@@ -494,6 +501,16 @@ fn build_cli() -> Command {
                         .help("Output format")
                         .value_parser(["human", "json"])
                         .default_value("human"),
+                )
+                .arg(
+                    Arg::new("references")
+                        .long("references")
+                        .help(
+                            "Also validate internal cross-references (session / \
+                             definition / annotation / citation) over the merged \
+                             document",
+                        )
+                        .action(ArgAction::SetTrue),
                 ),
         )
 }
@@ -715,6 +732,7 @@ fn handle_check_command(top: &ArgMatches, sub: &ArgMatches, config: &LexConfig) 
     };
 
     let expand_includes = !top.get_flag("no-includes");
+    let check_references = sub.get_flag("references");
 
     // `[labels]` is NOT loaded here: `check` loads it per-entry from each
     // file's own workspace (see `check::collect_file_diagnostics`), so a
@@ -743,6 +761,7 @@ fn handle_check_command(top: &ArgMatches, sub: &ArgMatches, config: &LexConfig) 
         rules: &config.diagnostics.rules,
         ext_schemas: &ext_schemas,
         enable_handlers,
+        check_references,
     };
 
     run(&paths, &opts)

--- a/crates/lex-cli/tests/integration/check.rs
+++ b/crates/lex-cli/tests/integration/check.rs
@@ -388,3 +388,168 @@ fn unknown_lex_canonical_still_flagged_by_plain_check() {
         .code(1)
         .stdout(predicate::str::contains("unknown-lex-canonical"));
 }
+
+// ============================================================================
+// --references: internal cross-reference validation (#760)
+// ============================================================================
+
+/// Each dangling reference kind (session / definition / annotation /
+/// citation) is flagged by `--references`, at warning severity.
+#[test]
+fn references_flags_each_dangling_kind() {
+    let dir = fixture_dir(&[(
+        "doc.lex",
+        "1. Intro\n\n    Def [Nope].\n    Session [#9.9].\n    \
+         Annotation [::ghost].\n    Citation [@missing2024].\n",
+    )]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("missing-definition-target")
+                .and(predicate::str::contains("missing-session-target"))
+                .and(predicate::str::contains("missing-annotation-target"))
+                .and(predicate::str::contains("missing-citation-target"))
+                .and(predicate::str::contains("warning:")),
+        );
+}
+
+/// The reference pass is opt-in: without `--references` a dangling
+/// reference produces no finding (the always-on analyser never emits
+/// these, which is what keeps the LSP quiet too).
+#[test]
+fn references_pass_is_opt_in() {
+    let dir = fixture_dir(&[("doc.lex", "1. Intro\n\n    Dangling [Nope].\n")]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// `ToCome` (`[TK]` / `[TK-id]`) placeholders are never flagged.
+#[test]
+fn references_skips_tk_placeholders() {
+    let dir = fixture_dir(&[("doc.lex", "1. Intro\n\n    A [TK] and [TK-later].\n")]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A reference whose target lives in an *included* file resolves with no
+/// finding — proving resolution runs over the merged tree (downward:
+/// reference in master, target in fragment).
+#[test]
+fn references_resolve_target_in_included_file() {
+    let dir = fixture_dir(&[
+        (
+            "master.lex",
+            "1. Top\n\n    See [Glossary].\n\n:: lex.include src=\"frag.lex\" ::\n",
+        ),
+        ("frag.lex", "Glossary:\n    Defined downstream.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "master.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// An *upward* reference — from a fragment to a target defined in the
+/// master — resolves when checked from the entry document. Bidirectional
+/// resolution over the single merged tree.
+#[test]
+fn references_resolve_upward_from_fragment_to_master() {
+    let dir = fixture_dir(&[
+        (
+            "master.lex",
+            ":: lex.include src=\"frag.lex\" ::\n\nGlossary:\n    Defined in the master.\n",
+        ),
+        (
+            "frag.lex",
+            "1. Fragment\n\n    Upward reference to [Glossary].\n",
+        ),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "master.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A dangling reference authored inside an included fragment is blamed on
+/// the fragment's path, not the entry document (origin-faithful).
+#[test]
+fn references_dangling_inside_include_blamed_on_fragment() {
+    let dir = fixture_dir(&[
+        ("master.lex", ":: lex.include src=\"frag.lex\" ::\n"),
+        ("frag.lex", "1. Frag\n\n    A dangling [Nope] reference.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "master.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("frag.lex")
+                .and(predicate::str::contains("missing-definition-target")),
+        );
+}
+
+/// A `.lex.toml` rule downgrade (`allow`) silences a reference kind.
+#[test]
+fn references_lex_toml_allow_silences_kind() {
+    let dir = fixture_dir(&[
+        ("doc.lex", "1. Intro\n\n    Dangling [Nope].\n"),
+        (
+            ".lex.toml",
+            "[diagnostics.rules]\nmissing_definition_target = \"allow\"\n",
+        ),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// Footnote resolution is bidirectional across the include merge (#760
+// fallout): a footnote reference inside an included fragment fires
+// missing-footnote over the merged tree, blamed on the fragment.
+// ============================================================================
+
+#[test]
+fn missing_footnote_inside_include_fires_blamed_on_fragment() {
+    let dir = fixture_dir(&[
+        ("book.lex", ":: lex.include src=\"frag.lex\" ::\n"),
+        ("frag.lex", "Text with [1] reference.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "book.lex"))
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("missing-footnote").and(predicate::str::contains("frag.lex")),
+        );
+}

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -570,6 +570,27 @@ pub struct DiagnosticsRulesConfig {
     /// `AnalysisDiagnostic` / `DiagnosticKind` pipeline.
     #[clapfig(value, default = "warn")]
     pub spellcheck: RuleConfig,
+    /// A session reference (`[#2.1]`) points at a session identifier
+    /// that exists nowhere in the merged document. Opt-in: emitted only
+    /// by `check --references`. Intrinsic default: warn.
+    #[clapfig(value, default = "warn")]
+    pub missing_session_target: RuleConfig,
+    /// A definition reference (`[Title]`) has no matching definition in
+    /// the merged document. Opt-in (`check --references`). Intrinsic
+    /// default: warn — every `[...]` is a reference, so this can be
+    /// chatty in prose-heavy docs and is trivially silenced per-rule.
+    #[clapfig(value, default = "warn")]
+    pub missing_definition_target: RuleConfig,
+    /// An annotation reference (`[::label]`) points at a label that no
+    /// annotation declares. Opt-in (`check --references`). Intrinsic
+    /// default: warn.
+    #[clapfig(value, default = "warn")]
+    pub missing_annotation_target: RuleConfig,
+    /// A citation (`[@key]`) has no matching annotation label or
+    /// definition subject in the merged document. Opt-in
+    /// (`check --references`). Intrinsic default: warn.
+    #[clapfig(value, default = "warn")]
+    pub missing_citation_target: RuleConfig,
     /// Schema-validation diagnostics for extension labels.
     pub schema: SchemaRulesConfig,
 }
@@ -591,6 +612,10 @@ impl DiagnosticsRulesConfig {
             "table-inconsistent-columns" => Some(&self.table_inconsistent_columns),
             "forbidden-label-prefix" => Some(&self.forbidden_label_prefix),
             "unknown-lex-canonical" => Some(&self.unknown_lex_canonical),
+            "missing-session-target" => Some(&self.missing_session_target),
+            "missing-definition-target" => Some(&self.missing_definition_target),
+            "missing-annotation-target" => Some(&self.missing_annotation_target),
+            "missing-citation-target" => Some(&self.missing_citation_target),
             // `spellcheck` is intentionally absent: spellcheck
             // diagnostics emit through a separate path (see
             // `lex-analysis/src/spellcheck.rs`) and do not flow

--- a/crates/lex-core/src/lex/wire/from_wire.rs
+++ b/crates/lex-core/src/lex/wire/from_wire.rs
@@ -328,12 +328,39 @@ fn paragraph_from_wire(
     } else {
         raw.split('\n').collect()
     };
+    // Stamp each reconstructed line's `TextContent` with a location.
+    // Without it `lex_analysis::inline::extract_references` early-returns
+    // (it keys off `TextContent.location`), so reference-based
+    // diagnostics (missing-footnote and the `check --references` family)
+    // never fire inside an included/spliced fragment. The byte span is
+    // synthetic — the wire `Range` carries no byte offsets — but it is
+    // used only as an additive base by the inline walker, so a per-line
+    // `0..len` span yields correct *relative* reference positions. The
+    // `line`/`origin_path` carry the paragraph's, advanced one line per
+    // split entry, so a reference finding is reported on the right line
+    // and blamed on its origin file.
+    let base_line = location.start.line;
+    let base_column = location.start.column;
+    let origin_path = location.origin_path.clone();
     let lines: Vec<ContentItem> = line_strings
         .into_iter()
-        .map(|line_str| {
+        .enumerate()
+        .map(|(idx, line_str)| {
+            let line = base_line + idx;
+            // The first line keeps the paragraph's start column;
+            // continuation lines begin at column 0.
+            let column = if idx == 0 { base_column } else { 0 };
+            let len = line_str.len();
+            let utf16_len: usize = line_str.chars().map(char::len_utf16).sum();
+            let mut range = crate::lex::ast::range::Range::new(
+                0..len,
+                crate::lex::ast::range::Position::new(line, column),
+                crate::lex::ast::range::Position::new(line, column + utf16_len),
+            );
+            range.origin_path = origin_path.clone();
             ContentItem::TextLine(TextLine::new(TextContent::from_string(
                 line_str.to_string(),
-                None,
+                Some(range),
             )))
         })
         .collect();


### PR DESCRIPTION
Closes #760. Part of epic #758 — stacks on #763 (base `check`); targets `feat/lexd-check-base` until that merges.

## What

Adds the opt-in `--references` flag to `lexd check`, validating **internal cross-references** over the merged document. A new pass `lex_analysis::diagnostics::analyze_references(doc) -> Vec<AnalysisDiagnostic>` walks every reference and flags dangling in-document targets:

| AST kind | Example | Code |
|---|---|---|
| `ReferenceType::Session` | `[#2.1]` | `missing-session-target` |
| `ReferenceType::General` | `[Title]` | `missing-definition-target` |
| `ReferenceType::AnnotationReference` | `[::label]` | `missing-annotation-target` |
| `ReferenceType::Citation` | `[@key]` | `missing-citation-target` |

`ToCome`/`NotSure` placeholders are skipped; footnotes stay on the always-on analyser; `Url`/`File` are out of scope (#761–#762).

## Context

- **Deliberately separate from `analyze_with_registry`/`analyze_with_rules`** so the always-on analyser — and thus the LSP on every keystroke — never emits these unless asked. `analyze_references` is pure AST resolution (no registry param) and is reusable: the LSP can opt in later. Do not fold it into the always-on path.
- **Merged-tree, bidirectional**: the pass runs over the single fully-expanded doc the CLI already passes, so a reference resolves against targets defined anywhere — any included fragment or the master — and a `missing-*` fires only when the target is absent from the whole tree. Resolution reuses the LSP's matching (`references::target_resolves`, mirroring `declaration_ranges` / `reference_matches`, case-insensitive throughout; citation keys fall back annotation-label → definition-subject).
- **Wiring**: `--references` on the `check` subcommand → `CheckOptions.check_references` → inside the `collect_file_diagnostics` seam, after the base `analyze_with_rules`, `analyze_references` runs on the same merged `document` and its findings are `apply_rules`'d (default `Warning`, configurable via `[diagnostics.rules]`) and appended to the `Vec<CheckFinding>`. New rule fields + `lookup_by_code` entries added in `lex-config`; they surface automatically in `lexd config gen`.
- **Column encoding is UTF-16, not bytes** (flagged by Copilot/Gemini, pushed back): the analysis-layer `Position.character` is UTF-16 code units by deliberate design (matching LSP `positionEncoding`), while `Range.span` is UTF-8 bytes — see `inline_positions.rs` / `inline.rs::position_at` and their tests. The synthetic per-line range stamped in `from_wire` therefore uses `0..len` (bytes) span + `column + utf16_len` (UTF-16) column, matching what the parser produces and what `extract_references` consumes.

## Footnote-inside-include gap (the foundation flagged this)

Root cause found and **fixed** (small): the wire round-trip in `lex-core/.../wire/from_wire.rs::paragraph_from_wire` reconstructed each spliced `TextLine`'s `TextContent` with `location: None`. `lex_analysis::inline::extract_references` early-returns when `TextContent.location` is `None`, so **no** reference diagnostic — `missing-footnote` included — ever fired inside an included fragment. Now each reconstructed line is stamped with a per-line `location` (line/origin carried from the paragraph), and `extract_references::make_range` carries the text's `origin_path` onto the reference range, so:

- `missing-footnote` now fires for a footnote reference authored inside an include, blamed on the fragment;
- the new `--references` checks are bidirectional for the same reason.

This affects only the include/wire-splice path; the full suite (2564 tests) is green.

## Tests

- `lex-analysis` unit tests (11): each dangling kind, resolved-clean, case-insensitive annotation match, citation-via-annotation-label, multi-key citations (exactly 2 for `[@a; @b]`), placeholders never flagged, default-Warning, and "always-on analyser does not emit these".
- `lex-cli` integration tests (8, in `tests/integration/check.rs`): each dangling kind flagged; opt-in gating; TK skipped; target in **included** file resolves (downward); **upward** fragment→master resolves; dangling inside include blamed on the fragment; `.lex.toml` `allow` silences a kind; `missing-footnote` inside an include fires and is blamed on the fragment.

`cargo nextest run --workspace --exclude lex-wasm`: 2564 passed, 1 skipped. `release-core gate`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7noCwaDvagCnu2PoSB6Vu
