### PR TITLE
refactor(lsp): further-decompose server.rs + dedup include resolution (on top of #775)

### DIFF
--- a/crates/lex-cli/src/check.rs
+++ b/crates/lex-cli/src/check.rs
@@ -39,20 +39,19 @@
 //! the new finding source unchanged.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use lex_analysis::diagnostics::{
     analyze_references, analyze_with_rules, apply_rules, collect_file_references,
     AnalysisDiagnostic, DiagnosticKind, DiagnosticSeverity as AnalysisSeverity,
 };
-use lex_config::{DiagnosticsRulesConfig, LabelsConfig, CONFIG_FILE_NAME};
+use lex_config::{
+    absolutize_path, find_nearest_config_dir, DiagnosticsRulesConfig, LabelsConfig,
+    CONFIG_FILE_NAME,
+};
 use lex_core::lex::ast::{Document, Position, Range};
 use lex_core::lex::builtins;
-use lex_core::lex::includes::{
-    resolve_file_reference, resolve_from_source, FsLoader, IncludeError, ResolveConfig,
-};
+use lex_core::lex::includes::{resolve_file_reference, IncludeError, ResolveConfig};
 use lex_core::lex::parsing::parse_document_permissive;
-use lex_extension_host::registry::Registry;
 use serde::Serialize;
 
 use crate::extension_setup::{boot_registry, ExtensionSetup};
@@ -365,7 +364,7 @@ pub fn collect_file_diagnostics(
     // actually using the feature) we run the resolver; assembly failures
     // become findings against the include site. Otherwise we parse
     // permissively so label-policy diagnostics still surface.
-    let entry_abs = absolutize(entry);
+    let entry_abs = absolutize_path(entry);
     // The resolution root, shared by include expansion and the
     // `--references` file-path pass so both resolve targets identically:
     // explicit override → nearest ancestor with `.lex.toml` → the entry
@@ -385,7 +384,7 @@ pub fn collect_file_diagnostics(
     let root = opts
         .includes_root
         .clone()
-        .map(|r| absolutize(&r))
+        .map(|r| absolutize_path(&r))
         .unwrap_or_else(|| workspace_for(&entry_abs));
 
     let document = if opts.expand_includes && source.contains("lex.include") {
@@ -394,18 +393,20 @@ pub fn collect_file_diagnostics(
             max_depth: opts.max_depth,
             max_total_includes: opts.max_total_includes,
         };
-        let loader = FsLoader::new(root.clone()).with_max_file_size(opts.max_file_size);
-        let registry = Registry::new();
-        if let Err(e) = builtins::register_into(&registry, Arc::new(loader), resolve_config.clone())
-        {
-            return Err(format!(
-                "could not configure include resolver for {}: {e}",
-                entry.display()
-            ));
-        }
-        match resolve_from_source(source, Some(entry_abs.clone()), &resolve_config, &registry) {
+        match builtins::resolve_buffer(
+            source,
+            Some(entry_abs.clone()),
+            &resolve_config,
+            opts.max_file_size,
+        ) {
             Ok(doc) => doc,
-            Err(err) => {
+            Err(builtins::ResolveBufferError::Registry(e)) => {
+                return Err(format!(
+                    "could not configure include resolver for {}: {e}",
+                    entry.display()
+                ));
+            }
+            Err(builtins::ResolveBufferError::Resolve(err)) => {
                 // The document did not assemble. Report the assembly
                 // failure as a finding blamed on its include site and
                 // stop here: analysing the *un*-expanded fallback tree
@@ -602,21 +603,6 @@ fn head_range() -> Range {
     Range::new(0..0, Position::new(0, 0), Position::new(0, 0))
 }
 
-/// Best-effort absolutize for resolver paths (canonicalize, falling back
-/// to cwd-join). Mirrors `main.rs::absolutize_path` so include resolution
-/// behaves identically to `convert`/`inspect`.
-fn absolutize(p: &Path) -> PathBuf {
-    if let Ok(canon) = p.canonicalize() {
-        return canon;
-    }
-    if p.is_absolute() {
-        return p.to_path_buf();
-    }
-    std::env::current_dir()
-        .map(|cwd| cwd.join(p))
-        .unwrap_or_else(|_| p.to_path_buf())
-}
-
 /// Emit the report and return `true` when any finding met the `fail_on`
 /// threshold. Human format groups per file with a trailing summary;
 /// JSON emits a single flat array across all files.
@@ -715,15 +701,7 @@ pub fn workspace_for(entry: &Path) -> PathBuf {
         .filter(|p| !p.as_os_str().is_empty())
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from("."));
-    let mut cur = fallback.canonicalize().unwrap_or_else(|_| fallback.clone());
-    loop {
-        if cur.join(CONFIG_FILE_NAME).is_file() {
-            return cur;
-        }
-        if !cur.pop() {
-            return fallback;
-        }
-    }
+    find_nearest_config_dir(&fallback).unwrap_or(fallback)
 }
 
 #[cfg(test)]

--- a/crates/lex-cli/src/cli_support.rs
+++ b/crates/lex-cli/src/cli_support.rs
@@ -11,7 +11,7 @@
 
 use clap::ArgMatches;
 use lex_babel::formats::lex::formatting_rules::FormattingRules;
-use lex_config::{LexConfig, PdfPageSize};
+use lex_config::{resolve_include_root, LexConfig, PdfPageSize};
 use lex_core::lex::includes::{LoadError, LoadedFile, Loader};
 use lex_core::lex::mojibake::detect_mojibake;
 use std::collections::HashMap;
@@ -20,7 +20,12 @@ use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use lex_config::CONFIG_FILE_NAME;
+// Path helpers now live in `lex-config` (deduplicated from the copies that
+// were in `lex-lsp` and `check.rs`); re-exported here under their existing
+// names so the command handlers' call sites are unchanged.
+pub(crate) use lex_config::{
+    absolutize_path, find_nearest_config_dir as find_nearest_lex_toml_dir,
+};
 
 /// Per-invocation include resolution settings derived from CLI flags +
 /// `[includes]` config + the entry-file's location.
@@ -72,60 +77,11 @@ impl IncludeOptions {
         }
     }
 
-    /// Resolution root for an entry file at `entry_path`, applying:
-    /// 1. `root_override` if present.
-    /// 2. Directory of the nearest `.lex.toml` walking up from the entry file.
-    /// 3. The entry file's own directory.
-    ///
-    /// In all three cases the returned path is run through
-    /// [`absolutize_path`] so it is absolute and lexically normalized —
-    /// `ResolveConfig::root` requires an absolute path or the
-    /// root-escape prefix check is weakened.
+    /// Resolution root for an entry file at `entry_path`. Thin adapter over
+    /// [`lex_config::resolve_include_root`] threading `root_override` through.
     pub(crate) fn resolved_root(&self, entry_path: &Path) -> PathBuf {
-        let raw = if let Some(r) = &self.root_override {
-            r.clone()
-        } else {
-            let start_dir = entry_path
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|| PathBuf::from("."));
-            find_nearest_lex_toml_dir(&start_dir).unwrap_or(start_dir)
-        };
-        absolutize_path(&raw)
+        resolve_include_root(entry_path, self.root_override.as_deref())
     }
-}
-
-/// Walk upward from `start` looking for a directory that contains
-/// `.lex.toml` (the canonical config name in this repo). Returns that
-/// directory, or `None` if we hit the filesystem root without finding one.
-pub(crate) fn find_nearest_lex_toml_dir(start: &Path) -> Option<PathBuf> {
-    let mut cur: PathBuf = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    loop {
-        if cur.join(CONFIG_FILE_NAME).is_file() {
-            return Some(cur);
-        }
-        if !cur.pop() {
-            return None;
-        }
-    }
-}
-
-/// Best-effort absolutize: try `Path::canonicalize` (handles symlinks
-/// and resolves `..` against the real filesystem), and fall back to
-/// `current_dir().join(path)` if the path doesn't exist on disk yet
-/// (rare but possible — e.g., a CLI flag pointing at a not-yet-created
-/// directory). Always returns an absolute path; the resolver requires
-/// one for the root-escape prefix check to be sound.
-pub(crate) fn absolutize_path(p: &Path) -> PathBuf {
-    if let Ok(canon) = p.canonicalize() {
-        return canon;
-    }
-    if p.is_absolute() {
-        return p.to_path_buf();
-    }
-    std::env::current_dir()
-        .map(|cwd| cwd.join(p))
-        .unwrap_or_else(|_| p.to_path_buf())
 }
 
 /// Read source content from a file path, or from stdin when the path is

--- a/crates/lex-cli/src/commands/inspect.rs
+++ b/crates/lex-cli/src/commands/inspect.rs
@@ -70,11 +70,21 @@ fn expand_includes_to_source(source: &str, entry_path: &str, inc: &IncludeOption
         max_depth: inc.max_depth,
         max_total_includes: inc.max_total_includes,
     };
-    let doc = builtins::resolve_buffer(source, Some(entry), &resolve_config, inc.max_file_size)
-        .unwrap_or_else(|e| {
-            eprintln!("Include resolution error: {e}");
-            std::process::exit(1);
-        });
+    let doc =
+        match builtins::resolve_buffer(source, Some(entry), &resolve_config, inc.max_file_size) {
+            Ok(doc) => doc,
+            // Preserve the two distinct stderr wordings the hand-rolled path had:
+            // registry-setup failures and include-resolution failures read
+            // differently so the user can tell them apart.
+            Err(builtins::ResolveBufferError::Registry(e)) => {
+                eprintln!("Failed to register lex.* built-ins: {e}");
+                std::process::exit(1);
+            }
+            Err(builtins::ResolveBufferError::Resolve(e)) => {
+                eprintln!("Include resolution error: {e}");
+                std::process::exit(1);
+            }
+        };
 
     // Re-serialize with default formatting rules; the goal is just
     // to feed downstream transforms the merged source, not to

--- a/crates/lex-cli/src/commands/inspect.rs
+++ b/crates/lex-cli/src/commands/inspect.rs
@@ -6,11 +6,9 @@ use lex_babel::{
 };
 use lex_config::LexConfig;
 use lex_core::lex::builtins;
-use lex_core::lex::includes::{resolve_from_source, FsLoader, ResolveConfig};
-use lex_extension_host::registry::Registry;
+use lex_core::lex::includes::ResolveConfig;
 use lexd::transforms;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 /// Handle the inspect command
 pub(crate) fn handle_inspect_command(
@@ -68,20 +66,12 @@ fn expand_includes_to_source(source: &str, entry_path: &str, inc: &IncludeOption
     let entry = absolutize_path(&PathBuf::from(entry_path));
     let root = inc.resolved_root(&entry);
     let resolve_config = ResolveConfig {
-        root: root.clone(),
+        root,
         max_depth: inc.max_depth,
         max_total_includes: inc.max_total_includes,
     };
-    let loader = FsLoader::new(root).with_max_file_size(inc.max_file_size);
-    let registry = Registry::new();
-    builtins::register_into(&registry, Arc::new(loader), resolve_config.clone()).unwrap_or_else(
-        |e| {
-            eprintln!("Failed to register lex.* built-ins: {e}");
-            std::process::exit(1);
-        },
-    );
-    let doc =
-        resolve_from_source(source, Some(entry), &resolve_config, &registry).unwrap_or_else(|e| {
+    let doc = builtins::resolve_buffer(source, Some(entry), &resolve_config, inc.max_file_size)
+        .unwrap_or_else(|e| {
             eprintln!("Include resolution error: {e}");
             std::process::exit(1);
         });

--- a/crates/lex-config/src/include_paths.rs
+++ b/crates/lex-config/src/include_paths.rs
@@ -1,0 +1,64 @@
+//! Shared filesystem-path helpers for include resolution.
+//!
+//! The CLI (`convert` / `inspect` / `check`) and the LSP server all need to
+//! turn an entry-file path + optional config root into the absolute,
+//! lexically-normalized [`ResolveConfig::root`](lex-core) the resolver's
+//! root-escape prefix check requires. These functions are the single source of
+//! that logic — previously copy-pasted across `lex-cli` and `lex-lsp`.
+
+use std::path::{Path, PathBuf};
+
+use crate::CONFIG_FILE_NAME;
+
+/// Best-effort absolutize: try [`Path::canonicalize`] first (handles symlinks
+/// and resolves `..` against the real filesystem), falling back to
+/// `current_dir().join(path)` when the path doesn't exist on disk yet. Always
+/// returns an absolute path; the resolver requires one for its root-escape
+/// prefix check to be sound.
+pub fn absolutize_path(p: &Path) -> PathBuf {
+    if let Ok(canon) = p.canonicalize() {
+        return canon;
+    }
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(p))
+        .unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Walk upward from `start` looking for a directory containing
+/// [`CONFIG_FILE_NAME`] (`.lex.toml`). Returns that directory, or `None` if the
+/// filesystem root is reached without finding one.
+pub fn find_nearest_config_dir(start: &Path) -> Option<PathBuf> {
+    let mut cur: PathBuf = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
+    loop {
+        if cur.join(CONFIG_FILE_NAME).is_file() {
+            return Some(cur);
+        }
+        if !cur.pop() {
+            return None;
+        }
+    }
+}
+
+/// Compute the include-resolution root for an entry document, applying:
+/// 1. `root_override` (e.g. `[includes].root` / `--includes-root`) if set.
+/// 2. Directory of the nearest `.lex.toml` walking up from the entry's dir.
+/// 3. The entry document's own directory.
+///
+/// The result is always run through [`absolutize_path`]. A bare filename
+/// (empty `parent()`) is treated as `.` so the ancestor walk still runs.
+pub fn resolve_include_root(entry_path: &Path, root_override: Option<&Path>) -> PathBuf {
+    let raw = if let Some(root) = root_override {
+        root.to_path_buf()
+    } else {
+        let start = entry_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        find_nearest_config_dir(&start).unwrap_or(start)
+    };
+    absolutize_path(&raw)
+}

--- a/crates/lex-config/src/lib.rs
+++ b/crates/lex-config/src/lib.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 
+mod include_paths;
 mod rule_config;
+pub use include_paths::{absolutize_path, find_nearest_config_dir, resolve_include_root};
 pub use rule_config::{RuleConfig, RuleOptions, Severity};
 
 /// Canonical config file name used by the CLI and LSP.

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -68,7 +68,9 @@ use lex_extension::{
 };
 use lex_extension_host::registry::{Registry, RegistryError};
 
-use crate::lex::includes::{Loader, ResolveConfig};
+use crate::lex::ast::Document;
+use crate::lex::includes::{resolve_from_source, FsLoader, IncludeError, Loader, ResolveConfig};
+use std::path::PathBuf;
 
 pub mod doc;
 pub mod include;
@@ -379,6 +381,55 @@ pub fn register_into(
 
     let doc_handler = Box::new(DocBuiltinsHandler);
     registry.register_namespace(DOC_NAMESPACE, doc::all_schemas(), doc_handler)
+}
+
+/// Failure from [`resolve_buffer`]: either the built-in registry could not be
+/// configured, or include resolution itself failed.
+#[derive(Debug)]
+pub enum ResolveBufferError {
+    /// `register_into` failed — the `lex.*`/`doc.*` namespaces could not be
+    /// attached. Should not happen with a fresh [`Registry`] in practice.
+    Registry(RegistryError),
+    /// Include resolution failed (cycle, missing target, depth/size limits, …).
+    /// Boxed because [`IncludeError`] is large and would otherwise bloat every
+    /// `Result` this error rides in (clippy `result_large_err`).
+    Resolve(Box<IncludeError>),
+}
+
+impl std::fmt::Display for ResolveBufferError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveBufferError::Registry(e) => {
+                write!(f, "could not configure include resolver: {e}")
+            }
+            ResolveBufferError::Resolve(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ResolveBufferError {}
+
+/// Resolve `:: lex.include ::` annotations in `source` against the filesystem,
+/// returning the merged [`Document`].
+///
+/// Builds a fresh [`Registry`] with the built-in `lex.*`/`doc.*` handlers
+/// wired to an [`FsLoader`] rooted at `config.root`, then runs
+/// [`resolve_from_source`]. This is the shared convenience the CLI
+/// (`convert`/`inspect`/`check`) and the LSP use instead of hand-rolling the
+/// loader + registry + resolve dance; callers that need a custom [`Loader`]
+/// (e.g. a scanning decorator) still wire it up themselves.
+pub fn resolve_buffer(
+    source: &str,
+    source_path: Option<PathBuf>,
+    config: &ResolveConfig,
+    max_file_size: u64,
+) -> Result<Document, ResolveBufferError> {
+    let loader = FsLoader::new(config.root.clone()).with_max_file_size(max_file_size);
+    let registry = Registry::new();
+    register_into(&registry, Arc::new(loader), config.clone())
+        .map_err(ResolveBufferError::Registry)?;
+    resolve_from_source(source, source_path, config, &registry)
+        .map_err(|e| ResolveBufferError::Resolve(Box::new(e)))
 }
 
 /// Reserved namespace owned by the document-level metadata family.

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -1,6 +1,5 @@
 //! Main language server implementation
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -9,10 +8,9 @@ use crate::extension_dispatch::{
     dispatch_completion as ext_dispatch_completion, dispatch_hover as ext_dispatch_hover,
     LspExtensionState,
 };
-use crate::features::commands::{self, execute_command};
+use crate::features::commands::{self};
 use crate::features::document_links::collect_document_links;
 use crate::features::document_symbols::collect_document_symbols;
-use crate::features::extract::{self, ExtractError};
 use crate::features::folding_ranges::folding_ranges as collect_folding_ranges;
 use crate::features::formatting::{self};
 use crate::features::go_to_definition::goto_definition;
@@ -22,20 +20,12 @@ use crate::features::semantic_tokens::collect_semantic_tokens;
 use lex_analysis::completion::{completion_items, CompletionWorkspace};
 use lex_analysis::diagnostics::{analyze as analyze_diagnostics, apply_rules};
 use lex_babel::formats::lex::formatting_rules::FormattingRules;
-use lex_babel::templates::{
-    build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
-};
-use lex_config::{LabelsConfig, LoadedLexConfig};
-use lex_core::lex::ast::{Document, Position as AstPosition};
-use lex_core::lex::builtins as lex_builtins;
-use lex_core::lex::includes::{FsLoader, ResolveConfig};
-use lex_lsp_core::prepare_paste::{
-    prepare_paste as prepare_paste_transform, PasteMode, PreparePasteParams, PreparePasteResult,
-};
+use lex_config::LoadedLexConfig;
+use lex_core::lex::ast::Document;
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tower_lsp::async_trait;
-use tower_lsp::jsonrpc::{Error, Result};
+use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
     CodeActionParams, CodeActionProviderCapability, CodeActionResponse, CompletionItem,
     CompletionOptions, CompletionParams, CompletionResponse, DidChangeConfigurationParams,
@@ -45,10 +35,10 @@ use tower_lsp::lsp_types::{
     FoldingRangeParams, FoldingRangeProviderCapability, FormattingOptions, GotoDefinitionParams,
     GotoDefinitionResponse, Hover, HoverContents, HoverParams, HoverProviderCapability,
     InitializeParams, InitializeResult, InitializedParams, Location, MarkupContent, MarkupKind,
-    OneOf, Position, Range, ReferenceParams, SemanticTokens, SemanticTokensFullOptions,
-    SemanticTokensOptions, SemanticTokensParams, SemanticTokensResult, ServerCapabilities,
-    ServerInfo, TextDocumentItem, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url,
-    WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities,
+    OneOf, ReferenceParams, SemanticTokens, SemanticTokensFullOptions, SemanticTokensOptions,
+    SemanticTokensParams, SemanticTokensResult, ServerCapabilities, ServerInfo, TextDocumentItem,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url, WorkDoneProgressOptions,
+    WorkspaceFoldersServerCapabilities,
 };
 use tower_lsp::Client;
 
@@ -56,10 +46,13 @@ use tower_lsp::lsp_types::Diagnostic;
 
 use tower_lsp::lsp_types::MessageType;
 
+mod command_dispatch;
 mod config_loading;
 mod convert;
 mod diagnostics;
 mod document_store;
+mod extension_boot;
+mod includes;
 #[cfg(test)]
 mod tests;
 
@@ -101,17 +94,17 @@ impl LspClient for Client {
 }
 
 pub struct LexLanguageServer<C = Client> {
-    client: C,
-    documents: DocumentStore,
-    workspace_roots: RwLock<Vec<PathBuf>>,
-    config: RwLock<LoadedLexConfig>,
+    pub(crate) client: C,
+    pub(crate) documents: DocumentStore,
+    pub(crate) workspace_roots: RwLock<Vec<PathBuf>>,
+    pub(crate) config: RwLock<LoadedLexConfig>,
     /// Extension registry + boot diagnostics, lazily populated on first
     /// extension-aware request (hover/completion/code_action). Held for
     /// the lifetime of the workspace; rebuilt when workspace folders
     /// change. `None` when the LSP is running outside any workspace
     /// (e.g. a single untitled buffer) — extension dispatch is a no-op
     /// in that case, and built-in providers handle every request.
-    extension: RwLock<Option<Arc<LspExtensionState>>>,
+    pub(crate) extension: RwLock<Option<Arc<LspExtensionState>>>,
     /// Serializes concurrent calls to [`Self::extension_state`] so the
     /// first request to land at boot does the work and every other
     /// request waits for that single boot to finish — instead of all
@@ -120,7 +113,7 @@ pub struct LexLanguageServer<C = Client> {
     /// `lex/trustRequest` prompts to the editor. Naturally happens
     /// when N requests arrive on file-open (semantic tokens + hover +
     /// document symbols + folding + …).
-    extension_init: tokio::sync::Mutex<()>,
+    pub(crate) extension_init: tokio::sync::Mutex<()>,
 }
 
 impl<C> LexLanguageServer<C>
@@ -137,151 +130,6 @@ where
             extension: RwLock::new(None),
             extension_init: tokio::sync::Mutex::new(()),
         }
-    }
-
-    /// Lazily boot the extension registry against the current workspace
-    /// root + config. Idempotent: once built, returns the cached state.
-    /// Returns `None` when no workspace is set (e.g. single-file mode);
-    /// extension dispatch is a no-op without a workspace anchor.
-    ///
-    /// Concurrency: the first request to land on a fresh workspace
-    /// takes the `extension_init` mutex and runs the boot; every
-    /// other concurrent request blocks on the mutex, then re-checks
-    /// the cache and reuses what the first one produced. Without
-    /// this serialization, an open-file event that fires several
-    /// providers at once (hover, completion, semantic tokens, folding,
-    /// document-symbols, …) would launch N parallel boots, with N
-    /// concurrent reads of the schema directory, N concurrent
-    /// subprocess spawns, and N `lex/trustRequest` prompts to the
-    /// editor. The mutex keeps the observable side effects to one
-    /// prompt and one set of spawns.
-    async fn extension_state(&self) -> Option<Arc<LspExtensionState>> {
-        // Fast path: already booted, no lock needed.
-        if let Some(s) = self.extension.read().await.clone() {
-            return Some(s);
-        }
-
-        // Slow path: serialize boot. Hold the init lock for the whole
-        // boot so the second-arriving request waits for the first.
-        let _guard = self.extension_init.lock().await;
-
-        // Re-check after acquiring the init lock — another task may
-        // have completed boot while we were waiting on the mutex.
-        if let Some(s) = self.extension.read().await.clone() {
-            return Some(s);
-        }
-
-        let workspace_root = {
-            let roots = self.workspace_roots.read().await;
-            roots.first().cloned()?
-        };
-        let labels_config = LabelsConfig {
-            namespaces: self.config.read().await.config.labels.clone(),
-        };
-
-        // boot_registry does synchronous filesystem IO (schema load,
-        // trust store open) and may attempt to spawn subprocess
-        // handlers — a few hundred milliseconds in the worst case. Run
-        // it on the blocking thread pool so the tokio runtime keeps
-        // serving other LSP requests while boot runs.
-        //
-        // The trust prompt handler bridges sync→async via
-        // `Handle::block_on` — safe because we're on a blocking-pool
-        // thread, not a runtime worker.
-        let workspace_root_owned = workspace_root.clone();
-        let trust_requester = std::sync::Arc::new(self.client.clone());
-        let runtime_handle = tokio::runtime::Handle::current();
-        let outcome = match tokio::task::spawn_blocking(move || {
-            lex_fmt::boot_registry(lex_fmt::ExtensionSetup {
-                workspace_root: workspace_root_owned.as_path(),
-                labels_config: &labels_config,
-                // The LSP server has no `--ext-schema` flag; only
-                // `[labels]` entries from `lex.toml` register schemas
-                // in this surface.
-                ext_schemas: &[],
-                // `enable_handlers` is irrelevant on the Lsp surface —
-                // that flag is the CLI shortcut for the trust-prompt
-                // path. The LSP consults the trust store + prompt
-                // handler directly.
-                enable_handlers: false,
-                surface_override: Some(lex_extension_host::Surface::LspSession),
-                // Forwards `lex/trustRequest` to the editor and awaits
-                // the user's decision. Already-pinned decisions in
-                // `<workspace>/.lex/trust.json` short-circuit before
-                // the prompt fires.
-                trust_prompt: Box::new(crate::trust_prompt::LspPromptHandler::new(
-                    trust_requester,
-                    runtime_handle,
-                )),
-                // Reports `lexd-lsp`'s version to subprocess handlers
-                // in their initialize handshake — what handlers expect
-                // to see, not the `lex-fmt` boot crate's version.
-                host_version: env!("CARGO_PKG_VERSION"),
-            })
-        })
-        .await
-        {
-            Ok(outcome) => outcome,
-            Err(_) => {
-                // Blocking task panicked or was cancelled. Skip
-                // extension boot for this session; the next request
-                // will retry.
-                return None;
-            }
-        };
-
-        // Surface boot diagnostics to the editor before we cache the
-        // state. Per-namespace failures (resolver errors, denied
-        // subprocess handlers, schema load problems) are stored on
-        // the outcome but the user has no way to see them otherwise
-        // — pre-validation diagnostics are attached to documents,
-        // but boot diagnostics aren't. `window/showMessage` is the
-        // right surface for one-shot status that's not tied to a
-        // specific document range.
-        for diag in &outcome.diagnostics {
-            let prefix = match &diag.namespace {
-                Some(ns) => format!("lex extension `{ns}`: "),
-                None => "lex extensions: ".to_string(),
-            };
-            self.client
-                .show_message(MessageType::WARNING, format!("{prefix}{}", diag.message))
-                .await;
-        }
-
-        // Cross-check `[diagnostics.rules]` extension entries against the
-        // freshly-booted registry. A `<namespace>.<code>` rule whose
-        // namespace is registered but doesn't declare the code is a dead
-        // letter — it retunes nothing. Surface each as a warning so the
-        // misspelling is visible; like boot diagnostics, it's session
-        // status with no document range to attach to. Unregistered
-        // namespaces pass silently (the user may install the extension
-        // later), so this never fires for staged-ahead rules.
-        // Collect findings under the lock, then drop it before awaiting
-        // any `show_message` — holding the config read lock across the
-        // network await could starve a concurrent config write.
-        let rule_findings = {
-            let cfg = self.config.read().await;
-            lex_fmt::validate_extension_diagnostic_rules(
-                &cfg.extension_diagnostic_rules,
-                &outcome.registry,
-            )
-        };
-        for finding in rule_findings {
-            self.client
-                .show_message(MessageType::WARNING, finding.message)
-                .await;
-        }
-
-        let state = Arc::new(LspExtensionState::from(outcome));
-        *self.extension.write().await = Some(state.clone());
-        Some(state)
-    }
-
-    /// Discard the cached extension registry. Called when workspace
-    /// folders change so the next request picks up the new root +
-    /// config.
-    async fn invalidate_extension_state(&self) {
-        *self.extension.write().await = None;
     }
 
     async fn parse_and_store(&self, uri: Url, text: String) {
@@ -310,179 +158,11 @@ where
             .await;
     }
 
-    /// Drives include resolution (when the URI is a file path) for
-    /// *diagnostic* purposes only. Always stores the **unresolved**
-    /// parse under `uri`; that's what every LSP feature
-    /// (semantic tokens, hover, goto-definition, document symbols) sees.
-    ///
-    /// Why not store the merged tree: nodes spliced in from included
-    /// files carry Ranges in the *included file's* coordinate space —
-    /// `range.start.line == 0` means "line 0 of chapter.lex", not
-    /// "line 0 of the host buffer." Serving those ranges back as if
-    /// they were positions in the host URI's text would highlight the
-    /// wrong tokens, send goto-definition to the wrong spot, etc. Until
-    /// we have an origin-path-aware location-mapping layer (PR 9+),
-    /// the safe behavior is to use the merged tree only to decide
-    /// whether resolution succeeded, and emit diagnostics if it didn't.
-    ///
-    /// Returns include-related diagnostics: empty on success or when
-    /// the document doesn't use includes at all; one diagnostic
-    /// pointing at the include site (or document head as fallback) on
-    /// resolver failure.
-    async fn resolve_and_upsert(&self, uri: &Url, text: &str) -> Vec<Diagnostic> {
-        // Standard parse goes in regardless — this is the tree every
-        // LSP feature works against.
-        self.documents.upsert(uri.clone(), text.to_string()).await;
-
-        // Fast path: no `lex.include` literal in source, nothing to
-        // resolve, nothing to diagnose. Avoids per-keystroke resolver
-        // work for documents that don't use the feature, and prevents
-        // the resolver's `ParseFailed` from firing as a spurious
-        // include diagnostic for ordinary parse errors.
-        if !text.contains("lex.include") {
-            return Vec::new();
-        }
-
-        let path = match uri.to_file_path() {
-            Ok(p) => p,
-            // Untitled / non-file URIs (e.g. `untitled:Untitled-1`)
-            // can't anchor relative include paths.
-            Err(_) => return Vec::new(),
-        };
-
-        // Canonicalize the entry path so it lives in the same absolute-
-        // path space as `inc_root` (`absolutize_path` calls
-        // `Path::canonicalize` which follows symlinks — important on
-        // macOS where /var → /private/var). Without this, host_dir
-        // (path.parent()) and inc_root differ by symlink resolution and
-        // every lookup fails the root-escape prefix check.
-        let path = absolutize_path(&path);
-
-        let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&path, &cfg.config);
-        let max_depth = cfg.config.includes.max_depth;
-        let max_total_includes = cfg.config.includes.max_total_includes;
-        let max_file_size = cfg.config.includes.max_file_size;
-        drop(cfg);
-
-        let resolve_config = ResolveConfig {
-            root: inc_root,
-            max_depth,
-            max_total_includes,
-        };
-
-        match lex_builtins::resolve_buffer(text, Some(path), &resolve_config, max_file_size) {
-            // Resolution succeeded. We *don't* store the merged tree —
-            // see fn-level docstring. The resolver was run only to
-            // surface errors; the tree itself is dropped.
-            Ok(_doc) => Vec::new(),
-            Err(lex_builtins::ResolveBufferError::Registry(e)) => {
-                vec![registry_setup_diagnostic(&e.to_string())]
-            }
-            Err(lex_builtins::ResolveBufferError::Resolve(err)) => {
-                vec![include_error_to_diagnostic(&err)]
-            }
-        }
-    }
-
-    async fn document_entry(&self, uri: &Url) -> Option<DocumentEntry> {
+    pub(crate) async fn document_entry(&self, uri: &Url) -> Option<DocumentEntry> {
         self.documents.get(uri).await
     }
 
-    /// Resolve a `lex.include` annotation at `position` to a Location
-    /// pointing at the target file. Returns `None` when the cursor isn't
-    /// on a `lex.include`, when the URI has no on-disk anchor (untitled
-    /// buffers), when the include has no `src=` parameter, when the
-    /// path resolves outside the include root, **or when the target
-    /// file does not exist on disk**. The last guard avoids navigating
-    /// the editor to a non-existent path — the user gets the
-    /// `include-not-found` diagnostic from PR 8 instead, which surfaces
-    /// the underlying problem clearly. The Location range is the file
-    /// head (line 0, column 0) — cross-file goto-def lands the user at
-    /// the top of the target.
-    async fn goto_for_include(
-        &self,
-        uri: &Url,
-        document: &Document,
-        position: AstPosition,
-    ) -> Option<Location> {
-        let annotation = lex_analysis::utils::find_annotation_at_position(document, position)?;
-        if !annotation.is_include() {
-            return None;
-        }
-        let src = annotation.include_src()?;
-
-        let host_path = absolutize_path(&uri.to_file_path().ok()?);
-        let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&host_path, &cfg.config);
-        drop(cfg);
-
-        let target = lex_core::lex::includes::resolve_file_reference(
-            &src,
-            Some(host_path.as_path()),
-            inc_root.as_path(),
-        )
-        .ok()?;
-        // Existence check: don't send the editor to nowhere.
-        // `resolve_file_reference` is filesystem-free (lexical only),
-        // so the path it returns may not exist. The PR 8 diagnostic
-        // already surfaces missing-target errors; goto-def returning
-        // None here lets the editor render its native "no definition
-        // found" UX instead of opening a phantom buffer.
-        if !target.is_file() {
-            return None;
-        }
-        let target_uri = Url::from_file_path(&target).ok()?;
-        Some(Location {
-            uri: target_uri,
-            range: head_range(),
-        })
-    }
-
-    /// Build a hover preview for a `lex.include` annotation at `position`.
-    /// The preview shows the target file's first two non-blank lines
-    /// (no AST parsing — just the raw text) — enough to confirm the
-    /// include points where the author thinks. Returns `None` when the
-    /// cursor isn't on a `lex.include`, the URI has no on-disk anchor,
-    /// or the target can't be loaded.
-    async fn hover_for_include(
-        &self,
-        uri: &Url,
-        document: &Document,
-        position: AstPosition,
-    ) -> Option<Hover> {
-        let annotation = lex_analysis::utils::find_annotation_at_position(document, position)?;
-        if !annotation.is_include() {
-            return None;
-        }
-        let src = annotation.include_src()?;
-
-        let host_path = absolutize_path(&uri.to_file_path().ok()?);
-        let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&host_path, &cfg.config);
-        drop(cfg);
-
-        let target = lex_core::lex::includes::resolve_file_reference(
-            &src,
-            Some(host_path.as_path()),
-            inc_root.as_path(),
-        )
-        .ok()?;
-
-        let loader = FsLoader::new(inc_root.clone());
-        let loaded = lex_core::lex::includes::Loader::load(&loader, target.as_path()).ok()?;
-        let preview = include_preview_markdown(&src, &target, &loaded.source);
-
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: preview,
-            }),
-            range: Some(to_lsp_range(annotation.header_location())),
-        })
-    }
-
-    async fn document(&self, uri: &Url) -> Option<Arc<Document>> {
+    pub(crate) async fn document(&self, uri: &Url) -> Option<Arc<Document>> {
         self.document_entry(uri).await.map(|entry| entry.document)
     }
 
@@ -975,282 +655,6 @@ where
     }
 
     async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {
-        let command = params.command.as_str();
-        match command {
-            commands::COMMAND_NEXT_ANNOTATION | commands::COMMAND_PREVIOUS_ANNOTATION => {
-                let uri_str = params.arguments.first().and_then(|v| v.as_str());
-                let pos_val = params.arguments.get(1);
-
-                if let (Some(uri_str), Some(pos_val)) = (uri_str, pos_val) {
-                    if let Ok(uri) = Url::parse(uri_str) {
-                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
-                            if let Some(document) = self.document(&uri).await {
-                                let ast_pos = from_lsp_position(position);
-                                let navigation = if command == commands::COMMAND_NEXT_ANNOTATION {
-                                    lex_analysis::annotations::next_annotation(&document, ast_pos)
-                                } else {
-                                    lex_analysis::annotations::previous_annotation(
-                                        &document, ast_pos,
-                                    )
-                                };
-
-                                if let Some(result) = navigation {
-                                    let location = to_lsp_location(&uri, &result.header);
-                                    return Ok(Some(
-                                        serde_json::to_value(location)
-                                            .map_err(|_| Error::internal_error())?,
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-                Ok(None)
-            }
-            commands::COMMAND_RESOLVE_ANNOTATION | commands::COMMAND_TOGGLE_ANNOTATIONS => {
-                let uri_str = params.arguments.first().and_then(|v| v.as_str());
-                let pos_val = params.arguments.get(1);
-
-                if let (Some(uri_str), Some(pos_val)) = (uri_str, pos_val) {
-                    if let Ok(uri) = Url::parse(uri_str) {
-                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
-                            if let Some(document) = self.document(&uri).await {
-                                let ast_pos = from_lsp_position(position);
-                                let _resolved = command == commands::COMMAND_RESOLVE_ANNOTATION;
-
-                                // For toggle, we need to check current status, but lex-analysis toggle takes a boolean "resolved".
-                                // Wait, lex-analysis toggle_annotation_resolution takes "resolved: bool".
-                                // If we want to toggle, we need to know current state.
-                                // But the command name "toggle_annotations" implies switching.
-                                // Let's check lex-analysis signature again.
-                                // toggle_annotation_resolution(doc, pos, resolved) -> Option<Edit>
-                                // It sets status=resolved if resolved=true, removes it if false.
-                                // So "resolve" command should pass true.
-                                // "toggle" command needs to check if it's currently resolved and flip it.
-
-                                let target_state =
-                                    if command == commands::COMMAND_RESOLVE_ANNOTATION {
-                                        true
-                                    } else {
-                                        // Check if currently resolved
-                                        if let Some(annotation) =
-                                            lex_analysis::utils::find_annotation_at_position(
-                                                &document, ast_pos,
-                                            )
-                                        {
-                                            let is_resolved =
-                                                annotation.data.parameters.iter().any(|p| {
-                                                    p.key == "status" && p.value == "resolved"
-                                                });
-                                            !is_resolved
-                                        } else {
-                                            return Ok(None);
-                                        }
-                                    };
-
-                                if let Some(edit) =
-                                    lex_analysis::annotations::toggle_annotation_resolution(
-                                        &document,
-                                        ast_pos,
-                                        target_state,
-                                    )
-                                {
-                                    let text_edit = TextEdit {
-                                        range: to_lsp_range(&edit.range),
-                                        new_text: edit.new_text,
-                                    };
-                                    let mut changes = HashMap::new();
-                                    changes.insert(uri, vec![text_edit]);
-                                    let workspace_edit = tower_lsp::lsp_types::WorkspaceEdit {
-                                        changes: Some(changes),
-                                        ..Default::default()
-                                    };
-                                    return Ok(Some(
-                                        serde_json::to_value(workspace_edit)
-                                            .map_err(|_| Error::internal_error())?,
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-                Ok(None)
-            }
-            commands::COMMAND_INSERT_ASSET => {
-                let uri_str = params.arguments.first().and_then(|v| v.as_str());
-                let pos_val = params.arguments.get(1);
-                let path_val = params.arguments.get(2).and_then(|v| v.as_str());
-
-                if let (Some(uri_str), Some(pos_val), Some(path)) = (uri_str, pos_val, path_val) {
-                    if let Ok(uri) = Url::parse(uri_str) {
-                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
-                            let file_path = PathBuf::from(path);
-                            let rules = FormattingRules::default();
-                            let entry = self.document_entry(&uri).await;
-                            let indent_level = entry
-                                .as_ref()
-                                .map(|entry| indent_level_from_position(entry, &position, &rules))
-                                .unwrap_or(0);
-                            let document_directory = document_directory_from_uri(&uri);
-                            let snippet = {
-                                let request = AssetSnippetRequest {
-                                    asset_path: file_path.as_path(),
-                                    document_directory: document_directory.as_deref(),
-                                    formatting: &rules,
-                                    indent_level,
-                                };
-                                build_asset_snippet(&request)
-                            };
-
-                            return Ok(Some(json!({
-                                "text": snippet.text,
-                                "cursorOffset": snippet.cursor_offset,
-                            })));
-                        }
-                    }
-                }
-                Ok(None)
-            }
-            commands::COMMAND_INSERT_VERBATIM => {
-                let uri_str = params.arguments.first().and_then(|v| v.as_str());
-                let pos_val = params.arguments.get(1);
-                let path_val = params.arguments.get(2).and_then(|v| v.as_str());
-
-                if let (Some(uri_str), Some(pos_val), Some(path)) = (uri_str, pos_val, path_val) {
-                    if let Ok(uri) = Url::parse(uri_str) {
-                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
-                            let file_path = PathBuf::from(path);
-                            let rules = FormattingRules::default();
-                            let entry = self.document_entry(&uri).await;
-                            let indent_level = entry
-                                .as_ref()
-                                .map(|entry| indent_level_from_position(entry, &position, &rules))
-                                .unwrap_or(0);
-                            let document_directory = document_directory_from_uri(&uri);
-                            let snippet_result = {
-                                let mut request =
-                                    VerbatimSnippetRequest::new(file_path.as_path(), &rules);
-                                request.document_directory = document_directory.as_deref();
-                                request.indent_level = indent_level;
-                                build_verbatim_snippet(&request)
-                            };
-
-                            match snippet_result {
-                                Ok(snippet) => {
-                                    return Ok(Some(json!({
-                                        "text": snippet.text,
-                                        "cursorOffset": snippet.cursor_offset,
-                                    })));
-                                }
-                                Err(err) => {
-                                    return Err(Error::invalid_params(format!(
-                                        "Failed to insert verbatim block: {err}"
-                                    )));
-                                }
-                            }
-                        }
-                    }
-                }
-                Ok(None)
-            }
-            commands::COMMAND_EXTRACT_TO_INCLUDE => {
-                self.handle_extract_to_include(&params.arguments).await
-            }
-            _ => execute_command(&params.command, &params.arguments),
-        }
-    }
-}
-
-impl<C> LexLanguageServer<C>
-where
-    C: LspClient,
-{
-    /// Handler for `lex.extractToInclude`. Args are **positional**:
-    /// `[uri: string, range: lsp.Range, src: string]`.
-    ///
-    /// Returns a `WorkspaceEdit` JSON value the editor applies atomically
-    /// (file creation + selection replacement). All validation failures
-    /// surface as `invalid_params` errors carrying the
-    /// [`ExtractError::message`] string for direct display.
-    async fn handle_extract_to_include(&self, arguments: &[Value]) -> Result<Option<Value>> {
-        let uri_str = arguments
-            .first()
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| Error::invalid_params("Missing 'uri' argument"))?;
-        let range_val = arguments
-            .get(1)
-            .ok_or_else(|| Error::invalid_params("Missing 'range' argument"))?;
-        let src = arguments
-            .get(2)
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| Error::invalid_params("Missing 'src' argument"))?;
-
-        let uri = Url::parse(uri_str)
-            .map_err(|_| Error::invalid_params(format!("Invalid uri: {uri_str}")))?;
-        let range: Range = serde_json::from_value(range_val.clone())
-            .map_err(|e| Error::invalid_params(format!("Invalid range: {e}")))?;
-
-        let host_path = uri
-            .to_file_path()
-            .map_err(|_| Error::invalid_params(ExtractError::InvalidHostUri.message()))?;
-        let host_path = absolutize_path(&host_path);
-
-        let entry = self
-            .document_entry(&uri)
-            .await
-            .ok_or_else(|| Error::invalid_params("Document not open in the server"))?;
-
-        let selection_text = slice_text_by_range(&entry.text, range)
-            .ok_or_else(|| Error::invalid_params("Selection range out of bounds"))?;
-
-        let host_indent = range.start.character as usize;
-
-        let cfg = self.config.read().await;
-        let inc_root = inc_root_for(&host_path, &cfg.config);
-        drop(cfg);
-
-        let edit = extract::build_extract_workspace_edit(
-            &uri,
-            &host_path,
-            range,
-            &selection_text,
-            host_indent,
-            src,
-            &inc_root,
-        )
-        .map_err(|e| Error::invalid_params(e.message()))?;
-
-        Ok(Some(
-            serde_json::to_value(edit).map_err(|_| Error::internal_error())?,
-        ))
-    }
-
-    /// Handler for the custom `lex/preparePaste` request (smart paste,
-    /// comms#73). The editor sends the document identity, the range the paste
-    /// replaces, and the raw clipboard text; the server reuses the
-    /// already-parsed buffer state to classify the paste and re-anchor the
-    /// clipboard to the caret's structural context, returning the text to
-    /// splice across the range plus the [`PasteMode`] it applied.
-    ///
-    /// Pure with respect to document state: it reads the parse, computes a
-    /// string, and mutates nothing. When the document is not open in the
-    /// server (no parse to consult), the response echoes the clipboard back in
-    /// `re-anchor` mode — a safe no-op so the editor still completes the paste.
-    pub async fn prepare_paste(&self, params: PreparePasteParams) -> Result<PreparePasteResult> {
-        let Some(entry) = self.document_entry(&params.text_document.uri).await else {
-            // No parsed buffer to consult — hand the clipboard back unchanged
-            // rather than fail; the editor applies it as an ordinary paste.
-            return Ok(PreparePasteResult {
-                text: params.pasted_text,
-                mode: PasteMode::Reanchor,
-            });
-        };
-
-        Ok(prepare_paste_transform(
-            &entry.document,
-            &entry.text,
-            params.range,
-            &params.pasted_text,
-        ))
+        self.execute_command_dispatch(params).await
     }
 }

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -11,23 +11,22 @@ use crate::extension_dispatch::{
 };
 use crate::features::commands::{self, execute_command};
 use crate::features::document_links::collect_document_links;
-use crate::features::document_symbols::{collect_document_symbols, LexDocumentSymbol};
+use crate::features::document_symbols::collect_document_symbols;
 use crate::features::extract::{self, ExtractError};
-use crate::features::folding_ranges::{folding_ranges as collect_folding_ranges, LexFoldingRange};
-use crate::features::formatting::{self, LineRange as FormattingLineRange, TextEditSpan};
+use crate::features::folding_ranges::folding_ranges as collect_folding_ranges;
+use crate::features::formatting::{self};
 use crate::features::go_to_definition::goto_definition;
-use crate::features::hover::{hover as compute_hover, HoverResult};
+use crate::features::hover::hover as compute_hover;
 use crate::features::references::find_references;
-use crate::features::semantic_tokens::{collect_semantic_tokens, LexSemanticToken};
-use lex_analysis::completion::{completion_items, CompletionCandidate, CompletionWorkspace};
+use crate::features::semantic_tokens::collect_semantic_tokens;
+use lex_analysis::completion::{completion_items, CompletionWorkspace};
 use lex_analysis::diagnostics::{analyze as analyze_diagnostics, apply_rules};
 use lex_babel::formats::lex::formatting_rules::FormattingRules;
 use lex_babel::templates::{
     build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
 };
 use lex_config::{LabelsConfig, LoadedLexConfig};
-use lex_core::lex::ast::links::DocumentLink as AstDocumentLink;
-use lex_core::lex::ast::{Document, Position as AstPosition, Range as AstRange};
+use lex_core::lex::ast::{Document, Position as AstPosition};
 use lex_core::lex::builtins as lex_builtins;
 use lex_core::lex::includes::{FsLoader, ResolveConfig};
 use lex_lsp_core::prepare_paste::{
@@ -101,126 +100,9 @@ impl LspClient for Client {
     }
 }
 
-pub trait FeatureProvider: Send + Sync + 'static {
-    fn semantic_tokens(&self, document: &Document) -> Vec<LexSemanticToken>;
-    fn document_symbols(&self, document: &Document) -> Vec<LexDocumentSymbol>;
-    fn folding_ranges(&self, document: &Document) -> Vec<LexFoldingRange>;
-    fn hover(&self, document: &Document, position: AstPosition) -> Option<HoverResult>;
-    fn goto_definition(&self, document: &Document, position: AstPosition) -> Vec<AstRange>;
-    fn references(
-        &self,
-        document: &Document,
-        position: AstPosition,
-        include_declaration: bool,
-    ) -> Vec<AstRange>;
-    fn document_links(&self, document: &Document) -> Vec<AstDocumentLink>;
-    fn format_document(
-        &self,
-        document: &Document,
-        source: &str,
-        rules: Option<FormattingRules>,
-    ) -> Vec<TextEditSpan>;
-    fn format_range(
-        &self,
-        document: &Document,
-        source: &str,
-        range: FormattingLineRange,
-        rules: Option<FormattingRules>,
-    ) -> Vec<TextEditSpan>;
-    fn completion(
-        &self,
-        document: &Document,
-        position: AstPosition,
-        current_line: Option<&str>,
-        workspace: Option<&CompletionWorkspace>,
-        trigger_char: Option<&str>,
-    ) -> Vec<CompletionCandidate>;
-    fn execute_command(&self, command: &str, arguments: &[Value]) -> Result<Option<Value>>;
-}
-
-#[derive(Default)]
-pub struct DefaultFeatureProvider;
-
-impl DefaultFeatureProvider {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-#[async_trait]
-impl FeatureProvider for DefaultFeatureProvider {
-    fn semantic_tokens(&self, document: &Document) -> Vec<LexSemanticToken> {
-        collect_semantic_tokens(document)
-    }
-
-    fn document_symbols(&self, document: &Document) -> Vec<LexDocumentSymbol> {
-        collect_document_symbols(document)
-    }
-
-    fn folding_ranges(&self, document: &Document) -> Vec<LexFoldingRange> {
-        collect_folding_ranges(document)
-    }
-
-    fn hover(&self, document: &Document, position: AstPosition) -> Option<HoverResult> {
-        compute_hover(document, position)
-    }
-
-    fn goto_definition(&self, document: &Document, position: AstPosition) -> Vec<AstRange> {
-        goto_definition(document, position)
-    }
-
-    fn references(
-        &self,
-        document: &Document,
-        position: AstPosition,
-        include_declaration: bool,
-    ) -> Vec<AstRange> {
-        find_references(document, position, include_declaration)
-    }
-
-    fn document_links(&self, document: &Document) -> Vec<AstDocumentLink> {
-        collect_document_links(document)
-    }
-
-    fn format_document(
-        &self,
-        document: &Document,
-        source: &str,
-        rules: Option<FormattingRules>,
-    ) -> Vec<TextEditSpan> {
-        formatting::format_document(document, source, rules)
-    }
-
-    fn format_range(
-        &self,
-        document: &Document,
-        source: &str,
-        range: FormattingLineRange,
-        rules: Option<FormattingRules>,
-    ) -> Vec<TextEditSpan> {
-        formatting::format_range(document, source, range, rules)
-    }
-
-    fn completion(
-        &self,
-        document: &Document,
-        position: AstPosition,
-        current_line: Option<&str>,
-        workspace: Option<&CompletionWorkspace>,
-        trigger_char: Option<&str>,
-    ) -> Vec<CompletionCandidate> {
-        completion_items(document, position, current_line, workspace, trigger_char)
-    }
-
-    fn execute_command(&self, command: &str, arguments: &[Value]) -> Result<Option<Value>> {
-        execute_command(command, arguments)
-    }
-}
-
-pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
+pub struct LexLanguageServer<C = Client> {
     client: C,
     documents: DocumentStore,
-    features: Arc<P>,
     workspace_roots: RwLock<Vec<PathBuf>>,
     config: RwLock<LoadedLexConfig>,
     /// Extension registry + boot diagnostics, lazily populated on first
@@ -241,23 +123,15 @@ pub struct LexLanguageServer<C = Client, P = DefaultFeatureProvider> {
     extension_init: tokio::sync::Mutex<()>,
 }
 
-impl LexLanguageServer<Client, DefaultFeatureProvider> {
-    pub fn new(client: Client) -> Self {
-        Self::with_features(client, Arc::new(DefaultFeatureProvider::new()))
-    }
-}
-
-impl<C, P> LexLanguageServer<C, P>
+impl<C> LexLanguageServer<C>
 where
     C: LspClient,
-    P: FeatureProvider,
 {
-    pub fn with_features(client: C, features: Arc<P>) -> Self {
+    pub fn new(client: C) -> Self {
         let config = load_config(None);
         Self {
             client,
             documents: DocumentStore::default(),
-            features,
             workspace_roots: RwLock::new(Vec::new()),
             config: RwLock::new(config),
             extension: RwLock::new(None),
@@ -666,10 +540,9 @@ where
 }
 
 #[async_trait]
-impl<C, P> tower_lsp::LanguageServer for LexLanguageServer<C, P>
+impl<C> tower_lsp::LanguageServer for LexLanguageServer<C>
 where
     C: LspClient,
-    P: FeatureProvider,
 {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         self.update_workspace_roots(&params).await;
@@ -847,7 +720,7 @@ where
     ) -> Result<Option<SemanticTokensResult>> {
         if let Some(entry) = self.document_entry(&params.text_document.uri).await {
             let DocumentEntry { document, text } = entry;
-            let tokens = self.features.semantic_tokens(&document);
+            let tokens = collect_semantic_tokens(&document);
             let data = encode_semantic_tokens(&tokens, text.as_str());
             Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: None,
@@ -863,7 +736,7 @@ where
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         if let Some(document) = self.document(&params.text_document.uri).await {
-            let symbols = self.features.document_symbols(&document);
+            let symbols = collect_document_symbols(&document);
             let converted: Vec<DocumentSymbol> = symbols.iter().map(to_document_symbol).collect();
             Ok(Some(DocumentSymbolResponse::Nested(converted)))
         } else {
@@ -898,7 +771,7 @@ where
                 }
             }
 
-            if let Some(result) = self.features.hover(&document, position) {
+            if let Some(result) = compute_hover(&document, position) {
                 return Ok(Some(Hover {
                     contents: HoverContents::Markup(MarkupContent {
                         kind: MarkupKind::Markdown,
@@ -913,7 +786,7 @@ where
 
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
         if let Some(document) = self.document(&params.text_document.uri).await {
-            let ranges = self.features.folding_ranges(&document);
+            let ranges = collect_folding_ranges(&document);
             Ok(Some(ranges.iter().map(to_lsp_folding_range).collect()))
         } else {
             Ok(None)
@@ -936,7 +809,7 @@ where
                 return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
             }
 
-            let ranges = self.features.goto_definition(&document, position);
+            let ranges = goto_definition(&document, position);
             if ranges.is_empty() {
                 Ok(None)
             } else {
@@ -956,9 +829,7 @@ where
         if let Some(document) = self.document(&uri).await {
             let position = from_lsp_position(params.text_document_position.position);
             let include_declaration = params.context.include_declaration;
-            let ranges = self
-                .features
-                .references(&document, position, include_declaration);
+            let ranges = find_references(&document, position, include_declaration);
             if ranges.is_empty() {
                 Ok(None)
             } else {
@@ -977,7 +848,7 @@ where
     async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
         let uri = params.text_document.uri;
         if let Some(document) = self.document(&uri).await {
-            let links = self.features.document_links(&document);
+            let links = collect_document_links(&document);
             let resolved: Vec<DocumentLink> = links
                 .iter()
                 .filter_map(|link| build_document_link(&uri, link))
@@ -993,9 +864,7 @@ where
         if let Some(entry) = self.document_entry(&uri).await {
             let DocumentEntry { document, text } = entry;
             let rules = self.resolve_formatting_rules(&params.options).await;
-            let edits = self
-                .features
-                .format_document(&document, text.as_str(), Some(rules));
+            let edits = formatting::format_document(&document, text.as_str(), Some(rules));
             Ok(Some(spans_to_text_edits(text.as_str(), edits)))
         } else {
             Ok(None)
@@ -1011,9 +880,7 @@ where
             let DocumentEntry { document, text } = entry;
             let line_range = to_formatting_line_range(&params.range);
             let rules = self.resolve_formatting_rules(&params.options).await;
-            let edits =
-                self.features
-                    .format_range(&document, text.as_str(), line_range, Some(rules));
+            let edits = formatting::format_range(&document, text.as_str(), line_range, Some(rules));
             Ok(Some(spans_to_text_edits(text.as_str(), edits)))
         } else {
             Ok(None)
@@ -1036,7 +903,7 @@ where
             // Extract current line text for resilient parsing (e.g. "::" without following newline)
             let current_line = text.lines().nth(position.line);
 
-            let candidates = self.features.completion(
+            let candidates = completion_items(
                 &document,
                 position,
                 current_line,
@@ -1289,17 +1156,14 @@ where
             commands::COMMAND_EXTRACT_TO_INCLUDE => {
                 self.handle_extract_to_include(&params.arguments).await
             }
-            _ => self
-                .features
-                .execute_command(&params.command, &params.arguments),
+            _ => execute_command(&params.command, &params.arguments),
         }
     }
 }
 
-impl<C, P> LexLanguageServer<C, P>
+impl<C> LexLanguageServer<C>
 where
     C: LspClient,
-    P: FeatureProvider,
 {
     /// Handler for `lex.extractToInclude`. Args are **positional**:
     /// `[uri: string, range: lsp.Range, src: string]`.

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -29,8 +29,7 @@ use lex_config::{LabelsConfig, LoadedLexConfig};
 use lex_core::lex::ast::links::DocumentLink as AstDocumentLink;
 use lex_core::lex::ast::{Document, Position as AstPosition, Range as AstRange};
 use lex_core::lex::builtins as lex_builtins;
-use lex_core::lex::includes::{resolve_from_source, FsLoader, ResolveConfig};
-use lex_extension_host::registry::Registry;
+use lex_core::lex::includes::{FsLoader, ResolveConfig};
 use lex_lsp_core::prepare_paste::{
     prepare_paste as prepare_paste_transform, PasteMode, PreparePasteParams, PreparePasteResult,
 };
@@ -493,28 +492,22 @@ where
         drop(cfg);
 
         let resolve_config = ResolveConfig {
-            root: inc_root.clone(),
+            root: inc_root,
             max_depth,
             max_total_includes,
         };
-        let loader = FsLoader::new(inc_root).with_max_file_size(max_file_size);
-        let registry = Registry::new();
-        if let Err(e) = lex_builtins::register_into(
-            &registry,
-            std::sync::Arc::new(loader),
-            resolve_config.clone(),
-        ) {
-            return vec![registry_setup_diagnostic(&e.to_string())];
-        }
 
-        match resolve_from_source(text, Some(path), &resolve_config, &registry) {
-            Ok(_doc) => {
-                // Resolution succeeded. We *don't* store the merged
-                // tree — see fn-level docstring. The resolver was run
-                // only to surface errors; the tree itself is dropped.
-                Vec::new()
+        match lex_builtins::resolve_buffer(text, Some(path), &resolve_config, max_file_size) {
+            // Resolution succeeded. We *don't* store the merged tree —
+            // see fn-level docstring. The resolver was run only to
+            // surface errors; the tree itself is dropped.
+            Ok(_doc) => Vec::new(),
+            Err(lex_builtins::ResolveBufferError::Registry(e)) => {
+                vec![registry_setup_diagnostic(&e.to_string())]
             }
-            Err(err) => vec![include_error_to_diagnostic(&err)],
+            Err(lex_builtins::ResolveBufferError::Resolve(err)) => {
+                vec![include_error_to_diagnostic(&err)]
+            }
         }
     }
 

--- a/crates/lex-lsp/src/server.rs
+++ b/crates/lex-lsp/src/server.rs
@@ -133,13 +133,11 @@ where
     }
 
     async fn parse_and_store(&self, uri: Url, text: String) {
-        // Try include resolution first when the document has an on-disk
-        // path. If resolution succeeds, the resolved (merged) tree is what
-        // we store and analyze; downstream features (semantic tokens,
-        // hover, goto) see the post-include AST. If resolution fails, we
-        // fall back to a plain parse so the rest of the LSP keeps working,
-        // and surface the include error as a diagnostic at the include
-        // site.
+        // `resolve_and_upsert` always stores the *unresolved* host-buffer
+        // parse (so feature positions stay in the host's coordinate space)
+        // and runs the include resolver only to surface diagnostics — see
+        // its docstring. We then analyze that stored (unresolved) tree and
+        // publish the include diagnostics alongside the analysis ones.
         let include_diags = self.resolve_and_upsert(&uri, &text).await;
 
         let mut diagnostics: Vec<Diagnostic> = include_diags;

--- a/crates/lex-lsp/src/server/command_dispatch.rs
+++ b/crates/lex-lsp/src/server/command_dispatch.rs
@@ -80,36 +80,26 @@ where
                         if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
                             if let Some(document) = self.document(&uri).await {
                                 let ast_pos = from_lsp_position(position);
-                                let _resolved = command == commands::COMMAND_RESOLVE_ANNOTATION;
 
-                                // For toggle, we need to check current status, but lex-analysis toggle takes a boolean "resolved".
-                                // Wait, lex-analysis toggle_annotation_resolution takes "resolved: bool".
-                                // If we want to toggle, we need to know current state.
-                                // But the command name "toggle_annotations" implies switching.
-                                // Let's check lex-analysis signature again.
-                                // toggle_annotation_resolution(doc, pos, resolved) -> Option<Edit>
-                                // It sets status=resolved if resolved=true, removes it if false.
-                                // So "resolve" command should pass true.
-                                // "toggle" command needs to check if it's currently resolved and flip it.
-
+                                // `toggle_annotation_resolution(doc, pos, resolved)` is a
+                                // setter: `resolved=true` stamps `status=resolved`, `false`
+                                // clears it. So the "resolve" command always passes `true`,
+                                // while "toggle" must read the current state and flip it.
                                 let target_state =
                                     if command == commands::COMMAND_RESOLVE_ANNOTATION {
                                         true
+                                    } else if let Some(annotation) =
+                                        lex_analysis::utils::find_annotation_at_position(
+                                            &document, ast_pos,
+                                        )
+                                    {
+                                        let is_resolved =
+                                            annotation.data.parameters.iter().any(|p| {
+                                                p.key == "status" && p.value == "resolved"
+                                            });
+                                        !is_resolved
                                     } else {
-                                        // Check if currently resolved
-                                        if let Some(annotation) =
-                                            lex_analysis::utils::find_annotation_at_position(
-                                                &document, ast_pos,
-                                            )
-                                        {
-                                            let is_resolved =
-                                                annotation.data.parameters.iter().any(|p| {
-                                                    p.key == "status" && p.value == "resolved"
-                                                });
-                                            !is_resolved
-                                        } else {
-                                            return Ok(None);
-                                        }
+                                        return Ok(None);
                                     };
 
                                 if let Some(edit) =

--- a/crates/lex-lsp/src/server/command_dispatch.rs
+++ b/crates/lex-lsp/src/server/command_dispatch.rs
@@ -1,0 +1,315 @@
+//! `workspace/executeCommand` + custom-request dispatch.
+//!
+//! The `LanguageServer::execute_command` trait method in `server.rs` is a thin
+//! delegate to [`LexLanguageServer::execute_command_dispatch`] here; this module
+//! holds the per-command argument parsing and the `lex.extractToInclude` /
+//! `lex/preparePaste` handlers. Per-command *behavior* lives in
+//! `lex-analysis` / `lex-babel` / `lex-lsp-core`; this is the wiring.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use lex_babel::formats::lex::formatting_rules::FormattingRules;
+use lex_babel::templates::{
+    build_asset_snippet, build_verbatim_snippet, AssetSnippetRequest, VerbatimSnippetRequest,
+};
+use lex_lsp_core::prepare_paste::{
+    prepare_paste as prepare_paste_transform, PasteMode, PreparePasteParams, PreparePasteResult,
+};
+use serde_json::{json, Value};
+use tower_lsp::jsonrpc::{Error, Result};
+use tower_lsp::lsp_types::{ExecuteCommandParams, Position, Range, TextEdit, Url};
+
+use super::{
+    absolutize_path, document_directory_from_uri, from_lsp_position, inc_root_for,
+    indent_level_from_position, slice_text_by_range, to_lsp_location, to_lsp_range,
+    LexLanguageServer, LspClient,
+};
+use crate::features::commands::{self, execute_command};
+use crate::features::extract::{self, ExtractError};
+
+impl<C> LexLanguageServer<C>
+where
+    C: LspClient,
+{
+    /// Dispatch a `workspace/executeCommand` request. Commands with bespoke
+    /// server-side handling are matched here; everything else falls through to
+    /// the stateless [`execute_command`](crate::features::commands::execute_command).
+    pub(crate) async fn execute_command_dispatch(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<Value>> {
+        let command = params.command.as_str();
+        match command {
+            commands::COMMAND_NEXT_ANNOTATION | commands::COMMAND_PREVIOUS_ANNOTATION => {
+                let uri_str = params.arguments.first().and_then(|v| v.as_str());
+                let pos_val = params.arguments.get(1);
+
+                if let (Some(uri_str), Some(pos_val)) = (uri_str, pos_val) {
+                    if let Ok(uri) = Url::parse(uri_str) {
+                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
+                            if let Some(document) = self.document(&uri).await {
+                                let ast_pos = from_lsp_position(position);
+                                let navigation = if command == commands::COMMAND_NEXT_ANNOTATION {
+                                    lex_analysis::annotations::next_annotation(&document, ast_pos)
+                                } else {
+                                    lex_analysis::annotations::previous_annotation(
+                                        &document, ast_pos,
+                                    )
+                                };
+
+                                if let Some(result) = navigation {
+                                    let location = to_lsp_location(&uri, &result.header);
+                                    return Ok(Some(
+                                        serde_json::to_value(location)
+                                            .map_err(|_| Error::internal_error())?,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(None)
+            }
+            commands::COMMAND_RESOLVE_ANNOTATION | commands::COMMAND_TOGGLE_ANNOTATIONS => {
+                let uri_str = params.arguments.first().and_then(|v| v.as_str());
+                let pos_val = params.arguments.get(1);
+
+                if let (Some(uri_str), Some(pos_val)) = (uri_str, pos_val) {
+                    if let Ok(uri) = Url::parse(uri_str) {
+                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
+                            if let Some(document) = self.document(&uri).await {
+                                let ast_pos = from_lsp_position(position);
+                                let _resolved = command == commands::COMMAND_RESOLVE_ANNOTATION;
+
+                                // For toggle, we need to check current status, but lex-analysis toggle takes a boolean "resolved".
+                                // Wait, lex-analysis toggle_annotation_resolution takes "resolved: bool".
+                                // If we want to toggle, we need to know current state.
+                                // But the command name "toggle_annotations" implies switching.
+                                // Let's check lex-analysis signature again.
+                                // toggle_annotation_resolution(doc, pos, resolved) -> Option<Edit>
+                                // It sets status=resolved if resolved=true, removes it if false.
+                                // So "resolve" command should pass true.
+                                // "toggle" command needs to check if it's currently resolved and flip it.
+
+                                let target_state =
+                                    if command == commands::COMMAND_RESOLVE_ANNOTATION {
+                                        true
+                                    } else {
+                                        // Check if currently resolved
+                                        if let Some(annotation) =
+                                            lex_analysis::utils::find_annotation_at_position(
+                                                &document, ast_pos,
+                                            )
+                                        {
+                                            let is_resolved =
+                                                annotation.data.parameters.iter().any(|p| {
+                                                    p.key == "status" && p.value == "resolved"
+                                                });
+                                            !is_resolved
+                                        } else {
+                                            return Ok(None);
+                                        }
+                                    };
+
+                                if let Some(edit) =
+                                    lex_analysis::annotations::toggle_annotation_resolution(
+                                        &document,
+                                        ast_pos,
+                                        target_state,
+                                    )
+                                {
+                                    let text_edit = TextEdit {
+                                        range: to_lsp_range(&edit.range),
+                                        new_text: edit.new_text,
+                                    };
+                                    let mut changes = HashMap::new();
+                                    changes.insert(uri, vec![text_edit]);
+                                    let workspace_edit = tower_lsp::lsp_types::WorkspaceEdit {
+                                        changes: Some(changes),
+                                        ..Default::default()
+                                    };
+                                    return Ok(Some(
+                                        serde_json::to_value(workspace_edit)
+                                            .map_err(|_| Error::internal_error())?,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(None)
+            }
+            commands::COMMAND_INSERT_ASSET => {
+                let uri_str = params.arguments.first().and_then(|v| v.as_str());
+                let pos_val = params.arguments.get(1);
+                let path_val = params.arguments.get(2).and_then(|v| v.as_str());
+
+                if let (Some(uri_str), Some(pos_val), Some(path)) = (uri_str, pos_val, path_val) {
+                    if let Ok(uri) = Url::parse(uri_str) {
+                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
+                            let file_path = PathBuf::from(path);
+                            let rules = FormattingRules::default();
+                            let entry = self.document_entry(&uri).await;
+                            let indent_level = entry
+                                .as_ref()
+                                .map(|entry| indent_level_from_position(entry, &position, &rules))
+                                .unwrap_or(0);
+                            let document_directory = document_directory_from_uri(&uri);
+                            let snippet = {
+                                let request = AssetSnippetRequest {
+                                    asset_path: file_path.as_path(),
+                                    document_directory: document_directory.as_deref(),
+                                    formatting: &rules,
+                                    indent_level,
+                                };
+                                build_asset_snippet(&request)
+                            };
+
+                            return Ok(Some(json!({
+                                "text": snippet.text,
+                                "cursorOffset": snippet.cursor_offset,
+                            })));
+                        }
+                    }
+                }
+                Ok(None)
+            }
+            commands::COMMAND_INSERT_VERBATIM => {
+                let uri_str = params.arguments.first().and_then(|v| v.as_str());
+                let pos_val = params.arguments.get(1);
+                let path_val = params.arguments.get(2).and_then(|v| v.as_str());
+
+                if let (Some(uri_str), Some(pos_val), Some(path)) = (uri_str, pos_val, path_val) {
+                    if let Ok(uri) = Url::parse(uri_str) {
+                        if let Ok(position) = serde_json::from_value::<Position>(pos_val.clone()) {
+                            let file_path = PathBuf::from(path);
+                            let rules = FormattingRules::default();
+                            let entry = self.document_entry(&uri).await;
+                            let indent_level = entry
+                                .as_ref()
+                                .map(|entry| indent_level_from_position(entry, &position, &rules))
+                                .unwrap_or(0);
+                            let document_directory = document_directory_from_uri(&uri);
+                            let snippet_result = {
+                                let mut request =
+                                    VerbatimSnippetRequest::new(file_path.as_path(), &rules);
+                                request.document_directory = document_directory.as_deref();
+                                request.indent_level = indent_level;
+                                build_verbatim_snippet(&request)
+                            };
+
+                            match snippet_result {
+                                Ok(snippet) => {
+                                    return Ok(Some(json!({
+                                        "text": snippet.text,
+                                        "cursorOffset": snippet.cursor_offset,
+                                    })));
+                                }
+                                Err(err) => {
+                                    return Err(Error::invalid_params(format!(
+                                        "Failed to insert verbatim block: {err}"
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                }
+                Ok(None)
+            }
+            commands::COMMAND_EXTRACT_TO_INCLUDE => {
+                self.handle_extract_to_include(&params.arguments).await
+            }
+            _ => execute_command(&params.command, &params.arguments),
+        }
+    }
+
+    /// Handler for `lex.extractToInclude`. Args are **positional**:
+    /// `[uri: string, range: lsp.Range, src: string]`.
+    ///
+    /// Returns a `WorkspaceEdit` JSON value the editor applies atomically
+    /// (file creation + selection replacement). All validation failures
+    /// surface as `invalid_params` errors carrying the
+    /// [`ExtractError::message`] string for direct display.
+    async fn handle_extract_to_include(&self, arguments: &[Value]) -> Result<Option<Value>> {
+        let uri_str = arguments
+            .first()
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::invalid_params("Missing 'uri' argument"))?;
+        let range_val = arguments
+            .get(1)
+            .ok_or_else(|| Error::invalid_params("Missing 'range' argument"))?;
+        let src = arguments
+            .get(2)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::invalid_params("Missing 'src' argument"))?;
+
+        let uri = Url::parse(uri_str)
+            .map_err(|_| Error::invalid_params(format!("Invalid uri: {uri_str}")))?;
+        let range: Range = serde_json::from_value(range_val.clone())
+            .map_err(|e| Error::invalid_params(format!("Invalid range: {e}")))?;
+
+        let host_path = uri
+            .to_file_path()
+            .map_err(|_| Error::invalid_params(ExtractError::InvalidHostUri.message()))?;
+        let host_path = absolutize_path(&host_path);
+
+        let entry = self
+            .document_entry(&uri)
+            .await
+            .ok_or_else(|| Error::invalid_params("Document not open in the server"))?;
+
+        let selection_text = slice_text_by_range(&entry.text, range)
+            .ok_or_else(|| Error::invalid_params("Selection range out of bounds"))?;
+
+        let host_indent = range.start.character as usize;
+
+        let cfg = self.config.read().await;
+        let inc_root = inc_root_for(&host_path, &cfg.config);
+        drop(cfg);
+
+        let edit = extract::build_extract_workspace_edit(
+            &uri,
+            &host_path,
+            range,
+            &selection_text,
+            host_indent,
+            src,
+            &inc_root,
+        )
+        .map_err(|e| Error::invalid_params(e.message()))?;
+
+        Ok(Some(
+            serde_json::to_value(edit).map_err(|_| Error::internal_error())?,
+        ))
+    }
+
+    /// Handler for the custom `lex/preparePaste` request (smart paste,
+    /// comms#73). The editor sends the document identity, the range the paste
+    /// replaces, and the raw clipboard text; the server reuses the
+    /// already-parsed buffer state to classify the paste and re-anchor the
+    /// clipboard to the caret's structural context, returning the text to
+    /// splice across the range plus the [`PasteMode`] it applied.
+    ///
+    /// Pure with respect to document state: it reads the parse, computes a
+    /// string, and mutates nothing. When the document is not open in the
+    /// server (no parse to consult), the response echoes the clipboard back in
+    /// `re-anchor` mode — a safe no-op so the editor still completes the paste.
+    pub async fn prepare_paste(&self, params: PreparePasteParams) -> Result<PreparePasteResult> {
+        let Some(entry) = self.document_entry(&params.text_document.uri).await else {
+            // No parsed buffer to consult — hand the clipboard back unchanged
+            // rather than fail; the editor applies it as an ordinary paste.
+            return Ok(PreparePasteResult {
+                text: params.pasted_text,
+                mode: PasteMode::Reanchor,
+            });
+        };
+
+        Ok(prepare_paste_transform(
+            &entry.document,
+            &entry.text,
+            params.range,
+            &params.pasted_text,
+        ))
+    }
+}

--- a/crates/lex-lsp/src/server/config_loading.rs
+++ b/crates/lex-lsp/src/server/config_loading.rs
@@ -15,10 +15,9 @@ use lex_config::{
     CONFIG_FILE_NAME, DIAGNOSTICS_RULES_PATH,
 };
 
-// Re-export the shared path helpers under this module's path so existing
-// `config_loading::{absolutize_path, find_nearest_config_dir}` call sites keep
-// working; the implementations now live in `lex-config` (deduplicated from the
-// copies in `lex-cli`).
+// Re-export the shared `absolutize_path` under this module's path so existing
+// `config_loading::absolutize_path` call sites keep working; the implementation
+// now lives in `lex-config` (deduplicated from the copies in `lex-cli`).
 pub(crate) use lex_config::absolutize_path;
 
 /// Load a [`LoadedLexConfig`] via clapfig, searching from an optional

--- a/crates/lex-lsp/src/server/config_loading.rs
+++ b/crates/lex-lsp/src/server/config_loading.rs
@@ -11,9 +11,15 @@ use std::path::{Path, PathBuf};
 
 use clapfig::{Boundary, Clapfig, SearchPath};
 use lex_config::{
-    collect_extension_diagnostic_rules, LexConfig, LoadedLexConfig, CONFIG_FILE_NAME,
-    DIAGNOSTICS_RULES_PATH,
+    collect_extension_diagnostic_rules, resolve_include_root, LexConfig, LoadedLexConfig,
+    CONFIG_FILE_NAME, DIAGNOSTICS_RULES_PATH,
 };
+
+// Re-export the shared path helpers under this module's path so existing
+// `config_loading::{absolutize_path, find_nearest_config_dir}` call sites keep
+// working; the implementations now live in `lex-config` (deduplicated from the
+// copies in `lex-cli`).
+pub(crate) use lex_config::absolutize_path;
 
 /// Load a [`LoadedLexConfig`] via clapfig, searching from an optional
 /// workspace root. The wrapper carries both the typed [`LexConfig`] and
@@ -63,57 +69,9 @@ pub(crate) fn best_matching_root(roots: &[PathBuf], document_path: &Path) -> Opt
         .cloned()
 }
 
-/// Compute the include-resolution root for an entry document.
-///
-/// Order:
-/// 1. `[includes].root` from `LexConfig` if set.
-/// 2. Directory of the nearest `.lex.toml` walking upward from the
-///    entry document's directory.
-/// 3. The entry document's own directory.
-///
-/// Always returns an absolute, lexically-normalized path so the
-/// resolver's root-escape prefix check is sound.
+/// Compute the include-resolution root for an entry document from the LSP's
+/// [`LexConfig`]. Thin adapter over [`lex_config::resolve_include_root`] that
+/// threads `[includes].root` through as the override.
 pub(crate) fn inc_root_for(entry_path: &Path, cfg: &LexConfig) -> PathBuf {
-    let raw = if let Some(root) = cfg.includes.root.as_ref() {
-        PathBuf::from(root)
-    } else {
-        let start = entry_path
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| PathBuf::from("."));
-        find_nearest_config_dir(&start).unwrap_or(start)
-    };
-    absolutize_path(&raw)
-}
-
-/// Walk upward from `start` looking for a directory that contains
-/// `.lex.toml`. Returns that directory, or `None` if we hit the
-/// filesystem root without finding one.
-pub(crate) fn find_nearest_config_dir(start: &Path) -> Option<PathBuf> {
-    let mut cur: PathBuf = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    loop {
-        if cur.join(CONFIG_FILE_NAME).is_file() {
-            return Some(cur);
-        }
-        if !cur.pop() {
-            return None;
-        }
-    }
-}
-
-/// Best-effort absolutize: try `Path::canonicalize` first (handles
-/// symlinks + resolves `..` against the real filesystem), falling back
-/// to `current_dir().join(path)` if the path doesn't exist on disk.
-/// Always returns an absolute path; `ResolveConfig::root` requires one
-/// for the root-escape prefix check to be sound.
-pub(crate) fn absolutize_path(p: &Path) -> PathBuf {
-    if let Ok(canon) = p.canonicalize() {
-        return canon;
-    }
-    if p.is_absolute() {
-        return p.to_path_buf();
-    }
-    std::env::current_dir()
-        .map(|cwd| cwd.join(p))
-        .unwrap_or_else(|_| p.to_path_buf())
+    resolve_include_root(entry_path, cfg.includes.root.as_deref().map(Path::new))
 }

--- a/crates/lex-lsp/src/server/convert.rs
+++ b/crates/lex-lsp/src/server/convert.rs
@@ -394,22 +394,14 @@ pub(crate) fn slice_text_by_range(text: &str, range: Range) -> Option<String> {
         if i < start_line || i > end_line {
             continue;
         }
-        let line_bytes = line.as_bytes();
         let from = if i == start_line { start_col } else { 0 };
-        let to = if i == end_line {
-            end_col
-        } else {
-            line_bytes.len()
-        };
-        if from > line_bytes.len() || to > line_bytes.len() {
-            return None;
-        }
-        // Reject ranges that cut a UTF-8 character in half rather than
-        // returning a string with replacement characters.
-        if !line.is_char_boundary(from) || !line.is_char_boundary(to) {
-            return None;
-        }
-        out.push_str(&line[from..to]);
+        let to = if i == end_line { end_col } else { line.len() };
+        // `str::get` returns `None` for out-of-bounds indices *and* for
+        // offsets that fall inside a multi-byte char, so it folds the
+        // bounds check and the UTF-8-boundary check into one — and never
+        // panics (unlike `&line[from..to]`).
+        let slice = line.get(from..to)?;
+        out.push_str(slice);
     }
     Some(out)
 }

--- a/crates/lex-lsp/src/server/extension_boot.rs
+++ b/crates/lex-lsp/src/server/extension_boot.rs
@@ -1,0 +1,164 @@
+//! Lazy boot of the extension registry for an LSP session.
+//!
+//! The registry is built on first extension-aware request and cached for the
+//! life of the workspace. Boot does blocking filesystem IO (schema load, trust
+//! store) and may spawn subprocess handlers, so it runs on the blocking pool;
+//! a mutex serializes concurrent first-requests into a single boot.
+
+use std::sync::Arc;
+
+use lex_config::LabelsConfig;
+use tower_lsp::lsp_types::MessageType;
+
+use crate::extension_dispatch::LspExtensionState;
+use crate::server::{LexLanguageServer, LspClient};
+
+impl<C> LexLanguageServer<C>
+where
+    C: LspClient,
+{
+    /// Lazily boot the extension registry against the current workspace
+    /// root + config. Idempotent: once built, returns the cached state.
+    /// Returns `None` when no workspace is set (e.g. single-file mode);
+    /// extension dispatch is a no-op without a workspace anchor.
+    ///
+    /// Concurrency: the first request to land on a fresh workspace
+    /// takes the `extension_init` mutex and runs the boot; every
+    /// other concurrent request blocks on the mutex, then re-checks
+    /// the cache and reuses what the first one produced. Without
+    /// this serialization, an open-file event that fires several
+    /// providers at once (hover, completion, semantic tokens, folding,
+    /// document-symbols, …) would launch N parallel boots, with N
+    /// concurrent reads of the schema directory, N concurrent
+    /// subprocess spawns, and N `lex/trustRequest` prompts to the
+    /// editor. The mutex keeps the observable side effects to one
+    /// prompt and one set of spawns.
+    pub(crate) async fn extension_state(&self) -> Option<Arc<LspExtensionState>> {
+        // Fast path: already booted, no lock needed.
+        if let Some(s) = self.extension.read().await.clone() {
+            return Some(s);
+        }
+
+        // Slow path: serialize boot. Hold the init lock for the whole
+        // boot so the second-arriving request waits for the first.
+        let _guard = self.extension_init.lock().await;
+
+        // Re-check after acquiring the init lock — another task may
+        // have completed boot while we were waiting on the mutex.
+        if let Some(s) = self.extension.read().await.clone() {
+            return Some(s);
+        }
+
+        let workspace_root = {
+            let roots = self.workspace_roots.read().await;
+            roots.first().cloned()?
+        };
+        let labels_config = LabelsConfig {
+            namespaces: self.config.read().await.config.labels.clone(),
+        };
+
+        // boot_registry does synchronous filesystem IO (schema load,
+        // trust store open) and may attempt to spawn subprocess
+        // handlers — a few hundred milliseconds in the worst case. Run
+        // it on the blocking thread pool so the tokio runtime keeps
+        // serving other LSP requests while boot runs.
+        //
+        // The trust prompt handler bridges sync→async via
+        // `Handle::block_on` — safe because we're on a blocking-pool
+        // thread, not a runtime worker.
+        let workspace_root_owned = workspace_root.clone();
+        let trust_requester = std::sync::Arc::new(self.client.clone());
+        let runtime_handle = tokio::runtime::Handle::current();
+        let outcome = match tokio::task::spawn_blocking(move || {
+            lex_fmt::boot_registry(lex_fmt::ExtensionSetup {
+                workspace_root: workspace_root_owned.as_path(),
+                labels_config: &labels_config,
+                // The LSP server has no `--ext-schema` flag; only
+                // `[labels]` entries from `lex.toml` register schemas
+                // in this surface.
+                ext_schemas: &[],
+                // `enable_handlers` is irrelevant on the Lsp surface —
+                // that flag is the CLI shortcut for the trust-prompt
+                // path. The LSP consults the trust store + prompt
+                // handler directly.
+                enable_handlers: false,
+                surface_override: Some(lex_extension_host::Surface::LspSession),
+                // Forwards `lex/trustRequest` to the editor and awaits
+                // the user's decision. Already-pinned decisions in
+                // `<workspace>/.lex/trust.json` short-circuit before
+                // the prompt fires.
+                trust_prompt: Box::new(crate::trust_prompt::LspPromptHandler::new(
+                    trust_requester,
+                    runtime_handle,
+                )),
+                // Reports `lexd-lsp`'s version to subprocess handlers
+                // in their initialize handshake — what handlers expect
+                // to see, not the `lex-fmt` boot crate's version.
+                host_version: env!("CARGO_PKG_VERSION"),
+            })
+        })
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(_) => {
+                // Blocking task panicked or was cancelled. Skip
+                // extension boot for this session; the next request
+                // will retry.
+                return None;
+            }
+        };
+
+        // Surface boot diagnostics to the editor before we cache the
+        // state. Per-namespace failures (resolver errors, denied
+        // subprocess handlers, schema load problems) are stored on
+        // the outcome but the user has no way to see them otherwise
+        // — pre-validation diagnostics are attached to documents,
+        // but boot diagnostics aren't. `window/showMessage` is the
+        // right surface for one-shot status that's not tied to a
+        // specific document range.
+        for diag in &outcome.diagnostics {
+            let prefix = match &diag.namespace {
+                Some(ns) => format!("lex extension `{ns}`: "),
+                None => "lex extensions: ".to_string(),
+            };
+            self.client
+                .show_message(MessageType::WARNING, format!("{prefix}{}", diag.message))
+                .await;
+        }
+
+        // Cross-check `[diagnostics.rules]` extension entries against the
+        // freshly-booted registry. A `<namespace>.<code>` rule whose
+        // namespace is registered but doesn't declare the code is a dead
+        // letter — it retunes nothing. Surface each as a warning so the
+        // misspelling is visible; like boot diagnostics, it's session
+        // status with no document range to attach to. Unregistered
+        // namespaces pass silently (the user may install the extension
+        // later), so this never fires for staged-ahead rules.
+        // Collect findings under the lock, then drop it before awaiting
+        // any `show_message` — holding the config read lock across the
+        // network await could starve a concurrent config write.
+        let rule_findings = {
+            let cfg = self.config.read().await;
+            lex_fmt::validate_extension_diagnostic_rules(
+                &cfg.extension_diagnostic_rules,
+                &outcome.registry,
+            )
+        };
+        for finding in rule_findings {
+            self.client
+                .show_message(MessageType::WARNING, finding.message)
+                .await;
+        }
+
+        let state = Arc::new(LspExtensionState::from(outcome));
+        *self.extension.write().await = Some(state.clone());
+        Some(state)
+    }
+
+    /// Discard the cached extension registry. Called when workspace
+    /// folders change so the next request picks up the new root +
+    /// config.
+    pub(crate) async fn invalidate_extension_state(&self) {
+        *self.extension.write().await = None;
+    }
+}

--- a/crates/lex-lsp/src/server/includes.rs
+++ b/crates/lex-lsp/src/server/includes.rs
@@ -1,0 +1,191 @@
+//! `lex.include` resolution for the language server.
+//!
+//! Drives include resolution for *diagnostic* purposes (the server always
+//! stores the unresolved host-buffer parse — see [`Self::resolve_and_upsert`])
+//! and powers goto-definition / hover previews for include sites.
+
+use lex_core::lex::ast::{Document, Position as AstPosition};
+use lex_core::lex::builtins as lex_builtins;
+use lex_core::lex::includes::{FsLoader, ResolveConfig};
+use tower_lsp::lsp_types::{
+    Diagnostic, Hover, HoverContents, Location, MarkupContent, MarkupKind, Url,
+};
+
+use super::{
+    absolutize_path, head_range, inc_root_for, include_error_to_diagnostic,
+    include_preview_markdown, registry_setup_diagnostic, to_lsp_range, LexLanguageServer,
+    LspClient,
+};
+
+impl<C> LexLanguageServer<C>
+where
+    C: LspClient,
+{
+    /// Drives include resolution (when the URI is a file path) for
+    /// *diagnostic* purposes only. Always stores the **unresolved**
+    /// parse under `uri`; that's what every LSP feature
+    /// (semantic tokens, hover, goto-definition, document symbols) sees.
+    ///
+    /// Why not store the merged tree: nodes spliced in from included
+    /// files carry Ranges in the *included file's* coordinate space —
+    /// `range.start.line == 0` means "line 0 of chapter.lex", not
+    /// "line 0 of the host buffer." Serving those ranges back as if
+    /// they were positions in the host URI's text would highlight the
+    /// wrong tokens, send goto-definition to the wrong spot, etc. Until
+    /// we have an origin-path-aware location-mapping layer (PR 9+),
+    /// the safe behavior is to use the merged tree only to decide
+    /// whether resolution succeeded, and emit diagnostics if it didn't.
+    ///
+    /// Returns include-related diagnostics: empty on success or when
+    /// the document doesn't use includes at all; one diagnostic
+    /// pointing at the include site (or document head as fallback) on
+    /// resolver failure.
+    pub(crate) async fn resolve_and_upsert(&self, uri: &Url, text: &str) -> Vec<Diagnostic> {
+        // Standard parse goes in regardless — this is the tree every
+        // LSP feature works against.
+        self.documents.upsert(uri.clone(), text.to_string()).await;
+
+        // Fast path: no `lex.include` literal in source, nothing to
+        // resolve, nothing to diagnose. Avoids per-keystroke resolver
+        // work for documents that don't use the feature, and prevents
+        // the resolver's `ParseFailed` from firing as a spurious
+        // include diagnostic for ordinary parse errors.
+        if !text.contains("lex.include") {
+            return Vec::new();
+        }
+
+        let path = match uri.to_file_path() {
+            Ok(p) => p,
+            // Untitled / non-file URIs (e.g. `untitled:Untitled-1`)
+            // can't anchor relative include paths.
+            Err(_) => return Vec::new(),
+        };
+
+        // Canonicalize the entry path so it lives in the same absolute-
+        // path space as `inc_root` (`absolutize_path` calls
+        // `Path::canonicalize` which follows symlinks — important on
+        // macOS where /var → /private/var). Without this, host_dir
+        // (path.parent()) and inc_root differ by symlink resolution and
+        // every lookup fails the root-escape prefix check.
+        let path = absolutize_path(&path);
+
+        let cfg = self.config.read().await;
+        let inc_root = inc_root_for(&path, &cfg.config);
+        let max_depth = cfg.config.includes.max_depth;
+        let max_total_includes = cfg.config.includes.max_total_includes;
+        let max_file_size = cfg.config.includes.max_file_size;
+        drop(cfg);
+
+        let resolve_config = ResolveConfig {
+            root: inc_root,
+            max_depth,
+            max_total_includes,
+        };
+
+        match lex_builtins::resolve_buffer(text, Some(path), &resolve_config, max_file_size) {
+            // Resolution succeeded. We *don't* store the merged tree —
+            // see fn-level docstring. The resolver was run only to
+            // surface errors; the tree itself is dropped.
+            Ok(_doc) => Vec::new(),
+            Err(lex_builtins::ResolveBufferError::Registry(e)) => {
+                vec![registry_setup_diagnostic(&e.to_string())]
+            }
+            Err(lex_builtins::ResolveBufferError::Resolve(err)) => {
+                vec![include_error_to_diagnostic(&err)]
+            }
+        }
+    }
+
+    /// Resolve a `lex.include` annotation at `position` to a Location
+    /// pointing at the target file. Returns `None` when the cursor isn't
+    /// on a `lex.include`, when the URI has no on-disk anchor (untitled
+    /// buffers), when the include has no `src=` parameter, when the
+    /// path resolves outside the include root, **or when the target
+    /// file does not exist on disk**. The last guard avoids navigating
+    /// the editor to a non-existent path — the user gets the
+    /// `include-not-found` diagnostic from PR 8 instead, which surfaces
+    /// the underlying problem clearly. The Location range is the file
+    /// head (line 0, column 0) — cross-file goto-def lands the user at
+    /// the top of the target.
+    pub(crate) async fn goto_for_include(
+        &self,
+        uri: &Url,
+        document: &Document,
+        position: AstPosition,
+    ) -> Option<Location> {
+        let annotation = lex_analysis::utils::find_annotation_at_position(document, position)?;
+        if !annotation.is_include() {
+            return None;
+        }
+        let src = annotation.include_src()?;
+
+        let host_path = absolutize_path(&uri.to_file_path().ok()?);
+        let cfg = self.config.read().await;
+        let inc_root = inc_root_for(&host_path, &cfg.config);
+        drop(cfg);
+
+        let target = lex_core::lex::includes::resolve_file_reference(
+            &src,
+            Some(host_path.as_path()),
+            inc_root.as_path(),
+        )
+        .ok()?;
+        // Existence check: don't send the editor to nowhere.
+        // `resolve_file_reference` is filesystem-free (lexical only),
+        // so the path it returns may not exist. The PR 8 diagnostic
+        // already surfaces missing-target errors; goto-def returning
+        // None here lets the editor render its native "no definition
+        // found" UX instead of opening a phantom buffer.
+        if !target.is_file() {
+            return None;
+        }
+        let target_uri = Url::from_file_path(&target).ok()?;
+        Some(Location {
+            uri: target_uri,
+            range: head_range(),
+        })
+    }
+
+    /// Build a hover preview for a `lex.include` annotation at `position`.
+    /// The preview shows the target file's first two non-blank lines
+    /// (no AST parsing — just the raw text) — enough to confirm the
+    /// include points where the author thinks. Returns `None` when the
+    /// cursor isn't on a `lex.include`, the URI has no on-disk anchor,
+    /// or the target can't be loaded.
+    pub(crate) async fn hover_for_include(
+        &self,
+        uri: &Url,
+        document: &Document,
+        position: AstPosition,
+    ) -> Option<Hover> {
+        let annotation = lex_analysis::utils::find_annotation_at_position(document, position)?;
+        if !annotation.is_include() {
+            return None;
+        }
+        let src = annotation.include_src()?;
+
+        let host_path = absolutize_path(&uri.to_file_path().ok()?);
+        let cfg = self.config.read().await;
+        let inc_root = inc_root_for(&host_path, &cfg.config);
+        drop(cfg);
+
+        let target = lex_core::lex::includes::resolve_file_reference(
+            &src,
+            Some(host_path.as_path()),
+            inc_root.as_path(),
+        )
+        .ok()?;
+
+        let loader = FsLoader::new(inc_root.clone());
+        let loaded = lex_core::lex::includes::Loader::load(&loader, target.as_path()).ok()?;
+        let preview = include_preview_markdown(&src, &target, &loaded.source);
+
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: preview,
+            }),
+            range: Some(to_lsp_range(annotation.header_location())),
+        })
+    }
+}

--- a/crates/lex-lsp/src/server/tests.rs
+++ b/crates/lex-lsp/src/server/tests.rs
@@ -2,26 +2,23 @@
 //!
 //! Split out of `server.rs` as a sibling module file (declared there as
 //! `#[cfg(test)] mod tests;`). All setup routes through a small set of
-//! harness types — [`NoopClient`] / [`MockFeatureProvider`] for the
-//! feature-dispatch tests, and [`CapturingClient`] / [`open_in_tempdir`]
-//! for the include-resolution integration tests that exercise the
-//! `FsLoader` end-to-end against a real `TempDir`.
+//! harness types — [`NoopClient`] for the lightweight router/smoke tests,
+//! and [`CapturingClient`] / [`open_in_tempdir`] for the include-resolution
+//! integration tests that exercise the `FsLoader` end-to-end against a real
+//! `TempDir`.
 
 use super::*;
-use crate::features::semantic_tokens::LexSemanticTokenKind;
+use crate::features::semantic_tokens::{LexSemanticToken, LexSemanticTokenKind};
 use lex_analysis::test_support::sample_source;
-use lex_core::lex::ast::links::LinkType;
+use lex_core::lex::ast::{Position as AstPosition, Range as AstRange};
 use serde::Deserialize;
 use std::fs;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use tempfile::tempdir;
 use tower_lsp::lsp_types::{
-    CompletionItemKind, DidOpenTextDocumentParams, DocumentFormattingParams, DocumentLinkParams,
-    DocumentRangeFormattingParams, DocumentSymbolParams, FoldingRangeKind, FoldingRangeParams,
-    FormattingOptions, FormattingProperty, GotoDefinitionParams, HoverParams, Position, Range,
-    ReferenceContext, ReferenceParams, SemanticTokensParams, SymbolKind, TextDocumentIdentifier,
-    TextDocumentItem, TextDocumentPositionParams,
+    DidOpenTextDocumentParams, DocumentSymbolParams, FormattingOptions, FormattingProperty,
+    GotoDefinitionParams, HoverParams, Position, Range, SemanticTokensParams,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
 };
 use tower_lsp::LanguageServer;
 
@@ -45,148 +42,6 @@ impl crate::trust_prompt::LspTrustRequester for NoopClient {
             decision: "denied".into(),
             reason: Some("test client".into()),
         })
-    }
-}
-
-#[derive(Default)]
-struct MockFeatureProvider {
-    semantic_tokens_called: AtomicUsize,
-    document_symbols_called: AtomicUsize,
-    hover_called: AtomicUsize,
-    folding_called: AtomicUsize,
-    last_hover_position: Mutex<Option<AstPosition>>,
-    definition_called: AtomicUsize,
-    references_called: AtomicUsize,
-    document_links_called: AtomicUsize,
-    last_references_include: Mutex<Option<bool>>,
-    formatting_called: AtomicUsize,
-    range_formatting_called: AtomicUsize,
-    completion_called: AtomicUsize,
-    execute_command_called: AtomicUsize,
-}
-
-impl FeatureProvider for MockFeatureProvider {
-    fn semantic_tokens(&self, _: &Document) -> Vec<LexSemanticToken> {
-        self.semantic_tokens_called.fetch_add(1, Ordering::SeqCst);
-        vec![LexSemanticToken {
-            kind: LexSemanticTokenKind::DocumentTitle,
-            range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
-        }]
-    }
-
-    fn document_symbols(&self, _: &Document) -> Vec<LexDocumentSymbol> {
-        self.document_symbols_called.fetch_add(1, Ordering::SeqCst);
-        vec![LexDocumentSymbol {
-            name: "symbol".into(),
-            detail: None,
-            kind: SymbolKind::FILE,
-            range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
-            selection_range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
-            children: Vec::new(),
-        }]
-    }
-
-    fn folding_ranges(&self, _: &Document) -> Vec<LexFoldingRange> {
-        self.folding_called.fetch_add(1, Ordering::SeqCst);
-        vec![LexFoldingRange {
-            start_line: 0,
-            start_character: Some(0),
-            end_line: 1,
-            end_character: Some(0),
-            kind: Some(FoldingRangeKind::Region),
-        }]
-    }
-
-    fn hover(&self, _: &Document, position: AstPosition) -> Option<HoverResult> {
-        self.hover_called.fetch_add(1, Ordering::SeqCst);
-        *self.last_hover_position.lock().unwrap() = Some(position);
-        Some(HoverResult {
-            range: AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
-            contents: "hover".into(),
-        })
-    }
-
-    fn goto_definition(&self, _: &Document, _: AstPosition) -> Vec<AstRange> {
-        self.definition_called.fetch_add(1, Ordering::SeqCst);
-        vec![AstRange::new(
-            0..5,
-            AstPosition::new(0, 0),
-            AstPosition::new(0, 5),
-        )]
-    }
-
-    fn references(&self, _: &Document, _: AstPosition, include_declaration: bool) -> Vec<AstRange> {
-        self.references_called.fetch_add(1, Ordering::SeqCst);
-        *self.last_references_include.lock().unwrap() = Some(include_declaration);
-        vec![AstRange::new(
-            0..5,
-            AstPosition::new(0, 0),
-            AstPosition::new(0, 5),
-        )]
-    }
-
-    fn document_links(&self, _: &Document) -> Vec<AstDocumentLink> {
-        self.document_links_called.fetch_add(1, Ordering::SeqCst);
-        vec![AstDocumentLink::new(
-            AstRange::new(0..5, AstPosition::new(0, 0), AstPosition::new(0, 5)),
-            "https://example.com".to_string(),
-            LinkType::Url,
-        )]
-    }
-
-    fn format_document(
-        &self,
-        _: &Document,
-        _: &str,
-        _: Option<FormattingRules>,
-    ) -> Vec<TextEditSpan> {
-        self.formatting_called.fetch_add(1, Ordering::SeqCst);
-        vec![TextEditSpan {
-            start: 0,
-            end: 0,
-            new_text: "formatted".into(),
-        }]
-    }
-
-    fn format_range(
-        &self,
-        _: &Document,
-        _: &str,
-        _: FormattingLineRange,
-        _: Option<FormattingRules>,
-    ) -> Vec<TextEditSpan> {
-        self.range_formatting_called.fetch_add(1, Ordering::SeqCst);
-        vec![TextEditSpan {
-            start: 0,
-            end: 0,
-            new_text: "range".into(),
-        }]
-    }
-
-    fn completion(
-        &self,
-        _: &Document,
-        _: AstPosition,
-        _: Option<&str>,
-        _: Option<&CompletionWorkspace>,
-        _: Option<&str>,
-    ) -> Vec<CompletionCandidate> {
-        self.completion_called.fetch_add(1, Ordering::SeqCst);
-        vec![CompletionCandidate {
-            label: "completion".into(),
-            detail: None,
-            kind: CompletionItemKind::TEXT,
-            insert_text: None,
-        }]
-    }
-
-    fn execute_command(&self, command: &str, _: &[Value]) -> Result<Option<Value>> {
-        self.execute_command_called.fetch_add(1, Ordering::SeqCst);
-        if command == "test.command" {
-            Ok(Some(Value::String("executed".into())))
-        } else {
-            Ok(None)
-        }
     }
 }
 
@@ -224,7 +79,7 @@ fn range_for_snippet(snippet: &str) -> AstRange {
     AstRange::new(start..end, start_pos, end_pos)
 }
 
-async fn open_sample_document(server: &LexLanguageServer<NoopClient, MockFeatureProvider>) {
+async fn open_sample_document(server: &LexLanguageServer<NoopClient>) {
     let uri = sample_uri();
     server
         .did_open(DidOpenTextDocumentParams {
@@ -236,6 +91,73 @@ async fn open_sample_document(server: &LexLanguageServer<NoopClient, MockFeature
             },
         })
         .await;
+}
+
+// The router methods are thin: look up the document, call the feature
+// free-function (densely tested in `lex-analysis` / `lex-lsp-core`), convert,
+// return. These smoke tests exercise the wiring + conversion over a real parse
+// of the sample document; per-feature behavior lives in the feature crates.
+
+#[tokio::test]
+async fn semantic_tokens_full_over_sample_returns_tokens() {
+    let server = LexLanguageServer::new(NoopClient);
+    open_sample_document(&server).await;
+
+    let result = server
+        .semantic_tokens_full(SemanticTokensParams {
+            text_document: TextDocumentIdentifier { uri: sample_uri() },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let data_len = match result {
+        SemanticTokensResult::Tokens(tokens) => tokens.data.len(),
+        SemanticTokensResult::Partial(partial) => partial.data.len(),
+    };
+    assert!(data_len > 0, "sample document should yield semantic tokens");
+}
+
+#[tokio::test]
+async fn document_symbol_over_sample_returns_outline() {
+    let server = LexLanguageServer::new(NoopClient);
+    open_sample_document(&server).await;
+
+    let response = server
+        .document_symbol(DocumentSymbolParams {
+            text_document: TextDocumentIdentifier { uri: sample_uri() },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    match response {
+        DocumentSymbolResponse::Nested(symbols) => assert!(!symbols.is_empty()),
+        _ => panic!("unexpected symbol response"),
+    }
+}
+
+#[tokio::test]
+async fn execute_command_unknown_is_invalid_request() {
+    let server = LexLanguageServer::new(NoopClient);
+
+    // Commands not matched by the router fall through to
+    // `features::commands::execute_command`, whose default arm rejects
+    // unknown commands with `invalid_request`.
+    let err = server
+        .execute_command(ExecuteCommandParams {
+            command: "does.not.exist".into(),
+            arguments: vec![],
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, tower_lsp::jsonrpc::ErrorCode::InvalidRequest);
 }
 
 #[test]
@@ -285,124 +207,6 @@ fn encode_semantic_tokens_splits_multi_line_ranges() {
     assert_eq!(actual_len, expected_len);
 }
 
-#[tokio::test]
-async fn semantic_tokens_call_feature_layer() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let result = server
-        .semantic_tokens_full(SemanticTokensParams {
-            text_document: TextDocumentIdentifier { uri: sample_uri() },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.semantic_tokens_called.load(Ordering::SeqCst), 1);
-    let data_len = match result {
-        SemanticTokensResult::Tokens(tokens) => tokens.data.len(),
-        SemanticTokensResult::Partial(partial) => partial.data.len(),
-    };
-    assert!(data_len > 0);
-}
-
-#[tokio::test]
-async fn document_symbols_call_feature_layer() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let response = server
-        .document_symbol(DocumentSymbolParams {
-            text_document: TextDocumentIdentifier { uri: sample_uri() },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    match response {
-        DocumentSymbolResponse::Nested(symbols) => assert!(!symbols.is_empty()),
-        _ => panic!("unexpected symbol response"),
-    }
-    assert_eq!(provider.document_symbols_called.load(Ordering::SeqCst), 1);
-}
-
-#[tokio::test]
-async fn hover_uses_feature_provider_position() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let hover = server
-        .hover(HoverParams {
-            text_document_position_params: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri: sample_uri() },
-                position: Position::new(0, 0),
-            },
-            work_done_progress_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert!(matches!(hover.contents, HoverContents::Markup(_)));
-    assert_eq!(provider.hover_called.load(Ordering::SeqCst), 1);
-    let stored = provider.last_hover_position.lock().unwrap().unwrap();
-    assert_eq!(stored.line, 0);
-    assert_eq!(stored.column, 0);
-}
-
-#[tokio::test]
-async fn folding_range_uses_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let ranges = server
-        .folding_range(FoldingRangeParams {
-            text_document: TextDocumentIdentifier { uri: sample_uri() },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.folding_called.load(Ordering::SeqCst), 1);
-    assert_eq!(ranges.len(), 1);
-}
-
-#[tokio::test]
-async fn goto_definition_uses_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let response = server
-        .goto_definition(GotoDefinitionParams {
-            text_document_position_params: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri: sample_uri() },
-                position: Position::new(0, 0),
-            },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.definition_called.load(Ordering::SeqCst), 1);
-    match response {
-        GotoDefinitionResponse::Array(locations) => assert_eq!(locations.len(), 1),
-        _ => panic!("unexpected goto definition response"),
-    }
-}
-
 #[derive(Deserialize)]
 struct SnippetResponse {
     text: String,
@@ -412,8 +216,7 @@ struct SnippetResponse {
 
 #[tokio::test]
 async fn execute_insert_commands() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
+    let server = LexLanguageServer::new(NoopClient);
     open_sample_document(&server).await;
 
     let temp_dir = tempdir().unwrap();
@@ -455,8 +258,7 @@ async fn execute_insert_commands() {
 
 #[tokio::test]
 async fn execute_annotation_navigation_commands() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
+    let server = LexLanguageServer::new(NoopClient);
     let uri = Url::parse("file:///annotations.lex").unwrap();
     let text = ":: note ::\n    First\n::\n\n:: note ::\n    Second\n::\n";
     server
@@ -522,109 +324,8 @@ async fn execute_annotation_navigation_commands() {
 }
 
 #[tokio::test]
-async fn references_use_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let result = server
-        .references(ReferenceParams {
-            text_document_position: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri: sample_uri() },
-                position: Position::new(0, 0),
-            },
-            context: ReferenceContext {
-                include_declaration: true,
-            },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.references_called.load(Ordering::SeqCst), 1);
-    assert_eq!(result.len(), 1);
-    assert_eq!(
-        *provider.last_references_include.lock().unwrap(),
-        Some(true)
-    );
-}
-
-#[tokio::test]
-async fn document_links_use_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let links = server
-        .document_link(DocumentLinkParams {
-            text_document: TextDocumentIdentifier { uri: sample_uri() },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.document_links_called.load(Ordering::SeqCst), 1);
-    assert_eq!(links.len(), 1);
-    assert_eq!(
-        links[0].target.as_ref().map(|url| url.as_str()),
-        Some("https://example.com/")
-    );
-}
-
-#[tokio::test]
-async fn formatting_uses_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let edits = server
-        .formatting(DocumentFormattingParams {
-            text_document: TextDocumentIdentifier { uri: sample_uri() },
-            options: FormattingOptions::default(),
-            work_done_progress_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.formatting_called.load(Ordering::SeqCst), 1);
-    assert_eq!(edits.len(), 1);
-    assert_eq!(edits[0].new_text, "formatted");
-}
-
-#[tokio::test]
-async fn range_formatting_uses_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-    open_sample_document(&server).await;
-
-    let edits = server
-        .range_formatting(DocumentRangeFormattingParams {
-            text_document: TextDocumentIdentifier { uri: sample_uri() },
-            range: Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, 0),
-            },
-            options: FormattingOptions::default(),
-            work_done_progress_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.range_formatting_called.load(Ordering::SeqCst), 1);
-    assert_eq!(edits.len(), 1);
-    assert_eq!(edits[0].new_text, "range");
-}
-
-#[tokio::test]
 async fn semantic_tokens_returns_none_when_document_missing() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     let result = server
         .semantic_tokens_full(SemanticTokensParams {
@@ -639,28 +340,8 @@ async fn semantic_tokens_returns_none_when_document_missing() {
 }
 
 #[tokio::test]
-async fn execute_command_uses_feature_provider() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider.clone());
-
-    let result = server
-        .execute_command(ExecuteCommandParams {
-            command: "test.command".into(),
-            arguments: vec![],
-            work_done_progress_params: Default::default(),
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(provider.execute_command_called.load(Ordering::SeqCst), 1);
-    assert_eq!(result, Value::String("executed".into()));
-}
-
-#[tokio::test]
 async fn hover_returns_none_without_document_entry() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     let hover = server
         .hover(HoverParams {
@@ -734,8 +415,7 @@ fn apply_formatting_overrides_applies_lex_properties() {
 
 #[tokio::test]
 async fn did_change_workspace_folders_adds_roots() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     // Start with one root via initialize
     server
@@ -768,8 +448,7 @@ async fn did_change_workspace_folders_adds_roots() {
 
 #[tokio::test]
 async fn did_change_workspace_folders_removes_roots() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     server
         .initialize(InitializeParams {
@@ -802,8 +481,7 @@ async fn did_change_workspace_folders_removes_roots() {
 
 #[tokio::test]
 async fn did_change_workspace_folders_does_not_duplicate() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     server
         .initialize(InitializeParams {
@@ -831,8 +509,7 @@ async fn did_change_workspace_folders_does_not_duplicate() {
 
 #[tokio::test]
 async fn initialize_advertises_workspace_folder_support() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     let result = server
         .initialize(InitializeParams::default())
@@ -909,7 +586,7 @@ async fn open_in_tempdir(
     files: &[(&str, &str)],
     entry: &str,
 ) -> (
-    LexLanguageServer<CapturingClient, DefaultFeatureProvider>,
+    LexLanguageServer<CapturingClient>,
     CapturingClient,
     Url,
     tempfile::TempDir,
@@ -927,8 +604,7 @@ async fn open_in_tempdir(
     let uri = Url::from_file_path(&entry_path).expect("file uri");
 
     let client = CapturingClient::default();
-    let server =
-        LexLanguageServer::with_features(client.clone(), Arc::new(DefaultFeatureProvider::new()));
+    let server = LexLanguageServer::new(client.clone());
 
     server
         .did_open(DidOpenTextDocumentParams {
@@ -1367,8 +1043,7 @@ async fn extract_to_include_surfaces_validation_errors_as_invalid_params() {
 
 #[tokio::test]
 async fn extract_to_include_capability_advertises_command() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
     let init = server
         .initialize(InitializeParams::default())
         .await
@@ -1415,8 +1090,7 @@ async fn includes_untitled_uri_skips_resolution_without_error() {
     // resolution. The server must handle these gracefully — no
     // panics, no spurious include diagnostics.
     let client = CapturingClient::default();
-    let server =
-        LexLanguageServer::with_features(client.clone(), Arc::new(DefaultFeatureProvider::new()));
+    let server = LexLanguageServer::new(client.clone());
     let uri: Url = "untitled:Untitled-1".parse().unwrap();
     server
         .did_open(DidOpenTextDocumentParams {
@@ -1450,8 +1124,7 @@ async fn includes_untitled_uri_skips_resolution_without_error() {
 
 #[tokio::test]
 async fn initialize_advertises_prepare_paste_capability() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
 
     let result = server
         .initialize(InitializeParams::default())
@@ -1467,8 +1140,7 @@ async fn initialize_advertises_prepare_paste_capability() {
 
 #[tokio::test]
 async fn prepare_paste_reanchors_against_open_buffer() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
     let uri = Url::from_file_path("/tmp/paste.lex").unwrap();
 
     server
@@ -1502,8 +1174,7 @@ async fn prepare_paste_reanchors_against_open_buffer() {
 
 #[tokio::test]
 async fn prepare_paste_passes_through_verbatim() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
     let uri = Url::from_file_path("/tmp/verb.lex").unwrap();
 
     server
@@ -1536,8 +1207,7 @@ async fn prepare_paste_passes_through_verbatim() {
 
 #[tokio::test]
 async fn prepare_paste_unopened_buffer_echoes_clipboard() {
-    let provider = Arc::new(MockFeatureProvider::default());
-    let server = LexLanguageServer::with_features(NoopClient, provider);
+    let server = LexLanguageServer::new(NoopClient);
     let uri = Url::from_file_path("/tmp/never-opened.lex").unwrap();
 
     let pasted = "anything\n    here\n".to_string();

--- a/crates/lex-lsp/src/server/tests.rs
+++ b/crates/lex-lsp/src/server/tests.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::features::semantic_tokens::{LexSemanticToken, LexSemanticTokenKind};
 use lex_analysis::test_support::sample_source;
 use lex_core::lex::ast::{Position as AstPosition, Range as AstRange};
+use lex_lsp_core::prepare_paste::{PasteMode, PreparePasteParams};
 use serde::Deserialize;
 use std::fs;
 use std::sync::Mutex;

--- a/crates/lex-lsp/tests/integration/robustness_proptest.rs
+++ b/crates/lex-lsp/tests/integration/robustness_proptest.rs
@@ -1,8 +1,7 @@
-use lexd_lsp::server::{DefaultFeatureProvider, LspClient};
+use lexd_lsp::server::LspClient;
 use lexd_lsp::trust_prompt::{LspTrustRequester, TrustRequestParams, TrustResponse};
 use lexd_lsp::LexLanguageServer;
 use proptest::prelude::*;
-use std::sync::Arc;
 use tower_lsp::lsp_types::{
     DidOpenTextDocumentParams, ExecuteCommandParams, TextDocumentItem, Url,
 };
@@ -46,8 +45,7 @@ proptest! {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let client = MockClient;
-            let features = Arc::new(DefaultFeatureProvider::new());
-            let server = LexLanguageServer::with_features(client, features);
+            let server = LexLanguageServer::new(client);
 
             // Try to parse args as JSON, if valid, use them, otherwise use empty array
             let arguments = serde_json::from_str(&args_json).unwrap_or_else(|_| vec![]);
@@ -71,8 +69,7 @@ proptest! {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let client = MockClient;
-            let features = Arc::new(DefaultFeatureProvider::new());
-            let server = LexLanguageServer::with_features(client, features);
+            let server = LexLanguageServer::new(client);
             let uri = Url::parse("file:///test.lex").unwrap();
 
             let params = DidOpenTextDocumentParams {


### PR DESCRIPTION
Builds **on top of #775** (which split the oversized files into `server/` submodules and got `server.rs` from 3644 → 1399). This continues that work along two axes the user asked for: *do better than 1399*, and *move the include-resolution logic that crept in into the crates that own it*.

Three reviewable commits, each green on its own (build + `cargo nextest` + clippy + pre-commit gate):

### 1. Cross-crate include dedup — `641e978`
#775 moved the include-resolution orchestration into submodules but left it **copy-pasted** across them (`check.rs` still documents its `absolutize` as *"Mirrors main.rs::absolutize_path"*). Eliminate it by hoisting into the owning crates:
- `lex-config::{absolutize_path, find_nearest_config_dir, resolve_include_root}` — the path helpers (were duplicated in `server/config_loading.rs`, `cli_support.rs`, `check.rs`).
- `lex-core::builtins::resolve_buffer` + `ResolveBufferError` — the build-registry + `FsLoader` + `resolve_from_source` dance (was hand-rolled at 3 sites).

Call sites delegate to the shared helpers; the `convert` path keeps its bespoke `MojibakeScanningLoader` (a custom `Loader` the generic helper can't cover).

### 2. Drop `FeatureProvider` + the `P` generic — `021d26a`
#775 kept this. It abstracted only 7 of ~20 router methods (the rest already call feature free-functions directly), so it was a mock-injection seam, not an architectural one. Remove the trait, `DefaultFeatureProvider`, the `features` field, and the `P` parameter; the 7 methods call the feature functions directly. The ~10 mock-counter wiring tests are replaced by 2 real-provider smoke tests + an unknown-command test.

### 3. Extract the last inline concerns — `490f652`
Move the three concern groups still inline in `server.rs` into `server/` submodules (following #775's convention): `extension_boot.rs` (lazy registry boot), `includes.rs` (resolve/goto/hover for `lex.include`), `command_dispatch.rs` (`executeCommand` parsing + extract-to-include + prepare-paste; the trait method delegates).

## Result

| file | 3644-baseline | after #775 | this PR |
|---|---|---|---|
| `server.rs` | 3644 | 1399 | **660** |

`server.rs` is now just the `LspClient` trait, the struct, and the `LanguageServer` router + lifecycle. No behavior change. Full workspace builds; 1639 tests pass; clippy clean.

## Note for reviewers

The include / extract / smart-paste tests drive the `LanguageServer` trait against a real server, so they stay as server-surface tests in `server/tests.rs` alongside the router they exercise (rather than moving into `includes.rs`/`command_dispatch.rs`). Happy to relocate if you'd prefer strict per-module placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3u42cH1xBV4znH3n29R6b