### PR TITLE
fix(markdown): export all verbatim groups + link anchorless file refs

### DIFF
--- a/CHANGELOG/unreleased-markdown-verbatim-groups-and-file-refs.md
+++ b/CHANGELOG/unreleased-markdown-verbatim-groups-and-file-refs.md
@@ -1,0 +1,1 @@
+- Export all verbatim groups in multi-group Definition blocks; link anchorless file references

--- a/crates/lex-babel/src/formats/markdown/serializer.rs
+++ b/crates/lex-babel/src/formats/markdown/serializer.rs
@@ -1090,14 +1090,21 @@ fn add_inline_to_node<'a>(
                 ReferenceType::NotSure => ref_text
                     .strip_prefix('@')
                     .map(|citation| format!("#ref-{citation}")),
-                // A file reference with no anchorable adjacent word (e.g. a bare
+                // A link-like reference (`Url` / `File` / `Session` / `General`,
+                // i.e. `AnchorKind::WholeLineCapable`) with no anchorable adjacent
+                // word reaches the serializer un-anchored — e.g. a bare
                 // `[./editors]` abutting another reference, so word-anchoring
-                // found no word to wrap) reaches the serializer un-anchored.
-                // Emit it as a self-link — the target is both the href and the
-                // link text — so the link survives instead of being escaped to
-                // literal `\[./editors\]`. The href matches the anchored-File
-                // path (`reference_href`, which is the raw target verbatim).
-                ReferenceType::File { target } => Some(target.clone()),
+                // found no word to wrap. Emit it as a self-link (the raw target
+                // is both href and link text, matching `reference_href` and the
+                // HTML serializer) so the link survives instead of being escaped
+                // to literal `\[./editors\]`. Marker-style kinds (footnote /
+                // citation / annotation-ref / `TK`) have no destination and stay
+                // on the plain-text path below. (#770)
+                kind if kind.anchoring()
+                    == lex_core::lex::ast::elements::inlines::AnchorKind::WholeLineCapable =>
+                {
+                    Some(ref_text.clone())
+                }
                 _ => None,
             };
 

--- a/crates/lex-babel/src/formats/markdown/serializer.rs
+++ b/crates/lex-babel/src/formats/markdown/serializer.rs
@@ -1090,6 +1090,14 @@ fn add_inline_to_node<'a>(
                 ReferenceType::NotSure => ref_text
                     .strip_prefix('@')
                     .map(|citation| format!("#ref-{citation}")),
+                // A file reference with no anchorable adjacent word (e.g. a bare
+                // `[./editors]` abutting another reference, so word-anchoring
+                // found no word to wrap) reaches the serializer un-anchored.
+                // Emit it as a self-link — the target is both the href and the
+                // link text — so the link survives instead of being escaped to
+                // literal `\[./editors\]`. The href matches the anchored-File
+                // path (`reference_href`, which is the raw target verbatim).
+                ReferenceType::File { target } => Some(target.clone()),
                 _ => None,
             };
 

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -177,7 +177,12 @@ fn splice_self_links_into(
             span: item.range().span.clone(),
             ir_index,
         });
-        ir_cursor = ir_index + 1;
+        // A lex item usually maps to exactly one IR node, but a multi-group
+        // verbatim block expands to one node per group (see `convert_children`
+        // / `from_lex_verbatim_groups`, #769). Advance the cursor by the actual
+        // node count so every subsequent slot's `ir_index` — and the recursion /
+        // sibling-splice indices derived from it — stay aligned with the IR list.
+        ir_cursor = ir_index + ir_node_count(item);
     }
 
     // Iterate structural items in parallel with `slots` for recursion.
@@ -233,7 +238,11 @@ fn splice_self_links_into(
         let ir_index = if preceding == 0 {
             0
         } else {
-            slots[preceding - 1].ir_index + 1
+            // Land just past the preceding element's *last* IR node. That
+            // element may expand to several nodes (a multi-group verbatim,
+            // #769), so step over all of them — not a fixed `+ 1` — or the
+            // sibling self-link would be spliced between the groups.
+            slots[preceding - 1].ir_index + ir_node_count(structural[preceding - 1])
         };
         let node = self_link_node(sl);
         if ir_index <= ir_children.len() {
@@ -242,6 +251,21 @@ fn splice_self_links_into(
             ir_children.push(node);
         }
     }
+}
+
+/// Number of IR `DocNode`s the item's *own* content expands to (excluding its
+/// leading attached-annotation nodes, which are counted separately). One for
+/// every item except a multi-group verbatim block, which `convert_children`
+/// expands into one node per group (#769) — the self-link index mapping must
+/// advance by that count to stay aligned with the IR list.
+fn ir_node_count(item: &LexContentItem) -> usize {
+    if let LexContentItem::VerbatimBlock(verbatim) = item {
+        let groups = verbatim.group_len();
+        if groups > 1 {
+            return groups;
+        }
+    }
+    1
 }
 
 /// True when `item` is a container whose IR counterpart holds a child `DocNode`

--- a/crates/lex-babel/src/ir/from_lex.rs
+++ b/crates/lex-babel/src/ir/from_lex.rs
@@ -370,6 +370,17 @@ fn convert_children(items: &[LexContentItem], level: usize, ctx: &ConvCtx) -> Ve
         .filter(|item| !matches!(item, LexContentItem::BlankLineGroup(_)))
         .flat_map(|item| {
             let mut nodes = extract_attached_annotations(item, level, ctx);
+            // A multi-group verbatim block (multiple subject/content pairs
+            // sharing one closing marker, e.g. `verbatim-11-group-shell.lex`)
+            // is flattened into one IR `DocNode::Verbatim` per group: the IR
+            // verbatim node carries a single subject + content, so without this
+            // every group after the first would be dropped (#769).
+            if let LexContentItem::VerbatimBlock(verbatim) = item {
+                if verbatim.group_len() > 1 {
+                    nodes.extend(from_lex_verbatim_groups(verbatim, ctx));
+                    return nodes;
+                }
+            }
             nodes.push(from_lex_content_item_with_level(item, level, ctx));
             nodes
         })
@@ -694,6 +705,60 @@ fn from_lex_verbatim(verbatim: &LexVerbatim, ctx: &ConvCtx) -> DocNode {
         content,
         parameters,
     })
+}
+
+/// Expand a multi-group verbatim block into one IR `DocNode::Verbatim` per
+/// group. A multi-group verbatim is always a plain code/text block (the typed
+/// media/tabular hydration in [`from_lex_verbatim`] only ever applies to a
+/// single-group block), so each group becomes a generic verbatim sharing the
+/// block's single closing label + parameters. Without this, only the first
+/// group survived the lex → IR conversion and later groups vanished from every
+/// serializer's output (#769).
+fn from_lex_verbatim_groups(verbatim: &LexVerbatim, ctx: &ConvCtx) -> Vec<DocNode> {
+    let language = Some(verbatim.closing_data.label.value.clone());
+    let parameters: Vec<(String, String)> = verbatim
+        .closing_data
+        .parameters
+        .iter()
+        .map(|p| (p.key.clone(), p.value.clone()))
+        .collect();
+
+    verbatim
+        .group()
+        .map(|group| {
+            let subject_str = group.subject.as_string();
+            let subject = if subject_str.is_empty() {
+                None
+            } else {
+                Some(subject_str.to_string())
+            };
+            // A reference line can anchor each group's subject (§2.3.2), exactly
+            // as for a single-group verbatim subject.
+            let subject_href = ctx
+                .anchors
+                .match_head_line(group.subject)
+                .map(|a| a.href.clone());
+            let content = group
+                .children
+                .iter()
+                .map(|item| {
+                    if let LexContentItem::VerbatimLine(vl) = item {
+                        vl.content.as_string().to_string()
+                    } else {
+                        String::new()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            DocNode::Verbatim(Verbatim {
+                subject,
+                subject_href,
+                language: language.clone(),
+                content,
+                parameters: parameters.clone(),
+            })
+        })
+        .collect()
 }
 
 /// Restore the verbatim subject as a default caption / title / alt on

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -561,6 +561,36 @@ fn test_anchored_file_reference_unchanged() {
     );
 }
 
+#[test]
+fn test_self_link_placed_after_multi_group_verbatim_not_between_groups() {
+    // Regression for the #769 fix: expanding a multi-group verbatim into N IR
+    // nodes must keep the self-link index mapping aligned, so a sibling
+    // reference-line self-link following the block lands AFTER all its groups —
+    // not spliced between them. A `[https://...]` alone on its line anchors the
+    // preceding element as a self-link.
+    let lex_src = "First:\n\n    cmd one\nSecond:\n\n    cmd two\n:: shell ::\n\n[https://after.example.com]\n\n2. Tail\n\n    More body.\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    // The self-link must appear after BOTH `cmd one` and `cmd two`.
+    let after_pos = md
+        .find("after.example.com")
+        .unwrap_or_else(|| panic!("self-link missing: {md}"));
+    let cmd_two_pos = md
+        .find("cmd two")
+        .unwrap_or_else(|| panic!("second group missing: {md}"));
+    assert!(
+        after_pos > cmd_two_pos,
+        "self-link must land after all verbatim groups, not between them: {md}"
+    );
+    // And before the tail section.
+    let tail_pos = md.find("Tail").unwrap();
+    assert!(
+        after_pos < tail_pos,
+        "self-link must precede the following section: {md}"
+    );
+}
+
 // ============================================================================
 // ISSUE C: Markdown List Formatting Tests
 // ============================================================================

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -464,6 +464,103 @@ fn test_placeholder_reference_as_text() {
     );
 }
 
+#[test]
+fn test_multi_group_verbatim_exports_every_group_as_a_fence() {
+    // lex#769: a verbatim block with multiple subject/content groups sharing one
+    // closing marker (`:: shell ::`) must export EVERY group as its own fenced
+    // code block. Pre-fix, only the first group survived the lex → IR conversion
+    // (the IR verbatim node holds a single subject + content), so groups 2..N
+    // silently vanished from the markdown.
+    let lex_src = "First group:\n\n    cmd one\nSecond group:\n\n    cmd two\nThird group:\n\n    cmd three\n:: shell ::\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    // Every group's command lands in the output, not just the first.
+    for cmd in ["cmd one", "cmd two", "cmd three"] {
+        assert!(md.contains(cmd), "group command `{cmd}` missing: {md}");
+    }
+    // No later group leaked as escaped prose.
+    assert!(
+        !md.contains("\\#") && !md.contains("cmd two cmd"),
+        "later groups must not render as escaped/joined prose: {md}"
+    );
+
+    // Walk the comrak tree: exactly three CodeBlocks, each carrying one command
+    // and the shared `shell` language hint.
+    let arena = Arena::new();
+    let options = ComrakOptions::default();
+    let root = parse_document(&arena, &md, &options);
+
+    fn collect_code_blocks<'a>(
+        node: &'a comrak::nodes::AstNode<'a>,
+        out: &mut Vec<(String, String)>,
+    ) {
+        if let NodeValue::CodeBlock(cb) = &node.data.borrow().value {
+            out.push((cb.info.clone(), cb.literal.clone()));
+        }
+        for child in node.children() {
+            collect_code_blocks(child, out);
+        }
+    }
+
+    let mut blocks = Vec::new();
+    collect_code_blocks(root, &mut blocks);
+    assert_eq!(
+        blocks.len(),
+        3,
+        "all three verbatim groups must become separate code fences: {blocks:?}"
+    );
+    for (info, literal) in &blocks {
+        assert_eq!(info, "shell", "each group keeps the shared language hint");
+        assert!(
+            literal.contains("cmd "),
+            "each fence carries its group's command: {literal:?}"
+        );
+    }
+}
+
+#[test]
+fn test_anchorless_file_reference_becomes_a_link_not_escaped_text() {
+    // lex#770: a `[./path]` file reference with no anchorable adjacent word
+    // (here the two refs abut each other, so word-anchoring finds no word to
+    // wrap) must still emit a real Markdown link using the target as its own
+    // link text — not fall through to escaped literal `\[./why\]`.
+    let lex_src = "Nav: [./editors] [./why]\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    // The anchorless `[./why]` is a self-link: text and href both the target.
+    assert!(
+        md.contains("[./why](./why)"),
+        "anchorless file ref must self-link, got: {md}"
+    );
+    // It must NOT be escaped as literal bracket text.
+    assert!(
+        !md.contains("\\[./why\\]"),
+        "anchorless file ref must not be escaped to literal text, got: {md}"
+    );
+}
+
+#[test]
+fn test_anchored_file_reference_unchanged() {
+    // Guard for lex#770: when an adjacent anchor word IS present, the existing
+    // word-anchoring path wins — `Editors [./editors]` links the word "Editors"
+    // to the target. The anchorless fix must not perturb this.
+    let lex_src = "See Editors [./editors] for details.\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    assert!(
+        md.contains("[Editors](./editors)"),
+        "anchored file ref must link the anchor word, got: {md}"
+    );
+    // The bare target must not also appear as a separate self-link.
+    assert!(
+        !md.contains("[./editors](./editors)"),
+        "anchored ref must not additionally self-link the target, got: {md}"
+    );
+}
+
 // ============================================================================
 // ISSUE C: Markdown List Formatting Tests
 // ============================================================================

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -542,6 +542,57 @@ fn test_anchorless_file_reference_becomes_a_link_not_escaped_text() {
 }
 
 #[test]
+fn test_anchorless_link_like_references_self_link_not_escaped() {
+    // Generalisation of the #770 fix (Copilot review on PR #771): every
+    // link-like reference kind (`Url` / `Session` / `General` / `File`, i.e.
+    // `AnchorKind::WholeLineCapable`) with no anchorable adjacent word must
+    // self-link rather than escape to literal brackets, matching the HTML
+    // serializer. The leading `X:` anchors the first ref, leaving the second
+    // ref of each pair anchorless.
+    let cases = [
+        (
+            "X: [https://a.example.com] [https://b.example.com]",
+            "b.example.com",
+        ),
+        ("X: [#sess-one] [#sess-two]", "#sess-two"),
+        ("X: [Introduction] [Conclusion]", "Conclusion"),
+    ];
+    for (lex_src, needle) in cases {
+        let lex_doc = STRING_TO_AST.run(format!("{lex_src}\n")).unwrap();
+        let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+        // The anchorless ref must appear as a link target (comrak may render a
+        // URL as a `<...>` autolink or `[..](..)`, so assert on the destination).
+        assert!(
+            md.contains(needle),
+            "anchorless link-like ref `{needle}` must survive as a link: {md}"
+        );
+        assert!(
+            !md.contains(&format!("\\[{needle}")) && !md.contains("\\]"),
+            "anchorless link-like ref must not be escaped to literal text: {md}"
+        );
+    }
+}
+
+#[test]
+fn test_marker_reference_still_escaped_not_self_linked() {
+    // Guard for the generalised #770 fix: a marker-style reference
+    // (`AnchorKind::MarkerOnly`, here a `[TK-ref]` placeholder) has no
+    // destination and must NOT become a self-link — it stays plain escaped text.
+    let lex_src = "This needs [TK-ref].\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    assert!(
+        md.contains("\\[TK-ref\\]"),
+        "marker-style placeholder must stay escaped, got: {md}"
+    );
+    assert!(
+        !md.contains("(TK-ref)"),
+        "marker-style placeholder must not self-link, got: {md}"
+    );
+}
+
+#[test]
 fn test_anchored_file_reference_unchanged() {
     // Guard for lex#770: when an adjacent anchor word IS present, the existing
     // word-anchoring path wins — `Editors [./editors]` links the word "Editors"


### PR DESCRIPTION
Closes #769.

Also fixes the **converter half** of #770 (anchorless `[./path]` file references). The content half of #770 (authoring nav links with `.lex` extensions) is handled separately in the comms repo.

## Bug 1 (#769) — multi-group verbatim blocks lose later groups

**Root cause:** `crates/lex-babel/src/ir/from_lex.rs::from_lex_verbatim` read only `verbatim.subject` + `verbatim.children` — the *first* group of a multi-group verbatim block (multiple subject/content pairs sharing one closing marker, e.g. `:: shell ::`). The IR `Verbatim` node holds a single subject+content, so the block's `additional_groups` were silently dropped during lex → IR conversion. Every group after the first vanished from the markdown.

**Fix:** `convert_children` now detects `group_len() > 1` and expands the block into one `DocNode::Verbatim` per group via the new `from_lex_verbatim_groups` (`from_lex.rs`), each group sharing the block's single closing label + parameters. A multi-group verbatim is always a plain code/text block (typed media/tabular hydration only ever applies to a single-group block), so each group becomes a generic verbatim → its own fenced code block.

Before (fixture `verbatim-11-group-shell.lex`, first block has 3 groups):
```
**Installing with home brew is simple**

``` shell

$ brew install lex
```
```
(groups 2 `$ lex help` and 3 `$ lexv <path>` dropped entirely)

After:
```
**Installing with home brew is simple**

``` shell

$ brew install lex
```

**From there the interactive help is available**

``` shell

$ lex help
```

**And the built-in viewer can be used to quickly view the parsing**

``` shell

$ lexv <path>
```
```

## Bug 2 (#770, converter half) — anchorless file refs dropped to escaped text

**Root cause:** `crates/lex-babel/src/formats/markdown/serializer.rs` — a `ReferenceType::File` reference (`[./editors]`) with no anchorable adjacent word reaches the serializer as an `InlineContent::Reference` (word-anchoring found no word to wrap). It fell through the `_ => None` arm and rendered as escaped literal text (`\[./why\]`), so the link silently vanished.

**Fix:** the `InlineContent::Reference` arm now handles `ReferenceType::File { target }` by returning `Some(target)` as the href; the existing link-building path then emits a self-link `[./why](./why)` (target as both text and href, matching the anchored-File href from `reference_href`). The anchored path (`Word [./x]` → links the word) is untouched.

Before: `Nav: [./editors] [./why]` → `[Nav:](./editors) \[./why\]`
After:  `Nav: [./editors] [./why]` → `[Nav:](./editors) [./why](./why)`

## Tests

`crates/lex-babel/tests/markdown/export.rs` (inline-source, no fixture dependency):
- `test_multi_group_verbatim_exports_every_group_as_a_fence` — three groups → three `shell` code fences (#769).
- `test_anchorless_file_reference_becomes_a_link_not_escaped_text` — `[./why]` self-links, not escaped (#770).
- `test_anchored_file_reference_unchanged` — guard: `Editors [./editors]` still anchors the word, no duplicate self-link (#770).

Full `cargo test --workspace --exclude lex-wasm` is green (0 failures) once the `comms` submodule is populated. (`release-core gate` green: fmt + clippy + lint.)

## Context

The repro the #769 issue points at (`comms/docs/tools.lex` `lex config` examples) actually surfaces **two** distinct defects. The `Definition:` blocks there with a `subject:` (trailing colon) parse correctly as multi-group verbatims and exposed this adapter bug. Some *other* code blocks in that file (e.g. section 3.1 / the section-5 body) fail at the **parser** level instead — their intro line ends with a period, not a colon, so the indented body never opens a verbatim and the `:: shell ::` close tag is orphaned. That is the **content half** (fix the source to use a colon subject) and is out of scope here — it's handled in the comms repo. This PR fixes only the genuine adapter defect: a correctly-parsed multi-group verbatim losing groups 2..N.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7noCwaDvagCnu2PoSB6Vu