### PR TITLE
fix(parser): keep [...]-led lines literal inside verbatim blocks

### DIFF
--- a/CHANGELOG/unreleased-verbatim-bracket-lines.md
+++ b/CHANGELOG/unreleased-verbatim-bracket-lines.md
@@ -1,0 +1,1 @@
+- Keep [...]-led lines literal inside verbatim blocks (lex#755)

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -322,6 +322,63 @@ fn test_reference_url_converted_to_link() {
 }
 
 #[test]
+fn test_verbatim_bracket_lines_stay_literal_not_autolinks() {
+    // lex#755: a `[...]`-led line inside a verbatim body (e.g. a TOML table
+    // header `[server]` or a dotted one `[formatting.rules]`) must stay literal
+    // inside the fence — it must NOT be ejected from the block and re-emitted as
+    // a dangling shortcut auto-link `[server](server)` outside it.
+    let lex_src =
+        "Config example:\n\n    [server]\n    [formatting.rules]\n    port = 8080\n:: toml ::\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    // Both bracket lines appear literally in the output...
+    assert!(
+        md.contains("[server]"),
+        "`[server]` must be present literally: {md}"
+    );
+    assert!(
+        md.contains("[formatting.rules]"),
+        "`[formatting.rules]` must be present literally: {md}"
+    );
+    // ...and never as a shortcut auto-link `(...)`.
+    assert!(
+        !md.contains("[server](server)") && !md.contains("](server)"),
+        "`[server]` must not become an auto-link: {md}"
+    );
+    assert!(
+        !md.contains("](formatting.rules)"),
+        "`[formatting.rules]` must not become an auto-link: {md}"
+    );
+
+    // The bracket lines must live INSIDE the code fence, not as a sibling
+    // paragraph after it. Parse the markdown and confirm the brackets only
+    // occur within a CodeBlock node and there is no Link node.
+    let arena = Arena::new();
+    let options = ComrakOptions::default();
+    let root = parse_document(&arena, &md, &options);
+
+    fn assert_brackets_only_in_code<'a>(node: &'a comrak::nodes::AstNode<'a>) {
+        let value = &node.data.borrow().value;
+        match value {
+            NodeValue::CodeBlock(cb) => {
+                assert!(
+                    cb.literal.contains("[server]") && cb.literal.contains("[formatting.rules]"),
+                    "code fence must contain both bracket lines: {:?}",
+                    cb.literal
+                );
+            }
+            NodeValue::Link(_) => panic!("verbatim bracket line leaked out as a link"),
+            _ => {}
+        }
+        for child in node.children() {
+            assert_brackets_only_in_code(child);
+        }
+    }
+    assert_brackets_only_in_code(root);
+}
+
+#[test]
 fn test_reference_anchor_converted_to_link() {
     let lex_src = "See section [#introduction] above.\n";
     let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -352,30 +352,42 @@ fn test_verbatim_bracket_lines_stay_literal_not_autolinks() {
     );
 
     // The bracket lines must live INSIDE the code fence, not as a sibling
-    // paragraph after it. Parse the markdown and confirm the brackets only
-    // occur within a CodeBlock node and there is no Link node.
+    // paragraph (auto-link OR escaped prose) after it. Walk the comrak tree and
+    // assert three things at once: (1) no Link node anywhere (no auto-link
+    // ejection), (2) the bracket text never appears in a Text node (no
+    // escaped-prose leak outside the fence), and (3) at least one CodeBlock
+    // carries both bracket lines.
     let arena = Arena::new();
     let options = ComrakOptions::default();
     let root = parse_document(&arena, &md, &options);
 
-    fn assert_brackets_only_in_code<'a>(node: &'a comrak::nodes::AstNode<'a>) {
-        let value = &node.data.borrow().value;
-        match value {
+    fn walk<'a>(node: &'a comrak::nodes::AstNode<'a>, saw_brackets_in_code: &mut bool) {
+        match &node.data.borrow().value {
+            NodeValue::Link(_) => panic!("verbatim bracket line leaked out as a link"),
             NodeValue::CodeBlock(cb) => {
+                if cb.literal.contains("[server]") && cb.literal.contains("[formatting.rules]") {
+                    *saw_brackets_in_code = true;
+                }
+            }
+            NodeValue::Text(t) => {
                 assert!(
-                    cb.literal.contains("[server]") && cb.literal.contains("[formatting.rules]"),
-                    "code fence must contain both bracket lines: {:?}",
-                    cb.literal
+                    !t.contains("[server]") && !t.contains("[formatting.rules]"),
+                    "bracket line leaked outside the fence as prose text: {t:?}"
                 );
             }
-            NodeValue::Link(_) => panic!("verbatim bracket line leaked out as a link"),
             _ => {}
         }
         for child in node.children() {
-            assert_brackets_only_in_code(child);
+            walk(child, saw_brackets_in_code);
         }
     }
-    assert_brackets_only_in_code(root);
+
+    let mut saw_brackets_in_code = false;
+    walk(root, &mut saw_brackets_in_code);
+    assert!(
+        saw_brackets_in_code,
+        "a code fence must carry both bracket lines literally: {md}"
+    );
 }
 
 #[test]

--- a/crates/lex-core/src/lex/anchoring.rs
+++ b/crates/lex-core/src/lex/anchoring.rs
@@ -57,6 +57,8 @@ use crate::lex::inlines::{
     determine_reference_type, parse_inlines, AnchorDirection, AnchorKind, InlineNode,
     ReferenceInline, WordAnchor,
 };
+use crate::lex::lexing::line_classification::classify_line_tokens;
+use crate::lex::token::{LineType, Token};
 use std::ops::Range;
 
 /// Result of the reference-line pre-pass.
@@ -252,10 +254,206 @@ fn list_marker_len(body: &str) -> Option<usize> {
     None
 }
 
+/// Per-physical-line classification used by the verbatim-region scan: the
+/// line's [`LineType`] and its indentation depth (number of leading 4-space
+/// indentation units).
+struct ClassifiedLine {
+    line_type: LineType,
+    indent: usize,
+}
+
+/// Classify one physical line the same way the lexer's line grouper does:
+/// tokenize it and run [`classify_line_tokens`], and count leading
+/// [`Token::Indentation`] tokens for the indentation depth.
+///
+/// A trailing newline is appended before tokenizing because the line text
+/// produced by [`physical_lines`] has its `\n` stripped, and the classifier's
+/// blank-line / colon handling expects the line's tokens as the lexer would
+/// emit them.
+fn classify_physical_line(text: &str) -> ClassifiedLine {
+    let with_newline = format!("{text}\n");
+    let tokens: Vec<Token> = crate::lex::lexing::base_tokenization::tokenize(&with_newline)
+        .into_iter()
+        .map(|(t, _)| t)
+        .collect();
+    let indent = tokens
+        .iter()
+        .take_while(|t| matches!(t, Token::Indentation))
+        .count();
+    ClassifiedLine {
+        line_type: classify_line_tokens(&tokens),
+        indent,
+    }
+}
+
+/// Compute which physical lines fall inside a verbatim block (subject through
+/// closing `:: label ::` marker, inclusive). Reference-line extraction must
+/// skip these lines: a verbatim block's body is raw, so a `[token]` line inside
+/// it (e.g. a TOML table header `[server]`) must stay literal — never be
+/// ejected and re-emitted as a whole-element anchor / auto-link (lex#755).
+///
+/// This mirrors the structural verbatim grammar
+/// ([`match_verbatim_block`](crate::lex::parsing::parser::GrammarMatcher::match_verbatim_block)):
+/// a subject line, then one or more groups of body content, terminated by a
+/// `DataMarkerLine` (`:: label ::`) at the subject's indentation. Body content
+/// may be deeper-indented (inflow) or at the subject's indentation (fullwidth /
+/// groups); a group is another subject + body before the single shared closing
+/// marker. Crucially the scan only marks a region verbatim once it has *seen*
+/// the closing marker — a subject with no closing marker is an ordinary
+/// session/definition and its lines stay eligible for reference extraction.
+///
+/// # The anchoring-slot exception
+///
+/// One position inside a verbatim region is deliberately *not* protected: the
+/// reference line that anchors the block's subject. Per §2.3 (see this module's
+/// header) a link-like reference on its own line directly below a subject — at
+/// the subject's indentation, with the indented body following — anchors that
+/// subject and is transparent to structure:
+///
+/// ```text
+/// Example Source:
+/// [./example.rs]       <- anchors "Example Source"; removed, NOT body
+///     fn main() {}     <- the actual (deeper-indented) body
+/// :: rust ::
+/// ```
+///
+/// That slot — the first non-blank line directly after a subject, at the
+/// subject's indentation — keeps its existing whole-element-anchor behavior.
+/// Every *other* line in the region (notably the deeper-indented inflow body
+/// where TOML headers like `[server]` live, lex#755) is protected and stays
+/// literal.
+fn verbatim_protected_lines(lines: &[PhysicalLine<'_>]) -> Vec<bool> {
+    let classified: Vec<ClassifiedLine> = lines
+        .iter()
+        .map(|l| classify_physical_line(l.text))
+        .collect();
+
+    let mut protected = vec![false; lines.len()];
+    let len = lines.len();
+    let mut idx = 0;
+
+    while idx < len {
+        // Skip blank lines between blocks.
+        if matches!(classified[idx].line_type, LineType::BlankLine) {
+            idx += 1;
+            continue;
+        }
+
+        // A verbatim block opens on a subject line.
+        if !matches!(
+            classified[idx].line_type,
+            LineType::SubjectLine | LineType::SubjectOrListItemLine
+        ) {
+            idx += 1;
+            continue;
+        }
+
+        let subject_idx = idx;
+        let subject_indent = classified[subject_idx].indent;
+
+        // Scan forward for a closing data marker at the subject's indentation.
+        // Allow further subject lines (verbatim groups) and any body lines in
+        // between. Stop — without claiming a verbatim block — if we hit a
+        // content line shallower than the subject that is not the closing
+        // marker, which means the structure closed before any closing marker
+        // appeared (so it was an ordinary session/definition, not verbatim).
+        let mut cursor = subject_idx + 1;
+        let mut closing: Option<usize> = None;
+        while cursor < len {
+            let line = &classified[cursor];
+            match line.line_type {
+                LineType::BlankLine => {
+                    cursor += 1;
+                }
+                LineType::DataMarkerLine if line.indent == subject_indent => {
+                    closing = Some(cursor);
+                    break;
+                }
+                _ => {
+                    if line.indent < subject_indent {
+                        break;
+                    }
+                    cursor += 1;
+                }
+            }
+        }
+
+        if let Some(closing_idx) = closing {
+            // Protect every line of the region except the subject lines
+            // themselves (they are normal anchorable head lines) and the
+            // anchoring slot directly after a subject (see the doc comment).
+            let mut after_subject = false;
+            for i in subject_idx..=closing_idx {
+                let is_subject = matches!(
+                    classified[i].line_type,
+                    LineType::SubjectLine | LineType::SubjectOrListItemLine
+                );
+                let is_blank = matches!(classified[i].line_type, LineType::BlankLine);
+
+                if is_subject {
+                    protected[i] = false;
+                    after_subject = true;
+                    continue;
+                }
+                if is_blank {
+                    // Blank lines never carry a reference; leave them
+                    // unprotected and keep looking for the anchoring slot, which
+                    // may follow a blank line after the subject.
+                    continue;
+                }
+                // First non-blank, non-subject line after a subject at the
+                // subject's indentation is the anchoring slot — leave it to the
+                // existing whole-element-anchor handling — *but only when real
+                // body content follows it*. The documented anchoring shape is
+                // `subject` / `[ref]` / indented-body / `:: marker ::`: the
+                // reference anchors the subject and the body follows. If instead
+                // the bracket line is itself the block's body (nothing but the
+                // closing marker follows), it must stay literal (lex#755), so we
+                // protect it rather than ejecting it as an anchor.
+                if after_subject
+                    && classified[i].indent == subject_indent
+                    && has_body_after(&classified, i, closing_idx)
+                {
+                    protected[i] = false;
+                    after_subject = false;
+                    continue;
+                }
+                after_subject = false;
+                protected[i] = true;
+            }
+            idx = closing_idx + 1;
+        } else {
+            // Not a verbatim block; resume scanning after the subject.
+            idx = subject_idx + 1;
+        }
+    }
+
+    protected
+}
+
+/// True when at least one non-blank, non-marker body line lies strictly between
+/// the anchoring-slot candidate at `slot_idx` and the block's closing marker at
+/// `closing_idx`. Used to tell the documented anchoring shape (a reference line
+/// whose subject's body follows it) from a verbatim block whose *only* content
+/// is the bracket line itself, which must stay literal (lex#755).
+fn has_body_after(classified: &[ClassifiedLine], slot_idx: usize, closing_idx: usize) -> bool {
+    ((slot_idx + 1)..closing_idx).any(|i| {
+        !matches!(
+            classified[i].line_type,
+            LineType::BlankLine | LineType::DataMarkerLine
+        )
+    })
+}
+
 /// Run the reference-line pre-pass over `source`.
 pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
     let lines = physical_lines(source);
     let loc = SourceLocation::new(source);
+
+    // Verbatim block bodies are raw: a `[token]` line inside one must stay
+    // literal, never be ejected as a reference line (lex#755). Compute the
+    // protected line set once and skip those lines below.
+    let in_verbatim = verbatim_protected_lines(&lines);
 
     let mut reference_lines: Vec<ReferenceLine> = Vec::new();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
@@ -270,6 +468,10 @@ pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
     let mut anchored_line: Vec<bool> = vec![false; lines.len()];
 
     for idx in 0..lines.len() {
+        // Lines inside a verbatim block body are raw — never a reference line.
+        if in_verbatim[idx] {
+            continue;
+        }
         let line = &lines[idx];
         let trimmed = line.trimmed();
         let Some(inner) = bracketed_inner(trimmed) else {
@@ -945,5 +1147,108 @@ mod tests {
         let (anchor, kind) = sole_whole_anchor(src);
         assert_eq!(anchor, "First item");
         assert_eq!(kind, AnchoredElement::ListItem);
+    }
+
+    // -- §lex#755: verbatim bodies are raw, `[...]`-led lines stay literal ---
+
+    /// Every `[...]`-led verbatim body line, in document order — collected by
+    /// walking the verbatim block's groups. Empty when there is no verbatim
+    /// block. Used to assert bracket lines survive the parse literally.
+    fn verbatim_body_lines(doc: &crate::lex::ast::Document) -> Vec<String> {
+        use crate::lex::ast::elements::ContentItem;
+        let mut out = Vec::new();
+        for child in &doc.root.children {
+            if let ContentItem::VerbatimBlock(vb) = child {
+                for group in vb.group() {
+                    for line in group.children.iter() {
+                        if let ContentItem::VerbatimLine(vl) = line {
+                            out.push(vl.content.as_string().to_string());
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn verbatim_body_bracket_lines_stay_literal() {
+        // The lex#755 repro: a TOML example inside an inflow verbatim block. A
+        // single-word table header (`[server]`) and a dotted one
+        // (`[formatting.rules]`) must both survive verbatim — never be ejected
+        // as reference lines and re-emitted as auto-links.
+        let src = "Config example:\n\n    [server]\n    [formatting.rules]\n    port = 8080\n:: toml ::\n\n";
+        let doc = parse_document(src).unwrap();
+
+        // No reference line was ejected from the verbatim body.
+        assert!(
+            doc.reference_lines.is_empty(),
+            "verbatim body lines must not become reference lines: {:?}",
+            doc.reference_lines
+        );
+        // And no inline reference leaked out of the raw body.
+        assert!(
+            doc.iter_all_references().next().is_none(),
+            "verbatim body must carry no parsed references"
+        );
+
+        // Both bracket lines are preserved literally inside the block.
+        let lines = verbatim_body_lines(&doc);
+        assert!(
+            lines.iter().any(|l| l == "[server]"),
+            "`[server]` must stay literal in the verbatim body: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l == "[formatting.rules]"),
+            "`[formatting.rules]` must stay literal in the verbatim body: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn fullwidth_verbatim_sole_bracket_body_stays_literal() {
+        // A fullwidth verbatim block whose entire body is a single bracket line.
+        // With no body following it, the bracket is the block's content, not an
+        // anchoring reference line for the subject — it must stay literal.
+        let src = "Config:\n[section]\n:: toml ::\n\n";
+        let doc = parse_document(src).unwrap();
+        assert!(
+            doc.reference_lines.is_empty(),
+            "sole-body bracket must not become a reference line: {:?}",
+            doc.reference_lines
+        );
+        let lines = verbatim_body_lines(&doc);
+        assert!(
+            lines.iter().any(|l| l == "[section]"),
+            "`[section]` must stay literal: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn prose_bracket_line_still_becomes_a_reference_line() {
+        // No-regression guard: a `[token]` line in ORDINARY prose (not inside a
+        // verbatim block) must still be extracted as a reference line and anchor
+        // the paragraph above — exactly as before lex#755's fix.
+        let src = "First paragraph line.\nThe project home page.\n[server]\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "The project home page.");
+        assert_eq!(kind, AnchoredElement::WholeLine);
+    }
+
+    #[test]
+    fn verbatim_subject_anchor_still_works_with_body_following() {
+        // No-regression guard for the documented anchoring shape: a reference
+        // line directly below a verbatim subject, with the indented body
+        // following, still anchors the subject (it is not protected as body).
+        let src = "Example Source:\n[https://lex.ing]\n    fn main() {}\n:: rust ::\n\n";
+        let (anchor, kind) = sole_whole_anchor(src);
+        assert_eq!(anchor, "Example Source");
+        assert_eq!(kind, AnchoredElement::Subject);
+        // The body line is still literal inside the block.
+        let doc = parse_document(src).unwrap();
+        let lines = verbatim_body_lines(&doc);
+        assert!(
+            lines.iter().any(|l| l == "fn main() {}"),
+            "verbatim body preserved: {lines:?}"
+        );
     }
 }

--- a/crates/lex-core/src/lex/anchoring.rs
+++ b/crates/lex-core/src/lex/anchoring.rs
@@ -266,13 +266,12 @@ struct ClassifiedLine {
 /// tokenize it and run [`classify_line_tokens`], and count leading
 /// [`Token::Indentation`] tokens for the indentation depth.
 ///
-/// A trailing newline is appended before tokenizing because the line text
-/// produced by [`physical_lines`] has its `\n` stripped, and the classifier's
-/// blank-line / colon handling expects the line's tokens as the lexer would
-/// emit them.
-fn classify_physical_line(text: &str) -> ClassifiedLine {
-    let with_newline = format!("{text}\n");
-    let tokens: Vec<Token> = crate::lex::lexing::base_tokenization::tokenize(&with_newline)
+/// `line_text` is sliced directly from the original source and so still carries
+/// its own trailing newline (every line except possibly the last) — no per-line
+/// allocation. The classifier's blank-line / colon handling tolerates the
+/// presence or absence of that newline either way.
+fn classify_physical_line(line_text: &str) -> ClassifiedLine {
+    let tokens: Vec<Token> = crate::lex::lexing::base_tokenization::tokenize(line_text)
         .into_iter()
         .map(|(t, _)| t)
         .collect();
@@ -322,10 +321,10 @@ fn classify_physical_line(text: &str) -> ClassifiedLine {
 /// Every *other* line in the region (notably the deeper-indented inflow body
 /// where TOML headers like `[server]` live, lex#755) is protected and stays
 /// literal.
-fn verbatim_protected_lines(lines: &[PhysicalLine<'_>]) -> Vec<bool> {
+fn verbatim_protected_lines(source: &str, lines: &[PhysicalLine<'_>]) -> Vec<bool> {
     let classified: Vec<ClassifiedLine> = lines
         .iter()
-        .map(|l| classify_physical_line(l.text))
+        .map(|l| classify_physical_line(source.get(l.start..l.end).unwrap_or("")))
         .collect();
 
     let mut protected = vec![false; lines.len()];
@@ -412,7 +411,7 @@ fn verbatim_protected_lines(lines: &[PhysicalLine<'_>]) -> Vec<bool> {
                 // protect it rather than ejecting it as an anchor.
                 if after_subject
                     && classified[i].indent == subject_indent
-                    && has_body_after(&classified, i, closing_idx)
+                    && has_inflow_body_after(&classified, i, closing_idx, subject_indent)
                 {
                     protected[i] = false;
                     after_subject = false;
@@ -431,17 +430,29 @@ fn verbatim_protected_lines(lines: &[PhysicalLine<'_>]) -> Vec<bool> {
     protected
 }
 
-/// True when at least one non-blank, non-marker body line lies strictly between
-/// the anchoring-slot candidate at `slot_idx` and the block's closing marker at
-/// `closing_idx`. Used to tell the documented anchoring shape (a reference line
-/// whose subject's body follows it) from a verbatim block whose *only* content
-/// is the bracket line itself, which must stay literal (lex#755).
-fn has_body_after(classified: &[ClassifiedLine], slot_idx: usize, closing_idx: usize) -> bool {
+/// True when *inflow* body content — a non-blank line indented strictly deeper
+/// than the subject — lies between the anchoring-slot candidate at `slot_idx`
+/// and the block's closing marker at `closing_idx`.
+///
+/// This is what tells the documented anchoring shape from a fullwidth body
+/// whose first line happens to be a bracket. The documented anchoring shape is
+/// `subject` / `[ref]` / *deeper-indented* body / `:: marker ::`: only then is
+/// the slot line a reference that anchors the subject. If the only content that
+/// follows is at the subject's own indentation (a fullwidth body), the bracket
+/// line is itself body and must stay literal (lex#755) — anchoring it would
+/// eject e.g. `[server]` from `Config:` / `[server]` / `port = 8080` /
+/// `:: toml ::` and reintroduce the bug for fullwidth blocks.
+fn has_inflow_body_after(
+    classified: &[ClassifiedLine],
+    slot_idx: usize,
+    closing_idx: usize,
+    subject_indent: usize,
+) -> bool {
     ((slot_idx + 1)..closing_idx).any(|i| {
         !matches!(
             classified[i].line_type,
             LineType::BlankLine | LineType::DataMarkerLine
-        )
+        ) && classified[i].indent > subject_indent
     })
 }
 
@@ -453,7 +464,7 @@ pub fn extract_reference_lines(source: &str) -> AnchoringPrepass {
     // Verbatim block bodies are raw: a `[token]` line inside one must stay
     // literal, never be ejected as a reference line (lex#755). Compute the
     // protected line set once and skip those lines below.
-    let in_verbatim = verbatim_protected_lines(&lines);
+    let in_verbatim = verbatim_protected_lines(source, &lines);
 
     let mut reference_lines: Vec<ReferenceLine> = Vec::new();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
@@ -1220,6 +1231,27 @@ mod tests {
         assert!(
             lines.iter().any(|l| l == "[section]"),
             "`[section]` must stay literal: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn fullwidth_verbatim_first_bracket_body_line_stays_literal() {
+        // Regression for the fullwidth variant (caught in review): when the
+        // first fullwidth body line is a bracket AND more body follows at the
+        // subject's own indentation, that bracket is still body — it must stay
+        // literal, not be ejected as an anchor for the subject. The anchoring
+        // slot only applies when *deeper-indented* (inflow) body follows.
+        let src = "Config:\n[server]\nport = 8080\n:: toml ::\n\n";
+        let doc = parse_document(src).unwrap();
+        assert!(
+            doc.reference_lines.is_empty(),
+            "fullwidth first-line bracket must not become a reference line: {:?}",
+            doc.reference_lines
+        );
+        let lines = verbatim_body_lines(&doc);
+        assert!(
+            lines.iter().any(|l| l == "[server]"),
+            "`[server]` must stay literal in the fullwidth body: {lines:?}"
         );
     }
 

--- a/crates/lex-core/src/lex/anchoring.rs
+++ b/crates/lex-core/src/lex/anchoring.rs
@@ -322,9 +322,25 @@ fn classify_physical_line(line_text: &str) -> ClassifiedLine {
 /// where TOML headers like `[server]` live, lex#755) is protected and stays
 /// literal.
 fn verbatim_protected_lines(source: &str, lines: &[PhysicalLine<'_>]) -> Vec<bool> {
+    // Fast path: a verbatim block necessarily ends in a `:: label ::` data
+    // marker, so a source with no `::` at all has no verbatim block and no line
+    // to protect. This skips per-line tokenization on the overwhelmingly common
+    // reference-bearing-but-verbatim-free document.
+    if !source.contains("::") {
+        return vec![false; lines.len()];
+    }
+
     let classified: Vec<ClassifiedLine> = lines
         .iter()
-        .map(|l| classify_physical_line(source.get(l.start..l.end).unwrap_or("")))
+        .map(|l| {
+            // Each line's `[start, end)` is a byte range carved from `source` by
+            // `physical_lines`, so it is always valid and on char boundaries; a
+            // miss is an invariant violation, not a recoverable case.
+            let line_text = source
+                .get(l.start..l.end)
+                .expect("physical-line byte range must be valid in its own source");
+            classify_physical_line(line_text)
+        })
         .collect();
 
     let mut protected = vec![false; lines.len()];
@@ -1162,9 +1178,10 @@ mod tests {
 
     // -- §lex#755: verbatim bodies are raw, `[...]`-led lines stay literal ---
 
-    /// Every `[...]`-led verbatim body line, in document order — collected by
-    /// walking the verbatim block's groups. Empty when there is no verbatim
-    /// block. Used to assert bracket lines survive the parse literally.
+    /// Every verbatim body line, in document order — collected by walking the
+    /// verbatim block's groups. Empty when there is no verbatim block. Used to
+    /// assert that a given bracket line survives the parse literally (the tests
+    /// look it up among these lines).
     fn verbatim_body_lines(doc: &crate::lex::ast::Document) -> Vec<String> {
         use crate::lex::ast::elements::ContentItem;
         let mut out = Vec::new();


### PR DESCRIPTION
Closes #755

## Summary

A verbatim block whose body contained a line that trims to a single bracketed link-like reference (a TOML table header like `[server]` or `[formatting.rules]`) lost that line: it was pulled out of the block and re-emitted by the babel markdown adapter as a dangling shortcut auto-link `[server](server)` outside the code fence. This silently shipped broken links to lex.ing and became a hard `mkdocs build --strict` failure.

This is a **parse-level** defect, not just a rendering one — the bracket line was missing from the verbatim block's AST entirely (only `port = 8080` survived inside the fence).

## Root cause

`crates/lex-core/src/lex/anchoring.rs` — `extract_reference_lines()`. The reference-line anchoring pre-pass (§2.3) runs over raw **physical source lines** with no awareness of verbatim block boundaries, *before* structural parsing. For each physical line it:

1. trims the line; if it is exactly `[<inner>]` and `<inner>` classifies to a whole-element-capable reference (`Url`/`File`/`Session`/`General`), it treats the line as a **reference line**;
2. records the line's byte range as removed and **drops its tokens from the stream** before the verbatim block matcher ever runs (`filter_tokens`, called from `transforms/standard.rs:175`);
3. collects it as a `ReferenceLine` that the markdown adapter later renders as an auto-link.

So `    [server]` (an indented TOML header inside the verbatim body) was classified as a `General` reference line, its tokens were removed, and it vanished from the verbatim block — exactly the reported symptom. The pre-pass duplicating the parser front-end this way is the same class of issue as lex#722/#724.

## Fix

Teach the pre-pass which physical lines fall inside a verbatim block and skip reference-line extraction for them. A new `verbatim_protected_lines()` mirrors the structural verbatim grammar (`GrammarMatcher::match_verbatim_block`) at the physical-line level: it classifies each line (via the lexer's own `classify_line_tokens` + leading-indentation count) and marks a region verbatim only once it has **seen** a closing `:: label ::` data marker at the subject's indentation — so a subject with no closing marker stays an ordinary session/definition.

Verbatim body lines are then skipped during reference extraction, so a `[token]` line inside a block stays literal.

### The one preserved exception

The documented anchoring shape — a link-like reference directly below a verbatim subject, with the indented body following — still anchors the subject (existing `reference_line_anchors_verbatim_subject` behavior):

```text
Example Source:
[https://lex.ing]     <- still anchors "Example Source"
    fn main() {}       <- the actual body
:: rust ::
```

That single slot (first non-blank line after a subject, at the subject's indent, **with body following**) is left to the existing whole-element-anchor handling. If the bracket line is instead the block's *only* body (nothing but the closing marker follows), it is treated as raw body and stays literal. Reference/auto-link behavior for ordinary non-verbatim prose is entirely unchanged.

## Before / after

Input:
```text
Config example:

    [server]
    port = 8080
:: toml ::
```

Before (`lexd convert --to markdown`):
```text
**Config example**

``` toml

port = 8080
```

[server](server)
```

After:
```text
**Config example**

``` toml

[server]
port = 8080
```
```

## Tests

- `crates/lex-core/src/lex/anchoring.rs` (parser-level):
  - `verbatim_body_bracket_lines_stay_literal` — `[server]` + `[formatting.rules]` in an inflow body stay literal, produce no reference lines and no parsed references.
  - `fullwidth_verbatim_sole_bracket_body_stays_literal` — a bracket line that is the whole fullwidth body stays literal.
  - `prose_bracket_line_still_becomes_a_reference_line` — **no-regression guard**: a `[token]` line in ordinary prose still anchors the paragraph above.
  - `verbatim_subject_anchor_still_works_with_body_following` — **no-regression guard**: the documented verbatim-subject anchor still fires.
- `crates/lex-babel/tests/markdown/export.rs`:
  - `test_verbatim_bracket_lines_stay_literal_not_autolinks` — end-to-end markdown: both bracket lines render literally inside the code fence and there is no Link node / `(...)` auto-link.

Full workspace suite green (2596 passed, excluding lex-wasm).

## Context

- The fix lives in the pre-pass, not the babel adapter, because the defect is the line being *removed from the token stream* before parsing — by the markdown stage the data is already gone.
- The verbatim region scan is a deliberate, scoped re-derivation of the verbatim grammar at the physical-line level rather than a refactor to share the matcher: the matcher operates on indentation-grouped containers produced *after* token filtering, so it isn't available at pre-pass time. Kept minimal and pinned to the matcher's shape via tests.
- The issue's "Also seen nearby" items (dual-group `Definition:` shell blocks rendering as escaped prose; relative nav links resolving to nothing) are explicitly **out of scope** here and will be filed separately. Note: multi-group verbatim blocks render only their first group through the markdown adapter today — that is a pre-existing, bracket-independent babel limitation (confirmed on a no-brackets group block), not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7noCwaDvagCnu2PoSB6Vu