### PR TITLE
docs: PRD + ADR for Markdown↔Lex lossless round-trip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,127 @@
+# Lex ↔ Format Conversion
+
+The vocabulary of converting Lex documents to and from other document formats
+(Markdown, HTML, PDF, …) via lex-babel. This glossary covers the concepts that
+govern round-trip fidelity — the terms that are easy to conflate when reasoning
+about what survives a conversion.
+
+## Language
+
+**Conversion**:
+Transforming a document between two formats. A **Reader** parses a foreign
+format into a Lex AST (`Format::parse`); a **Serializer** emits a Lex AST into a
+foreign format (`Format::serialize`). "Markdown → Lex" runs the Markdown Reader
+then the Lex Serializer.
+_Avoid_: import/export (use only for user-facing CLI text).
+
+**Round-trip**:
+Converting a document out to another format and back. Fidelity claims are always
+about a specific pair and direction (e.g. "Lex → Markdown → Lex").
+_Avoid_: reversible, symmetric.
+
+**Equivalence Set**:
+The subset of constructs that both Lex and a given foreign format can represent
+natively, and which are therefore _required_ to round-trip losslessly. Lex is
+strictly more expressive than Markdown, so constructs outside the set (e.g.
+annotations, references) are **Declared Lossy** rather than bugs.
+_Avoid_: supported, compatible.
+
+**Faithfulness** (the primary invariant):
+A Serializer is faithful when the text it emits re-parses to the same AST it was
+given. For conversion: the Lex text produced from Markdown must re-parse to the
+same **Skeleton** the Markdown Reader built —
+`skeleton(lex_parse(lex_serialize(md_read(src)))) == skeleton(md_read(src))`.
+Format-agnostic (protects every Reader) and robust to a foreign format's cosmetic
+re-normalization. The primary property under test; "equivalent constructs
+round-trip losslessly" = Faithfulness + the Equivalence Set list.
+
+**Skeleton**:
+An AST reduced to what Faithfulness compares: Document Title + Block structure +
+inline content, with all **BlankLineGroup** nodes removed. Two ASTs are
+faithful-equal iff their Skeletons match. Blank _counts_ are decoration (Declared
+Lossy — "multiple blanks → single"); Block _structure_ and the Title are not.
+Re-parsing serialized Lex necessarily re-introduces BlankLineGroups the Reader
+never emitted, so equality must be taken over Skeletons, not raw ASTs. (This is
+the same reduction `ir::from_lex` already performs when it strips BlankLineGroups.)
+
+**Declared Lossy**:
+A conversion that is knowingly, documentedly non-round-trippable because one
+format cannot represent a construct of the other. Distinct from a fidelity
+_bug_, where both formats _can_ represent the construct but the pipeline
+mangles it.
+
+**Block**:
+A structural sibling element in a Lex document body — Paragraph, List, Session,
+Verbatim, Definition, Annotation, Table. Blocks are the units that must be
+_separated_ from one another in surface syntax.
+
+**Block Separation**:
+The blank line(s) that must sit between two sibling Blocks in Lex surface
+syntax. In Lex a blank line is _semantically load-bearing_: two adjacent text
+lines with no blank between them are ONE two-line Paragraph, while the same two
+lines with a blank between them are TWO Paragraphs. Separation is therefore a
+structural requirement of the grammar, not decoration.
+
+**BlankLineGroup**:
+An AST node recording blank lines that were present in _parsed Lex source_.
+lex-core's parser emits them; foreign-format Readers do not. Today the Lex
+Serializer emits Block Separation _only_ when it visits a BlankLineGroup — so
+ASTs produced by non-Lex Readers serialize with no separation and re-parse
+wrong. (This is the systemic defect under investigation.)
+
+**Document Title**:
+The optional first line of a Lex document, stored in `Document.title` (not a
+body Block). lex-core's parser assigns it by a purely syntactic rule: the title
+is the first block **iff** it is a single-line Paragraph at the very start of
+the document immediately followed by a blank line. A leading blank line
+suppresses the rule (the first Paragraph then stays in the body). Markdown has
+no distinct title concept; the Markdown Reader promotes a leading `# H1` to the
+Document Title.
+
+**Title escape**:
+A leading blank line the Lex Serializer emits when `Document.title == ""` and the
+first Block is a steal-able single-line Paragraph. It suppresses the grammar's
+title rule (`<document-title>` requires the _first_ non-annotation line), keeping
+the Paragraph in the body. Spec-sanctioned — it changes no grammar; it produces
+valid Lex the existing parser reads as title-less. Note: `lexd format`'s blank
+normalization currently strips it and re-promotes the title (a formatter-layer
+concern, tracked separately, not this work).
+
+## Flagged ambiguities
+
+**"Lossless"** — always scope it: lossless _for the Equivalence Set_. A bare
+"round-trips losslessly" is false for Lex ↔ Markdown because Lex is more
+expressive.
+
+**"Round-trip"** — always name the pair and direction. "Lex → Markdown → Lex"
+and "Markdown → Lex → Markdown" are different claims with different failure
+modes. Faithfulness (`parse∘serialize`) is a serializer property; a full
+foreign round-trip additionally depends on the Reader.
+
+## Example dialogue
+
+> **Dev:** The Markdown converter drops blank lines — two paragraphs come out as one.
+>
+> **Expert:** It doesn't drop _blank lines_, it drops **Block Separation**. In Lex
+> a blank line isn't whitespace, it's the boundary between two Blocks. Without it
+> those two Paragraphs are one two-line Paragraph.
+>
+> **Dev:** So the Markdown Reader should insert the blanks?
+>
+> **Expert:** That's the shallow fix. Separation is a property of the _grammar_,
+> so the **Lex Serializer** should emit it structurally — then RFC-XML and every
+> future Reader are fixed too. `BlankLineGroup` stays, but only to carry blanks
+> _beyond_ the structural minimum.
+>
+> **Dev:** And the lost title on `# H1` docs?
+>
+> **Expert:** Same rule at the title boundary — a **Document Title** needs a blank
+> after it. The only subtlety is a **title-less** doc: Lex's title rule steals a
+> lone first line, so the serializer emits a **Title escape** (a leading blank).
+> That's spec-valid — it changes no grammar.
+>
+> **Dev:** Is any of this "lossy"?
+>
+> **Expert:** Blank _counts_ are — three blanks become one, that's **Declared
+> Lossy**. Block _structure_ and the Title are not; losing those is a
+> **Faithfulness** bug.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,20 +70,25 @@ ASTs produced by non-Lex Readers serialize with no separation and re-parse
 wrong. (This is the systemic defect under investigation.)
 
 **Document Title**:
-The optional first line of a Lex document, stored in `Document.title`
-(`Option<DocumentTitle>`; absent = `None`), not a body Block. lex-core's parser assigns it by a purely syntactic rule: the title
-is the first block **iff** it is a single-line Paragraph at the very start of
-the document immediately followed by a blank line. A leading blank line
-suppresses the rule (the first Paragraph then stays in the body). Markdown has
-no distinct title concept; the Markdown Reader promotes a leading `# H1` to the
-Document Title.
+The optional title of a Lex document, stored in `Document.title`
+(`Option<DocumentTitle>`; absent = `None`), not a body Block. Per
+`grammar-core.lex`: `<document-title> = <title-line> <subtitle-line>? <blank-line>`
+— the **first non-annotation line** at document start (after any document-level
+metadata/annotations, anchored on the synthetic `DocumentStart`), optionally
+followed by a subtitle line (when the title line ends with a colon and a
+non-indented second line precedes the blank), then a blank line, with **no
+indented content** after the blank (indented content would make it a Session
+instead). Anything that breaks this shape — a leading blank line, a multi-line
+first block, indented following content — means no title, and the first block
+stays in the body. Markdown has no distinct title concept; the Markdown Reader
+promotes a leading `# H1` to the Document Title.
 
 **Title escape**:
 A leading blank line the Lex Serializer emits when the document has no title
-(`Document.title` is `None` — the field is `Option<DocumentTitle>`) and the
-first Block is a steal-able single-line Paragraph. It suppresses the grammar's
-title rule (`<document-title>` requires the _first_ non-annotation line), keeping
-the Paragraph in the body. Spec-sanctioned — it changes no grammar; it produces
+(`Document.title` is `None` — the field is `Option<DocumentTitle>`) and the first
+Block would otherwise satisfy the **Document Title** shape (a first non-annotation
+line the parser would read as the title). The leading blank breaks that shape, so
+the grammar's title rule can't match, keeping the Block in the body. Spec-sanctioned — it changes no grammar; it produces
 valid Lex the existing parser reads as title-less. Note: `lexd format`'s blank
 normalization currently strips it and re-promotes the title (a formatter-layer
 concern, tracked separately, not this work).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,8 +70,8 @@ ASTs produced by non-Lex Readers serialize with no separation and re-parse
 wrong. (This is the systemic defect under investigation.)
 
 **Document Title**:
-The optional first line of a Lex document, stored in `Document.title` (not a
-body Block). lex-core's parser assigns it by a purely syntactic rule: the title
+The optional first line of a Lex document, stored in `Document.title`
+(`Option<DocumentTitle>`; absent = `None`), not a body Block. lex-core's parser assigns it by a purely syntactic rule: the title
 is the first block **iff** it is a single-line Paragraph at the very start of
 the document immediately followed by a blank line. A leading blank line
 suppresses the rule (the first Paragraph then stays in the body). Markdown has
@@ -79,7 +79,8 @@ no distinct title concept; the Markdown Reader promotes a leading `# H1` to the
 Document Title.
 
 **Title escape**:
-A leading blank line the Lex Serializer emits when `Document.title == ""` and the
+A leading blank line the Lex Serializer emits when the document has no title
+(`Document.title` is `None` — the field is `Option<DocumentTitle>`) and the
 first Block is a steal-able single-line Paragraph. It suppresses the grammar's
 title rule (`<document-title>` requires the _first_ non-annotation line), keeping
 the Paragraph in the body. Spec-sanctioned — it changes no grammar; it produces

--- a/docs/adr/0001-lex-serializer-structural-block-separation.md
+++ b/docs/adr/0001-lex-serializer-structural-block-separation.md
@@ -15,7 +15,9 @@ Paragraphs. Separation is a grammar requirement, not decoration.
 The serializer emitted that separation **only** when it visited a
 `BlankLineGroup` node. lex-core's parser produces those nodes, so `lex → lex`
 round-tripped fine. But every other Reader (Markdown — the format
-`interop-scope.lex` calls "Lex's lingua franca", where round-trip is the
+[`interop-scope.lex`](https://github.com/lex-fmt/comms/blob/main/docs/interop-scope.lex)
+(in the `lex-fmt/comms` repo, vendored here as the `comms/` submodule) calls
+"Lex's lingua franca", where round-trip is the
 release bar — and RFC-XML) builds an AST with **no** `BlankLineGroup` nodes. Its
 output therefore serialized with blocks jammed together and re-parsed as merged
 paragraphs, lost document titles, and invalid lists.

--- a/docs/adr/0001-lex-serializer-structural-block-separation.md
+++ b/docs/adr/0001-lex-serializer-structural-block-separation.md
@@ -1,0 +1,67 @@
+# Lex Serializer derives block separation structurally
+
+## Status
+
+accepted
+
+## Context
+
+The Lex Serializer (`lex-babel/src/formats/lex/serializer.rs`) turns a Lex AST
+into Lex text. Blank lines between sibling blocks are load-bearing in Lex: two
+adjacent text lines with no blank between them parse as **one** two-line
+Paragraph, while the same lines with a blank between them parse as **two**
+Paragraphs. Separation is a grammar requirement, not decoration.
+
+The serializer emitted that separation **only** when it visited a
+`BlankLineGroup` node. lex-core's parser produces those nodes, so `lex → lex`
+round-tripped fine. But every other Reader (Markdown — the format
+`interop-scope.lex` calls "Lex's lingua franca", where round-trip is the
+release bar — and RFC-XML) builds an AST with **no** `BlankLineGroup` nodes. Its
+output therefore serialized with blocks jammed together and re-parsed as merged
+paragraphs, lost document titles, and invalid lists.
+
+Two symptoms had already been patched per-block inside the serializer
+(`visit_verbatim_block` for lex#505, `leave_annotation` for lex#682) — each an
+ad-hoc structural-separation rule for one block type. They were the same root
+cause surfacing twice.
+
+## Decision
+
+The serializer emits the grammar-mandated block separation **itself**, derived
+from the structure (a separation matrix over ordered sibling block-type pairs),
+independent of any `BlankLineGroup`. `BlankLineGroup`, when present, requests
+*additional* blanks beyond the structural minimum.
+
+This composes non-destructively because `ensure_blank_lines(n)` is
+**max-composing** (it pushes newlines up to `n`, never additively): a structural
+minimum of 1 and a `BlankLineGroup(k)` yield `max(1, k)`. For lex-sourced ASTs
+the `BlankLineGroup` already carries ≥ the minimum, so **`lex → lex` output is
+byte-identical to before** — zero regression — while Reader-built ASTs finally
+get their separators.
+
+The document-title blank (a title must be followed by a blank or it merges into
+the first body block) and the title-escape for title-less documents (a leading
+blank suppresses Lex's title-steal rule — `<document-title>` requires the *first*
+line) are the same structural rule applied to the title boundary. **No grammar
+or lexer change:** the title-steal rule in `grammar-core.lex` is intentional and
+untouched; the serializer merely emits spec-valid output.
+
+## Considered alternatives
+
+- **Readers synthesize `BlankLineGroup`s.** Rejected: it is a per-Reader patch
+  that duplicates separation logic into every current and future Reader, leaves
+  the lex#505/#682 band-aids in place, and re-introduces the defect each time a
+  Reader is added. It fixes Markdown, not the shared choke point.
+
+## Consequences
+
+- The lex#505 and lex#682 special cases are subsumed by the general rule and
+  deleted.
+- The round-trip proptest's `session_strategy`, which pre-inserted
+  `BlankLineGroup`s between generated blocks specifically because "paragraphs
+  merge without blank lines", no longer needs to — reader-shaped ASTs (no
+  separators) become first-class test inputs, which is exactly what regression
+  coverage for this bug requires.
+- The separation matrix becomes the single, explicit home for "what separates
+  block A from block B", replacing knowledge that was implicit in parser
+  behavior and scattered patches.

--- a/docs/adr/0001-lex-serializer-structural-block-separation.md
+++ b/docs/adr/0001-lex-serializer-structural-block-separation.md
@@ -6,7 +6,7 @@ accepted
 
 ## Context
 
-The Lex Serializer (`lex-babel/src/formats/lex/serializer.rs`) turns a Lex AST
+The Lex Serializer (`crates/lex-babel/src/formats/lex/serializer.rs`) turns a Lex AST
 into Lex text. Blank lines between sibling blocks are load-bearing in Lex: two
 adjacent text lines with no blank between them parse as **one** two-line
 Paragraph, while the same lines with a blank between them parse as **two**
@@ -40,7 +40,8 @@ byte-identical to before** — zero regression — while Reader-built ASTs final
 get their separators.
 
 The document-title blank (a title must be followed by a blank or it merges into
-the first body block) and the title-escape for title-less documents (a leading
+the first body block — the same boundary a prior lex#687 patch addressed
+point-wise) and the title-escape for title-less documents (a leading
 blank suppresses Lex's title-steal rule — `<document-title>` requires the *first*
 line) are the same structural rule applied to the title boundary. **No grammar
 or lexer change:** the title-steal rule in `grammar-core.lex` is intentional and

--- a/docs/prd/markdown-lex-roundtrip.md
+++ b/docs/prd/markdown-lex-roundtrip.md
@@ -164,11 +164,12 @@ Set), and within that vocabulary it is exact.
 - **Reader-shaped property test.** Extend the round-trip proptest to generate
   **reader-shaped** documents — sibling blocks with *no* pre-inserted
   `BlankLineGroup` separators — then assert Skeleton equality after
-  serialize→parse. The current `session_strategy` pre-inserts `BlankLineGroup`s
-  between blocks (with the comment "Paragraphs merge without blank lines — always
-  separate them"), which encodes the serializer's weakness into the test inputs
-  and masks the bug; that pre-insertion is removed, making reader-shaped ASTs
-  first-class inputs.
+  serialize→parse. Every generator strategy that currently pre-inserts
+  `BlankLineGroup`s between blocks — `session_strategy`, `definition_strategy`,
+  and `nested_session_strategy`, each carrying the same comment "Paragraphs merge
+  without blank lines — always separate them" — encodes the serializer's weakness
+  into the test inputs and masks the bug; that pre-insertion is removed from all
+  of them, making reader-shaped ASTs first-class inputs.
 
 - **Fixture / corpus tests.** Drive the real Markdown reader over the existing
   fixtures (`kitchensink.md`, `comrak-readme.md`, `markdown-reference-commonmark.md`)
@@ -210,8 +211,9 @@ Set), and within that vocabulary it is exact.
   separation as *data* (present only when a `BlankLineGroup` node existed) rather
   than as a *structural property of the grammar*. Every non-Lex reader produces
   ASTs without those nodes, so all of them were latently broken; Markdown is
-  simply where it was noticed. The two prior fixes (lex#505, lex#506… lex#682)
-  were the same bug patched one block type at a time.
+  simply where it was noticed. The prior point fixes (verbatim lex#505,
+  annotation lex#682, and the title-boundary lex#687) were the same bug patched
+  one block/boundary at a time.
 - The vocabulary for this area (Faithfulness, Skeleton, Block Separation,
   BlankLineGroup, Document Title, Title escape, Equivalence Set, Declared Lossy)
   is defined in `CONTEXT.md`.

--- a/docs/prd/markdown-lex-roundtrip.md
+++ b/docs/prd/markdown-lex-roundtrip.md
@@ -1,0 +1,220 @@
+# PRD: Markdown ↔ Lex lossless round-trip for equivalent constructs
+
+> Status: ready-for-agent (unpublished — file only)
+> Related: `docs/adr/0001-lex-serializer-structural-block-separation.md`, `CONTEXT.md`, `comms/docs/interop-scope.lex`
+
+## Problem Statement
+
+I convert a Markdown document to Lex and the structure falls apart. Two
+paragraphs become one. A document that starts with a `# Heading` loses the
+heading — it silently merges into the following text. A bulleted list comes out
+as a bare `-` line with the item text stranded on the next line. When I convert
+that generated Lex back to Markdown, or just re-open it, it is not the document I
+started with.
+
+`comms/docs/interop-scope.lex` states that Markdown is Lex's lingua franca and
+that "round-trip discipline is the bar, and is what we measure regressions
+against." Today that bar is not met: a Markdown document built from ordinary,
+Lex-representable constructs does not survive the trip through Lex.
+
+## Solution
+
+Markdown → Lex produces Lex text that, when re-parsed, is the *same document* the
+Markdown reader understood — for every construct both formats can represent
+(paragraphs, headings, lists, definitions, code blocks, and inline emphasis /
+code). Blocks stay separate. A leading heading becomes and remains the document
+title. Lists stay lists. Round-tripping a document composed of these shared
+constructs changes nothing structural.
+
+Constructs that only Lex has (annotations, citation references, sessions deeper
+than Markdown's six heading levels) remain **Declared Lossy** — Lex is more
+expressive than Markdown, so a perfect round-trip there is out of scope by
+definition. The guarantee is scoped to the shared vocabulary (the Equivalence
+Set), and within that vocabulary it is exact.
+
+## User Stories
+
+1. As an author converting Markdown to Lex, I want two blank-line-separated
+   paragraphs to remain two paragraphs, so that my document's structure is
+   preserved.
+2. As an author, I want a Markdown document that begins with `# Title` to produce
+   a Lex document whose title is "Title", so that the heading is not lost.
+3. As an author, I want that title to survive re-parsing (a blank line follows
+   it), so that converting and re-opening does not silently merge the title into
+   the first paragraph.
+4. As an author of a Markdown document with no leading heading, I want my first
+   paragraph to stay a body paragraph and not be promoted into the document
+   title, so that a paragraph is never turned into a heading on the way back to
+   Markdown.
+5. As an author, I want an unordered list to convert to a valid Lex list whose
+   items round-trip, so that my list is not flattened into a bare marker plus
+   orphaned text.
+6. As an author, I want an ordered list to keep its ordering and markers, so that
+   numbered steps stay numbered.
+7. As an author, I want nested lists to keep their nesting, so that sub-points
+   stay under their parents.
+8. As an author, I want a fenced code block to become a Lex verbatim block and
+   back, so that my code samples are preserved verbatim.
+9. As an author, I want inline code (`` `x` ``), bold, and italic to survive the
+   round-trip, so that inline emphasis is not lost or corrupted.
+10. As an author, I want a definition-style construct to round-trip as a Lex
+    definition, so that term/description pairs keep their meaning.
+11. As an author, I want a paragraph immediately followed by a list (no blank
+    line in my Markdown) to still convert correctly, so that tight Markdown is
+    handled.
+12. As an author, I want a heading followed by body content to keep the content
+    nested under the resulting session, so that document hierarchy is preserved.
+13. As an author converting a large real-world Markdown file (README, reference
+    doc), I want the whole document to round-trip structurally, so that I can
+    trust the converter on non-trivial input.
+14. As a Lex author exporting to Markdown, I want a titled Lex document to become
+    a `# H1`-led Markdown document, so that the title reads as a heading.
+15. As a Lex author, I want a document composed of Equivalence-Set constructs to
+    survive Lex → Markdown → Lex unchanged, so that exporting for collaboration
+    and re-importing is safe.
+16. As a contributor using the RFC-XML importer, I want its output to serialize
+    to valid, separated Lex too, so that the fix is not Markdown-specific.
+17. As a maintainer, I want a single Faithfulness invariant that fails loudly when
+    any reader-built document serializes to Lex that re-parses differently, so
+    that this class of bug cannot regress silently.
+18. As a maintainer, I want the property test to generate reader-shaped documents
+    (blocks with no pre-inserted blank-line separators), so that the test
+    exercises the real failure mode instead of masking it.
+19. As a maintainer, I want existing `lex → lex` output to be byte-for-byte
+    unchanged by this fix, so that the formatter and all Lex-sourced pipelines
+    are not disturbed.
+20. As a maintainer, I want the per-block blank-line special cases (verbatim
+    lex#505, annotation lex#682) removed once the general rule subsumes them, so
+    that the serializer has one separation rule rather than scattered patches.
+21. As an author, I want multiple consecutive blank lines to be acceptably
+    normalized to a single separator, so that blank-run collapsing is understood
+    and expected rather than surprising.
+22. As an author, I want inline code that contains a backtick (Markdown's
+    ``double-backtick`` form) to degrade predictably rather than emit Lex that
+    re-parses into corrupted text, so that an unrepresentable case fails cleanly.
+
+## Implementation Decisions
+
+- **Deep fix in the Lex Serializer (`lex-babel` lex format serializer).** Block
+  separation is emitted by the serializer as a structural property of the
+  grammar, not read out of `BlankLineGroup` nodes. This fixes every reader
+  (Markdown, RFC-XML, future) at the one shared choke point. See ADR-0001.
+
+- **Separation matrix.** Introduce an explicit rule for the minimum blank-line
+  separation required between each ordered pair of sibling block types
+  (paragraph→paragraph = 1; paragraph→list = 0; title→first-block = 1; etc.).
+  The matrix is the single, named home for "what separates block A from block B",
+  derived from and verified against the lex-core parser's actual behavior.
+
+- **Max-composition with `BlankLineGroup`.** The serializer's blank emission is
+  max-composing (ensure-at-least-N semantics, not additive). Applying a
+  structural minimum alongside an existing `BlankLineGroup(count = k)` yields
+  `max(minimum, k)`. Because Lex-sourced ASTs already carry a `BlankLineGroup`
+  ≥ the minimum between blocks, **`lex → lex` output is byte-identical** to
+  today. `BlankLineGroup` is retained, re-scoped to mean "extra blanks beyond the
+  structural minimum".
+
+- **Document title blank.** A `Document.title` is followed by the structural
+  separator (the title→first-block cell of the matrix), so an `# H1`-led
+  Markdown document round-trips with its title intact.
+
+- **Title escape for title-less documents.** When the document has no title and
+  its first block is a title-steal-able single-line paragraph, the serializer
+  emits a leading blank line. This suppresses the grammar's `<document-title>`
+  rule (which requires the *first* non-annotation line), keeping the paragraph in
+  the body. This is spec-valid Lex and changes **no grammar or lexer rule**; the
+  title-steal rule in `grammar-core.lex` is intentional and untouched.
+
+- **Delete the band-aids.** The verbatim (lex#505) and annotation (lex#682)
+  special-case blank emitters are removed; the general separation rule subsumes
+  them.
+
+- **No change to lex-core.** The parser, lexer, and grammar spec are unchanged.
+  The fix lives entirely in the babel Lex serializer.
+
+- **Out-of-band formatter follow-up.** `lexd format` currently strips a leading
+  blank and re-promotes a title-less document's first line to a title. That is a
+  formatter-normalization concern in a different layer; it is filed as a separate
+  follow-up and is **not** part of this work. `convert` faithfulness does not
+  depend on it.
+
+## Testing Decisions
+
+- **What a good test asserts here:** external behavior — that a document read by
+  any reader, serialized to Lex, and re-parsed, is the *same document*
+  (structurally). Tests compare **Skeletons** (title + block structure + inline
+  content, ignoring blank-*count* decoration), never serializer internals or
+  exact byte output (except the one deliberate byte-stability check on
+  `lex → lex`).
+
+- **Single seam — reuse `canon()`.** The Faithfulness invariant is expressed with
+  the existing `canon(&Document) -> Canon` skeleton reducer from the
+  `format_invariants` test module (it already captures title, subtitle,
+  annotations, and children). The invariant under test:
+  `canon(md_read(src)) == canon(parse(serialize(md_read(src))))`. This is the
+  direct sibling of the existing `check_semantic_preserved`
+  (`canon(parse(D)) == canon(parse(format(D)))`). `canon()` is promoted to a
+  shared test-support location so both the format-invariant tests and the new
+  conversion-faithfulness tests use one comparator.
+
+- **Modules tested:** the Lex serializer (via the invariant) and the
+  Markdown→Lex path end-to-end (via the real reader over fixtures). RFC-XML is
+  covered opportunistically by the same invariant since the fix is reader-agnostic.
+
+- **Reader-shaped property test.** Extend the round-trip proptest to generate
+  **reader-shaped** documents — sibling blocks with *no* pre-inserted
+  `BlankLineGroup` separators — then assert Skeleton equality after
+  serialize→parse. The current `session_strategy` pre-inserts `BlankLineGroup`s
+  between blocks (with the comment "Paragraphs merge without blank lines — always
+  separate them"), which encodes the serializer's weakness into the test inputs
+  and masks the bug; that pre-insertion is removed, making reader-shaped ASTs
+  first-class inputs.
+
+- **Fixture / corpus tests.** Drive the real Markdown reader over the existing
+  fixtures (`kitchensink.md`, `comrak-readme.md`, `markdown-reference-commonmark.md`)
+  and assert the Faithfulness invariant end-to-end. Add targeted small cases:
+  H1-led document, title-less document, each block-type adjacency pair
+  (paragraph→paragraph, paragraph→list, list→paragraph, heading→body,
+  paragraph→verbatim, paragraph→definition), and the backtick-in-code-span
+  degrade case.
+
+- **Prior art:** `format_invariants/mod.rs` (`canon`, `check_idempotent`,
+  `check_semantic_preserved`); `round_trip_proptest/mod.rs` (`assert_ast_equiv`,
+  the strategy generators); `markdown/import.rs` (`md_to_lex`,
+  `assert_lex_output_valid` — whose "reparsed doc is non-empty" check is upgraded
+  to the full Faithfulness invariant).
+
+- **Regression guard for `lex → lex`:** a check that a representative set of
+  Lex-sourced documents serialize byte-identically before and after the change,
+  encoding the "zero regression" guarantee.
+
+## Out of Scope
+
+- Any change to the lex-core parser, lexer, or grammar specification.
+- The `lexd format` leading-blank / title re-promotion behavior (separate
+  formatter-layer follow-up).
+- Perfect preservation of blank-line *counts* — collapsing a run of blank lines
+  to a single structural separator is Declared Lossy and accepted.
+- Round-tripping Lex-only constructs that Markdown cannot represent: annotations
+  (Markdown import does not parse them back), citation references (rendered as
+  plain text), sessions deeper than heading level 6, and verbatim post-wall
+  indentation (lex#276).
+- Representing a backtick *inside* inline code: Lex code spans are literal and
+  cannot contain their own delimiter. In scope is only that this case degrades
+  predictably (no corrupted re-parse), not that it round-trips.
+- New foreign formats (Pandoc, LaTeX, HTML import) — see `interop-scope.lex`.
+
+## Further Notes
+
+- The root cause is singular and systemic: the serializer treated block
+  separation as *data* (present only when a `BlankLineGroup` node existed) rather
+  than as a *structural property of the grammar*. Every non-Lex reader produces
+  ASTs without those nodes, so all of them were latently broken; Markdown is
+  simply where it was noticed. The two prior fixes (lex#505, lex#506… lex#682)
+  were the same bug patched one block type at a time.
+- The vocabulary for this area (Faithfulness, Skeleton, Block Separation,
+  BlankLineGroup, Document Title, Title escape, Equivalence Set, Declared Lossy)
+  is defined in `CONTEXT.md`.
+- The architectural choice (structural separation in the serializer vs. readers
+  synthesizing `BlankLineGroup`s) and its rejected alternative are recorded in
+  ADR-0001.

--- a/docs/prd/markdown-lex-roundtrip.md
+++ b/docs/prd/markdown-lex-roundtrip.md
@@ -1,7 +1,7 @@
 # PRD: Markdown ↔ Lex lossless round-trip for equivalent constructs
 
 > Status: ready-for-agent (unpublished — file only)
-> Related: `docs/adr/0001-lex-serializer-structural-block-separation.md`, `CONTEXT.md`, `comms/docs/interop-scope.lex`
+> Related: `docs/adr/0001-lex-serializer-structural-block-separation.md`, `CONTEXT.md`, [interop-scope.lex](https://github.com/lex-fmt/comms/blob/main/docs/interop-scope.lex) (`lex-fmt/comms` repo)
 
 ## Problem Statement
 
@@ -12,7 +12,9 @@ as a bare `-` line with the item text stranded on the next line. When I convert
 that generated Lex back to Markdown, or just re-open it, it is not the document I
 started with.
 
-`comms/docs/interop-scope.lex` states that Markdown is Lex's lingua franca and
+[`interop-scope.lex`](https://github.com/lex-fmt/comms/blob/main/docs/interop-scope.lex)
+(in the `lex-fmt/comms` repo, mounted here as the `comms/` submodule) states that
+Markdown is Lex's lingua franca and
 that "round-trip discipline is the bar, and is what we measure regressions
 against." Today that bar is not met: a Markdown document built from ordinary,
 Lex-representable constructs does not survive the trip through Lex.
@@ -203,7 +205,8 @@ Set), and within that vocabulary it is exact.
 - Representing a backtick *inside* inline code: Lex code spans are literal and
   cannot contain their own delimiter. In scope is only that this case degrades
   predictably (no corrupted re-parse), not that it round-trips.
-- New foreign formats (Pandoc, LaTeX, HTML import) — see `interop-scope.lex`.
+- New foreign formats (Pandoc, LaTeX, HTML import) — see
+  [interop-scope.lex](https://github.com/lex-fmt/comms/blob/main/docs/interop-scope.lex).
 
 ## Further Notes
 


### PR DESCRIPTION
Docs-only branch that roots the Markdown↔Lex round-trip work: a domain glossary, an ADR for the fix's architecture, and a PRD scoped to the shared Markdown/Lex construct set. No code changes — `/to-issues` slices the PRD into implementation tickets next.

## Why

Markdown → Lex currently mangles structure: two paragraphs merge into one, an `# H1`-led document loses its title, lists flatten to a bare `-`. `comms/docs/interop-scope.lex` makes Markdown round-trip the release bar; today it fails.

## Root cause (systemic)

The Lex serializer derives **Block Separation** from `BlankLineGroup` nodes, which only lex-core's parser emits. Every non-Lex reader (Markdown, RFC-XML) builds an AST without them, so its output serializes with blocks jammed together and re-parses wrong. The prior per-block fixes (lex#505 verbatim, lex#682 annotation) were the same bug patched twice.

## Contents

- **`CONTEXT.md`** — conversion-domain glossary (Faithfulness, Skeleton, Block Separation, BlankLineGroup, Document Title, Title escape, Equivalence Set, Declared Lossy).
- **`docs/adr/0001-lex-serializer-structural-block-separation.md`** — decision: emit block separation structurally in the serializer, max-composing with `BlankLineGroup` so `lex → lex` stays byte-identical; subsume and delete the band-aids; **no grammar change**. Records the rejected alternative (readers synthesize blanks).
- **`docs/prd/markdown-lex-roundtrip.md`** — PRD: problem/solution, user stories, implementation + testing decisions (Faithfulness invariant via the reused `canon()` skeleton comparator + reader-shaped proptest), Declared-Lossy / out-of-scope list.

## Context

This PR is intentionally **docs-only** — the deliverable is the shared vocabulary + the recorded architectural decision + the scoped PRD, produced via a design grill. Implementation and tests are deliberately deferred to `/to-issues` slices so the fix can be reviewed against a written spec. The chosen fix is the *deep* one (serializer-level, benefiting every reader) over the shallow per-reader patch — see ADR-0001 for why, and don't "simplify" it back to making the Markdown reader synthesize blanks. The `lexd format` title re-promotion is a known, separate formatter-layer concern (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdxsRGgN2raGxMCet5371z