### PR TITLE
feat(cli): lexd check --references — URL well-formedness validation

### DIFF
--- a/CHANGELOG/unreleased-lexd-check-references-urls.md
+++ b/CHANGELOG/unreleased-lexd-check-references-urls.md
@@ -1,0 +1,1 @@
+- lexd check --references: URL well-formedness validation (malformed-url; embedded space / empty host); pure parse, no network

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "pathdiff",
  "serde_json",
  "tempfile",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ once_cell = "1.21"
 pathdiff = "0.2"
 comrak = "0.29"
 sha2 = "0.10"
+url = "2.4"
 
 [profile.dist]
 inherits = "release"

--- a/crates/lex-analysis/Cargo.toml
+++ b/crates/lex-analysis/Cargo.toml
@@ -24,6 +24,7 @@ lex-extension-host = { workspace = true }
 lsp-types = { workspace = true }
 pathdiff = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -68,8 +68,9 @@ pub enum DiagnosticKind {
     /// label or definition subject in the merged document. Opt-in
     /// (`check --references`).
     MissingCitationTarget,
-    /// A URL reference (`[https://…]`, `[mailto:…]`) that is not
-    /// well-formed (embedded space, empty host, otherwise unparseable).
+    /// A URL reference (`[http://…]`, `[https://…]`, `[mailto:…]`) that
+    /// is not well-formed (embedded space, empty host, otherwise
+    /// unparseable).
     /// Opt-in (`check --references`); a pure parse check — network
     /// reachability is out of scope. Emitted by [`analyze_references`].
     MalformedUrl,

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -440,27 +440,23 @@ pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
 }
 
 /// Is `target` a malformed URL? Pure, IO-free well-formedness check —
-/// **never opens a connection**. Classification
-/// ([`is_url_reference`](lex_core::lex::inlines)) already guarantees one
-/// of the `http://` / `https://` / `mailto:` scheme prefixes, so this
-/// catches what classification can't: embedded spaces, an empty host on
-/// a `//`-authority scheme, and otherwise-unparseable targets.
+/// **never opens a connection**. Classification (`ReferenceType::Url`)
+/// already guarantees one of the `http://` / `https://` / `mailto:`
+/// scheme prefixes, so this catches what classification can't: embedded
+/// spaces, an empty host, and otherwise-unparseable targets.
+///
+/// A bare `url::Url::parse(...).is_err()` is sufficient: under the WHATWG
+/// URL standard the `url` crate implements, the special schemes we
+/// validate (`http`/`https`) require a non-empty host, so a missing host
+/// (`https://`) already parse-fails with `EmptyHost`; `mailto:` is
+/// host-less and parses fine — exactly the behavior we want, with no
+/// scheme-specific host check needed.
 ///
 /// A future opt-in `--check-urls-online` would layer network
 /// reachability *on top* of this — deliberately unimplemented here
 /// (issue #762: reachability out of scope).
 fn url_is_malformed(target: &str) -> bool {
-    let Ok(parsed) = url::Url::parse(target) else {
-        // Unparseable (e.g. an embedded space) — malformed.
-        return true;
-    };
-    // For the `//`-authority schemes we validate, a present-but-empty
-    // host (e.g. `https://`) is malformed. `mailto:` has no host
-    // component, so an empty host is expected there and not flagged.
-    if matches!(parsed.scheme(), "http" | "https") {
-        return parsed.host_str().is_none_or(str::is_empty);
-    }
-    false
+    url::Url::parse(target).is_err()
 }
 
 /// Walk every label site in the document and re-classify via

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -68,6 +68,11 @@ pub enum DiagnosticKind {
     /// label or definition subject in the merged document. Opt-in
     /// (`check --references`).
     MissingCitationTarget,
+    /// A URL reference (`[https://…]`, `[mailto:…]`) that is not
+    /// well-formed (embedded space, empty host, otherwise unparseable).
+    /// Opt-in (`check --references`); a pure parse check — network
+    /// reachability is out of scope. Emitted by [`analyze_references`].
+    MalformedUrl,
 }
 
 /// Severity for analysis-emitted diagnostics. The analyser populates
@@ -153,6 +158,7 @@ impl DiagnosticKind {
             DiagnosticKind::MissingDefinitionTarget => "missing-definition-target".into(),
             DiagnosticKind::MissingAnnotationTarget => "missing-annotation-target".into(),
             DiagnosticKind::MissingCitationTarget => "missing-citation-target".into(),
+            DiagnosticKind::MalformedUrl => "malformed-url".into(),
         }
     }
 }
@@ -332,13 +338,19 @@ pub fn analyze_with_rules(
 /// - [`ReferenceType::General`] → `missing-definition-target`
 /// - [`ReferenceType::AnnotationReference`] → `missing-annotation-target`
 /// - [`ReferenceType::Citation`] → `missing-citation-target`
+/// - [`ReferenceType::Url`] → `malformed-url` (well-formedness only)
+///
+/// The `Url` arm is *not* a cross-reference check: it validates the URL
+/// is well-formed (a pure, IO-free parse — **no network**, by design;
+/// reachability is out of scope, issue #762). It runs in this pass
+/// because well-formedness is pure and `--references` already gates it.
 ///
 /// `ToCome` / `NotSure` are intentional placeholders and never flagged;
 /// `FootnoteNumber` is validated by the always-on analyser
-/// ([`check_footnotes`]); `Url` / `File` are out of scope here (epic
-/// #758, issues #761–#762). All emitted diagnostics default to
-/// [`DiagnosticSeverity::Warning`] — callers apply
-/// `[diagnostics.rules]` via [`apply_rules`] for per-kind overrides.
+/// ([`check_footnotes`]); `File` is out of scope here (issue #761). All
+/// emitted diagnostics default to [`DiagnosticSeverity::Warning`] —
+/// callers apply `[diagnostics.rules]` via [`apply_rules`] for per-kind
+/// overrides.
 pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
     use crate::reference_targets::{targets_from_reference_type, ReferenceTarget};
     use crate::references::target_resolves;
@@ -365,6 +377,23 @@ pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
                         label.trim()
                     ),
                 ),
+                ReferenceType::Url { target } if !target.trim().is_empty() => {
+                    // URL references are validated for well-formedness
+                    // only — a pure, IO-free parse check (no network: see
+                    // [`url_is_malformed`]). This is self-contained (no
+                    // document resolution), so it emits inline and
+                    // `continue`s like the citation arm rather than
+                    // falling through to the target-resolution tail.
+                    if url_is_malformed(target.trim()) {
+                        diagnostics.push(AnalysisDiagnostic {
+                            range: reference.range.clone(),
+                            severity: DiagnosticSeverity::Warning,
+                            kind: DiagnosticKind::MalformedUrl,
+                            message: format!("URL [{}] is malformed", target.trim()),
+                        });
+                    }
+                    continue;
+                }
                 ReferenceType::Citation(data) => {
                     // A citation may carry multiple keys; each is its own
                     // potential dangling target. Emit per unresolved key.
@@ -408,6 +437,30 @@ pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
         }
     });
     diagnostics
+}
+
+/// Is `target` a malformed URL? Pure, IO-free well-formedness check —
+/// **never opens a connection**. Classification
+/// ([`is_url_reference`](lex_core::lex::inlines)) already guarantees one
+/// of the `http://` / `https://` / `mailto:` scheme prefixes, so this
+/// catches what classification can't: embedded spaces, an empty host on
+/// a `//`-authority scheme, and otherwise-unparseable targets.
+///
+/// A future opt-in `--check-urls-online` would layer network
+/// reachability *on top* of this — deliberately unimplemented here
+/// (issue #762: reachability out of scope).
+fn url_is_malformed(target: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(target) else {
+        // Unparseable (e.g. an embedded space) — malformed.
+        return true;
+    };
+    // For the `//`-authority schemes we validate, a present-but-empty
+    // host (e.g. `https://`) is malformed. `mailto:` has no host
+    // component, so an empty host is expected there and not flagged.
+    if matches!(parsed.scheme(), "http" | "https") {
+        return parsed.host_str().is_none_or(str::is_empty);
+    }
+    false
 }
 
 /// Walk every label site in the document and re-classify via
@@ -1445,5 +1498,66 @@ mod tests {
         let diags = reference_diags("1. Intro\n\n    See [Nope].\n");
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
+    }
+
+    // ========================================================================
+    // URL well-formedness (issue #762). Validated inside analyze_references;
+    // pure parse, no network.
+    // ========================================================================
+
+    #[test]
+    fn malformed_url_embedded_space_flagged() {
+        // An embedded space makes the URL unparseable.
+        let codes = ref_codes("1. Intro\n\n    See [https://exa mple.com].\n");
+        assert_eq!(codes, vec!["malformed-url"]);
+    }
+
+    #[test]
+    fn malformed_url_empty_host_flagged() {
+        // `https://` with no host is well-formed-prefix but empty-host.
+        let codes = ref_codes("1. Intro\n\n    See [https:// ].\n");
+        assert_eq!(codes, vec!["malformed-url"]);
+    }
+
+    #[test]
+    fn well_formed_https_url_not_flagged() {
+        assert!(
+            reference_diags("1. Intro\n\n    See [https://example.com/path?q=1].\n").is_empty(),
+            "a well-formed https URL must not be flagged"
+        );
+    }
+
+    #[test]
+    fn well_formed_http_url_not_flagged() {
+        assert!(reference_diags("1. Intro\n\n    See [http://example.com].\n").is_empty());
+    }
+
+    #[test]
+    fn well_formed_mailto_not_flagged() {
+        // `mailto:` has no host component — an empty host is expected and
+        // must not be flagged.
+        assert!(
+            reference_diags("1. Intro\n\n    Write [mailto:hi@example.com].\n").is_empty(),
+            "a well-formed mailto must not be flagged"
+        );
+    }
+
+    #[test]
+    fn malformed_url_defaults_to_warning() {
+        let diags = reference_diags("1. Intro\n\n    See [https://exa mple.com].\n");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].kind, DiagnosticKind::MalformedUrl);
+        assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
+    }
+
+    #[test]
+    fn url_check_makes_no_network_calls_by_construction() {
+        // `url_is_malformed` is a pure parse over a string — it borrows no
+        // socket, client, or runtime, so the default check path cannot
+        // make a network call. Exercising both a well-formed and a
+        // malformed URL here documents that the only work done is parsing.
+        assert!(!url_is_malformed("https://example.com"));
+        assert!(url_is_malformed("https://exa mple.com"));
+        assert!(!url_is_malformed("mailto:a@b.com"));
     }
 }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -385,12 +385,13 @@ pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
                     // document resolution), so it emits inline and
                     // `continue`s like the citation arm rather than
                     // falling through to the target-resolution tail.
-                    if url_is_malformed(target.trim()) {
+                    let target = target.trim();
+                    if url_is_malformed(target) {
                         diagnostics.push(AnalysisDiagnostic {
                             range: reference.range.clone(),
                             severity: DiagnosticSeverity::Warning,
                             kind: DiagnosticKind::MalformedUrl,
-                            message: format!("URL [{}] is malformed", target.trim()),
+                            message: format!("URL [{target}] is malformed"),
                         });
                     }
                     continue;

--- a/crates/lex-babel/Cargo.toml
+++ b/crates/lex-babel/Cargo.toml
@@ -27,7 +27,7 @@ markup5ever_rcdom = "0.38"
 serde = { workspace = true }
 tempfile = { workspace = true, optional = true }
 which = { version = "8", optional = true }
-url = "2.4"
+url = { workspace = true }
 pathdiff = { workspace = true }
 roxmltree = "0.21"
 regex = { workspace = true }

--- a/crates/lex-cli/tests/integration/check.rs
+++ b/crates/lex-cli/tests/integration/check.rs
@@ -553,3 +553,115 @@ fn missing_footnote_inside_include_fires_blamed_on_fragment() {
             predicate::str::contains("missing-footnote").and(predicate::str::contains("frag.lex")),
         );
 }
+
+// ============================================================================
+// --references: URL well-formedness validation (#762)
+//
+// Well-formedness only — a pure parse, no network. Fires under the same
+// --references flag as the cross-reference checks.
+// ============================================================================
+
+/// A malformed URL (embedded space) is flagged `malformed-url` at warning
+/// severity, under `--references`.
+#[test]
+fn references_flags_malformed_url() {
+    let dir = fixture_dir(&[("doc.lex", "1. Intro\n\n    See [https://exa mple.com].\n")]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("malformed-url").and(predicate::str::contains("warning:")),
+        );
+}
+
+/// A well-formed `https://` URL is not flagged.
+#[test]
+fn references_well_formed_https_url_clean() {
+    let dir = fixture_dir(&[(
+        "doc.lex",
+        "1. Intro\n\n    See [https://example.com/path].\n",
+    )]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A well-formed `mailto:` is not flagged (no host component expected).
+#[test]
+fn references_well_formed_mailto_clean() {
+    let dir = fixture_dir(&[(
+        "doc.lex",
+        "1. Intro\n\n    Write [mailto:hi@example.com].\n",
+    )]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// URL validation is opt-in: without `--references`, a malformed URL
+/// produces no finding.
+#[test]
+fn references_url_check_is_opt_in() {
+    let dir = fixture_dir(&[("doc.lex", "1. Intro\n\n    See [https://exa mple.com].\n")]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A malformed URL authored inside an included fragment is blamed on the
+/// fragment's path, not the entry document (origin-faithful).
+#[test]
+fn references_malformed_url_inside_include_blamed_on_fragment() {
+    let dir = fixture_dir(&[
+        ("master.lex", ":: lex.include src=\"frag.lex\" ::\n"),
+        (
+            "frag.lex",
+            "1. Frag\n\n    A bad [https://exa mple.com] link.\n",
+        ),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "master.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("frag.lex").and(predicate::str::contains("malformed-url")),
+        );
+}
+
+/// A `.lex.toml` rule downgrade (`allow`) silences `malformed-url`.
+#[test]
+fn references_lex_toml_allow_silences_malformed_url() {
+    let dir = fixture_dir(&[
+        ("doc.lex", "1. Intro\n\n    See [https://exa mple.com].\n"),
+        (
+            ".lex.toml",
+            "[diagnostics.rules]\nmalformed_url = \"allow\"\n",
+        ),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -591,8 +591,9 @@ pub struct DiagnosticsRulesConfig {
     /// (`check --references`). Intrinsic default: warn.
     #[clapfig(value, default = "warn")]
     pub missing_citation_target: RuleConfig,
-    /// A URL reference (`[https://…]`, `[mailto:…]`) that is not
-    /// well-formed (embedded space, empty host, otherwise unparseable).
+    /// A URL reference (`[http://…]`, `[https://…]`, `[mailto:…]`) that
+    /// is not well-formed (embedded space, empty host, otherwise
+    /// unparseable).
     /// Opt-in (`check --references`); well-formedness only — network
     /// reachability is not checked. Intrinsic default: warn.
     #[clapfig(value, default = "warn")]

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -591,6 +591,12 @@ pub struct DiagnosticsRulesConfig {
     /// (`check --references`). Intrinsic default: warn.
     #[clapfig(value, default = "warn")]
     pub missing_citation_target: RuleConfig,
+    /// A URL reference (`[https://…]`, `[mailto:…]`) that is not
+    /// well-formed (embedded space, empty host, otherwise unparseable).
+    /// Opt-in (`check --references`); well-formedness only — network
+    /// reachability is not checked. Intrinsic default: warn.
+    #[clapfig(value, default = "warn")]
+    pub malformed_url: RuleConfig,
     /// Schema-validation diagnostics for extension labels.
     pub schema: SchemaRulesConfig,
 }
@@ -616,6 +622,7 @@ impl DiagnosticsRulesConfig {
             "missing-definition-target" => Some(&self.missing_definition_target),
             "missing-annotation-target" => Some(&self.missing_annotation_target),
             "missing-citation-target" => Some(&self.missing_citation_target),
+            "malformed-url" => Some(&self.malformed_url),
             // `spellcheck` is intentionally absent: spellcheck
             // diagnostics emit through a separate path (see
             // `lex-analysis/src/spellcheck.rs`) and do not flow


### PR DESCRIPTION
Closes #762. Part of the `lexd check` epic (#758). Stacks on #764 (issue #760) — base branch is `feat/lexd-check-refs-internal`.

## What

Under the existing `--references` flag, validate `ReferenceType::Url` references (`http://`, `https://`, `mailto:`) for **well-formedness only**. Emits `malformed-url` (default severity warning, rule-configurable) on embedded spaces, an empty host, or otherwise-unparseable targets.

## Context (for a stranger)

- **Extended `analyze_references`, did not add a sibling pass.** URL well-formedness is pure (no IO), so it slots into the existing pure `analyze_references(doc)` pass in `crates/lex-analysis/src/diagnostics.rs` as a new `Url` arm — keeping it reusable by the LSP later and automatically gated by `--references` on the CLI. The arm is self-contained (no document resolution), so it emits inline and `continue`s like the citation arm rather than falling through to the cross-ref target-resolution tail.
- **No network, by construction.** `url_is_malformed` is a pure `url::Url::parse` over a string — it borrows no client/socket/runtime. Reachability is explicitly out of scope (slow/flaky/privacy-sensitive). A future `--check-urls-online` would layer reachability on top; deliberately unimplemented here.
- **`mailto:` has no host**, so an empty host is only flagged for the `//`-authority schemes (`http`/`https`).
- **URL-parser dependency:** the `url` crate (2.4) was already a direct dependency of `lex-babel`. Promoted it to `[workspace.dependencies]` and consumed it via `workspace = true` from both `lex-babel` and `lex-analysis` — reuses what's there, no new external dep.

## Diagnostic code

`malformed-url` — new `DiagnosticKind::MalformedUrl` + `.code()` string (lex-analysis) and `DiagnosticsRulesConfig::malformed_url` + `lookup_by_code` entry (lex-config). Auto-surfaces in `lexd config gen`.

## Tests

- lex-analysis unit tests: embedded-space + empty-host flagged; well-formed http/https/mailto clean; default warning; no-network-by-construction.
- check.rs integration tests: malformed flagged under `--references`; well-formed https/mailto clean; opt-in (silent without `--references`); origin-blamed on the fragment for an include; `.lex.toml` `allow` silences `malformed-url`.
- Full suite green: `cargo nextest run --workspace --exclude lex-wasm` → 2577 passed.

## Conflict note (#761 sibling)

The concurrent #761 (file-path validation) PR will also add a `DiagnosticKind` variant + a `DiagnosticsRulesConfig` field + a `lookup_by_code` arm. Those three spots are the only expected overlap; whichever lands second takes a trivial mechanical rebase. No file-path logic touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7noCwaDvagCnu2PoSB6Vu