### PR TITLE
Document title model (ADR-0002): first paragraph is the title; :: doc.untitled :: opts out (#783)

### DIFF
--- a/CHANGELOG/unreleased-783-title-model.md
+++ b/CHANGELOG/unreleased-783-title-model.md
@@ -1,0 +1,1 @@
+- Document title model (ADR-0002): first paragraph is the title regardless of leading blanks; :: doc.untitled :: builtin suppresses title promotion; Markdown reader/serializer map H1 ↔ title and heading-less ↔ doc.untitled

--- a/crates/lex-babel/src/formats/lex/annotation_inline.rs
+++ b/crates/lex-babel/src/formats/lex/annotation_inline.rs
@@ -24,6 +24,7 @@
 //!
 //! `Table` annotations are left untouched — `Table::accept` already emits them.
 
+use lex_core::lex::ast::elements::BlankLineGroup;
 use lex_core::lex::ast::traits::AstNode;
 use lex_core::lex::ast::{Annotation, ContentItem, Document};
 
@@ -70,11 +71,54 @@ pub fn inline_attached_annotations(doc: &mut Document) {
     // only the annotation item when it attached). `process_stream` then cleans
     // each body and re-sorts the whole stream by source position, weaving them
     // back where they were authored.
+    //
+    // Insert at the head, not the tail: a reader-built document (Markdown,
+    // RFC-XML, …) has no real source positions — every item shares the default
+    // (0, 0, 0) key — so the subsequent stable sort preserves insertion order.
+    // Document-level annotations there (notably the ADR-0002 `:: doc.untitled ::`
+    // no-title marker, which the parser only honors when it *leads*) must sit at
+    // the head. For a lex-sourced document the positional sort governs instead,
+    // so a genuine container-end annotation still sorts back to the tail.
+    // Whether the document carried genuine document-level annotations (as
+    // opposed to element-attached ones that merely bubble up here). Only those
+    // need the structural head-blank below.
+    let had_doc_anns = !doc_anns.is_empty();
+
     let children = doc.root.children.as_mut_vec();
-    for ann in doc_anns {
-        children.push(ContentItem::Annotation(ann));
+    for ann in doc_anns.into_iter().rev() {
+        children.insert(0, ContentItem::Annotation(ann));
     }
     process_stream(children);
+    if had_doc_anns {
+        ensure_blank_after_leading_marker_annotations(children);
+    }
+}
+
+/// A leading marker annotation (`:: label ::`, empty body) at the document head
+/// is document-level: the parser promotes it out of the body only when a blank
+/// separates it from the first content block (the document-start rule). A
+/// reader-built AST carries no `BlankLineGroup`, so without this the
+/// serialized marker would sit flush against the first paragraph and re-parse
+/// as an annotation *attached* to that paragraph rather than a document-level
+/// one — the `:: doc.untitled ::` no-title marker would then be lost (ADR-0002).
+///
+/// Guarded by `had_doc_anns` at the call site so it never fires on a marker
+/// that was element-attached in the source (`:: foo ::` with no following blank
+/// attaches forward and must stay that way). Insert the structural blank only
+/// when one is not already present, so a lex-sourced document (whose
+/// `BlankLineGroup` survives the round-trip) stays byte-identical.
+fn ensure_blank_after_leading_marker_annotations(items: &mut Vec<ContentItem>) {
+    let mut end = 0;
+    while matches!(items.get(end), Some(ContentItem::Annotation(a)) if a.children.is_empty()) {
+        end += 1;
+    }
+    // A leading marker run exists and is followed by a non-blank content block.
+    if end > 0 && end < items.len() && !matches!(items[end], ContentItem::BlankLineGroup(_)) {
+        items.insert(
+            end,
+            ContentItem::BlankLineGroup(BlankLineGroup::new(1, Vec::new())),
+        );
+    }
 }
 
 /// Split annotations attached to one element: those whose source line falls

--- a/crates/lex-babel/src/formats/lex/annotation_inline.rs
+++ b/crates/lex-babel/src/formats/lex/annotation_inline.rs
@@ -85,9 +85,13 @@ pub fn inline_attached_annotations(doc: &mut Document) {
     let had_doc_anns = !doc_anns.is_empty();
 
     let children = doc.root.children.as_mut_vec();
-    for ann in doc_anns.into_iter().rev() {
-        children.insert(0, ContentItem::Annotation(ann));
-    }
+    // Prepend the document-level annotations in a single pass. `insert(0, …)` in
+    // a loop is O(M·N) — every insertion shifts the entire existing tail — so
+    // build the head first and append the original stream (O(M + N)).
+    let mut rest = std::mem::take(children);
+    children.reserve(doc_anns.len() + rest.len());
+    children.extend(doc_anns.into_iter().map(ContentItem::Annotation));
+    children.append(&mut rest);
     process_stream(children);
     if had_doc_anns {
         ensure_blank_after_leading_marker_annotations(children);

--- a/crates/lex-babel/src/formats/markdown/parser.rs
+++ b/crates/lex-babel/src/formats/markdown/parser.rs
@@ -44,14 +44,17 @@ pub fn parse_from_markdown(source: &str) -> Result<Document, FormatError> {
 
     // Title model (ADR-0002): record the title on the IR so `to_lex` sets
     // `Document.title` (surviving the Lex round-trip via the title→body blank).
-    // A heading-less source genuinely has no title — emit the explicit
-    // `:: doc.untitled ::` no-title marker so the parser does not promote the
-    // first body paragraph into a title on re-parse.
+    // A heading-less source *with content* genuinely has no title — emit the
+    // explicit `:: doc.untitled ::` no-title marker so the parser does not
+    // promote the first body paragraph into a title on re-parse. A genuinely
+    // empty document has no paragraph to promote, so it needs no marker;
+    // emitting one there would turn an empty Markdown file into a non-empty Lex
+    // document and break empty ↔ empty faithfulness.
     match document_title {
         Some(title) => {
             ir_doc.title = Some(vec![InlineContent::Text(title)]);
         }
-        None => {
+        None if !ir_doc.children.is_empty() => {
             ir_doc
                 .document_annotations
                 .push(crate::ir::nodes::Annotation {
@@ -61,6 +64,7 @@ pub fn parse_from_markdown(source: &str) -> Result<Document, FormatError> {
                     form: LabelForm::Canonical,
                 });
         }
+        None => {}
     }
 
     // Step 4: Convert IR to Lex AST

--- a/crates/lex-babel/src/formats/markdown/parser.rs
+++ b/crates/lex-babel/src/formats/markdown/parser.rs
@@ -33,13 +33,35 @@ pub fn parse_from_markdown(source: &str) -> Result<Document, FormatError> {
     let options = default_comrak_options();
     let root = parse_document(&arena, source, &options);
 
-    // Step 2: Convert Comrak AST to IR events
-    let events = comrak_ast_to_events(root)?;
+    // Step 2: Convert Comrak AST to IR events. A leading `# H1` is lifted out
+    // as the document title (Markdown's only title concept, ADR-0002).
+    let (events, document_title) = comrak_ast_to_events(root)?;
 
     // Step 3: Convert events to IR tree
-    let ir_doc = events_to_tree(&events).map_err(|e| {
+    let mut ir_doc = events_to_tree(&events).map_err(|e| {
         FormatError::ParseError(format!("Failed to build IR tree from events: {e}"))
     })?;
+
+    // Title model (ADR-0002): record the title on the IR so `to_lex` sets
+    // `Document.title` (surviving the Lex round-trip via the title→body blank).
+    // A heading-less source genuinely has no title — emit the explicit
+    // `:: doc.untitled ::` no-title marker so the parser does not promote the
+    // first body paragraph into a title on re-parse.
+    match document_title {
+        Some(title) => {
+            ir_doc.title = Some(vec![InlineContent::Text(title)]);
+        }
+        None => {
+            ir_doc
+                .document_annotations
+                .push(crate::ir::nodes::Annotation {
+                    label: "doc.untitled".to_string(),
+                    parameters: Vec::new(),
+                    content: Vec::new(),
+                    form: LabelForm::Canonical,
+                });
+        }
+    }
 
     // Step 4: Convert IR to Lex AST
     let lex_doc = crate::from_ir(&ir_doc);
@@ -64,8 +86,17 @@ fn default_comrak_options() -> ComrakOptions<'static> {
 
 type DefinitionPieces = Option<(Vec<InlineContent>, Vec<InlineContent>)>;
 
-/// Convert Comrak AST to IR events
-fn comrak_ast_to_events<'a>(root: &'a AstNode<'a>) -> Result<Vec<Event>, FormatError> {
+/// Convert Comrak AST to IR events, plus the document title lifted from a
+/// leading `# H1` (if any).
+///
+/// Per ADR-0002, Markdown's only title concept is a leading level-1 heading:
+/// when present it is consumed here and returned as the title (the caller
+/// records it on `Document.title`), *not* emitted as a body paragraph. A
+/// document with no leading H1 returns `None`, and the caller marks it
+/// title-less with `:: doc.untitled ::`.
+fn comrak_ast_to_events<'a>(
+    root: &'a AstNode<'a>,
+) -> Result<(Vec<Event>, Option<String>), FormatError> {
     let mut events = vec![Event::StartDocument];
 
     // Check if first child is an H1 heading - if so, treat it as document title
@@ -86,21 +117,10 @@ fn comrak_ast_to_events<'a>(root: &'a AstNode<'a>) -> Result<Vec<Event>, FormatE
         }
     }
 
-    // If we found a document title, emit it as a special event
-    // For now, we'll emit it as a paragraph that becomes the document title
-    // when converted back to Lex AST
-    if let Some(title) = document_title {
-        // Emit document title as a paragraph followed by an implicit blank
-        // The from_ir conversion will recognize this as the document title
-        events.push(Event::StartParagraph);
-        events.push(Event::Inline(InlineContent::Text(title)));
-        events.push(Event::EndParagraph);
-    }
-
     collect_children_with_definitions(children_iter, &mut events)?;
 
     events.push(Event::EndDocument);
-    Ok(events)
+    Ok((events, document_title))
 }
 
 /// Collect text content from a node (for extracting document title)

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -185,16 +185,17 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 //          the inlines-spec fixtures fail Tier-2 here because their indented
 //          grammar-production blocks de-indent on the first format.
 //   #791 — leading document-level annotations reorder around the title / first
-//          block on serialize. This is the idempotence (Tier-1) breaker for the
-//          inlines-spec fixtures (their lead paragraph hoists above the leading
-//          annotations on the second format) and both tiers for the two document
-//          fixtures + the document-level annotation fixture. May be subsumed by
-//          the #783 title-model work.
+//          block on serialize. The #783 title-model work (document-level
+//          annotations now serialize at the head) subsumed the inlines-spec
+//          Tier-1 fixtures — they pass now. What remains is the subtitle case
+//          (document-09) and the multiple-document-level annotation fixture
+//          (annotation-27, Tier-2), where title/subtitle/annotation ordering is
+//          still not reconciled.
 //   #792 — ragged/mismatched-row tables get padded + a separator row injected,
 //          adding cells (Tier-2 only).
-//   #783 — the `:: doc.untitled ::` title-model sentinel is rejected by the
-//          NormalizeLabels stage (`doc.*` reserved), so `format` errors — both
-//          tiers, until the ADR-0002 title model lands.
+//   #783 — the `:: doc.untitled ::` title-model sentinel (document-06) now
+//          parses and round-trips under the ADR-0002 title model, so it is no
+//          longer a known failure.
 // -----------------------------------------------------------------------------
 
 const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
@@ -214,22 +215,15 @@ const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     ("table.docs/table-23-cell-with-annotation.lex", "lex#790"),
     ("verbatim.docs/verbatim-13-group-spades.lex", "lex#790"),
     // #791 — leading annotations reorder around the title/first block (2nd pass).
+    // The inlines-spec fixtures (their lead paragraph hoisted above the leading
+    // annotations on the second format) are fixed by the #783 title-model work:
+    // document-level annotations now serialize at the head. The subtitle case
+    // still reorders — its title/subtitle interleaving with leading annotations
+    // is not yet handled.
     (
         "document.docs/document-09-subtitle-with-annotations.lex",
         "lex#791",
     ),
-    ("inlines.docs/specs/formatting/formatting.lex", "lex#791"),
-    (
-        "inlines.docs/specs/formatting/inlines-general.lex",
-        "lex#791",
-    ),
-    ("inlines.docs/specs/references/citations.lex", "lex#791"),
-    (
-        "inlines.docs/specs/references/references-general.lex",
-        "lex#791",
-    ),
-    // #783 — `:: doc.untitled ::` sentinel rejected by NormalizeLabels.
-    ("document.docs/document-06-title-untitled.lex", "lex#783"),
 ];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
@@ -265,8 +259,6 @@ const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     ),
     // #792 — ragged table rows padded + separator row injected.
     ("table.docs/table-13-flat-mismatched-rows.lex", "lex#792"),
-    // #783 — `:: doc.untitled ::` sentinel rejected by NormalizeLabels.
-    ("document.docs/document-06-title-untitled.lex", "lex#783"),
 ];
 
 #[cfg(test)]

--- a/crates/lex-babel/tests/html/export.rs
+++ b/crates/lex-babel/tests/html/export.rs
@@ -407,23 +407,23 @@ fn test_document_title_from_lex_document() {
 }
 
 #[test]
-fn test_document_untitled_marker_rejected_today() {
-    // document-06 now leads with `:: doc.untitled ::`, the ADR-0002 no-title
-    // marker. TODO(#783): doc.untitled lands in slice 3 — update to title-less
-    // expectations (default <title>, first paragraph stays body). Until the
-    // parser honors the doc.* builtin, NormalizeLabels rejects the reserved
-    // prefix, so parsing this fixture errors. Assert today's actual behavior
-    // rather than silently dropping the coverage.
+fn test_document_untitled_marker_is_title_less() {
+    // document-06 leads with `:: doc.untitled ::`, the ADR-0002 no-title marker
+    // (#783): the parser honors it, suppressing title promotion, so the first
+    // paragraph stays body and no document title is emitted. HTML falls back to
+    // the default `<title>`; the first paragraph renders as a `<p>`, not a heading.
     let lex_src = std::fs::read_to_string(
         "../../comms/specs/elements/document.docs/document-06-title-untitled.lex",
     )
     .expect("document-06 spec file should exist");
-    let err = STRING_TO_AST
-        .run(lex_src.to_string())
-        .expect_err("doc.untitled is rejected by NormalizeLabels until slice #783");
+    let html = lex_to_html(&lex_src, HtmlTheme::Modern);
     assert!(
-        err.to_string().contains("uses the reserved `doc.*` prefix"),
-        "expected the NormalizeLabels reserved doc.* rejection, got: {err}"
+        !html.contains("<title>Just a paragraph with no title.</title>"),
+        "the first paragraph must not become the document title; got: {html}"
+    );
+    assert!(
+        html.contains("<p class=\"lex-paragraph\">Just a paragraph with no title.</p>"),
+        "the first paragraph must render as body, got: {html}"
     );
 }
 

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -767,23 +767,30 @@ fn test_document_title_exported_as_h1() {
 }
 
 #[test]
-fn test_document_untitled_marker_rejected_today() {
-    // document-06 now leads with `:: doc.untitled ::`, the ADR-0002 no-title
-    // marker. TODO(#783): doc.untitled lands in slice 3 — update to title-less
-    // expectations (the first paragraph stays body, no H1 title is emitted).
-    // Until the parser honors the doc.* builtin, NormalizeLabels rejects the
-    // reserved prefix, so parsing this fixture errors. Assert that today's
-    // actual behavior rather than silently dropping the coverage.
+fn test_document_untitled_marker_is_title_less() {
+    // document-06 leads with `:: doc.untitled ::`, the ADR-0002 no-title marker
+    // (#783): the parser honors it, so the document has no title and the first
+    // paragraph stays body. Exporting to Markdown emits no `# H1` heading — the
+    // no-title marker is dropped (Markdown's absent title *is* the round-trip).
     let lex_src = std::fs::read_to_string(
         "../../comms/specs/elements/document.docs/document-06-title-untitled.lex",
     )
     .expect("document-06 spec file should exist");
-    let err = STRING_TO_AST
+    let lex_doc = STRING_TO_AST
         .run(lex_src)
-        .expect_err("doc.untitled is rejected by NormalizeLabels until slice #783");
+        .expect("document-06 parses title-less");
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
     assert!(
-        err.to_string().contains("uses the reserved `doc.*` prefix"),
-        "expected the NormalizeLabels reserved doc.* rejection, got: {err}"
+        !md.starts_with("# "),
+        "a title-less document must not emit an H1 heading, got: {md}"
+    );
+    assert!(
+        !md.contains("doc.untitled"),
+        "the no-title marker must not leak into Markdown, got: {md}"
+    );
+    assert!(
+        md.starts_with("Just a paragraph with no title."),
+        "the first paragraph must lead the Markdown body, got: {md}"
     );
 }
 

--- a/crates/lex-babel/tests/markdown/import.rs
+++ b/crates/lex-babel/tests/markdown/import.rs
@@ -861,3 +861,20 @@ fn title_model_single_heading_less_paragraph_is_faithful() {
     let doc = md_to_lex(md);
     assert!(doc.title.is_none());
 }
+
+#[test]
+fn title_model_empty_document_emits_no_untitled_marker() {
+    // A genuinely empty (or blank-only) Markdown document has no paragraph to
+    // promote, so it must NOT carry a `:: doc.untitled ::` marker — emitting one
+    // would turn an empty file into a non-empty Lex document.
+    for md in ["", "\n\n", "   \n"] {
+        let doc = md_to_lex(md);
+        assert!(doc.title.is_none(), "empty source has no title ({md:?})");
+        assert!(
+            !doc.annotations
+                .iter()
+                .any(|a| a.data.label.value == "doc.untitled"),
+            "empty source must not manufacture a doc.untitled marker ({md:?})"
+        );
+    }
+}

--- a/crates/lex-babel/tests/markdown/import.rs
+++ b/crates/lex-babel/tests/markdown/import.rs
@@ -709,17 +709,16 @@ fn test_lex_validity_kitchensink() {
 // stay within paragraph adjacency. Other block-adjacency pairs (paragraph→list,
 // heading→body, …) arrive with #782 and are NOT asserted faithful here yet.
 //
-// A note on the leading `## Heading`: lex-core's title-steal rule promotes a
+// A note on the leading `## Heading`: lex-core's title rule promotes a
 // *single-line* first paragraph, at the document's top, to the Document Title on
-// re-parse. The Markdown reader does not populate `Document.title`, so a
-// heading-less two-paragraph source is NOT faithful yet — the first paragraph is
-// body on read but title on re-parse. Reconciling that is the ADR-0002 title
-// model, honored via `:: doc.untitled ::`, which lands in slice #783. To grade
-// paragraph→paragraph separation *in isolation* here, the multi-paragraph cases
-// nest their paragraphs under a `## Heading` (a Lex Session): the session body is
-// past the document-title boundary, so its adjacent paragraphs are separated
-// purely by the matrix. Without the fix, they merge into one paragraph on
-// re-parse.
+// re-parse. Under the ADR-0002 title model (slice #783, now landed) the Markdown
+// reader reconciles this on both sides: a leading `# H1` populates
+// `Document.title`, and a heading-less source emits the `:: doc.untitled ::`
+// no-title marker so its first paragraph stays body on re-parse. The
+// multi-paragraph cases below still nest their paragraphs under a `## Heading`
+// (a Lex Session) to grade paragraph→paragraph separation *in isolation*, away
+// from the title boundary; the title-model faithfulness cases are asserted
+// directly in the `title_model` tests further down.
 // ============================================================================
 
 /// Count `Paragraph` children directly under a reparsed session (the Markdown
@@ -806,4 +805,59 @@ fn test_faithful_multiline_paragraph_not_split() {
         paragraphs, 1,
         "a soft-wrapped Markdown paragraph must stay one Lex paragraph; Lex was:\n{lex_text}"
     );
+}
+
+// ============================================================================
+// TITLE MODEL FAITHFULNESS (ADR-0002 / lex#783)
+//
+// The Markdown reader maps a leading `# H1` to the Document Title and a
+// heading-less source to the `:: doc.untitled ::` no-title marker. Both must
+// survive Markdown → Lex → Lex (Skeleton-equal): the title's trailing blank
+// keeps it a title on re-parse, and the marker keeps the first paragraph in the
+// body rather than letting it be promoted.
+// ============================================================================
+
+#[test]
+fn title_model_h1_led_document_is_faithful() {
+    let md = "# My Title\n\nFirst paragraph.\n\nSecond paragraph.\n";
+    crate::skeleton::check_faithful(&MarkdownFormat, md).unwrap();
+    // The H1 is the title, not a body paragraph.
+    let doc = md_to_lex(md);
+    assert_eq!(doc.title.as_ref().map(|t| t.as_str()), Some("My Title"));
+}
+
+#[test]
+fn title_model_heading_less_document_is_faithful() {
+    // Heading-less: the reader records "no title" with `:: doc.untitled ::`, the
+    // first paragraph stays body, and the round-trip never invents a heading.
+    let md = "First paragraph.\n\nSecond paragraph.\n";
+    crate::skeleton::check_faithful(&MarkdownFormat, md).unwrap();
+
+    let doc = md_to_lex(md);
+    assert!(doc.title.is_none(), "heading-less source has no title");
+    assert!(
+        doc.annotations
+            .iter()
+            .any(|a| a.data.label.value == "doc.untitled"),
+        "heading-less source carries the doc.untitled marker"
+    );
+
+    // Round-trips back to heading-less Markdown (no `# H1` invented).
+    let lex_text = LexFormat::default().serialize(&doc).unwrap();
+    let reparsed = LexFormat::default().parse(&lex_text).unwrap();
+    assert!(reparsed.title.is_none(), "re-parse must stay title-less");
+    let md_again = MarkdownFormat.serialize(&doc).unwrap();
+    assert!(
+        !md_again.starts_with("# "),
+        "round-trip must not promote the first paragraph to a heading; got:\n{md_again}"
+    );
+}
+
+#[test]
+fn title_model_single_heading_less_paragraph_is_faithful() {
+    // A lone heading-less paragraph must not be stolen as a title on re-parse.
+    let md = "Just one paragraph.\n";
+    crate::skeleton::check_faithful(&MarkdownFormat, md).unwrap();
+    let doc = md_to_lex(md);
+    assert!(doc.title.is_none());
 }

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_commonmark_reference.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_commonmark_reference.snap
@@ -3,6 +3,7 @@ source: crates/lex-babel/tests/markdown/import.rs
 expression: serialized
 ---
 <document>
+  <annotation>doc.untitled</annotation>
   <session>CommonMark
     <paragraph>1 line(s)
       <text-line>CommonMark is a rationalized version of Markdown s…</text-line>

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_readme.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_readme.snap
@@ -4,9 +4,6 @@ expression: serialized
 ---
 <document>
   <paragraph>1 line(s)
-    <text-line>Comrak</text-line>
-  </paragraph>
-  <paragraph>1 line(s)
     <text-line>Build status [https://github.com/kivikakk/comrak/a…</text-line>
   </paragraph>
   <paragraph>1 line(s)

--- a/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_reference.snap
+++ b/crates/lex-babel/tests/markdown/snapshots/lib__markdown__import__markdown_import_comrak_reference.snap
@@ -3,6 +3,7 @@ source: crates/lex-babel/tests/markdown/import.rs
 expression: serialized
 ---
 <document>
+  <annotation>doc.untitled</annotation>
   <session>Comrak [https://comrak.ee/]
     <paragraph>1 line(s)
       <text-line>Build status [https://github.com/kivikakk/comrak/a…</text-line>

--- a/crates/lex-babel/tests/skeleton/mod.rs
+++ b/crates/lex-babel/tests/skeleton/mod.rs
@@ -142,6 +142,16 @@ fn canon_annotations(anns: &[Annotation]) -> Vec<Canon> {
 }
 
 fn canon_annotation(ann: &Annotation) -> Canon {
+    // A marker annotation (`:: label ::`, no body) re-parses with a lone
+    // empty-Paragraph artifact, while a reader builds it with no children at
+    // all. Both are the same marker, so drop empty-paragraph children here —
+    // the Faithfulness analog of the serializer's `clean_annotation`. Without
+    // this a reader-emitted marker (e.g. the ADR-0002 `:: doc.untitled ::`)
+    // would never compare equal to its own re-parse.
+    let children: Vec<Canon> = canon_items(ann.children.iter())
+        .into_iter()
+        .filter(|c| !is_empty_paragraph(c))
+        .collect();
     Canon::Annotation {
         // `.value` is the canonical label; the formatter re-emits the source
         // spelling form, which reparses back to the same canonical value.
@@ -152,8 +162,18 @@ fn canon_annotation(ann: &Annotation) -> Canon {
             .iter()
             .map(|p| (p.key.clone(), p.value.clone()))
             .collect(),
-        children: canon_items(ann.children.iter()),
+        children,
     }
+}
+
+/// True for a content-free `Canon::Paragraph` — the empty-body artifact a
+/// marker annotation re-parses into. See [`canon_annotation`].
+fn is_empty_paragraph(c: &Canon) -> bool {
+    matches!(
+        c,
+        Canon::Paragraph { text, refs, annotations }
+            if text.is_empty() && refs.is_empty() && annotations.is_empty()
+    )
 }
 
 fn canon_items<'a, I: Iterator<Item = &'a ContentItem>>(items: I) -> Vec<Canon> {

--- a/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
+++ b/crates/lex-core/src/lex/assembling/stages/normalize_labels.rs
@@ -152,6 +152,16 @@ pub fn classify_label(input: &str) -> Resolution {
         return Resolution::Resolved((*canonical).to_string(), LabelForm::Shortcut);
     }
 
+    // The Reserved-core-builtin `doc.*` marker flags (currently
+    // `doc.untitled`, general.lex §4) are honored, not rejected. They
+    // are boolean flags the parser interprets (ADR-0002), carry no
+    // render schema, and so are NOT in `CANONICAL_LABELS`; accept them
+    // here as their own `doc.*` verbatim, tagged Canonical so emitters
+    // round-trip the exact `doc.untitled` spelling.
+    if builtins::doc::is_doc_reserved_marker(input) {
+        return Resolution::Resolved(input.to_string(), LabelForm::Canonical);
+    }
+
     // doc.* is reserved-forbidden — reject before any other branch,
     // EXCEPT for the curated built-in canonicals from #615
     // (doc.title, doc.author, doc.date, doc.tags, doc.category,
@@ -578,6 +588,39 @@ mod tests {
                 "{forbidden} must reject as Forbidden"
             );
         }
+    }
+
+    #[test]
+    fn classify_doc_untitled_reserved_marker_resolves_as_canonical() {
+        // `doc.untitled` (ADR-0002) is a Reserved-core-builtin marker: it is
+        // honored, not rejected, and tagged Canonical so emitters round-trip the
+        // exact spelling. It is NOT in CANONICAL_LABELS (no render schema), so it
+        // reaches acceptance via the dedicated reserved-marker carve-out.
+        assert_eq!(
+            classify_label("doc.untitled"),
+            Resolution::Resolved("doc.untitled".to_string(), LabelForm::Canonical),
+        );
+        assert!(!builtins::is_canonical_label("doc.untitled"));
+        // A different, unregistered `doc.*` still rejects — the carve-out is
+        // exactly the closed reserved set, not an open `doc.*` allowance.
+        assert_eq!(
+            classify_label("doc.untitledx"),
+            Resolution::Rejected(RejectReason::Forbidden {
+                input: "doc.untitledx".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn doc_untitled_marker_parses_in_strict_mode() {
+        // End-to-end: `:: doc.untitled ::` at the document head parses (no
+        // reserved-prefix rejection) and suppresses title promotion — the first
+        // paragraph stays in the body and `Document.title` is `None`.
+        let doc = parse(":: doc.untitled ::\n\nFirst paragraph.\n\nSecond paragraph.\n");
+        assert!(doc.title.is_none(), "doc.untitled must suppress the title");
+        let ann = doc.annotations.first().expect("document-level annotation");
+        assert_eq!(ann.data.label.value, "doc.untitled");
+        assert_eq!(ann.data.label.form, LabelForm::Canonical);
     }
 
     #[test]

--- a/crates/lex-core/src/lex/builtins/doc.rs
+++ b/crates/lex-core/src/lex/builtins/doc.rs
@@ -54,6 +54,26 @@ pub fn is_doc_builtin(label: &str) -> bool {
     DOC_BUILTIN_LABELS.contains(&label)
 }
 
+/// The Reserved-core-builtin `doc.*` marker flags (comms `general.lex`
+/// §4). Distinct from [`DOC_BUILTIN_LABELS`]: these are boolean flags
+/// written in marker form (`:: doc.untitled ::`, no value), honored by
+/// the **parser** as document-level semantics rather than rendered as
+/// metadata — so they carry no `render` schema and are not part of the
+/// registry-mirrored [`crate::lex::builtins::CANONICAL_LABELS`]. Only
+/// the core may add to this closed set; adding one is a minor version
+/// bump (§4).
+///
+/// - `doc.untitled` — suppresses document-title promotion (ADR-0002).
+pub const DOC_RESERVED_MARKERS: &[&str] = &["doc.untitled"];
+
+/// `true` if `label` names a Reserved-core-builtin `doc.*` marker flag
+/// (currently only `doc.untitled`). `NormalizeLabels` accepts these
+/// through the otherwise-forbidden `doc.*` namespace without requiring a
+/// registered render schema.
+pub fn is_doc_reserved_marker(label: &str) -> bool {
+    DOC_RESERVED_MARKERS.contains(&label)
+}
+
 /// Common shape: every `doc.*` metadata label attaches to the document,
 /// carries its value as the annotation body (single-line text), and
 /// declares the `markdown` + `html` render hooks that
@@ -314,6 +334,21 @@ mod tests {
         assert!(!is_doc_builtin("doc."));
         assert!(!is_doc_builtin("title"));
         assert!(!is_doc_builtin("lex.metadata.title"));
+    }
+
+    #[test]
+    fn doc_untitled_is_a_reserved_marker_not_a_metadata_builtin() {
+        // `doc.untitled` (ADR-0002 / general.lex §4) is a Reserved-core-builtin
+        // marker flag: honored by the parser, but NOT a render-bearing metadata
+        // builtin, so it must stay out of DOC_BUILTIN_LABELS / all_schemas().
+        assert!(is_doc_reserved_marker("doc.untitled"));
+        assert!(!is_doc_builtin("doc.untitled"));
+        assert!(!DOC_BUILTIN_LABELS.contains(&"doc.untitled"));
+        assert!(!all_schemas().iter().any(|s| s.label == "doc.untitled"));
+        // The set is closed; nothing else is a reserved marker.
+        assert!(!is_doc_reserved_marker("doc.title"));
+        assert!(!is_doc_reserved_marker("doc.bogus"));
+        assert!(!is_doc_reserved_marker("untitled"));
     }
 
     #[test]

--- a/crates/lex-core/src/lex/parsing/engine.rs
+++ b/crates/lex-core/src/lex/parsing/engine.rs
@@ -371,6 +371,72 @@ Final paragraph.
         assert!(has_sessions, "Should contain sessions");
     }
 
+    // ── Document title model (ADR-0002) ────────────────────────────────────
+
+    #[test]
+    fn title_promoted_despite_leading_blank_lines() {
+        // ADR-0002 drops the leading-blank suppression special case: a lone first
+        // paragraph is the title regardless of any leading blank lines.
+        let source = "\n\nTitle line\n\nBody paragraph.\n";
+        let tokens = lex_helper(source).expect("tokenize");
+        let out = parse_flat(tokens, source).expect("parse");
+        assert_eq!(
+            out.title.as_ref().map(|t| t.as_str()),
+            Some("Title line"),
+            "leading blanks must no longer suppress the title"
+        );
+    }
+
+    #[test]
+    fn title_promoted_without_leading_blank() {
+        let source = "Title line\n\nBody paragraph.\n";
+        let tokens = lex_helper(source).expect("tokenize");
+        let out = parse_flat(tokens, source).expect("parse");
+        assert_eq!(out.title.as_ref().map(|t| t.as_str()), Some("Title line"));
+    }
+
+    #[test]
+    fn doc_untitled_marker_suppresses_title() {
+        // A `:: doc.untitled ::` among the leading document-level annotations
+        // suppresses promotion: no title, first paragraph stays in the body.
+        let source = ":: doc.untitled ::\n\nFirst paragraph.\n\nSecond paragraph.\n";
+        let tokens = lex_helper(source).expect("tokenize");
+        let out = parse_flat(tokens, source).expect("parse");
+        assert!(out.title.is_none(), "doc.untitled must suppress the title");
+        let paragraphs = out
+            .root
+            .children
+            .iter()
+            .filter(|c| matches!(c, ContentItem::Paragraph(_)))
+            .count();
+        assert_eq!(paragraphs, 2, "both paragraphs stay in the body");
+    }
+
+    #[test]
+    fn first_non_paragraph_element_is_not_a_title() {
+        // A document that opens with a session (a title line + indented body)
+        // has no document title — that element starts the document.
+        let source = "Section:\n\n    Body content.\n";
+        let tokens = lex_helper(source).expect("tokenize");
+        let out = parse_flat(tokens, source).expect("parse");
+        assert!(
+            out.title.is_none(),
+            "a leading session is not promoted to a title"
+        );
+    }
+
+    #[test]
+    fn colon_first_line_promotes_title_and_subtitle() {
+        // A first line ending in a colon + a second line is title + subtitle;
+        // the structural colon is stripped from the title content.
+        let source = "Sapiens:\nA Brief History of Humankind\n\nBody.\n";
+        let tokens = lex_helper(source).expect("tokenize");
+        let out = parse_flat(tokens, source).expect("parse");
+        let title = out.title.expect("title present");
+        assert_eq!(title.as_str(), "Sapiens");
+        assert_eq!(title.subtitle_str(), Some("A Brief History of Humankind"));
+    }
+
     #[test]
     fn test_parse_empty_input() {
         let source = "";

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -37,6 +37,7 @@ impl GrammarMatcher {
     /// consumed token indices.
     ///
     /// Returns (matched_pattern, consumed_indices)
+    #[allow(clippy::too_many_arguments)]
     fn try_match(
         tokens: &[LineContainer],
         start_idx: usize,
@@ -45,6 +46,7 @@ impl GrammarMatcher {
         has_preceding_blank: bool,
         has_preceding_boundary: bool,
         prev_was_session: bool,
+        suppress_title: bool,
     ) -> Option<(PatternMatch, Range<usize>)> {
         if start_idx >= tokens.len() {
             return None;
@@ -201,18 +203,31 @@ impl GrammarMatcher {
                         },
                         "blank_line_group" => PatternMatch::BlankLineGroup,
                         "document_title_with_subtitle" => {
+                            // A `:: doc.untitled ::` among the leading document-level
+                            // annotations suppresses title promotion (ADR-0002).
+                            if suppress_title {
+                                continue;
+                            }
                             // No container lookahead needed: the subtitle variant
                             // consumed two lines (title + subtitle) before blank lines.
                             // A session only has one line before blank + container, so
                             // the presence of a container after the blank is NOT ambiguous
                             // here — it's the document body, not a session body.
-                            // Match: DocumentStart(0) + title(1) + subtitle(2) + blank lines
+                            // `<lead>` absorbs any leading blank lines (ADR-0002), so the
+                            // title/subtitle sit at DocumentStart(0) + lead + 1 / + 2.
+                            let lead_count = caps
+                                .name("lead")
+                                .map(|m| Self::count_consumed_tokens(m.as_str()))
+                                .unwrap_or(0);
                             PatternMatch::DocumentTitle {
-                                title_idx: 1,
-                                subtitle_idx: Some(2),
+                                title_idx: 1 + lead_count,
+                                subtitle_idx: Some(2 + lead_count),
                             }
                         }
                         "document_title" => {
+                            if suppress_title {
+                                continue;
+                            }
                             // Imperative negative lookahead: not followed by container
                             let next_idx = start_idx + consumed_count;
                             if next_idx < tokens.len()
@@ -221,9 +236,13 @@ impl GrammarMatcher {
                                 // Followed by container — this is a session, not a title
                                 continue;
                             }
-                            // Match is: DocumentStart(0) + title line(1) + blank lines
+                            // Match is: DocumentStart(0) + lead blanks + title line + blank lines
+                            let lead_count = caps
+                                .name("lead")
+                                .map(|m| Self::count_consumed_tokens(m.as_str()))
+                                .unwrap_or(0);
                             PatternMatch::DocumentTitle {
-                                title_idx: 1,
+                                title_idx: 1 + lead_count,
                                 subtitle_idx: None,
                             }
                         }
@@ -587,7 +606,49 @@ pub fn parse_with_declarative_grammar(
     source: &str,
 ) -> Result<Vec<ParseNode>, String> {
     let tokens = fold_prose_continuations(tokens);
-    parse_with_declarative_grammar_internal(tokens, source, true, true)
+    // A `:: doc.untitled ::` among the leading document-level annotations
+    // suppresses document-title promotion for the whole document (ADR-0002).
+    // Detected here, at the one root entry point, so both parse paths (engine
+    // and the `Parsing` transform stage) honor it without threading a flag in.
+    let suppress_title = leading_untitled_marker(&tokens, source);
+    parse_with_declarative_grammar_internal(tokens, source, true, true, suppress_title)
+}
+
+/// True when the leading document-level annotations (the run before the
+/// synthetic `DocumentStart` marker) contain a `:: doc.untitled ::` marker.
+/// This is the ADR-0002 no-title opt-out, honored by the parser itself.
+fn leading_untitled_marker(tokens: &[LineContainer], source: &str) -> bool {
+    for token in tokens {
+        if let LineContainer::Token(line) = token {
+            match line.line_type {
+                // The metadata/content boundary — stop before the body so a
+                // `doc.untitled` appearing later (as body content) is ignored.
+                LineType::DocumentStart => break,
+                LineType::DataMarkerLine if line_is_untitled_marker(line, source) => {
+                    return true;
+                }
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+/// True when `line` is exactly the `:: doc.untitled ::` marker annotation
+/// (marker form, no params, no body). Reconstructs the line's source text from
+/// its token spans and matches the closed `:: label ::` shape.
+fn line_is_untitled_marker(line: &crate::lex::token::LineToken, source: &str) -> bool {
+    let (Some(start), Some(end)) = (
+        line.token_spans.iter().map(|s| s.start).min(),
+        line.token_spans.iter().map(|s| s.end).max(),
+    ) else {
+        return false;
+    };
+    let text = source.get(start..end).unwrap_or("").trim();
+    text.strip_prefix("::")
+        .and_then(|rest| rest.trim().strip_suffix("::"))
+        .map(|inner| inner.trim() == "doc.untitled")
+        .unwrap_or(false)
 }
 
 /// True when a line token is paragraph prose (a `ParagraphLine` or `DialogLine`).
@@ -698,6 +759,7 @@ fn parse_with_declarative_grammar_internal(
     source: &str,
     allow_sessions: bool,
     is_doc_start: bool,
+    suppress_title: bool,
 ) -> Result<Vec<ParseNode>, String> {
     let mut items: Vec<ParseNode> = Vec::new();
     let mut idx = 0;
@@ -729,6 +791,7 @@ fn parse_with_declarative_grammar_internal(
             has_preceding_blank,
             has_preceding_boundary,
             prev_was_session,
+            suppress_title,
         ) {
             let mut pending_nodes = Vec::new();
 
@@ -758,7 +821,7 @@ fn parse_with_declarative_grammar_internal(
                 range.clone(),
                 source,
                 &move |children, src| {
-                    parse_with_declarative_grammar_internal(children, src, is_session, false)
+                    parse_with_declarative_grammar_internal(children, src, is_session, false, false)
                 },
             )?;
             pending_nodes.push(item);
@@ -785,6 +848,7 @@ fn parse_with_declarative_grammar_internal(
                         inner.clone(),
                         source,
                         allow_sessions,
+                        false,
                         false,
                     )?;
                     items.extend(orphaned);

--- a/crates/lex-core/src/lex/parsing/parser/grammar.rs
+++ b/crates/lex-core/src/lex/parsing/parser/grammar.rs
@@ -94,15 +94,19 @@ pub(super) const GRAMMAR_PATTERNS: &[(&str, &str)] = &[
     // (Rust regex crate does not support lookahead)
     // Title accepts same line types as session: paragraph, subject, list, or subject-or-list-item
     //
+    // Leading blank lines between the document start and the title are consumed
+    // by the optional `<lead>` group: per ADR-0002 they are irrelevant and no
+    // longer suppress title promotion (the parser drops that special case).
+    //
     // Subtitle variant: title line ending with colon (subject-line) + second line + blank lines.
     // Tried first so subtitle form wins over plain title.
     (
         "document_title_with_subtitle",
-        r"^<document-start-line>(?P<title><subject-line>|<subject-or-list-item-line>)(?P<subtitle><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank>(<blank-line>)+)",
+        r"^<document-start-line>(?P<lead>(<blank-line>)*)(?P<title><subject-line>|<subject-or-list-item-line>)(?P<subtitle><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank>(<blank-line>)+)",
     ),
     (
         "document_title",
-        r"^<document-start-line>(?P<title><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank>(<blank-line>)+)",
+        r"^<document-start-line>(?P<lead>(<blank-line>)*)(?P<title><paragraph-line>|<subject-line>|<list-line>|<subject-or-list-item-line>)(?P<blank>(<blank-line>)+)",
     ),
     // Document start marker: synthetic boundary between metadata and content
     // Only matched when there's no document title (fallback)


### PR DESCRIPTION
Refs #783. Slice 3 of the Markdown↔Lex faithfulness epic — implements the settled document-title model (ADR-0002) end-to-end across lex-core and lex-babel. Targets the epic branch `epic/markdown-lex-faithfulness`.

## Context (for a stranger)

The old title rule promoted a lone first paragraph to `Document.title` only when no blank line preceded it — a leading blank *suppressed* the title, making a whitespace char semantically load-bearing. And there was no way to say "this document has no title", so a heading-less Markdown source lost round-trip fidelity: its first paragraph was body on read but got stolen as a title on re-parse. ADR-0002 settles both.

**Parser (lex-core) — a sanctioned grammar/behavior change (ADR-0002):**
- The title is the first content element *when it is a paragraph*, regardless of leading blank lines. The grammar `document_title` / `document_title_with_subtitle` patterns now absorb an optional leading-blank run (`<lead>`), and `parser.rs` offsets the title/subtitle indices by that run. The leading-blank suppression special case is gone.
- `:: doc.untitled ::` is registered as a **Reserved-core-builtin marker** (`builtins::doc::DOC_RESERVED_MARKERS`, per comms `general.lex` §4). It is a boolean flag, not render-bearing metadata, so it is deliberately **not** in `CANONICAL_LABELS`/`all_schemas()` (which the registry-mirror test guards) — instead `NormalizeLabels` gets a dedicated carve-out that accepts it (tagged `Canonical`) while third-party `doc.*` still rejects.
- Title suppression is detected once at the single root parse entry (`parse_with_declarative_grammar`) by scanning the leading document-level annotations (before the synthetic `DocumentStart`) for the marker, then threaded to the title match arms. Both parse paths (engine + the `Parsing` transform stage) get it for free with no public-signature change.

**Babel:**
- Markdown reader (`parse_from_markdown`): a leading `# H1` sets `Document.title`; a heading-less source emits the `:: doc.untitled ::` marker into `document_annotations`. (The H1 is no longer emitted as a body paragraph.)
- Markdown serializer already emits no heading when there is no title, and the marker produces no YAML/heading — verified.
- Lex serializer: document-level annotations now serialize at the document **head** (they were appended at the tail, which for reader-built ASTs — all-default source positions — left the marker after the body). A structural trailing blank is inserted after a leading marker-annotation run *only when one is not already present*, so the marker stays document-level on re-parse. This is guarded so it never fires on an element-attached `:: foo ::` (the `annotation-24` forward-attach case).
- The title's trailing blank (title→first-block separation) was already emitted by the existing lex#687 path; no change needed there.
- `canon()` (the #781 faithfulness reducer) now drops a marker annotation's empty-body re-parse artifact, the Faithfulness analog of the serializer's `clean_annotation` — otherwise a reader-emitted marker never compares equal to its own re-parse.

## Known-fails touched

- **document-06** (`document-06-title-untitled`): removed from both `TIER1/TIER2_FIXTURE_KNOWN_FAIL` (`lex#783`) — it now parses title-less and round-trips. The two `document-06` export tests (markdown + html) that asserted the reserved-`doc.*` PARSE ERROR are flipped to assert the real title-less behavior.
- **#791 (advanced):** the four inlines-spec Tier-1 fixtures (`formatting`, `inlines-general`, `citations`, `references-general`) now pass — the head-serialization of document-level annotations subsumed their reorder. Removed from `TIER1_FIXTURE_KNOWN_FAIL`. **#791 is not fully closed:** `document-09-subtitle-with-annotations` (title/subtitle interleaving with leading annotations) and `annotation-27` (Tier-2) still fail and remain listed.

## What is deferred / out of scope

- Session-title hoisting (`document-05`) — #784-area, separate.
- How a Lex subtitle maps to Markdown — separate mapping decision.
- #790 (nested-body de-indent / ragged tables) / #792 — untouched.

## What reviewers must NOT ask for

- Do **not** un-reserve third-party `doc.*` — only the closed `DOC_RESERVED_MARKERS` set is honored; `doc.bogus` still rejects (tested).
- Do not chase #790/#792.

## Testing

- New parser unit tests (engine + normalize_labels): leading-blank still promotes the title; `doc.untitled` suppresses it and stays document-level; third-party `doc.*` still rejects; colon-line title+subtitle; leading non-paragraph element is not a title.
- New title-model faithfulness (canon) tests: H1-led, heading-less (doc.untitled) with full md→lex→md round-trip, single heading-less paragraph.
- `doc.rs`: `doc.untitled` is a reserved marker, not a metadata builtin (kept out of the schema-mirror).
- No new lex text fixtures authored — uses the curated comms fixtures + in-code cases.
- `release-core gate` green; `cargo nextest run --workspace --exclude lex-wasm` → 2640 passed. Titled fixtures verified byte-identical through `lexd format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
