### PR TITLE
docs: ADR-0002 document title model (first line is title; :: doc.untitled ::)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,7 +76,8 @@ The optional title of a Lex document, stored in `Document.title`
 one line, or two lines when the first line ends with a colon (title + subtitle;
 the colon is structural and stripped). Leading blank lines are irrelevant. If the
 first content element is anything else (Session, List, Definition, Verbatim,
-Annotation), there is **no title** and the document starts with that element. A
+Table, Annotation), there is **no title** and the document starts with that
+element. A
 multi-line first paragraph _without_ a leading-line colon is a paragraph, not a
 title — the colon is the explicit signal that distinguishes a two-line title from
 a two-line paragraph. Markdown has no distinct title concept; the Markdown Reader

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,27 +71,26 @@ wrong. (This is the systemic defect under investigation.)
 
 **Document Title**:
 The optional title of a Lex document, stored in `Document.title`
-(`Option<DocumentTitle>`; absent = `None`), not a body Block. Per
-`grammar-core.lex`: `<document-title> = <title-line> <subtitle-line>? <blank-line>`
-— the **first non-annotation line** at document start (after any document-level
-metadata/annotations, anchored on the synthetic `DocumentStart`), optionally
-followed by a subtitle line (when the title line ends with a colon and a
-non-indented second line precedes the blank), then a blank line, with **no
-indented content** after the blank (indented content would make it a Session
-instead). Anything that breaks this shape — a leading blank line, a multi-line
-first block, indented following content — means no title, and the first block
-stays in the body. Markdown has no distinct title concept; the Markdown Reader
-promotes a leading `# H1` to the Document Title.
+(`Option<DocumentTitle>`; absent = `None`), not a body Block. Settled model
+(ADR-0002): the title is the **first content element when it is a paragraph** —
+one line, or two lines when the first line ends with a colon (title + subtitle;
+the colon is structural and stripped). Leading blank lines are irrelevant. If the
+first content element is anything else (Session, List, Definition, Verbatim,
+Annotation), there is **no title** and the document starts with that element. A
+multi-line first paragraph _without_ a leading-line colon is a paragraph, not a
+title — the colon is the explicit signal that distinguishes a two-line title from
+a two-line paragraph. Markdown has no distinct title concept; the Markdown Reader
+maps a leading `# H1` to the Document Title.
 
-**Title escape**:
-A leading blank line the Lex Serializer emits when the document has no title
-(`Document.title` is `None` — the field is `Option<DocumentTitle>`) and the first
-Block would otherwise satisfy the **Document Title** shape (a first non-annotation
-line the parser would read as the title). The leading blank breaks that shape, so
-the grammar's title rule can't match, keeping the Block in the body. Spec-sanctioned — it changes no grammar; it produces
-valid Lex the existing parser reads as title-less. Note: `lexd format`'s blank
-normalization currently strips it and re-promotes the title (a formatter-layer
-concern, tracked separately, not this work).
+**No-title marker** (`:: doc.untitled ::`):
+A registered `doc.*` builtin annotation that explicitly declares a document has
+no title. Honored by the **parser** (not just babel): when present among the
+leading document-level annotations, it suppresses title promotion so the first
+paragraph stays in the body. It is how a Reader represents a titled-format source
+(e.g. Markdown with no leading heading) whose missing title must round-trip
+faithfully. Replaces the rejected "leading-blank title escape" — it survives
+`lexd format` (it is real content, not strippable whitespace) and is
+discoverable. See ADR-0002.
 
 ## Flagged ambiguities
 
@@ -122,9 +121,10 @@ foreign round-trip additionally depends on the Reader.
 > **Dev:** And the lost title on `# H1` docs?
 >
 > **Expert:** Same rule at the title boundary — a **Document Title** needs a blank
-> after it. The only subtlety is a **title-less** doc: Lex's title rule steals a
-> lone first line, so the serializer emits a **Title escape** (a leading blank).
-> That's spec-valid — it changes no grammar.
+> after it. And the model is settled now (ADR-0002): the first content line _is_
+> the title if it's a paragraph. A Markdown doc with no heading genuinely has no
+> title, so the Reader writes an explicit **No-title marker** (`:: doc.untitled ::`)
+> that the parser honors — no whitespace tricks.
 >
 > **Dev:** Is any of this "lossy"?
 >

--- a/docs/adr/0002-document-title-model.md
+++ b/docs/adr/0002-document-title-model.md
@@ -30,13 +30,13 @@ Markdown round-trip work forced it into the open. Three things collided:
 Leading blank lines are irrelevant — they no longer suppress the title. A title
 is one line, or two lines when the first line ends with a colon (title +
 subtitle; the colon is structural and stripped, per the existing
-`<subtitle-line>` rule). A first line without a trailing colon that spans
-multiple lines is a paragraph, not a title — the colon is the explicit signal
-that disambiguates a two-line title from a two-line paragraph.
+`<subtitle-line>` rule). A first paragraph whose first line has no trailing
+colon and spans multiple lines is a paragraph, not a title — the colon is the
+explicit signal that disambiguates a two-line title from a two-line paragraph.
 
 **2. If the first content element is anything other than a paragraph** — session,
-list, definition, verbatim, annotation — there is **no title**; the document
-starts with that element. (Already the parser's behavior.)
+list, definition, verbatim, table, annotation — there is **no title**; the
+document starts with that element. (Already the parser's behavior.)
 
 **3. A document may explicitly declare no title with `:: doc.untitled ::`.** This
 is a registered `doc.*` builtin, honored by the **parser** (not just babel): when
@@ -56,10 +56,9 @@ because leading blanks no longer carry title semantics.
   corpus doc uses it), and `lexd format` strips it. Replaced by the explicit
   `:: doc.untitled ::` annotation, which survives formatting and is discoverable.
 - **Any number of lines can be a title (no colon required).** Rejected: it can't
-  be distinguished from a multi-line paragraph. The colon-introduced subtitle
-  (option b) is the principled disambiguator and matches how publishers and
-  library cataloging separate a main title from its subtitle into distinct
-  fields.
+  be distinguished from a multi-line paragraph. The colon-introduced subtitle is
+  the principled disambiguator and matches how publishers and library cataloging
+  separate a main title from its subtitle into distinct fields.
 - **Empty-valued `:: doc.title: ::` to mean "no title".** Rejected in favor of a
   dedicated `doc.untitled` flag: "empty title" vs "no title" reads ambiguously; a
   boolean opt-out states intent clearly.
@@ -69,8 +68,8 @@ because leading blanks no longer carry title semantics.
 - lex-core parser change (title rule) + a new registered `doc.untitled` builtin
   label. Blast radius on the tracked corpus is ~zero (no doc starts with a
   leading blank). `document-06-title-empty` is renamed/repurposed to match the
-  settled behavior; `document-05-session-hoist`'s hoisting question is tracked
-  separately.
+  settled behavior; `document-05-title-session-hoist`'s hoisting question is
+  tracked separately.
 - The Markdown Reader emits `:: doc.untitled ::` for a heading-less source; the
   Markdown Serializer maps a Lex title to `# H1`. A leading `# H1` maps to the
   title. This replaces the "leading-blank title escape" that an earlier plan

--- a/docs/adr/0002-document-title-model.md
+++ b/docs/adr/0002-document-title-model.md
@@ -1,0 +1,82 @@
+# Document title model: first content line is the title; explicit `:: doc.untitled ::` opts out
+
+## Status
+
+accepted (supersedes the title-handling portions of ADR-0001)
+
+## Context
+
+Lex's document-title rule has been the murkiest corner of the grammar, and the
+Markdown round-trip work forced it into the open. Three things collided:
+
+- The parser assigned a title only when the first line was a lone paragraph
+  followed by a blank, and a **leading blank line suppressed** it. That made a
+  leading blank *semantically load-bearing*, which in turn made `lexd format`'s
+  "strip leading/trailing blank lines" normalization **unsound**: formatting a
+  title-less document silently promoted its first line to a title
+  (`title=None` → `title="One"`).
+- Fixtures encoded intent the parser didn't implement (`document-06-title-empty`
+  is named title-less but parses titled; `document-05-title-session-hoist`
+  expects hoisting that doesn't happen).
+- The whole tracked corpus (`trifecta/`, `benchmark/`) is 100% title-first; no
+  document uses a leading blank or is title-less. The idiom is "documents have a
+  title", but there was no honest way to express "this one doesn't" — needed
+  because formats with formal titles (Markdown) legitimately lack one, and that
+  must round-trip.
+
+## Decision
+
+**1. The title is the first content element, when that element is a paragraph.**
+Leading blank lines are irrelevant — they no longer suppress the title. A title
+is one line, or two lines when the first line ends with a colon (title +
+subtitle; the colon is structural and stripped, per the existing
+`<subtitle-line>` rule). A first line without a trailing colon that spans
+multiple lines is a paragraph, not a title — the colon is the explicit signal
+that disambiguates a two-line title from a two-line paragraph.
+
+**2. If the first content element is anything other than a paragraph** — session,
+list, definition, verbatim, annotation — there is **no title**; the document
+starts with that element. (Already the parser's behavior.)
+
+**3. A document may explicitly declare no title with `:: doc.untitled ::`.** This
+is a registered `doc.*` builtin, honored by the **parser** (not just babel): when
+present among the leading document-level annotations, title promotion is
+suppressed and all content stays in the body. It is how a Reader represents a
+titled-format source (e.g. Markdown) that has no title, so the absence
+round-trips faithfully.
+
+Consequences of (1): the parser drops the leading-blank suppression special case
+(a simplification), and `lexd format`'s blank-stripping becomes meaning-preserving
+because leading blanks no longer carry title semantics.
+
+## Considered alternatives
+
+- **Leading blank = "no title" (the "title escape").** Rejected: a whitespace
+  trick for a semantic distinction — surprising, invisible, non-idiomatic (no
+  corpus doc uses it), and `lexd format` strips it. Replaced by the explicit
+  `:: doc.untitled ::` annotation, which survives formatting and is discoverable.
+- **Any number of lines can be a title (no colon required).** Rejected: it can't
+  be distinguished from a multi-line paragraph. The colon-introduced subtitle
+  (option b) is the principled disambiguator and matches how publishers and
+  library cataloging separate a main title from its subtitle into distinct
+  fields.
+- **Empty-valued `:: doc.title: ::` to mean "no title".** Rejected in favor of a
+  dedicated `doc.untitled` flag: "empty title" vs "no title" reads ambiguously; a
+  boolean opt-out states intent clearly.
+
+## Consequences
+
+- lex-core parser change (title rule) + a new registered `doc.untitled` builtin
+  label. Blast radius on the tracked corpus is ~zero (no doc starts with a
+  leading blank). `document-06-title-empty` is renamed/repurposed to match the
+  settled behavior; `document-05-session-hoist`'s hoisting question is tracked
+  separately.
+- The Markdown Reader emits `:: doc.untitled ::` for a heading-less source; the
+  Markdown Serializer maps a Lex title to `# H1`. A leading `# H1` maps to the
+  title. This replaces the "leading-blank title escape" that an earlier plan
+  (issue for slice T2) carried.
+- Open, non-blocking: how a Lex **subtitle** maps to Markdown (which has no
+  subtitle concept) — a conversion-mapping convention or a Declared-Lossy call,
+  decided separately.
+- ADR-0001 stands for block separation; its "no grammar change" note applied to
+  the block-separation fix and is now qualified by this ADR for the title model.

--- a/docs/prd/markdown-lex-roundtrip.md
+++ b/docs/prd/markdown-lex-roundtrip.md
@@ -44,10 +44,10 @@ Set), and within that vocabulary it is exact.
 3. As an author, I want that title to survive re-parsing (a blank line follows
    it), so that converting and re-opening does not silently merge the title into
    the first paragraph.
-4. As an author of a Markdown document with no leading heading, I want my first
-   paragraph to stay a body paragraph and not be promoted into the document
-   title, so that a paragraph is never turned into a heading on the way back to
-   Markdown.
+4. As an author of a Markdown document with no leading heading, I want the
+   converted Lex to record that the document has no title (via `:: doc.untitled ::`),
+   so that my first paragraph stays a body paragraph and is never turned into a
+   heading on the way back to Markdown.
 5. As an author, I want an unordered list to convert to a valid Lex list whose
    items round-trip, so that my list is not flattened into a bare marker plus
    orphaned text.
@@ -120,25 +120,32 @@ Set), and within that vocabulary it is exact.
   separator (the title→first-block cell of the matrix), so an `# H1`-led
   Markdown document round-trips with its title intact.
 
-- **Title escape for title-less documents.** When the document has no title and
-  its first block is a title-steal-able single-line paragraph, the serializer
-  emits a leading blank line. This suppresses the grammar's `<document-title>`
-  rule (which requires the *first* non-annotation line), keeping the paragraph in
-  the body. This is spec-valid Lex and changes **no grammar or lexer rule**; the
-  title-steal rule in `grammar-core.lex` is intentional and untouched.
+- **Document title model (ADR-0002).** The title is the first content element
+  when it is a paragraph (one line, or two lines when the first ends with a colon
+  — title + subtitle); leading blank lines are irrelevant. A titled-format source
+  (Markdown) that has **no** title round-trips via an explicit **no-title marker**
+  `:: doc.untitled ::` — a registered `doc.*` builtin the **parser** honors to
+  suppress title promotion. The Markdown Reader emits it for a heading-less
+  source; the parser and serializer both respect it. This replaces the earlier
+  "leading-blank title escape" idea (a whitespace trick that `lexd format` would
+  strip). See ADR-0002.
 
 - **Delete the band-aids.** The verbatim (lex#505) and annotation (lex#682)
   special-case blank emitters are removed; the general separation rule subsumes
   them.
 
-- **No change to lex-core.** The parser, lexer, and grammar spec are unchanged.
-  The fix lives entirely in the babel Lex serializer.
+- **Scope note on lex-core.** The block-separation fix lives entirely in the babel
+  Lex serializer (no lex-core change). The title model (ADR-0002) *does* change
+  lex-core — the parser drops leading-blank title suppression and honors the new
+  `doc.untitled` builtin — and is tracked as its own slice.
 
-- **Out-of-band formatter follow-up.** `lexd format` currently strips a leading
-  blank and re-promotes a title-less document's first line to a title. That is a
-  formatter-normalization concern in a different layer; it is filed as a separate
-  follow-up and is **not** part of this work. `convert` faithfulness does not
-  depend on it.
+- **Formatter soundness (resolved by ADR-0002).** An earlier plan carried a
+  concern that `lexd format` strips a leading blank and re-promotes a title-less
+  document's first line to a title. Under the settled title model that concern
+  dissolves: leading blanks no longer carry title meaning (so stripping them is
+  meaning-preserving), and "no title" is expressed by `:: doc.untitled ::`, which
+  the formatter preserves as real content. No separate formatter follow-up is
+  needed.
 
 ## Testing Decisions
 
@@ -193,9 +200,11 @@ Set), and within that vocabulary it is exact.
 
 ## Out of Scope
 
-- Any change to the lex-core parser, lexer, or grammar specification.
-- The `lexd format` leading-blank / title re-promotion behavior (separate
-  formatter-layer follow-up).
+- Any lex-core change *beyond* the title model (ADR-0002): the block-separation
+  fix touches only the babel serializer. The only sanctioned lex-core changes here
+  are the title-rule simplification and the `doc.untitled` builtin from ADR-0002.
+- Session-title hoisting (the `document-05` fixture's aspiration) — tracked
+  separately, not part of this work.
 - Perfect preservation of blank-line *counts* — collapsing a run of blank lines
   to a single structural separator is Declared Lossy and accepted.
 - Round-tripping Lex-only constructs that Markdown cannot represent: annotations
@@ -218,8 +227,9 @@ Set), and within that vocabulary it is exact.
   annotation lex#682, and the title-boundary lex#687) were the same bug patched
   one block/boundary at a time.
 - The vocabulary for this area (Faithfulness, Skeleton, Block Separation,
-  BlankLineGroup, Document Title, Title escape, Equivalence Set, Declared Lossy)
-  is defined in `CONTEXT.md`.
+  BlankLineGroup, Document Title, No-title marker, Equivalence Set, Declared
+  Lossy) is defined in `CONTEXT.md`.
 - The architectural choice (structural separation in the serializer vs. readers
   synthesizing `BlankLineGroup`s) and its rejected alternative are recorded in
-  ADR-0001.
+  ADR-0001. The document title model (first content line is the title;
+  `:: doc.untitled ::` opts out) is recorded in ADR-0002.


### PR DESCRIPTION
Follow-up to #780. Settles the document-title corner that the Markdown round-trip work forced into the open, and reworks the PRD/CONTEXT to match.

## Decision (ADR-0002)

1. **The title is the first content element, when it's a paragraph** — one line, or two lines when line 1 ends with a colon (title + subtitle; colon is structural, stripped). Leading blank lines are irrelevant. If the first element is a session/list/definition/verbatim/annotation, there's no title.
2. **`:: doc.untitled ::`** — a registered `doc.*` builtin, honored by the **parser**, that explicitly declares no title. This is how a heading-less Markdown source round-trips faithfully.

## Why this replaces the earlier plan

The earlier plan (PR #780) proposed a leading-blank "title escape" for title-less docs and deferred a `lexd format` re-promotion bug. That was a whitespace trick for a semantic distinction — surprising, non-idiomatic (zero corpus docs use it), and `lexd format` strips it. The explicit marker is discoverable, survives formatting, and round-trips in both directions. As a bonus, once leading blanks carry no title meaning, `lexd format`'s blank-stripping becomes sound — the deferred formatter follow-up dissolves.

## Evidence behind it

- Grammar makes `<document-title>` optional; the colon→subtitle rule already models multi-line titles (matches how libraries/publishers split main-title vs subtitle into distinct fields).
- The whole tracked corpus (`trifecta/`, `benchmark/`) is 100% title-first; no doc uses a leading blank or is title-less.
- Fixtures `document-06-title-empty` (parses titled despite its name) and `document-05-title-session-hoist` (unhoisted) encode intent the parser doesn't implement — this ADR settles the first; the hoisting question is tracked separately.

## Contents

- `docs/adr/0002-document-title-model.md` — new
- `CONTEXT.md` — `No-title marker` replaces `Title escape`; Document Title definition updated to the settled model
- `docs/prd/markdown-lex-roundtrip.md` — title-model decision, scope note (lex-core changes limited to the title rule + `doc.untitled`), formatter concern marked resolved, user story 4 reworked

## Context

This is a spec decision reached with the repo owner, not a mechanical doc edit. The key non-obvious point for a reviewer/implementer: the title model **does** change lex-core (parser drops leading-blank suppression; new `doc.untitled` builtin honored at parse time) — deliberately, and scoped to just that. Don't reintroduce the leading-blank escape. The block-separation fix (ADR-0001) remains babel-only. Implementation issue #783 is being reworked to match; #781/#782 are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdxsRGgN2raGxMCet5371z