### PR TITLE
fix(check): try_exists for file refs + tighten is_url_like against Windows drive paths

### DIFF
--- a/CHANGELOG/unreleased-check-refs-followups.md
+++ b/CHANGELOG/unreleased-check-refs-followups.md
@@ -1,0 +1,1 @@
+- lexd check --references: use try_exists for file refs and tighten is_url_like against Windows drive paths

--- a/crates/lex-analysis/src/diagnostics.rs
+++ b/crates/lex-analysis/src/diagnostics.rs
@@ -572,11 +572,35 @@ pub fn collect_file_references(document: &Document) -> Vec<FileReference> {
 /// `mailto:`) plus a generic `scheme://` catch, so a verbatim
 /// `src=<url>` is excluded from the file-path existence check the same
 /// way an inline `[<url>]` is classified `Url` and skipped.
+///
+/// The generic `scheme://` arm requires a *real* URL scheme rather than
+/// a bare `"://"` substring: the part before `://` must be a valid
+/// RFC 3986 scheme — start with an ASCII letter, then ASCII
+/// alphanumerics / `+` / `-` / `.` — and be at least two characters
+/// long. The length-≥2 floor is the point of the fix: a single-letter
+/// "scheme" is exactly the Windows drive-letter ambiguity, so `C://path`
+/// is *not* treated as a URL (it falls through to be resolved / flagged
+/// as a platform-absolute path), while every real scheme we care about
+/// (`http`, `https`, …) is ≥2 chars and still matches. `mailto:` has no
+/// `//`, so it keeps its own explicit prefix arm.
 fn is_url_like(src: &str) -> bool {
     src.starts_with("http://")
         || src.starts_with("https://")
         || src.starts_with("mailto:")
-        || src.contains("://")
+        || has_url_scheme(src)
+}
+
+/// Does `src` begin with a genuine `scheme://` (a length-≥2 RFC 3986
+/// scheme), as opposed to a Windows drive path like `C://…`?
+fn has_url_scheme(src: &str) -> bool {
+    let Some((scheme, _)) = src.split_once("://") else {
+        return false;
+    };
+    scheme.len() >= 2
+        && scheme.starts_with(|c: char| c.is_ascii_alphabetic())
+        && scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
 }
 
 /// Walk every label site in the document and re-classify via
@@ -1736,5 +1760,21 @@ mod tests {
             "Photo:\n    Caption.\n:: image src=\"https://example.com/diagram.png\" ::\n\n"
         )
         .is_empty());
+    }
+
+    #[test]
+    fn is_url_like_matches_real_schemes_not_windows_drives() {
+        // A genuine `scheme://` URL is URL-like and filtered out.
+        assert!(is_url_like("https://example.com"));
+        assert!(is_url_like("http://example.com"));
+        assert!(is_url_like("mailto:user@example.com"));
+        // A length-≥2 custom scheme still matches.
+        assert!(is_url_like("ftp://host/path"));
+        // A Windows drive path is NOT a URL — its single-letter "scheme"
+        // is exactly the ambiguity the length-≥2 floor disambiguates.
+        assert!(!is_url_like("C://path"));
+        assert!(!is_url_like("C:\\path"));
+        // A plain relative path is not URL-like.
+        assert!(!is_url_like("./rel/path"));
     }
 }

--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -493,12 +493,20 @@ fn file_reference_diagnostics(document: &Document, root: &Path) -> Vec<AnalysisD
         let origin = file_ref.range.origin();
         let target = &file_ref.target;
         let message = match resolve_file_reference(target, origin, root) {
-            Ok(resolved) => {
-                if resolved.exists() {
-                    continue;
-                }
-                format!("File reference '{target}' does not exist")
-            }
+            Ok(resolved) => match resolved.try_exists() {
+                // Genuinely absent — emit the finding.
+                Ok(false) => format!("File reference '{target}' does not exist"),
+                // Exists — no finding.
+                Ok(true) => continue,
+                // Existence could not be *determined* (e.g. permission
+                // denied on a parent dir). `exists()` would have collapsed
+                // this IO error into a `false` and reported a phantom
+                // "does not exist"; the file may well be there but
+                // unreadable, so don't flag it. The real problem is an
+                // IO/permission error, not a missing target — and we have
+                // no diagnostic kind for that, so silently skip.
+                Err(_) => continue,
+            },
             // The reference is invalid for the same reason it would be as
             // an include path, but phrase it in file-reference terms
             // rather than leaking the resolver's include-specific Display.


### PR DESCRIPTION
Two small follow-up fixes addressing review nits left from #766 (the `lexd check --references` file-path validation, issue #761 — already merged and closed).

## Fix 1 — `try_exists()` instead of `exists()`

`file_reference_diagnostics` (`crates/lex-cli/src/check.rs`) checked target existence with `Path::exists()`, which collapses "the file is genuinely absent" and "existence could not be determined" (permission/IO error) into the same `false`, risking a phantom `missing-file-target`. Switched to `Path::try_exists()` with three-way handling:

- `Ok(false)` → genuinely missing → emit `missing-file-target` (unchanged behavior).
- `Ok(true)` → exists → no finding.
- `Err(_)` → existence undetermined (e.g. permission denied on a parent dir) → skip. The file may well exist but be unreadable; the real problem is an IO error, not a missing target, and there is no diagnostic kind for that — so silently not-flagging is the right call (no new diagnostic kind invented).

The surrounding origin-aware resolution (`resolve_file_reference`, `RootEscape`/`AbsolutePath` handling) is untouched.

## Fix 2 — `is_url_like` must not swallow a Windows `C://path`

`is_url_like` (`crates/lex-analysis/src/diagnostics.rs`) filtered URL-ish `src=` targets out of the file-path pass using a generic `target.contains("://")`, which also matches a Windows drive path like `C://path` — wrongly skipping it instead of resolving/flagging it as a platform-absolute path. Replaced the generic catch with `has_url_scheme()`: the part before `://` must be a valid RFC 3986 scheme (starts with an ASCII letter, then ASCII alphanumerics / `+` / `-` / `.`) **of length ≥ 2**. The length-≥2 floor is the disambiguator — a single-letter "scheme" is exactly the Windows drive-letter ambiguity, so `C://path` and `C:\path` are no longer treated as URLs, while every real scheme we care about (`http`, `https`, …) is ≥2 chars and still matches. `mailto:` has no `//`, so it keeps its explicit prefix arm.

## Tests

- Fix 2: added `is_url_like_matches_real_schemes_not_windows_drives` asserting `https://…`/`http://`/`mailto:`/`ftp://…` are URL-like and `C://path`, `C:\path`, `./rel/path` are not.
- Fix 1: the genuinely-missing (`Ok(false)`) path is already covered by the `references_*` integration tests in `crates/lex-cli/tests/integration/check.rs` (all 44 pass). The `Err(_)` arm can't be portably unit-tested — simulating an undetermined-existence IO error requires an unreadable parent directory, which is root/OS-dependent and fragile — so it's handled by inspection.

Relates to #761 (already closed; not using a closing keyword).

## Context

These are nits from the #766 review threads. Scope is deliberately narrow: no behavior change to genuinely-missing detection, no new diagnostic kind for the IO-error case, and no touching the origin-aware resolver. Reusing `lex-core`'s private `is_url_reference` was considered but it only covers `http`/`https`/`mailto:` and lacks the generic `scheme://` catch, so the local `has_url_scheme` is the minimal correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7noCwaDvagCnu2PoSB6Vu