### PR TITLE
fix(lsp): compensate auto-indent on fresh-line smart paste (#743)

### DIFF
--- a/CHANGELOG/unreleased-smart-paste-fresh-caret-indent.md
+++ b/CHANGELOG/unreleased-smart-paste-fresh-caret-indent.md
@@ -1,0 +1,1 @@
+- smart paste: compensate for editor auto-indent on fresh-line pastes so the anchor is not duplicated

--- a/crates/lex-lsp-core/src/prepare_paste.rs
+++ b/crates/lex-lsp-core/src/prepare_paste.rs
@@ -27,7 +27,7 @@
 //!   merge strips line 1 and re-anchors the rest. On a fresh line the transform
 //!   subtracts any whitespace the editor auto-indented ahead of the caret that
 //!   the request range does not overwrite, so the anchor is never doubled
-//!   (comms#73 #3, [`surviving_leading_indent`]).
+//!   (comms#73 #3, `surviving_leading_indent`).
 
 use lex_analysis::utils::find_verbatim_at_position;
 use lex_core::lex::ast::{Document, Position as AstPosition};

--- a/crates/lex-lsp-core/src/prepare_paste.rs
+++ b/crates/lex-lsp-core/src/prepare_paste.rs
@@ -24,7 +24,10 @@
 //! - **§4.2/§4.3 baseline + offset** ([`reanchor`]): dedent the clipboard to its
 //!   common baseline, re-apply the anchor as one constant offset.
 //! - **§4.4 first line** (inside [`reanchor`]): fresh-line re-anchors every line;
-//!   merge strips line 1 and re-anchors the rest.
+//!   merge strips line 1 and re-anchors the rest. On a fresh line the transform
+//!   subtracts any whitespace the editor auto-indented ahead of the caret that
+//!   the request range does not overwrite, so the anchor is never doubled
+//!   (comms#73 #3, [`surviving_leading_indent`]).
 
 use lex_analysis::utils::find_verbatim_at_position;
 use lex_core::lex::ast::{Document, Position as AstPosition};
@@ -118,7 +121,20 @@ pub fn prepare_paste(
         | PasteMode::PassthroughSingleLine => pasted_text.to_string(),
         PasteMode::Reanchor => {
             let anchor = resolve_anchor(document, source, range.start);
-            reanchor(pasted_text, anchor, fresh_line)
+            // §4.4 / comms#73 #3: on a fresh-line paste the editor may have
+            // auto-indented the caret line with whitespace the (possibly empty)
+            // request range does not overwrite. That whitespace survives the
+            // edit, so the server must account for it — otherwise the anchor it
+            // emits on the first line stacks on top of the surviving spaces and
+            // the line is double-indented. Merge pastes follow existing content
+            // (no leading whitespace survives ahead of the splice), so this only
+            // applies to fresh lines.
+            let caret_indent = if fresh_line {
+                surviving_leading_indent(source, range.start)
+            } else {
+                0
+            };
+            reanchor(pasted_text, anchor, fresh_line, caret_indent)
         }
     };
 
@@ -317,15 +333,53 @@ pub fn is_fresh_line(source: &str, pos: Position) -> bool {
     }
 }
 
+/// §4.4 / comms#73 #3: the display width of the leading whitespace on `pos`'s
+/// line that lies *before* `pos` and therefore survives a replacement of the
+/// request range (whose start is `pos`). This is the whitespace an editor may
+/// have auto-indented onto a fresh line without the range covering it.
+///
+/// Walks chars up to the caret's byte offset (LSP columns are byte offsets in
+/// this server — see [`is_fresh_line`]) accumulating display width, stopping at
+/// the caret or at the first non-whitespace char. Callers invoke it only for
+/// fresh-line pastes, where the prefix is whitespace by definition; the
+/// non-whitespace `break` and the past-end case keep it total regardless.
+fn surviving_leading_indent(source: &str, pos: Position) -> usize {
+    let Some(line) = line_at(source, pos.line as usize) else {
+        return 0;
+    };
+    let caret = pos.character as usize;
+    let mut bytes_seen = 0;
+    let mut width = 0;
+    for ch in line.chars() {
+        if bytes_seen >= caret {
+            break;
+        }
+        match ch {
+            ' ' => width += 1,
+            '\t' => width += TAB_WIDTH - (width % TAB_WIDTH),
+            _ => break,
+        }
+        bytes_seen += ch.len_utf8();
+    }
+    width
+}
+
 /// The re-anchor transform (§4.2–§4.4), pure whitespace arithmetic over lines.
 ///
 /// - `anchor`: target content indentation (display columns).
 /// - `fresh_line`: §4.4 — `true` re-anchors every line; `false` (merge) strips
 ///   line 1 down to the clipboard baseline (preserving any relative indentation
 ///   it carried *beyond* the baseline) with no anchor, and re-anchors lines 2..n.
+/// - `caret_indent`: display width of whitespace already on the caret line that
+///   precedes the splice point and survives the edit (§4.4 / comms#73 #3). On a
+///   fresh line an editor may auto-indent the caret without the request range
+///   covering that whitespace; subtracting it from the first emitted line keeps
+///   the anchor from stacking on top of the surviving spaces. Zero for merge
+///   pastes and for fresh lines whose range already covers (or starts before)
+///   the leading whitespace.
 ///
 /// The clipboard's trailing newline (and internal blank lines) are preserved.
-pub fn reanchor(pasted_text: &str, anchor: usize, fresh_line: bool) -> String {
+pub fn reanchor(pasted_text: &str, anchor: usize, fresh_line: bool, caret_indent: usize) -> String {
     // Split into lines while remembering whether the text ended with a newline,
     // so we can reproduce a trailing newline exactly (§6).
     let had_trailing_newline = pasted_text.ends_with('\n');
@@ -375,7 +429,21 @@ pub fn reanchor(pasted_text: &str, anchor: usize, fresh_line: bool) -> String {
         }
 
         // §4.3: max(0, original_indent + delta) spaces, then stripped content.
-        let new_indent = (orig_indent as isize + delta).max(0) as usize;
+        let mut new_indent = (orig_indent as isize + delta).max(0) as usize;
+        // §4.4 / comms#73 #3: the first emitted line shares the caret's physical
+        // line, so any whitespace already present before the splice (and not
+        // overwritten by the range) is still in the buffer. Drop that much from
+        // the emitted indent so the two don't add up to a doubled anchor. Only
+        // the first line is affected; this branch is reached at idx == 0 only on
+        // a fresh-line paste (merge handles its own first line above), and
+        // `caret_indent` is zero for every non-fresh paste, so the guard is
+        // exact. A `saturating_sub` keeps it total when the surviving whitespace
+        // already exceeds the target — an insert-only edit cannot remove it, so
+        // the line clamps to no added indent (exact dedent then needs the editor
+        // to expand the range, per the §4.4 contract).
+        if idx == 0 {
+            new_indent = new_indent.saturating_sub(caret_indent);
+        }
         out.extend(std::iter::repeat_n(' ', new_indent));
         out.push_str(content);
     }

--- a/crates/lex-lsp-core/src/prepare_paste.rs
+++ b/crates/lex-lsp-core/src/prepare_paste.rs
@@ -126,9 +126,10 @@ pub fn prepare_paste(
             // request range does not overwrite. That whitespace survives the
             // edit, so the server must account for it — otherwise the anchor it
             // emits on the first line stacks on top of the surviving spaces and
-            // the line is double-indented. Merge pastes follow existing content
-            // (no leading whitespace survives ahead of the splice), so this only
-            // applies to fresh lines.
+            // the line is double-indented. A merge paste's first line is not
+            // anchored at all (it continues existing content, §4.4), so there is
+            // no anchor to double there; compensation only matters where the
+            // first line carries an anchor, i.e. on a fresh line.
             let caret_indent = if fresh_line {
                 surviving_leading_indent(source, range.start)
             } else {

--- a/crates/lex-lsp-core/src/prepare_paste.rs
+++ b/crates/lex-lsp-core/src/prepare_paste.rs
@@ -434,15 +434,16 @@ pub fn reanchor(pasted_text: &str, anchor: usize, fresh_line: bool, caret_indent
         // §4.4 / comms#73 #3: the first emitted line shares the caret's physical
         // line, so any whitespace already present before the splice (and not
         // overwritten by the range) is still in the buffer. Drop that much from
-        // the emitted indent so the two don't add up to a doubled anchor. Only
-        // the first line is affected; this branch is reached at idx == 0 only on
-        // a fresh-line paste (merge handles its own first line above), and
-        // `caret_indent` is zero for every non-fresh paste, so the guard is
-        // exact. A `saturating_sub` keeps it total when the surviving whitespace
-        // already exceeds the target — an insert-only edit cannot remove it, so
-        // the line clamps to no added indent (exact dedent then needs the editor
-        // to expand the range, per the §4.4 contract).
-        if idx == 0 {
+        // the emitted indent so the two don't add up to a doubled anchor. The
+        // `fresh_line` guard makes the fresh-line-only contract self-contained:
+        // merge handles its own first line above (and passes `caret_indent` 0
+        // anyway), so this is reachable at idx == 0 only on a fresh line, but
+        // stating it guards against future misuse. A `saturating_sub` keeps it
+        // total when the surviving whitespace already exceeds the target — an
+        // insert-only edit cannot remove it, so the line clamps to no added
+        // indent (exact dedent then needs the editor to expand the range, per
+        // the §4.4 contract).
+        if idx == 0 && fresh_line {
             new_indent = new_indent.saturating_sub(caret_indent);
         }
         out.extend(std::iter::repeat_n(' ', new_indent));

--- a/crates/lex-lsp-core/src/prepare_paste/tests.rs
+++ b/crates/lex-lsp-core/src/prepare_paste/tests.rs
@@ -236,6 +236,32 @@ fn is_fresh_line_whitespace_only_prefix_with_later_multibyte_is_fresh() {
     assert!(is_fresh_line(source, pos(2, 4)));
 }
 
+#[test]
+fn surviving_leading_indent_counts_tabs_in_display_columns() {
+    // Auto-indent compensation measures the surviving whitespace in display
+    // columns (TAB_WIDTH), not bytes, so it matches the space-based anchor
+    // arithmetic for editors that indent with tabs. A single tab before the
+    // caret (byte offset 1) is 4 columns.
+    let source = "Top\n\n\t\n";
+    assert_eq!(surviving_leading_indent(source, pos(2, 1)), 4);
+}
+
+#[test]
+fn surviving_leading_indent_mixes_tabs_and_spaces() {
+    // Tab (advances to column 4) followed by two spaces = 6 columns; the caret
+    // is past all three (byte offset 3).
+    let source = "Top\n\n\t  \n";
+    assert_eq!(surviving_leading_indent(source, pos(2, 3)), 6);
+}
+
+#[test]
+fn surviving_leading_indent_stops_at_caret() {
+    // Only whitespace *before* the caret survives: a caret mid-indent counts
+    // just the spaces up to its byte offset, not the rest of the line.
+    let source = "Top\n\n        body\n";
+    assert_eq!(surviving_leading_indent(source, pos(2, 4)), 4);
+}
+
 // ---------------------------------------------------------------------------
 // Classification (§3), innermost-first.
 // ---------------------------------------------------------------------------

--- a/crates/lex-lsp-core/src/prepare_paste/tests.rs
+++ b/crates/lex-lsp-core/src/prepare_paste/tests.rs
@@ -154,7 +154,7 @@ fn reanchor_table() {
     ];
 
     for case in cases {
-        let got = reanchor(case.pasted, case.anchor, case.fresh_line);
+        let got = reanchor(case.pasted, case.anchor, case.fresh_line, 0);
         assert_eq!(
             got, case.expected,
             "case `{}`: got {:?}, expected {:?}",
@@ -166,8 +166,36 @@ fn reanchor_table() {
 #[test]
 fn reanchor_baseline_is_min_over_nonblank_lines() {
     // baseline must ignore blank lines: min(8, 4) = 4, not 0 from the blank.
-    let got = reanchor("        deep\n\n    shallow\n", 4, true);
+    let got = reanchor("        deep\n\n    shallow\n", 4, true, 0);
     assert_eq!(got, "        deep\n\n    shallow\n");
+}
+
+#[test]
+fn reanchor_subtracts_surviving_caret_indent_from_first_line() {
+    // comms#73 #3: the editor auto-indented the fresh line to the anchor (4) but
+    // its empty range leaves those 4 spaces in the buffer. The first emitted
+    // line must drop them (4 - 4 = 0) so the buffer total is the anchor, not
+    // double it; line 2 is a brand-new line and takes the full §4.3 treatment.
+    let got = reanchor("first\n    second\n", 4, true, 4);
+    assert_eq!(got, "first\n        second\n");
+}
+
+#[test]
+fn reanchor_caret_indent_only_affects_first_line() {
+    // A surviving caret indent shallower than the anchor still leaves the rest
+    // of the block at full anchor depth: baseline 0, anchor 8, caret_indent 4.
+    // line1: 8 - 4 = 4 emitted (+ 4 surviving = 8 total); line2: 4 + 8 = 12.
+    let got = reanchor("parent\n    child\n", 8, true, 4);
+    assert_eq!(got, "    parent\n            child\n");
+}
+
+#[test]
+fn reanchor_caret_indent_clamps_when_it_exceeds_target() {
+    // Surviving whitespace deeper than the anchor: an insert-only edit cannot
+    // remove it, so the first line clamps to no added indent (saturating_sub).
+    // Exact dedent here needs the editor to expand the range — the §4.4 contract.
+    let got = reanchor("only\n    tail\n", 4, true, 8);
+    assert_eq!(got, "only\n        tail\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -358,6 +386,24 @@ fn fresh_line_reanchors_first_line_too() {
 }
 
 #[test]
+fn fresh_line_with_auto_indent_does_not_double_anchor() {
+    // comms#73 #3, end-to-end: the editor auto-indented the fresh line to the
+    // session level (4 spaces) and sends a collapsed caret *after* them — an
+    // empty range that does not overwrite the whitespace. The returned first
+    // line must carry no anchor of its own (the 4 surviving spaces already are
+    // the anchor); without the compensation it would emit 4 more and the spliced
+    // line would land at column 8.
+    let source = "Top\n\n    existing\n    \n    tail\n";
+    let doc = parse_document(source).expect("parse");
+    // Line 3 is the whitespace-only auto-indented line; caret at its end (col 4).
+    let result = prepare_paste(&doc, source, empty_range(3, 4), "first\n    second\n");
+    assert_eq!(result.mode, PasteMode::Reanchor);
+    // First line emits no leading space (4 already survive in the buffer);
+    // second line re-anchors fully to 8.
+    assert_eq!(result.text, "first\n        second\n");
+}
+
+#[test]
 fn merge_first_line_joins_existing_content() {
     let source = "Top\n\n    existing text\n";
     let doc = parse_document(source).expect("parse");
@@ -400,8 +446,13 @@ fn selection_replace_anchor_from_selection_start() {
     };
     let result = prepare_paste(&doc, source, range, "a\n    b\n");
     assert_eq!(result.mode, PasteMode::Reanchor);
-    // Anchor 8 (nested content indent): a -> 8, b(4) -> 12.
-    assert_eq!(result.text, "        a\n            b\n");
+    // Anchor 8 (nested content indent). The selection starts at column 8, *after*
+    // the line's 8 leading spaces — those spaces are not in the replaced range
+    // and survive the splice, so the first emitted line carries no anchor of its
+    // own (8 - 8 = 0) and lands at column 8 once spliced; line 2 is a fresh line
+    // at 8 + delta(8) = 12 (comms#73 #3). Returning "        a" here would
+    // double the indent against the surviving spaces.
+    assert_eq!(result.text, "a\n            b\n");
 }
 
 #[test]


### PR DESCRIPTION
Resolves item **#3** of issue #743 (smart-paste refinements from the comms#73 spec review). Items #1 and #2 already shipped in #746; this PR closes the last one.

## What

A fresh-line collapsed-caret paste could **double-indent** its first line. When an editor auto-indents a fresh line and sends an *empty* range at the caret, the line's leading whitespace is not part of the replaced range — it survives the splice — but the re-anchor transform still emitted the full anchor on the first line, so the surviving spaces and the emitted anchor stacked.

The transform now subtracts the whitespace that survives ahead of the splice point (new `surviving_leading_indent`) from the first emitted line, so the spliced total equals the anchor.

## Context

- **Why server-side, not a client contract.** The issue offered two fixes: (A) every editor expands the range to cover the leading whitespace, or (B) the server accounts for whitespace outside the edit. Picked **B** — it keeps the logic in the LSP per spec §1 ("logic lives in lex-lsp, editors contribute only a thin capture-and-apply shim") instead of pushing range-expansion into all four editor shims, and it's correct for *any* shim in the common indent direction.
- **Known limit (intentional, not a gap to "fix").** Exact *dedent* — auto-indent **deeper** than the anchor — still needs the editor to expand the range, because an insert-only edit cannot remove surviving whitespace. In that case the first line clamps to no added indent (`saturating_sub`). This is the documented §4.4 contract edge; the spec clarification itself is tracked separately (this PR is lex code only, per scope decision).
- **Latent bug also corrected.** `selection_replace_anchor_from_selection_start` previously expected the first line to carry the full anchor even though the selection starts at a content column (whitespace before it survives) — that would double-indent in a real editor. Its expectation is updated to the correct, non-doubling result.
- **Out of scope:** the comms `smart-paste.lex` §2/§4.4 spec wording, and the editor shim changes for exact dedent.

## Tests

- Pure transform: `reanchor` gains a `caret_indent` param; new cases cover subtract-on-first-line, first-line-only effect, and the deeper-than-target clamp.
- End-to-end: `fresh_line_with_auto_indent_does_not_double_anchor` drives a real auto-indented fresh line through `prepare_paste`.
- All `lex-lsp-core` (85) and `lexd-lsp` (89) tests green; gate green.