### PR TITLE
fix: native table hint no longer flags schema.bad-attachment (#777)

### DIFF
--- a/CHANGELOG/unreleased-table-hint-bad-attachment.md
+++ b/CHANGELOG/unreleased-table-hint-bad-attachment.md
@@ -1,0 +1,1 @@
+- Fix lexd check false-positive schema.bad-attachment on the native table ':: table align=… header=… ::' hint — lex.tabular.table now attaches to table (plus the historical verbatim form), body is optional, and align/header are type-checked params (lex#777)

--- a/crates/lex-analysis/src/label_dispatch.rs
+++ b/crates/lex-analysis/src/label_dispatch.rs
@@ -806,4 +806,46 @@ mod tests {
             "document-level annotation should match attaches_to: [document], got: {diags:?}"
         );
     }
+
+    /// Regression for lex#777: a native `Table` carrying the
+    /// organizational-hint annotation `:: table align=… header=… ::`
+    /// must NOT produce a `schema.bad-attachment` diagnostic. There is
+    /// one table type (the native `Table` AST node); the parser always
+    /// attaches this annotation to it (`HostNodeKind::Table`). The
+    /// `lex.tabular.table` schema now declares `attaches_to:
+    /// ["table", "verbatim"]`, so the native form validates.
+    #[test]
+    fn native_table_hint_does_not_bad_attach() {
+        use lex_core::lex::builtins::tabular::lex_tabular_table_schema;
+
+        // No-op handler — we only exercise schema pre-validation
+        // (attachment + param types), not handler dispatch.
+        struct NoopHandler;
+        impl LexHandler for NoopHandler {}
+
+        let registry = Registry::new();
+        registry
+            .register_namespace(
+                "lex",
+                vec![lex_tabular_table_schema()],
+                Box::new(NoopHandler),
+            )
+            .unwrap();
+
+        // Native table: subject + indented pipe rows. The hint
+        // annotation lives in the table's block and attaches to the
+        // native `Table` node.
+        let doc = parse(
+            "Scores:\n    | Name | Score |\n    | Alice | 95 |\n\n    :: table align=lr header=1 ::\n",
+        );
+        let mut diags = Vec::new();
+        dispatch_labels(&doc, &registry, &mut diags);
+        assert!(
+            !diags.iter().any(|d| matches!(
+                d.kind,
+                DiagnosticKind::SchemaValidation(SchemaValidationKind::BadAttachment)
+            )),
+            "native-table hint must not bad-attach (lex#777), got: {diags:?}"
+        );
+    }
 }

--- a/crates/lex-analysis/src/label_dispatch.rs
+++ b/crates/lex-analysis/src/label_dispatch.rs
@@ -840,12 +840,18 @@ mod tests {
         );
         let mut diags = Vec::new();
         dispatch_labels(&doc, &registry, &mut diags);
+        // Assert NO schema-validation diagnostic of any kind: the fix
+        // covers attachment (BadAttachment), the now-Optional body
+        // (BodyShapeMismatch), and the declared `align`/`header` params
+        // (MissingParam / ParamTypeMismatch). A narrower BadAttachment-only
+        // check would pass even if the body/param expectations regressed.
+        let schema_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| matches!(d.kind, DiagnosticKind::SchemaValidation(_)))
+            .collect();
         assert!(
-            !diags.iter().any(|d| matches!(
-                d.kind,
-                DiagnosticKind::SchemaValidation(SchemaValidationKind::BadAttachment)
-            )),
-            "native-table hint must not bad-attach (lex#777), got: {diags:?}"
+            schema_diags.is_empty(),
+            "native-table hint must not raise any schema-validation diagnostic (lex#777), got: {schema_diags:?}"
         );
     }
 }

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -679,9 +679,9 @@ mod tests {
             .expect("lex.tabular.table schema must be registered");
         assert!(schema.verbatim_label);
         // Native organizational-hint form attaches to `table`; the
-        // historical verbatim form attaches to `verbatim`. Both valid.
-        assert!(schema.attaches_to.contains(&"table".to_string()));
-        assert!(schema.attaches_to.contains(&"verbatim".to_string()));
+        // historical verbatim form attaches to `verbatim`. Assert the
+        // exact set so an accidental extra target is caught.
+        assert_eq!(schema.attaches_to, ["table", "verbatim"].map(String::from));
     }
 
     #[test]

--- a/crates/lex-core/src/lex/builtins/mod.rs
+++ b/crates/lex-core/src/lex/builtins/mod.rs
@@ -678,7 +678,10 @@ mod tests {
             .schema_for(tabular::LEX_TABULAR_TABLE)
             .expect("lex.tabular.table schema must be registered");
         assert!(schema.verbatim_label);
-        assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+        // Native organizational-hint form attaches to `table`; the
+        // historical verbatim form attaches to `verbatim`. Both valid.
+        assert!(schema.attaches_to.contains(&"table".to_string()));
+        assert!(schema.attaches_to.contains(&"verbatim".to_string()));
     }
 
     #[test]

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -146,14 +146,13 @@ pub fn lex_tabular_table_schema() -> Schema {
              (#615 unified registry surface)."
                 .into(),
         ),
-        params: {
-            // Organizational-hint params carried by the native-table
-            // marker form (`:: table align=lr header=1 ::`). Optional —
-            // a bare `:: table ::` (or the historical verbatim form) is
-            // still valid. Declaring them gives type-checking +
-            // completion instead of silent pass-through.
-            let mut params = BTreeMap::new();
-            params.insert(
+        // Organizational-hint params carried by the native-table marker
+        // form (`:: table align=lr header=1 ::`). Optional — a bare
+        // `:: table ::` (or the historical verbatim form) is still valid.
+        // Declaring them gives type-checking + completion instead of
+        // silent pass-through.
+        params: BTreeMap::from([
+            (
                 "align".to_string(),
                 ParamSpec {
                     ty: ParamType::String,
@@ -165,8 +164,8 @@ pub fn lex_tabular_table_schema() -> Schema {
                     pattern: None,
                     values: Vec::new(),
                 },
-            );
-            params.insert(
+            ),
+            (
                 "header".to_string(),
                 ParamSpec {
                     ty: ParamType::Int,
@@ -176,9 +175,8 @@ pub fn lex_tabular_table_schema() -> Schema {
                     pattern: None,
                     values: Vec::new(),
                 },
-            );
-            params
-        },
+            ),
+        ]),
         attaches_to: vec!["table".into(), "verbatim".into()],
         body: BodyShape {
             kind: BodyKind::Text,
@@ -219,9 +217,9 @@ mod tests {
         );
         // The native organizational-hint form attaches to a `table`;
         // the historical verbatim form (still emitted by babel's
-        // `to_lex`) attaches to a `verbatim`. Both must be accepted.
-        assert!(schema.attaches_to.contains(&"table".to_string()));
-        assert!(schema.attaches_to.contains(&"verbatim".to_string()));
+        // `to_lex`) attaches to a `verbatim`. Assert the exact set so an
+        // accidental extra attachment target is caught as a regression.
+        assert_eq!(schema.attaches_to, ["table", "verbatim"].map(String::from));
         assert_eq!(schema.body.kind, BodyKind::Text);
         // The native marker form (`:: table align=… ::`) has no body,
         // so presence is optional.

--- a/crates/lex-core/src/lex/builtins/tabular.rs
+++ b/crates/lex-core/src/lex/builtins/tabular.rs
@@ -11,7 +11,9 @@
 //! "verbatim hydration" responsibility doesn't share its hook with
 //! AST-substitution (the `lex.include` lifecycle).
 
-use lex_extension::schema::{BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, Schema};
+use lex_extension::schema::{
+    BodyKind, BodyPresence, BodyShape, Capabilities, HookSet, ParamSpec, ParamType, Schema,
+};
 use lex_extension::wire::{Position, Range, WireInline, WireNode, WireRow, WireTableCell};
 use std::collections::BTreeMap;
 
@@ -144,13 +146,47 @@ pub fn lex_tabular_table_schema() -> Schema {
              (#615 unified registry surface)."
                 .into(),
         ),
-        params: BTreeMap::new(),
-        attaches_to: vec!["verbatim".into()],
+        params: {
+            // Organizational-hint params carried by the native-table
+            // marker form (`:: table align=lr header=1 ::`). Optional —
+            // a bare `:: table ::` (or the historical verbatim form) is
+            // still valid. Declaring them gives type-checking +
+            // completion instead of silent pass-through.
+            let mut params = BTreeMap::new();
+            params.insert(
+                "align".to_string(),
+                ParamSpec {
+                    ty: ParamType::String,
+                    required: false,
+                    default: None,
+                    description: Some(
+                        "Per-column alignment hint, one char per column (`l`/`c`/`r`).".into(),
+                    ),
+                    pattern: None,
+                    values: Vec::new(),
+                },
+            );
+            params.insert(
+                "header".to_string(),
+                ParamSpec {
+                    ty: ParamType::Int,
+                    required: false,
+                    default: None,
+                    description: Some("Number of leading header rows.".into()),
+                    pattern: None,
+                    values: Vec::new(),
+                },
+            );
+            params
+        },
+        attaches_to: vec!["table".into(), "verbatim".into()],
         body: BodyShape {
             kind: BodyKind::Text,
-            presence: BodyPresence::Required,
+            presence: BodyPresence::Optional,
             description: Some(
-                "Pipe-table source: header row, alignment row, then one row per body line.".into(),
+                "Pipe-table source: header row, alignment row, then one row per body line. \
+                 Absent for the native-table marker form (`:: table align=… ::`)."
+                    .into(),
             ),
         },
         verbatim_label: true,
@@ -181,9 +217,15 @@ mod tests {
             schema.verbatim_label,
             "tabular.table must be a verbatim label"
         );
-        assert_eq!(schema.attaches_to, vec!["verbatim".to_string()]);
+        // The native organizational-hint form attaches to a `table`;
+        // the historical verbatim form (still emitted by babel's
+        // `to_lex`) attaches to a `verbatim`. Both must be accepted.
+        assert!(schema.attaches_to.contains(&"table".to_string()));
+        assert!(schema.attaches_to.contains(&"verbatim".to_string()));
         assert_eq!(schema.body.kind, BodyKind::Text);
-        assert_eq!(schema.body.presence, BodyPresence::Required);
+        // The native marker form (`:: table align=… ::`) has no body,
+        // so presence is optional.
+        assert_eq!(schema.body.presence, BodyPresence::Optional);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`lexd check` emitted a false-positive `schema.bad-attachment` error on the **native table's** organizational-hint annotation — the spec's own canonical `:: table align=… ::` / `:: table header=… ::` syntax. The annotation is functionally honored (alignment/header applied by `ApplyTableConfig`), so the diagnostic was purely spurious — but it fired on nearly every real table in the corpus, and on babel's `md → lex` output.

### Root cause

There is **one** table type (the native `Table` AST node). Today's parser always attaches the `lex.tabular.table` label to that native `Table` (`HostNodeKind::Table`). But the schema still declared only the **historical verbatim** node shape:

- `attaches_to: ["verbatim"]`
- `body.presence: Required`

The analyser walks the table's annotation as `HostNodeKind::Table`, compares against `attaches_to: ["verbatim"]`, and emits `schema.bad-attachment`.

## Schema change (`crates/lex-core/src/lex/builtins/tabular.rs`)

```diff
-        params: BTreeMap::new(),
-        attaches_to: vec!["verbatim".into()],
+        params: { align: String (optional), header: Int (optional) },
+        attaches_to: vec!["table".into(), "verbatim".into()],
         body: BodyShape {
             kind: BodyKind::Text,
-            presence: BodyPresence::Required,
+            presence: BodyPresence::Optional,
```

- **`attaches_to: ["table", "verbatim"]`** — `table` for the native annotation; `verbatim` kept because babel's `to_lex` still emits the historical `:: lex.tabular.table ::` verbatim closer (representation 2).
- **`body.presence: Optional`** — the native marker form (`:: table align=lr ::`) has no body; the verbatim form carries the pipe-source body.
- **`align` (String) / `header` (Int)** declared as optional params, so they get type-checking + completion instead of silent pass-through.

`verbatim_label: true`, the `ir_build` hook, and `on_format` are untouched — they serve the babel IR↔Lex round-trip.

## Tests

- Updated schema unit assertions: `tabular.rs` (`tabular_table_is_a_verbatim_label`) and `mod.rs` (`tabular_table_schema_is_registered`) — now assert `attaches_to` contains both `table` and `verbatim`, presence `Optional`. The `lex.media.*` assertions stay `["verbatim"]`.
- Added regression test `native_table_hint_does_not_bad_attach` in `crates/lex-analysis/src/label_dispatch.rs`: registers the real `lex.tabular.table` builtin schema, parses a native table carrying `:: table align=lr header=1 ::`, and asserts no `BadAttachment` diagnostic. Self-contained (inline `.lex` source, no `comms/` fixture dependency).

## Verification

- `cargo test -p lex-core -p lex-analysis` — all green.
- `release-core gate` — OK (fmt + clippy + lints).
- `lexd check` on a native table with `:: table align=lr header=1 ::` → **exit 0** (was exit 1).
- `lexd check comms/specs/elements/table.lex` → exit 0.
- Param type-checking: `:: table header=abc ::` → `schema.param-type-mismatch` (correctly flagged); `header=1` passes.

> Note: `comms/specs/benchmark/080-gentle-introduction.lex` and `comms/docs/about.lex` still exit non-zero, but on **unrelated** diagnostics (a `lex.metadata.author`-on-paragraph bad-attachment and `unclosed-annotation` warnings respectively) — not the `lex.tabular.table` issue this PR fixes.

Fixes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)