### PR TITLE
feat(cli): lexd check --references — file-path reference validation

### DIFF
--- a/CHANGELOG/unreleased-lexd-check-references-files.md
+++ b/CHANGELOG/unreleased-lexd-check-references-files.md
@@ -1,1 +1,1 @@
-- lexd check --references: file-path reference validation (inline [./x] + image/data verbatim src=), origin-aware against the merged document; excludes lex.include (validated by base command)
+- lexd check --references: file-path reference validation (inline [./x] + any verbatim block's src=), origin-aware against the merged document; excludes lex.include (validated by base command)

--- a/CHANGELOG/unreleased-lexd-check-references-files.md
+++ b/CHANGELOG/unreleased-lexd-check-references-files.md
@@ -1,0 +1,1 @@
+- lexd check --references: file-path reference validation (inline [./x] + image/data verbatim src=), origin-aware against the merged document; excludes lex.include (validated by base command)

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -529,12 +529,32 @@ pub fn collect_file_references(document: &Document) -> Vec<FileReference> {
     // Image/data verbatim `src=` parameters. The verbatim's own range
     // carries its origin; `lex.include` is an annotation, not a verbatim
     // block, so it is structurally excluded here.
+    //
+    // Two normalizations the inline path gets for free but verbatim does
+    // not, because a verbatim `src=` parameter is *not* pre-classified:
+    //
+    // - **Unquote.** `src="./x.png"` stores the raw, still-quoted value
+    //   on `Parameter.value`; we resolve a *path*, so unquote via the
+    //   canonical `Parameter::unquoted_value` (the same path
+    //   `Annotation::include_src` takes) — otherwise existence-checks
+    //   look for a filename that literally includes the quotes.
+    // - **Skip URLs.** The media `src` is documented as "URL or path", so
+    //   `src=https://…/d.png` is a URL, not a local file; checking it on
+    //   disk would be a guaranteed false positive. (Inline refs are
+    //   already classified `Url` vs `File`, so only this arm needs it.)
     for item in document.root.iter_all_nodes() {
         if let ContentItem::VerbatimBlock(verbatim) = item {
-            if let Some(src) = verbatim.src_parameter() {
-                if !src.trim().is_empty() {
+            if let Some(param) = verbatim
+                .closing_data
+                .parameters
+                .iter()
+                .find(|p| p.key == "src")
+            {
+                let target = param.unquoted_value();
+                let trimmed = target.trim();
+                if !trimmed.is_empty() && !is_url_like(trimmed) {
                     refs.push(FileReference {
-                        target: src.to_string(),
+                        target: target.clone(),
                         range: verbatim.range().clone(),
                     });
                 }
@@ -543,6 +563,18 @@ pub fn collect_file_references(document: &Document) -> Vec<FileReference> {
     }
 
     refs
+}
+
+/// Is `src` a URL rather than a local file path? Mirrors the inline
+/// reference classifier's URL detection (`http://`, `https://`,
+/// `mailto:`) plus a generic `scheme://` catch, so a verbatim
+/// `src=<url>` is excluded from the file-path existence check the same
+/// way an inline `[<url>]` is classified `Url` and skipped.
+fn is_url_like(src: &str) -> bool {
+    src.starts_with("http://")
+        || src.starts_with("https://")
+        || src.starts_with("mailto:")
+        || src.contains("://")
 }
 
 /// Walk every label site in the document and re-classify via
@@ -1679,8 +1711,28 @@ mod tests {
     }
 
     #[test]
+    fn verbatim_src_is_unquoted() {
+        // A quoted `src="./x.png"` is collected as the bare path, not the
+        // still-quoted raw value — otherwise the existence check looks for
+        // a filename that literally includes the quotes.
+        let source = "Photo:\n    Caption.\n:: image src=\"./diagram.png\" ::\n\n";
+        assert_eq!(file_ref_targets(source), vec!["./diagram.png".to_string()]);
+    }
+
+    #[test]
     fn ignores_url_references() {
         // URLs are out of scope for the file-path pass (#762 owns them).
+        // Inline `[<url>]` is classified `Url` (not `File`); a verbatim
+        // `src=<url>` is not pre-classified, so the collector filters it.
         assert!(file_ref_targets("1. Intro\n\n    See [https://example.com].\n").is_empty());
+        assert!(file_ref_targets(
+            "Photo:\n    Caption.\n:: image src=https://example.com/diagram.png ::\n\n"
+        )
+        .is_empty());
+        // Quoted URL form, too.
+        assert!(file_ref_targets(
+            "Photo:\n    Caption.\n:: image src=\"https://example.com/diagram.png\" ::\n\n"
+        )
+        .is_empty());
     }
 }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -74,6 +74,15 @@ pub enum DiagnosticKind {
     /// Opt-in (`check --references`); a pure parse check — network
     /// reachability is out of scope. Emitted by [`analyze_references`].
     MalformedUrl,
+    /// A file-path reference — an inline `ReferenceType::File`
+    /// (`[./x.txt]`, `[../y]`, `[/abs]`) or an image/data verbatim
+    /// `src=` — that points at no file on disk, or whose target escapes
+    /// the resolution root / is a platform-absolute path. Opt-in:
+    /// emitted only by `check --references` (the existence check is
+    /// IO-bearing, so it runs in the CLI seam, not the pure analyser).
+    /// `lex.include src=` is excluded — its path is validated by the
+    /// base command via include expansion.
+    MissingFileTarget,
 }
 
 /// Severity for analysis-emitted diagnostics. The analyser populates
@@ -160,6 +169,7 @@ impl DiagnosticKind {
             DiagnosticKind::MissingAnnotationTarget => "missing-annotation-target".into(),
             DiagnosticKind::MissingCitationTarget => "missing-citation-target".into(),
             DiagnosticKind::MalformedUrl => "malformed-url".into(),
+            DiagnosticKind::MissingFileTarget => "missing-file-target".into(),
         }
     }
 }
@@ -459,6 +469,80 @@ pub fn analyze_references(document: &Document) -> Vec<AnalysisDiagnostic> {
 /// (issue #762: reachability out of scope).
 fn url_is_malformed(target: &str) -> bool {
     url::Url::parse(target).is_err()
+}
+
+/// A non-include file-path reference and the range to blame it on.
+///
+/// Produced by [`collect_file_references`] for the opt-in
+/// `check --references` *file-path* pass. The range is origin-stamped
+/// (it comes from the reference's authoring file, via
+/// [`extract_references`] for inline refs or the verbatim node's own
+/// range), so a consumer that resolves `target` relative to that origin
+/// — and blames findings on it — stays origin-faithful across an include
+/// merge.
+#[derive(Debug, Clone)]
+pub struct FileReference {
+    /// The raw path target as authored (`./x.txt`, `../y`, `/abs`).
+    pub target: String,
+    /// Origin-stamped range to resolve against and blame.
+    pub range: Range,
+}
+
+/// Collect every **non-include** file-path reference in the (merged)
+/// `document`: inline [`ReferenceType::File`] (`[./x.txt]`, `[../y]`,
+/// `[/abs]`) and image/data verbatim `src=` parameters.
+///
+/// This is the pure (no-IO) half of the `check --references` file-path
+/// check: it gathers the targets and their origin-stamped ranges; the
+/// caller performs filesystem resolution + existence (which needs a
+/// resolution root and disk access, neither of which belongs in a pure
+/// `&Document` analysis).
+///
+/// `lex.include src=` is intentionally **not** collected: it is an
+/// *annotation*, not a verbatim block, so it never matches the verbatim
+/// `src=` arm — and after include expansion it has been spliced out
+/// entirely (its path already validated by the base command, #759).
+///
+/// Inline refs reuse [`extract_references`], whose ranges are already
+/// origin-stamped (see `inline::ReferenceWalker::make_range`). Verbatim
+/// `src=` carries the verbatim node's own range, which the include
+/// resolver stamps with the authoring file's origin.
+pub fn collect_file_references(document: &Document) -> Vec<FileReference> {
+    use lex_core::lex::ast::traits::AstNode;
+
+    let mut refs = Vec::new();
+
+    // Inline `[./x]` file references — origin-stamped via extract_references.
+    crate::utils::for_each_text_content(document, &mut |text| {
+        for reference in extract_references(text) {
+            if let ReferenceType::File { target } = &reference.reference_type {
+                if !target.trim().is_empty() {
+                    refs.push(FileReference {
+                        target: target.clone(),
+                        range: reference.range.clone(),
+                    });
+                }
+            }
+        }
+    });
+
+    // Image/data verbatim `src=` parameters. The verbatim's own range
+    // carries its origin; `lex.include` is an annotation, not a verbatim
+    // block, so it is structurally excluded here.
+    for item in document.root.iter_all_nodes() {
+        if let ContentItem::VerbatimBlock(verbatim) = item {
+            if let Some(src) = verbatim.src_parameter() {
+                if !src.trim().is_empty() {
+                    refs.push(FileReference {
+                        target: src.to_string(),
+                        range: verbatim.range().clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    refs
 }
 
 /// Walk every label site in the document and re-classify via
@@ -1557,5 +1641,46 @@ mod tests {
         assert!(!url_is_malformed("https://example.com"));
         assert!(url_is_malformed("https://exa mple.com"));
         assert!(!url_is_malformed("mailto:a@b.com"));
+    }
+
+    // ========================================================================
+    // collect_file_references (file-path pass, #761) unit tests
+    // ========================================================================
+
+    fn file_ref_targets(source: &str) -> Vec<String> {
+        let doc = parse_document_permissive(source).expect("permissive parse");
+        let mut targets: Vec<String> = collect_file_references(&doc)
+            .into_iter()
+            .map(|r| r.target)
+            .collect();
+        targets.sort();
+        targets
+    }
+
+    #[test]
+    fn collects_inline_file_references() {
+        // The three inline file-reference shapes (`./`, `../`, `/`) are
+        // all collected; a non-file `[General]` reference is not.
+        let source = "1. Intro\n\n    See [./a.txt] and [../b] and [/c] but not [Nope].\n";
+        assert_eq!(
+            file_ref_targets(source),
+            vec!["../b".to_string(), "./a.txt".to_string(), "/c".to_string()]
+        );
+    }
+
+    #[test]
+    fn collects_verbatim_src_but_not_lex_include() {
+        // An image verbatim `src=` is collected. `lex.include` is an
+        // annotation (not a verbatim block) and is structurally excluded
+        // — collecting it here would double-validate a path the base
+        // command already checks via expansion.
+        let source = "Photo:\n    Caption.\n:: image src=./diagram.png ::\n\n";
+        assert_eq!(file_ref_targets(source), vec!["./diagram.png".to_string()]);
+    }
+
+    #[test]
+    fn ignores_url_references() {
+        // URLs are out of scope for the file-path pass (#762 owns them).
+        assert!(file_ref_targets("1. Intro\n\n    See [https://example.com].\n").is_empty());
     }
 }

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -75,8 +75,8 @@ pub enum DiagnosticKind {
     /// reachability is out of scope. Emitted by [`analyze_references`].
     MalformedUrl,
     /// A file-path reference — an inline `ReferenceType::File`
-    /// (`[./x.txt]`, `[../y]`, `[/abs]`) or an image/data verbatim
-    /// `src=` — that points at no file on disk, or whose target escapes
+    /// (`[./x.txt]`, `[../y]`, `[/abs]`) or a verbatim block's `src=`
+    /// parameter — that points at no file on disk, or whose target escapes
     /// the resolution root / is a platform-absolute path. Opt-in:
     /// emitted only by `check --references` (the existence check is
     /// IO-bearing, so it runs in the CLI seam, not the pure analyser).
@@ -490,7 +490,8 @@ pub struct FileReference {
 
 /// Collect every **non-include** file-path reference in the (merged)
 /// `document`: inline [`ReferenceType::File`] (`[./x.txt]`, `[../y]`,
-/// `[/abs]`) and image/data verbatim `src=` parameters.
+/// `[/abs]`) and the `src=` parameter of any verbatim block (image,
+/// data, video, …) — `lex.include` excepted (see below).
 ///
 /// This is the pure (no-IO) half of the `check --references` file-path
 /// check: it gathers the targets and their origin-stamped ranges; the
@@ -526,9 +527,10 @@ pub fn collect_file_references(document: &Document) -> Vec<FileReference> {
         }
     });
 
-    // Image/data verbatim `src=` parameters. The verbatim's own range
-    // carries its origin; `lex.include` is an annotation, not a verbatim
-    // block, so it is structurally excluded here.
+    // Any verbatim block's `src=` parameter (image, data, video, …). The
+    // verbatim's own range carries its origin; `lex.include` is an
+    // annotation, not a verbatim block, so it is structurally excluded
+    // here.
     //
     // Two normalizations the inline path gets for free but verbatim does
     // not, because a verbatim `src=` parameter is *not* pre-classified:

--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -42,13 +42,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use lex_analysis::diagnostics::{
-    analyze_references, analyze_with_rules, apply_rules, AnalysisDiagnostic,
-    DiagnosticSeverity as AnalysisSeverity,
+    analyze_references, analyze_with_rules, apply_rules, collect_file_references,
+    AnalysisDiagnostic, DiagnosticKind, DiagnosticSeverity as AnalysisSeverity,
 };
 use lex_config::{DiagnosticsRulesConfig, LabelsConfig, CONFIG_FILE_NAME};
-use lex_core::lex::ast::{Position, Range};
+use lex_core::lex::ast::{Document, Position, Range};
 use lex_core::lex::builtins;
-use lex_core::lex::includes::{resolve_from_source, FsLoader, IncludeError, ResolveConfig};
+use lex_core::lex::includes::{
+    resolve_file_reference, resolve_from_source, FsLoader, IncludeError, ResolveConfig,
+};
 use lex_core::lex::parsing::parse_document_permissive;
 use lex_extension_host::registry::Registry;
 use serde::Serialize;
@@ -363,25 +365,26 @@ pub fn collect_file_diagnostics(
     // actually using the feature) we run the resolver; assembly failures
     // become findings against the include site. Otherwise we parse
     // permissively so label-policy diagnostics still surface.
+    let entry_abs = absolutize(entry);
+    // The resolution root, shared by include expansion and the
+    // `--references` file-path pass so both resolve targets identically:
+    // explicit override → nearest ancestor with `.lex.toml` → the entry
+    // file's own directory (`workspace_for`). NOT the entry directory
+    // unconditionally, which would spuriously trip root-escape for valid
+    // workspace-relative paths when the entry lives in a subdir.
+    let root = opts
+        .includes_root
+        .clone()
+        .map(|r| absolutize(&r))
+        .unwrap_or_else(|| workspace_for(&entry_abs));
+
     let document = if opts.expand_includes && source.contains("lex.include") {
-        let entry_abs = absolutize(entry);
-        // Default include root mirrors `convert`/`inspect`
-        // (`IncludeOptions::resolved_root`): the nearest ancestor
-        // containing `.lex.toml`, falling back to the entry file's own
-        // directory — NOT the entry directory unconditionally, which
-        // would spuriously trip `include-root-escape` for valid
-        // workspace-relative includes when the entry lives in a subdir.
-        let root = opts
-            .includes_root
-            .clone()
-            .map(|r| absolutize(&r))
-            .unwrap_or_else(|| workspace_for(&entry_abs));
         let resolve_config = ResolveConfig {
             root: root.clone(),
             max_depth: opts.max_depth,
             max_total_includes: opts.max_total_includes,
         };
-        let loader = FsLoader::new(root).with_max_file_size(opts.max_file_size);
+        let loader = FsLoader::new(root.clone()).with_max_file_size(opts.max_file_size);
         let registry = Registry::new();
         if let Err(e) = builtins::register_into(&registry, Arc::new(loader), resolve_config.clone())
         {
@@ -426,6 +429,15 @@ pub fn collect_file_diagnostics(
     // a `.lex.toml` downgrade silences a kind identically.
     if opts.check_references {
         let mut reference_diagnostics = analyze_references(&document);
+        // File-path references (inline `[./x]` + image/data verbatim
+        // `src=`) are validated here rather than inside the pure
+        // `analyze_references` pass because existence is IO-bearing: it
+        // needs the resolution `root` and disk access, neither of which
+        // belongs in a pure `&Document` analysis. `lex.include src=` is
+        // intentionally not seen here — by this point it has been spliced
+        // out by expansion (its path already validated by the base
+        // command), so only genuine file references remain.
+        reference_diagnostics.extend(file_reference_diagnostics(&document, &root));
         apply_rules(&mut reference_diagnostics, |code| {
             opts.rules.lookup_by_code(code).cloned()
         });
@@ -435,6 +447,61 @@ pub fn collect_file_diagnostics(
     }
 
     Ok(findings)
+}
+
+/// Validate every non-include file-path reference in the (merged)
+/// `document` against the filesystem, emitting a `missing-file-target`
+/// diagnostic for each target that does not exist on disk — or that
+/// escapes `root` / is a platform-absolute path.
+///
+/// The references themselves (inline `[./x.txt]` + image/data verbatim
+/// `src=`, with `lex.include src=` structurally excluded) come from the
+/// pure [`collect_file_references`] pass; this function adds only the
+/// IO: resolution + existence.
+///
+/// **Origin-aware resolution is the crux.** Each reference's range
+/// carries the `origin_path` of the file it was authored in (the
+/// resolver stamps it during include expansion), so a `[./foo]` inside
+/// an included chapter resolves against *that chapter's* directory, not
+/// the entry file's. We hand that origin to [`resolve_file_reference`]
+/// as `ref_origin`: relative targets resolve from its parent directory,
+/// root-absolute (`/foo`) targets from `root`. Root-escape and
+/// platform-absolute targets reuse the resolver's
+/// [`IncludeError::RootEscape`] / [`IncludeError::AbsolutePath`] and
+/// surface as the same `missing-file-target` code (with the error's
+/// message) — from the author's standpoint the reference still points at
+/// nothing reachable.
+///
+/// Every finding's range is the reference's own (origin-stamped) range,
+/// so [`analysis_finding`] blames it on the file the reference was
+/// authored in. Default severity `Warning`; the caller applies
+/// `[diagnostics.rules]` for per-rule overrides.
+fn file_reference_diagnostics(document: &Document, root: &Path) -> Vec<AnalysisDiagnostic> {
+    let mut diagnostics = Vec::new();
+    for file_ref in collect_file_references(document) {
+        let origin = file_ref.range.origin();
+        let message = match resolve_file_reference(&file_ref.target, origin, root) {
+            Ok(resolved) => {
+                if resolved.exists() {
+                    continue;
+                }
+                format!("File reference '{}' does not exist", file_ref.target)
+            }
+            // Root-escape / platform-absolute: the reference is invalid
+            // for the same reason it would be as an include path. Reuse
+            // the resolver's own message so the diagnostic explains the
+            // escape rather than a bland "missing".
+            Err(err) => err.to_string(),
+        };
+
+        diagnostics.push(AnalysisDiagnostic {
+            range: file_ref.range,
+            severity: AnalysisSeverity::Warning,
+            kind: DiagnosticKind::MissingFileTarget,
+            message,
+        });
+    }
+    diagnostics
 }
 
 /// Map an analyser diagnostic into a [`CheckFinding`], resolving the

--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -429,7 +429,7 @@ pub fn collect_file_diagnostics(
     // a `.lex.toml` downgrade silences a kind identically.
     if opts.check_references {
         let mut reference_diagnostics = analyze_references(&document);
-        // File-path references (inline `[./x]` + image/data verbatim
+        // File-path references (inline `[./x]` + any verbatim block's
         // `src=`) are validated here rather than inside the pure
         // `analyze_references` pass because existence is IO-bearing: it
         // needs the resolution `root` and disk access, neither of which
@@ -454,7 +454,7 @@ pub fn collect_file_diagnostics(
 /// diagnostic for each target that does not exist on disk — or that
 /// escapes `root` / is a platform-absolute path.
 ///
-/// The references themselves (inline `[./x.txt]` + image/data verbatim
+/// The references themselves (inline `[./x.txt]` + any verbatim block's
 /// `src=`, with `lex.include src=` structurally excluded) come from the
 /// pure [`collect_file_references`] pass; this function adds only the
 /// IO: resolution + existence.

--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -467,10 +467,11 @@ pub fn collect_file_diagnostics(
 /// as `ref_origin`: relative targets resolve from its parent directory,
 /// root-absolute (`/foo`) targets from `root`. Root-escape and
 /// platform-absolute targets reuse the resolver's
-/// [`IncludeError::RootEscape`] / [`IncludeError::AbsolutePath`] and
-/// surface as the same `missing-file-target` code (with the error's
-/// message) — from the author's standpoint the reference still points at
-/// nothing reachable.
+/// [`IncludeError::RootEscape`] / [`IncludeError::AbsolutePath`] guards
+/// (the resolution rules are identical) but are reported with
+/// *file-reference* wording, since `IncludeError`'s own Display strings
+/// speak of "include path" — confusing on a `missing-file-target`
+/// finding that is about a `[./x]` or an image `src=`.
 ///
 /// Every finding's range is the reference's own (origin-stamped) range,
 /// so [`analysis_finding`] blames it on the file the reference was
@@ -480,17 +481,25 @@ fn file_reference_diagnostics(document: &Document, root: &Path) -> Vec<AnalysisD
     let mut diagnostics = Vec::new();
     for file_ref in collect_file_references(document) {
         let origin = file_ref.range.origin();
-        let message = match resolve_file_reference(&file_ref.target, origin, root) {
+        let target = &file_ref.target;
+        let message = match resolve_file_reference(target, origin, root) {
             Ok(resolved) => {
                 if resolved.exists() {
                     continue;
                 }
-                format!("File reference '{}' does not exist", file_ref.target)
+                format!("File reference '{target}' does not exist")
             }
-            // Root-escape / platform-absolute: the reference is invalid
-            // for the same reason it would be as an include path. Reuse
-            // the resolver's own message so the diagnostic explains the
-            // escape rather than a bland "missing".
+            // The reference is invalid for the same reason it would be as
+            // an include path, but phrase it in file-reference terms
+            // rather than leaking the resolver's include-specific Display.
+            Err(IncludeError::RootEscape { .. }) => {
+                format!("File reference '{target}' escapes the resolution root")
+            }
+            Err(IncludeError::AbsolutePath { .. }) => {
+                format!("File reference '{target}' is a platform-absolute path (not allowed)")
+            }
+            // Any other resolver error is unexpected here; surface it
+            // verbatim rather than mislabel it.
             Err(err) => err.to_string(),
         };
 

--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -372,6 +372,16 @@ pub fn collect_file_diagnostics(
     // file's own directory (`workspace_for`). NOT the entry directory
     // unconditionally, which would spuriously trip root-escape for valid
     // workspace-relative paths when the entry lives in a subdir.
+    //
+    // Computed from `entry_abs` (the fully-canonicalized entry), NOT
+    // reused from `workspace` above: `workspace_for(entry)` canonicalizes
+    // only the entry's *parent*, so on a platform where an ancestor is a
+    // symlink (macOS `/var` -> `/private/var`) it yields the pre-canonical
+    // form, while the resolver's own paths are fully canonical. A root in
+    // the symlink form then fails the canonical-prefix root-escape check
+    // for every include. `workspace_for(&entry_abs)` is the canonical form
+    // the resolver agrees with — the duplicate ancestor probe is the price
+    // of that correctness.
     let root = opts
         .includes_root
         .clone()

--- a/crates/lex-cli/tests/integration/check.rs
+++ b/crates/lex-cli/tests/integration/check.rs
@@ -670,7 +670,7 @@ fn references_lex_toml_allow_silences_malformed_url() {
 // --references: file-path reference validation (#761)
 //
 // Validates non-include file-path references (inline `ReferenceType::File`
-// + image/data verbatim `src=`) against the filesystem, origin-aware.
+// + any verbatim block's `src=`) against the filesystem, origin-aware.
 // `lex.include src=` is excluded — the base command validates it.
 // ============================================================================
 
@@ -723,8 +723,7 @@ fn references_existing_inline_file_is_clean() {
         .stdout(predicate::str::is_empty());
 }
 
-/// A missing image/data verbatim `src=` is flagged; an existing one is
-/// not (second file in the pair exists).
+/// A missing verbatim `src=` is flagged; an existing one is not.
 #[test]
 fn references_flags_missing_verbatim_src() {
     let dir = fixture_dir(&[

--- a/crates/lex-cli/tests/integration/check.rs
+++ b/crates/lex-cli/tests/integration/check.rs
@@ -730,8 +730,10 @@ fn references_flags_missing_verbatim_src() {
     let dir = fixture_dir(&[
         REFS_ROOT_TOML,
         (
+            // Quoted `src="..."` is the common authoring form; this also
+            // exercises end-to-end unquoting before the existence check.
             "doc.lex",
-            "Sunset Photo:\n    Caption.\n:: image src=./missing.png ::\n\n",
+            "Sunset Photo:\n    Caption.\n:: image src=\"./missing.png\" ::\n\n",
         ),
     ]);
     lexd()
@@ -752,8 +754,9 @@ fn references_existing_verbatim_src_is_clean() {
     let dir = fixture_dir(&[
         REFS_ROOT_TOML,
         (
+            // Quoted form again — the existence check must unquote first.
             "doc.lex",
-            "Sunset Photo:\n    Caption.\n:: image src=./diagram.png ::\n\n",
+            "Sunset Photo:\n    Caption.\n:: image src=\"./diagram.png\" ::\n\n",
         ),
         ("diagram.png", "binary-ish\n"),
     ]);

--- a/crates/lex-cli/tests/integration/check.rs
+++ b/crates/lex-cli/tests/integration/check.rs
@@ -665,3 +665,216 @@ fn references_lex_toml_allow_silences_malformed_url() {
         .success()
         .stdout(predicate::str::is_empty());
 }
+
+// ============================================================================
+// --references: file-path reference validation (#761)
+//
+// Validates non-include file-path references (inline `ReferenceType::File`
+// + image/data verbatim `src=`) against the filesystem, origin-aware.
+// `lex.include src=` is excluded — the base command validates it.
+// ============================================================================
+
+/// A `.lex.toml` at the fixture root pins the resolution root to the
+/// fixture dir, so relative file references resolve there regardless of
+/// the test runner's CWD. (Without it the root is the entry file's own
+/// directory, which is the same here — but this makes intent explicit
+/// and matches how authors run `check` from a workspace.)
+const REFS_ROOT_TOML: (&str, &str) = (".lex.toml", "");
+
+/// A missing inline file reference (`[./nope.txt]`) is flagged at warning
+/// severity with the new code; an existing one is not.
+#[test]
+fn references_flags_missing_inline_file() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        ("doc.lex", "1. Intro\n\n    See [./nope.txt] for details.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("missing-file-target")
+                .and(predicate::str::contains("warning:"))
+                .and(predicate::str::contains("./nope.txt")),
+        );
+}
+
+/// An inline file reference whose target exists on disk is clean.
+#[test]
+fn references_existing_inline_file_is_clean() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        (
+            "doc.lex",
+            "1. Intro\n\n    See [./there.txt] for details.\n",
+        ),
+        ("there.txt", "I exist.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A missing image/data verbatim `src=` is flagged; an existing one is
+/// not (second file in the pair exists).
+#[test]
+fn references_flags_missing_verbatim_src() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        (
+            "doc.lex",
+            "Sunset Photo:\n    Caption.\n:: image src=./missing.png ::\n\n",
+        ),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("missing-file-target")
+                .and(predicate::str::contains("./missing.png")),
+        );
+}
+
+#[test]
+fn references_existing_verbatim_src_is_clean() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        (
+            "doc.lex",
+            "Sunset Photo:\n    Caption.\n:: image src=./diagram.png ::\n\n",
+        ),
+        ("diagram.png", "binary-ish\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// The key origin-aware test: a `[./local.txt]` authored *inside* an
+/// included chapter resolves relative to THAT chapter's directory, not
+/// the entry file's. The target file sits next to the chapter (in a
+/// subdir); the entry dir has no such file. Resolution must succeed.
+#[test]
+fn references_inline_file_inside_include_resolves_against_origin_dir() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        ("master.lex", ":: lex.include src=\"chapters/ch1.lex\" ::\n"),
+        (
+            "chapters/ch1.lex",
+            "1. Chapter\n\n    See [./local.txt] next door.\n",
+        ),
+        // Target lives next to the chapter — origin-relative resolution
+        // finds it here. There is deliberately no `local.txt` at the
+        // entry dir, so an entry-relative resolver would wrongly flag it.
+        ("chapters/local.txt", "I live by the chapter.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "master.lex"))
+        .arg("--references")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// Counterpart to the above: the same `[./local.txt]` inside the chapter,
+/// but with the file placed only at the ENTRY dir. Origin-aware
+/// resolution looks beside the chapter, does not find it, and flags it —
+/// blamed on the chapter's path, not the master.
+#[test]
+fn references_inline_file_inside_include_does_not_resolve_against_entry_dir() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        ("master.lex", ":: lex.include src=\"chapters/ch1.lex\" ::\n"),
+        (
+            "chapters/ch1.lex",
+            "1. Chapter\n\n    See [./local.txt] next door.\n",
+        ),
+        // Placed at the entry dir, NOT beside the chapter: origin-aware
+        // resolution (chapter-relative) must miss it.
+        ("local.txt", "I live by the master.\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "master.lex"))
+        .arg("--references")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(
+            predicate::str::contains("missing-file-target")
+                .and(predicate::str::contains("ch1.lex")),
+        );
+}
+
+/// A root-escaping reference (`[../../etc/passwd]`) is flagged — it never
+/// reaches the filesystem; the resolver's root-escape guard fires and is
+/// surfaced as `missing-file-target`.
+#[test]
+fn references_root_escape_is_flagged() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        ("doc.lex", "1. Intro\n\n    See [../../etc/passwd].\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("missing-file-target"));
+}
+
+/// The file-path pass is opt-in: without `--references`, a missing inline
+/// file reference produces no finding.
+#[test]
+fn references_file_pass_is_opt_in() {
+    let dir = fixture_dir(&[
+        REFS_ROOT_TOML,
+        ("doc.lex", "1. Intro\n\n    See [./nope.txt].\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A `.lex.toml` rule downgrade (`allow`) silences the file-target kind.
+#[test]
+fn references_file_target_lex_toml_allow_silences() {
+    let dir = fixture_dir(&[
+        (
+            ".lex.toml",
+            "[diagnostics.rules]\nmissing_file_target = \"allow\"\n",
+        ),
+        ("doc.lex", "1. Intro\n\n    See [./nope.txt].\n"),
+    ]);
+    lexd()
+        .arg("check")
+        .arg(path_in(&dir, "doc.lex"))
+        .arg("--references")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -599,7 +599,7 @@ pub struct DiagnosticsRulesConfig {
     #[clapfig(value, default = "warn")]
     pub malformed_url: RuleConfig,
     /// A file-path reference — an inline `[./x.txt]` / `[../y]` / `[/abs]`
-    /// or an image/data verbatim `src=` — points at a file that does not
+    /// or a verbatim block's `src=` — points at a file that does not
     /// exist on disk (or escapes the resolution root / is a
     /// platform-absolute path). Opt-in (`check --references`).
     /// `lex.include src=` is excluded — the base command validates it via

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -598,6 +598,14 @@ pub struct DiagnosticsRulesConfig {
     /// reachability is not checked. Intrinsic default: warn.
     #[clapfig(value, default = "warn")]
     pub malformed_url: RuleConfig,
+    /// A file-path reference — an inline `[./x.txt]` / `[../y]` / `[/abs]`
+    /// or an image/data verbatim `src=` — points at a file that does not
+    /// exist on disk (or escapes the resolution root / is a
+    /// platform-absolute path). Opt-in (`check --references`).
+    /// `lex.include src=` is excluded — the base command validates it via
+    /// expansion. Intrinsic default: warn.
+    #[clapfig(value, default = "warn")]
+    pub missing_file_target: RuleConfig,
     /// Schema-validation diagnostics for extension labels.
     pub schema: SchemaRulesConfig,
 }
@@ -624,6 +632,7 @@ impl DiagnosticsRulesConfig {
             "missing-annotation-target" => Some(&self.missing_annotation_target),
             "missing-citation-target" => Some(&self.missing_citation_target),
             "malformed-url" => Some(&self.malformed_url),
+            "missing-file-target" => Some(&self.missing_file_target),
             // `spellcheck` is intentionally absent: spellcheck
             // diagnostics emit through a separate path (see
             // `lex-analysis/src/spellcheck.rs`) and do not flow


### PR DESCRIPTION
Closes #761. Part of epic #758. **Stacks on #764** (#760, `--references` internal cross-references) — base branch is `feat/lexd-check-refs-internal`; review/merge #764 first.

## What

Under the **existing** `--references` flag (no new flag), validate that **non-include** file-path references point at files that exist on disk:

| Source | Example |
|---|---|
| inline `ReferenceType::File` | `[./x.txt]`, `[../y]`, `[/abs]` |
| image/data verbatim `src=` | `:: image src=./diagram.png ::` |

`lex.include src=` is **excluded** — structurally (it is an *annotation*, not a verbatim block, so it never matches the `src=` arm) and because include expansion has already spliced it out, its path validated by the base command (#759).

## Context — where it lives + how origin-aware resolution is wired

The existence check is **IO-bearing** (needs the resolution root + disk access), so it does *not* live in the pure `analyze_references(doc)` pass. It is split:

- **Pure half** — `collect_file_references(&Document) -> Vec<FileReference>` in `lex-analysis/src/diagnostics.rs`: gathers inline `File` refs (via `extract_references`, whose ranges are already origin-stamped per #764) + verbatim `src=` (the verbatim node's own range), each with its **origin-stamped** range.
- **IO half** — `file_reference_diagnostics(document, root)` in `lex-cli/src/check.rs`, called from the `collect_file_diagnostics` seam under `--references`. For each reference it calls `resolve_file_reference(target, ref_origin = range.origin(), root)` (`includes.rs:1170`) then checks `.exists()`.

**Origin-aware resolution is the crux:** a `[./foo]` inside an included chapter resolves against *that chapter's* directory (from the range's `origin_path`), not the entry file's. The resolution `root` is the same one the base command computes (override → nearest `.lex.toml` → entry dir); it was lifted out of the include-only branch so both passes share it.

Root-escape (`../../etc/passwd`) and platform-absolute targets reuse the resolver's `RootEscape` / `AbsolutePath` errors and surface as the same code (with the resolver's message).

**Note (why not `find_all_links`):** the obvious `Document::find_all_links()` was tried and rejected — its `LinkCollector` builds link ranges from inline marker ranges that the resolver does **not** origin-stamp, so origin came back `None` and chapter-relative resolution silently fell back to the entry dir. `extract_references` is the origin-correct path (it copies origin from the `TextContent` base range, per #764). Don't "simplify" back to `find_all_links` without first fixing origin propagation into `LinkCollector`.

## New diagnostic code

`missing-file-target` — default `Warning`, rule-configurable via `[diagnostics.rules].missing_file_target` (new field in `lex-config` + `lookup_by_code` entry; auto-surfaces in `lexd config gen`). Findings are blamed origin-faithfully on the authoring file.

## Known limitation

With `--no-includes`, references inside unexpanded includes are never seen (the resolver doesn't run), so they aren't validated — consistent with the rest of `check`.

## Tests

- `lex-analysis`: 3 unit tests for `collect_file_references` (collects inline `./`/`../`/`/` shapes; collects verbatim `src=` but not `lex.include`; ignores URLs).
- `lex-cli` integration (`tests/integration/check.rs`): missing inline file flagged + existing clean; missing/existing verbatim `src=`; **the key origin-aware pair** — `[./local.txt]` inside an included chapter resolves beside the chapter (not the entry dir) and is blamed on the chapter; root-escape flagged; opt-in gating; `.lex.toml allow` silences the kind.
- Full workspace suite green (2576 passed); `release-core gate` green.

## #762 sibling conflict

A mechanical conflict is expected with #762 (URL validation): both add a `DiagnosticKind` variant + a `DiagnosticsRulesConfig` field + a `lookup_by_code` entry in the same three locations. Whichever merges second takes a small rebase. No logic overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7noCwaDvagCnu2PoSB6Vu