### PR TITLE
feat(ci): notify editor extensions on release (#804)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,36 @@ jobs:
       CRATES_IO_KEY: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Layer 2 of the cross-repo release cascade (lex-fmt/lex#640). The
+  # reusable rust-cli.yml does NOT dispatch downstreams itself — its
+  # notify-downstreams job is a no-op placeholder, because the fan-out
+  # list is repo-specific and lives co-located with its upstream. So a
+  # lex release must fire the dispatch here, mirroring comms's and
+  # tree-sitter-lex's release.yml.
+  #
+  # lex's direct downstreams are the editor extensions, which submodule
+  # lex and listen for `upstream-released` from BOTH lex and
+  # tree-sitter-lex (the two-hop cascade). Without this step a lex
+  # release never reached them and each editor had to be dispatched by
+  # hand. See arthur-debert/release#804.
+  notify-downstreams:
+    needs: release
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify downstream editors
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: v${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          for repo in lex-fmt/vscode lex-fmt/nvim lex-fmt/lexed; do
+            echo "Notifying ${repo} of lex@${VERSION}"
+            gh api "repos/${repo}/dispatches" --method POST \
+              -f event_type=upstream-released \
+              -F "client_payload[source]=lex" \
+              -F "client_payload[version]=${VERSION}" \
+              -F "client_payload[ts]=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -F "client_payload[run_url]=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
     needs: release
     if: success()
     runs-on: ubuntu-latest
+    # This job authenticates the dispatch via the RELEASE_TOKEN PAT
+    # (GH_TOKEN below), so its automatic GITHUB_TOKEN needs no scopes.
+    # Drop them to none to keep the blast radius minimal.
+    permissions: {}
     steps:
       - name: Notify downstream editors
         env:

--- a/CHANGELOG/unreleased-notify-editors.md
+++ b/CHANGELOG/unreleased-notify-editors.md
@@ -1,0 +1,1 @@
+- Notify editor extensions on release so the lex->editors cascade leg fires (release#804)


### PR DESCRIPTION
## What

Adds a `notify-downstreams` job to `release.yml` that fires `repository_dispatch` (`upstream-released`, `source=lex`) to `lex-fmt/{vscode,nvim,lexed}` after a successful release.

## Why

The reusable `rust-cli.yml@v3`'s `notify-downstreams` job is a deliberate **no-op placeholder** — the fan-out list is repo-specific, so the dispatch must live in the thin caller (as `comms`'s and `tree-sitter-lex`'s `release.yml` already do). lex had no such job, so a lex release never fired `upstream-released` to the editors, and each editor had to be dispatched by hand (the workaround documented in the issue).

The editors submodule lex and listen for `upstream-released` from both lex and tree-sitter-lex (the two-hop cascade); this restores the lex leg.

Fixes arthur-debert/release#804.

> Note: the upstream-first alternative (a `notify-downstreams` *input* on `rust-cli.yml` so thin callers stay one job) is tracked separately in release#804; this is the immediate consumer-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)