### PR TITLE
test(babel): real Markdown reader over fixture corpus + adjacency/degrade (#785)

### DIFF
--- a/CHANGELOG/unreleased-784-reader-shaped-proptest.md
+++ b/CHANGELOG/unreleased-784-reader-shaped-proptest.md
@@ -1,0 +1,1 @@
+- Reader-shaped round-trip proptest: generate sibling blocks with no pre-inserted BlankLineGroups and assert Skeleton (canon) faithfulness after serialize→parse

--- a/CHANGELOG/unreleased-785-real-reader-fixtures.md
+++ b/CHANGELOG/unreleased-785-real-reader-fixtures.md
@@ -1,0 +1,1 @@
+- faithfulness: real Markdown reader over fixture corpus + adjacency/degrade cases (lex#785)

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -12,23 +12,24 @@
 //! reference, …) currently FAILS end-to-end Faithfulness through the real reader.
 //! The empirical causes, all **pre-existing** and confirmed by minimal repros:
 //!
-//!   - **lex#790 (nested block bodies collapse on serialize)** — the dominant
-//!     blocker, and broader than #790's written repros (verbatim/definition/table)
-//!     suggest. Its most pervasive manifestation is **lists**: the Markdown reader
-//!     builds every list item as `ListItem { text: "", children: [Paragraph] }`
-//!     (comrak's block model — an item contains a paragraph). The Lex serializer
-//!     emits that as the loose form `-\n    text`, which lex-core does **not**
-//!     re-parse as a list — it collapses the whole list into one Paragraph blob.
-//!     So NO reader-built list round-trips, nor does any definition body carrying
-//!     a paragraph+list, nor a colon-terminated paragraph before a verbatim (the
-//!     paragraph is absorbed as the verbatim subject and the body de-indents).
-//!     Any #790 fix must cover reader-built loose lists, not only the named
-//!     verbatim/definition/table cases.
+//!   - **lex#798 (reader-built loose lists collapse on serialize)** — the dominant
+//!     blocker. The Markdown reader builds every list item as
+//!     `ListItem { text: "", children: [Paragraph] }` (comrak's block model — an
+//!     item contains a paragraph). The Lex serializer emits that as the loose form
+//!     `-\n    text`, which lex-core does **not** re-parse as a list — it collapses
+//!     the whole list into one Paragraph blob. So NO reader-built list round-trips;
+//!     since every real fixture contains lists, this alone sinks all of them. Same
+//!     root *mechanism* as #790 (a nested block body under a marker collapses to a
+//!     paragraph) but a distinct, separately-tracked manifestation — #790's title
+//!     and repros name only verbatim/definition/table.
+//!   - **lex#790 (verbatim/definition nested bodies de-indent)** — a definition
+//!     body carrying a paragraph+list, and a colon-terminated paragraph before a
+//!     verbatim (the paragraph is absorbed as the verbatim subject and the body
+//!     de-indents). Present in comrak-readme / comrak-reference on top of #798.
 //!   - **lex#795 (session-marker inference)** — a heading whose text begins with a
 //!     marker-like token (`## 1\. Primary Session` in kitchensink) serializes to
 //!     `1. Primary Session`, which re-parses with a Numerical session marker where
-//!     the reader had `style: None`. A distinct axis from #790; filed by this
-//!     slice.
+//!     the reader had `style: None`. A distinct axis; filed by this slice.
 //!   - **lex#791 (leading-annotation reorder)** — `20-ideas-naked.md`'s leading
 //!     document-level annotations reorder around the title on serialize.
 //!
@@ -39,9 +40,9 @@
 //! fixture is driven through the real reader, and each one still blocked by a
 //! tracked bug is listed against that issue. The sweep asserts (a) no *unlisted*
 //! fixture violates Faithfulness (so a genuinely-new regression fails loudly) and
-//! (b) every *listed* fixture still violates it (anti-rot — the moment #790/#791/
-//! #795 is fixed, the fixture flips to faithful and this list forces its removal,
-//! turning the acceptance criterion into a live end-to-end assertion). The floor
+//! (b) every *listed* fixture still violates it (anti-rot — the moment its bug
+//! (#798/#790/#791/#795) is fixed, the fixture flips to faithful and this list
+//! forces its removal, turning the criterion into a live assertion). The floor
 //! that DOES hold today — the reader always emits well-formed, re-parseable Lex —
 //! is asserted directly (`every_fixture_reader_output_is_reparseable`).
 
@@ -99,12 +100,14 @@ const FIXTURES: &[(&str, &str)] = &[
 /// sweep fails loudly if a listed fixture starts passing (promote it) or an
 /// unlisted one starts failing (a new regression).
 const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #790 — reader-built loose lists (and def/verbatim nested bodies) collapse
-    // on serialize; kitchensink ALSO hits #795 (numbered-heading session marker).
-    ("kitchensink", "lex#790 (+ lex#795)"),
-    ("comrak-readme", "lex#790"),
-    ("commonmark-reference", "lex#790"),
-    ("comrak-reference", "lex#790"),
+    // #798 — reader-built loose lists collapse on serialize (every fixture has
+    // lists, so #798 blocks them all). kitchensink ALSO hits #795 (numbered
+    // heading); comrak-readme / comrak-reference ALSO hit #790 (colon-para →
+    // verbatim-subject absorption). See the module docs for the full analysis.
+    ("kitchensink", "lex#798 (+ lex#795)"),
+    ("comrak-readme", "lex#798 (+ lex#790)"),
+    ("commonmark-reference", "lex#798"),
+    ("comrak-reference", "lex#798 (+ lex#790)"),
     // #791 — leading document-level annotations reorder around the title.
     ("ideas-naked", "lex#791"),
 ];
@@ -190,7 +193,7 @@ fn every_fixture_reader_output_is_reparseable() {
 // is not title-promoted, isolating the pair from the title boundary.
 //
 // Empirically today: para→para, heading→body, para→verbatim, para→definition
-// round-trip faithfully; para→list and list→para do NOT (blocked by lex#790 —
+// round-trip faithfully; para→list and list→para do NOT (blocked by lex#798 —
 // reader-built loose lists collapse on serialize). The blocked pair is asserted
 // as a currently-failing known gap rather than skipped, with the same anti-rot
 // as the fixture sweep.
@@ -231,13 +234,13 @@ fn adjacency_paragraph_to_definition() {
 }
 
 /// paragraph→list and list→paragraph are the two adjacency pairs blocked by
-/// lex#790. Asserted as currently-failing (not skipped): the Markdown reader
+/// lex#798. Asserted as currently-failing (not skipped): the Markdown reader
 /// builds loose list items (`ListItem { text: "", children: [Paragraph] }`)
 /// which the serializer emits as `-\n    text` — a form lex-core re-parses as a
-/// paragraph, collapsing the list. When #790 is fixed these round-trip and this
+/// paragraph, collapsing the list. When #798 is fixed these round-trip and this
 /// test fails, prompting promotion to plain `check_faithful(...).unwrap()`.
 #[test]
-fn adjacency_list_pairs_blocked_by_lex790() {
+fn adjacency_list_pairs_blocked_by_lex798() {
     let para_to_list = format!("{H1}Lead in.\n\n- one\n- two\n");
     let list_to_para = format!("{H1}- one\n- two\n\nTrailer.\n");
     for (name, md) in [
@@ -246,7 +249,7 @@ fn adjacency_list_pairs_blocked_by_lex790() {
     ] {
         assert!(
             check_faithful(&MarkdownFormat, md).is_err(),
-            "{name} now round-trips faithfully — lex#790 appears fixed; \
+            "{name} now round-trips faithfully — lex#798 appears fixed; \
              promote this to a live `check_faithful(...).unwrap()` adjacency assertion"
         );
     }

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -338,7 +338,7 @@ fn backtick_in_code_span_degrades_predictably() {
         1,
         "degrade must yield exactly one body block, got:\n{lex_text}"
     );
-    assert_eq!(paragraphs, vec!["Use `a`b` here.".to_string()]);
+    assert_eq!(paragraphs, vec!["Use `a`b` here."]);
 
     // And it is Skeleton-faithful at the text level: dropping the code-span
     // markup does not change the compared text, so this particular degrade

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -1,0 +1,345 @@
+//! Real-reader fixture corpus + adjacency-pair + degrade cases (lex#785).
+//!
+//! Slice 5 of the Markdown↔Lex faithfulness epic: end-to-end confidence on real
+//! documents, driven through the **real Markdown reader** (`MarkdownFormat::parse`,
+//! comrak), not synthetic ASTs. The invariant under test is Faithfulness
+//! (CONTEXT.md): `canon(md_read(src)) == canon(reparse(serialize(md_read(src))))`,
+//! via the shared `crate::skeleton::check_faithful`.
+//!
+//! ## MAJOR FINDING — real documents do NOT round-trip faithfully today
+//!
+//! Every real fixture (`010-kitchensink.md`, `comrak-readme.md`, the CommonMark
+//! reference, …) currently FAILS end-to-end Faithfulness through the real reader.
+//! The empirical causes, all **pre-existing** and confirmed by minimal repros:
+//!
+//!   - **lex#790 (nested block bodies collapse on serialize)** — the dominant
+//!     blocker, and broader than #790's written repros (verbatim/definition/table)
+//!     suggest. Its most pervasive manifestation is **lists**: the Markdown reader
+//!     builds every list item as `ListItem { text: "", children: [Paragraph] }`
+//!     (comrak's block model — an item contains a paragraph). The Lex serializer
+//!     emits that as the loose form `-\n    text`, which lex-core does **not**
+//!     re-parse as a list — it collapses the whole list into one Paragraph blob.
+//!     So NO reader-built list round-trips, nor does any definition body carrying
+//!     a paragraph+list, nor a colon-terminated paragraph before a verbatim (the
+//!     paragraph is absorbed as the verbatim subject and the body de-indents).
+//!     Any #790 fix must cover reader-built loose lists, not only the named
+//!     verbatim/definition/table cases.
+//!   - **lex#795 (session-marker inference)** — a heading whose text begins with a
+//!     marker-like token (`## 1\. Primary Session` in kitchensink) serializes to
+//!     `1. Primary Session`, which re-parses with a Numerical session marker where
+//!     the reader had `style: None`. A distinct axis from #790; filed by this
+//!     slice.
+//!   - **lex#791 (leading-annotation reorder)** — `20-ideas-naked.md`'s leading
+//!     document-level annotations reorder around the title on serialize.
+//!
+//! ## How this suite stays honest (no forced green, no weakened canon)
+//!
+//! It does NOT skip or weaken the assertions to go green. Instead it uses the same
+//! **known-failure sweep** the formatter suite uses (`format_invariants`): every
+//! fixture is driven through the real reader, and each one still blocked by a
+//! tracked bug is listed against that issue. The sweep asserts (a) no *unlisted*
+//! fixture violates Faithfulness (so a genuinely-new regression fails loudly) and
+//! (b) every *listed* fixture still violates it (anti-rot — the moment #790/#791/
+//! #795 is fixed, the fixture flips to faithful and this list forces its removal,
+//! turning the acceptance criterion into a live end-to-end assertion). The floor
+//! that DOES hold today — the reader always emits well-formed, re-parseable Lex —
+//! is asserted directly (`every_fixture_reader_output_is_reparseable`).
+
+use lex_babel::format::Format;
+use lex_babel::formats::lex::LexFormat;
+use lex_babel::formats::markdown::MarkdownFormat;
+use lex_core::lex::ast::ContentItem;
+use std::path::PathBuf;
+
+use crate::skeleton::{canon, check_faithful};
+
+fn crate_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn read(rel: &str) -> String {
+    let path = crate_path(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+// ============================================================================
+// REAL-READER FIXTURE CORPUS (acceptance criterion 1)
+// ============================================================================
+
+/// The real Markdown fixtures, keyed by a stable name, path relative to the
+/// crate root. `010-kitchensink.md` and `20-ideas-naked.md` are the curated
+/// comms benchmark markdown fixtures (the tests/fixtures/kitchensink.md sibling
+/// is an empty placeholder). comrak-readme + the two references are large real
+/// documents that already live in tests/fixtures.
+const FIXTURES: &[(&str, &str)] = &[
+    (
+        "kitchensink",
+        "../../comms/specs/benchmark/010-kitchensink.md",
+    ),
+    ("comrak-readme", "tests/fixtures/comrak-readme.md"),
+    (
+        "commonmark-reference",
+        "tests/fixtures/markdown-reference-commonmark.md",
+    ),
+    (
+        "comrak-reference",
+        "tests/fixtures/markdown-reference-comrak.md",
+    ),
+    (
+        "ideas-naked",
+        "../../comms/specs/benchmark/20-ideas-naked.md",
+    ),
+];
+
+/// Fixtures whose end-to-end Faithfulness is BLOCKED by a tracked pre-existing
+/// bug, mapped to the dominant tracked issue. See the module docs for the full
+/// per-fixture cause analysis (kitchensink is additionally blocked by #795).
+///
+/// DO NOT clear an entry by weakening `canon` — fix the referenced bug. The
+/// sweep fails loudly if a listed fixture starts passing (promote it) or an
+/// unlisted one starts failing (a new regression).
+const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
+    // #790 — reader-built loose lists (and def/verbatim nested bodies) collapse
+    // on serialize; kitchensink ALSO hits #795 (numbered-heading session marker).
+    ("kitchensink", "lex#790 (+ lex#795)"),
+    ("comrak-readme", "lex#790"),
+    ("commonmark-reference", "lex#790"),
+    ("comrak-reference", "lex#790"),
+    // #791 — leading document-level annotations reorder around the title.
+    ("ideas-naked", "lex#791"),
+];
+
+/// Drive the real reader over every fixture and grade Faithfulness against the
+/// known-failure list. Asserts no unlisted fixture fails and no listed fixture
+/// passes (anti-rot).
+#[test]
+fn faithfulness_over_real_fixtures() {
+    let mut unexpected_fail = Vec::new();
+    let mut unexpected_pass = Vec::new();
+    let mut blocked = Vec::new();
+
+    for (key, rel) in FIXTURES {
+        let src = read(rel);
+        let issue = FIXTURE_KNOWN_FAIL
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, i)| *i);
+        match (check_faithful(&MarkdownFormat, &src), issue) {
+            (Ok(()), None) => {}
+            (Ok(()), Some(issue)) => unexpected_pass.push(format!(
+                "{key}: listed as known-failing ({issue}) but now round-trips faithfully — \
+                 remove it from FIXTURE_KNOWN_FAIL and let this become a live assertion"
+            )),
+            (Err(report), None) => unexpected_fail.push(format!("[{key}]\n{report}")),
+            (Err(_), Some(issue)) => blocked.push(format!("{key} -> {issue}")),
+        }
+    }
+
+    if !blocked.is_empty() {
+        eprintln!(
+            "faithfulness_over_real_fixtures: {} fixture(s) blocked by tracked bugs:\n  {}",
+            blocked.len(),
+            blocked.join("\n  ")
+        );
+    }
+
+    let mut problems = Vec::new();
+    if !unexpected_pass.is_empty() {
+        problems.push(unexpected_pass.join("\n"));
+    }
+    if !unexpected_fail.is_empty() {
+        problems.push(format!(
+            "{} NEW Faithfulness violation(s) (not in FIXTURE_KNOWN_FAIL):\n\n{}",
+            unexpected_fail.len(),
+            unexpected_fail.join("\n\n========\n\n")
+        ));
+    }
+    assert!(problems.is_empty(), "{}", problems.join("\n\n"));
+}
+
+/// The property that DOES hold end-to-end today, even while full Faithfulness is
+/// blocked: the reader's Lex output is always well-formed and re-parses without
+/// error into a non-empty document. This is the "predictable, non-corrupt"
+/// floor — the reader never emits Lex that fails to parse.
+#[test]
+fn every_fixture_reader_output_is_reparseable() {
+    let lex = LexFormat::default();
+    for (key, rel) in FIXTURES {
+        let src = read(rel);
+        let doc = MarkdownFormat
+            .parse(&src)
+            .unwrap_or_else(|e| panic!("[{key}] reader failed: {e}"));
+        let lex_text = lex
+            .serialize(&doc)
+            .unwrap_or_else(|e| panic!("[{key}] serialize failed: {e}"));
+        let reparsed = lex.parse(&lex_text).unwrap_or_else(|e| {
+            panic!("[{key}] reader produced non-reparseable Lex: {e}\n--- Lex ---\n{lex_text}")
+        });
+        assert!(
+            !reparsed.root.children.is_empty(),
+            "[{key}] reader output re-parsed to an empty document"
+        );
+    }
+}
+
+// ============================================================================
+// TARGETED ADJACENCY PAIRS (acceptance criterion 2)
+//
+// Each block-type adjacency pair as a minimal Markdown input to the real reader.
+// Inputs are wrapped in a `# T` H1 (the Document Title) so the first body block
+// is not title-promoted, isolating the pair from the title boundary.
+//
+// Empirically today: para→para, heading→body, para→verbatim, para→definition
+// round-trip faithfully; para→list and list→para do NOT (blocked by lex#790 —
+// reader-built loose lists collapse on serialize). The blocked pair is asserted
+// as a currently-failing known gap rather than skipped, with the same anti-rot
+// as the fixture sweep.
+// ============================================================================
+
+const H1: &str = "# T\n\n";
+
+#[test]
+fn adjacency_paragraph_to_paragraph() {
+    check_faithful(
+        &MarkdownFormat,
+        &format!("{H1}First body.\n\nSecond body.\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn adjacency_heading_to_body() {
+    check_faithful(&MarkdownFormat, &format!("{H1}## Section\n\nBody text.\n")).unwrap();
+}
+
+#[test]
+fn adjacency_paragraph_to_verbatim() {
+    check_faithful(
+        &MarkdownFormat,
+        &format!("{H1}Lead in.\n\n```rust\nfn x() {{}}\n```\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn adjacency_paragraph_to_definition() {
+    check_faithful(
+        &MarkdownFormat,
+        &format!("{H1}Lead in.\n\n**Term**:\n\nDescription.\n"),
+    )
+    .unwrap();
+}
+
+/// paragraph→list and list→paragraph are the two adjacency pairs blocked by
+/// lex#790. Asserted as currently-failing (not skipped): the Markdown reader
+/// builds loose list items (`ListItem { text: "", children: [Paragraph] }`)
+/// which the serializer emits as `-\n    text` — a form lex-core re-parses as a
+/// paragraph, collapsing the list. When #790 is fixed these round-trip and this
+/// test fails, prompting promotion to plain `check_faithful(...).unwrap()`.
+#[test]
+fn adjacency_list_pairs_blocked_by_lex790() {
+    let para_to_list = format!("{H1}Lead in.\n\n- one\n- two\n");
+    let list_to_para = format!("{H1}- one\n- two\n\nTrailer.\n");
+    for (name, md) in [
+        ("paragraph->list", &para_to_list),
+        ("list->paragraph", &list_to_para),
+    ] {
+        assert!(
+            check_faithful(&MarkdownFormat, md).is_err(),
+            "{name} now round-trips faithfully — lex#790 appears fixed; \
+             promote this to a live `check_faithful(...).unwrap()` adjacency assertion"
+        );
+    }
+}
+
+// ============================================================================
+// H1-LED / TITLE-LESS (acceptance criterion 2)
+//
+// The title-model faithfulness cases (ADR-0002 / lex#783) are also asserted
+// directly in import.rs; these restate them here as the fixture-suite's own
+// H1-led and title-less coverage so the acceptance criterion is self-contained.
+// ============================================================================
+
+#[test]
+fn h1_led_document_is_faithful() {
+    let md = "# My Title\n\nFirst paragraph.\n\nSecond paragraph.\n";
+    check_faithful(&MarkdownFormat, md).unwrap();
+    let doc = MarkdownFormat.parse(md).unwrap();
+    assert_eq!(
+        doc.title.as_ref().map(|t| t.as_str()),
+        Some("My Title"),
+        "leading # H1 is the Document Title, not a body paragraph"
+    );
+}
+
+#[test]
+fn title_less_document_is_faithful() {
+    let md = "First paragraph.\n\nSecond paragraph.\n";
+    check_faithful(&MarkdownFormat, md).unwrap();
+    let doc = MarkdownFormat.parse(md).unwrap();
+    assert!(doc.title.is_none(), "heading-less source has no title");
+    assert!(
+        doc.annotations
+            .iter()
+            .any(|a| a.data.label.value == "doc.untitled"),
+        "heading-less source carries the :: doc.untitled :: marker"
+    );
+}
+
+// ============================================================================
+// DECLARED-LOSSY DEGRADE: backtick inside a code span (acceptance criterion 3)
+//
+// Markdown's double-backtick code span `` `` a`b `` `` can contain a literal
+// backtick; a Lex code span is single-backtick delimited and literal, so it
+// CANNOT represent an embedded backtick. This is Declared Lossy — the code-span
+// *markup* is dropped. The requirement is a PREDICTABLE degrade: the produced
+// Lex must re-parse to well-formed text, never corrupt structure.
+// ============================================================================
+
+#[test]
+fn backtick_in_code_span_degrades_predictably() {
+    let md = "Use `` a`b `` here.\n";
+    let doc = MarkdownFormat.parse(md).unwrap();
+    let lex = LexFormat::default();
+    let lex_text = lex.serialize(&doc).unwrap();
+
+    // The degrade must not corrupt structure: the Lex re-parses cleanly...
+    let reparsed = lex
+        .parse(&lex_text)
+        .unwrap_or_else(|e| panic!("degraded Lex did not re-parse: {e}\n{lex_text}"));
+
+    // ...into exactly one body Paragraph (well-formed text), not a spurious
+    // verbatim / definition / broken nesting, and the text content survives
+    // (the backtick chars become literal text — no data lost to corruption).
+    let paragraphs: Vec<&str> = reparsed
+        .root
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ContentItem::Paragraph(p) => Some(p),
+            _ => None,
+        })
+        .flat_map(|p| p.lines.iter())
+        .filter_map(|l| match l {
+            ContentItem::TextLine(tl) => Some(tl.content.as_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        reparsed
+            .root
+            .children
+            .iter()
+            .filter(|c| !matches!(c, ContentItem::BlankLineGroup(_)))
+            .count(),
+        1,
+        "degrade must yield exactly one body block, got:\n{lex_text}"
+    );
+    assert_eq!(paragraphs, vec!["Use `a`b` here.".to_string()]);
+
+    // And it is Skeleton-faithful at the text level: dropping the code-span
+    // markup does not change the compared text, so this particular degrade
+    // happens to survive `canon` too (the guarantee is non-corruption, not
+    // round-trip; here both hold).
+    assert_eq!(canon(&doc), canon(&reparsed));
+}

--- a/crates/lex-babel/tests/markdown/mod.rs
+++ b/crates/lex-babel/tests/markdown/mod.rs
@@ -4,6 +4,7 @@
 
 mod annotations;
 mod export;
+mod faithfulness_fixtures;
 mod frontmatter;
 mod import;
 mod sessions;

--- a/crates/lex-babel/tests/round_trip_proptest/mod.rs
+++ b/crates/lex-babel/tests/round_trip_proptest/mod.rs
@@ -14,6 +14,8 @@ use lex_core::lex::ast::*;
 use lex_core::lex::parsing::parse_document;
 use proptest::prelude::*;
 
+use crate::skeleton::canon;
+
 // -----------------------------------------------------------------------------
 // AST Node Generators
 // -----------------------------------------------------------------------------
@@ -112,34 +114,15 @@ fn definition_strategy() -> impl Strategy<Value = Definition> {
                 true
             },
         ),
-        prop::collection::vec(any::<bool>(), 0..5),
     )
-        .prop_map(|(subject, children, blank_decisions)| {
-            // Pre-compute element types before moving
-            let is_para: Vec<bool> = children
-                .iter()
-                .map(|c| matches!(c, ContentElement::Paragraph(_)))
-                .collect();
-
-            let mut spaced_children = Vec::new();
-            for (i, child) in children.into_iter().enumerate() {
-                if i > 0 {
-                    // Paragraphs merge without blank lines — always separate them.
-                    // Paragraph↔list transitions: randomly include blank line to
-                    // stress-test the parser's match_paragraph lookahead.
-                    let both_para = is_para[i - 1] && is_para[i];
-                    let want_blank = blank_decisions.get(i - 1).copied().unwrap_or(true);
-                    if both_para || want_blank {
-                        spaced_children.push(ContentElement::BlankLineGroup(BlankLineGroup {
-                            count: 1,
-                            source_tokens: vec![],
-                            location: Default::default(),
-                        }));
-                    }
-                }
-                spaced_children.push(child);
-            }
-            Definition::new(TextContent::from_string(subject, None), spaced_children)
+        // Reader-shaped: no pre-inserted BlankLineGroup separators between body
+        // children. The serializer's separation matrix (lex#782/#783) now supplies
+        // every structural blank, so the old "always separate paragraphs" workaround
+        // is obsolete — the children go in exactly as a foreign reader would build
+        // them. `matrix.rs::faithful_definition_followed_by_each_non_hijack_block`
+        // is the proof this shape round-trips.
+        .prop_map(|(subject, children)| {
+            Definition::new(TextContent::from_string(subject, None), children)
         })
 }
 
@@ -217,51 +200,19 @@ fn session_strategy() -> impl Strategy<Value = Session> {
                 true
             },
         ),
-        prop::collection::vec(any::<bool>(), 0..5),
     )
-        .prop_map(|(title, content, blank_decisions)| {
-            // Pre-compute element types before moving
-            let is_para: Vec<bool> = content
-                .iter()
-                .map(|c| matches!(c, SessionContent::Element(ContentElement::Paragraph(_))))
-                .collect();
-
-            let mut spaced_content = Vec::new();
-            for (i, c) in content.into_iter().enumerate() {
-                if i > 0 {
-                    // Paragraphs merge without blank lines — always separate them.
-                    // Paragraph↔list transitions: randomly include blank line to
-                    // stress-test the parser's match_paragraph lookahead.
-                    let both_para = is_para[i - 1] && is_para[i];
-                    let want_blank = blank_decisions.get(i - 1).copied().unwrap_or(true);
-                    if both_para || want_blank {
-                        spaced_content.push(SessionContent::Element(
-                            ContentElement::BlankLineGroup(BlankLineGroup {
-                                count: 1,
-                                source_tokens: vec![],
-                                location: Default::default(),
-                            }),
-                        ));
-                    }
-                }
-                spaced_content.push(c);
-            }
-            // Trailing blank after last element (preserves session boundary behavior)
-            spaced_content.push(SessionContent::Element(ContentElement::BlankLineGroup(
-                BlankLineGroup {
-                    count: 1,
-                    source_tokens: vec![],
-                    location: Default::default(),
-                },
-            )));
-
-            Session {
-                title: TextContent::from_string(title, None),
-                marker: None,
-                children: SessionContainer::from_typed(spaced_content),
-                annotations: vec![],
-                location: Default::default(),
-            }
+        // Reader-shaped: no pre-inserted BlankLineGroups between body elements and
+        // no trailing separator — the shape a foreign reader produces. The
+        // separation matrix (lex#782/#783) supplies the structural blanks on
+        // serialize, so the old "always separate paragraphs" + trailing-boundary
+        // workarounds are obsolete. `matrix.rs::faithful_blocks_nested_in_a_session_body`
+        // proves a mixed reader-shaped session body round-trips.
+        .prop_map(|(title, content)| Session {
+            title: TextContent::from_string(title, None),
+            marker: None,
+            children: SessionContainer::from_typed(content),
+            annotations: vec![],
+            location: Default::default(),
         })
 }
 
@@ -275,24 +226,17 @@ fn nested_session_strategy() -> impl Strategy<Value = Session> {
         ),
         session_strategy(),
     )
+        // Reader-shaped: the leading paragraph(s) and the nested child session are
+        // adjacent siblings with no BlankLineGroup between them; the matrix supplies
+        // the Paragraph→Session structural blank on serialize.
         .prop_map(|(title, content, child_session)| {
-            let mut spaced_content: Vec<SessionContent> = Vec::new();
-            for c in content {
-                spaced_content.push(c);
-                spaced_content.push(SessionContent::Element(ContentElement::BlankLineGroup(
-                    BlankLineGroup {
-                        count: 1,
-                        source_tokens: vec![],
-                        location: Default::default(),
-                    },
-                )));
-            }
-            spaced_content.push(SessionContent::Session(child_session));
+            let mut children: Vec<SessionContent> = content;
+            children.push(SessionContent::Session(child_session));
 
             Session {
                 title: TextContent::from_string(title, None),
                 marker: None,
-                children: SessionContainer::from_typed(spaced_content),
+                children: SessionContainer::from_typed(children),
                 annotations: vec![],
                 location: Default::default(),
             }
@@ -897,6 +841,189 @@ proptest! {
         assert_eq!(
             formatted_1, formatted_2,
             "Formatting is not idempotent!\nFirst:\n{formatted_1}\nSecond:\n{formatted_2}"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Reader-shaped faithfulness (lex#784)
+// -----------------------------------------------------------------------------
+//
+// The regression guard for the whole class of "reader's document falls apart on
+// serialize" bugs. A *reader-shaped* document is one a foreign-format Reader
+// (Markdown, RFC-XML, …) actually produces: sibling blocks carrying NO
+// `BlankLineGroup` separators — blank lines are a Lex serialization concern the
+// Reader never emits. With the separation matrix landed (#782/#783) the
+// serializer now supplies every structural blank, so a reader-shaped AST is a
+// valid input and must survive serialize→reparse *Skeleton-equal* (the
+// Faithfulness invariant, `canon`; CONTEXT.md).
+//
+// The generator draws only the block kinds that round-trip faithfully as bare
+// siblings and excludes the adjacencies the parser provably cannot separate yet
+// — mirrored exactly from `tests/lex_separation/matrix.rs`:
+//   - A Definition immediately before a closer-led block (Verbatim/Table/
+//     Annotation) is hijacked: the verbatim/table matcher re-anchors the next
+//     `:: label ::` closer onto the definition's `subject:` line, swallowing the
+//     pair. No blank count fixes it (matrix.rs::is_known_hijack). We generate
+//     Verbatim (not Table/Annotation) as a closer-led sibling, so the only such
+//     adjacency reachable here is Definition→Verbatim, which the generator
+//     rejects.
+//   - Bare Annotation siblings do not round-trip as siblings (the parser
+//     re-attaches or hoists a floating annotation), so Annotation is never
+//     generated as a top-level block.
+//   - Ragged tables normalize on serialize (lex#792) and top-level Tables would
+//     otherwise stress an orthogonal axis; Table is out of the reader-content set
+//     this slice targets (paragraphs, lists, sessions, definitions, verbatim).
+//
+// Each kind we DO generate is backed by a passing `matrix.rs::faithful_*` example
+// proving that shape is faithful; this proptest generalizes them over random
+// content and arbitrary sibling orderings.
+
+/// The block kinds the reader-shaped generator emits, tagged so the proptest can
+/// reject the documented Definition→Verbatim hijack adjacency by kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReaderBlockKind {
+    Paragraph,
+    List,
+    Session,
+    Definition,
+    Verbatim,
+}
+
+/// A reader-shaped nested (unordered) list: a parent item whose body is a nested
+/// sub-list, plus a plain sibling item — NO `BlankLineGroup` anywhere. Mirrors
+/// the shape `matrix.rs::faithful_nested_lists` proves faithful (item text
+/// followed directly by a child list).
+fn nested_list_strategy() -> impl Strategy<Value = List> {
+    (
+        "[a-zA-Z0-9]+( [a-zA-Z0-9]+)*",
+        list_strategy(),
+        "[a-zA-Z0-9]+( [a-zA-Z0-9]+)*",
+    )
+        .prop_map(|(parent_text, inner, sibling_text)| {
+            let parent = ListItem::with_content(
+                "-".to_string(),
+                parent_text,
+                vec![ContentElement::List(inner)],
+            );
+            let sibling = ListItem {
+                marker: TextContent::from_string("-".to_string(), None),
+                text: vec![TextContent::from_string(format!("{sibling_text}\n"), None)],
+                children: GeneralContainer::empty(),
+                annotations: vec![],
+                location: Default::default(),
+            };
+            let mut container = ListContainer::empty();
+            container.push(ContentItem::ListItem(parent));
+            container.push(ContentItem::ListItem(sibling));
+            let mut list = List::new(vec![]);
+            list.items = container;
+            list.marker = Some(SequenceMarker {
+                raw_text: TextContent::from_string("-".to_string(), None),
+                style: DecorationStyle::Plain,
+                separator: Separator::Period,
+                form: Form::Short,
+                location: Default::default(),
+            });
+            list
+        })
+}
+
+/// A single reader-shaped top-level block, paired with its kind tag. Covers the
+/// reader-content set: paragraphs, unordered/ordered/nested lists, sessions,
+/// definitions, and verbatim blocks. No branch inserts a `BlankLineGroup`.
+fn reader_block_strategy() -> impl Strategy<Value = (ReaderBlockKind, SessionContent)> {
+    prop_oneof![
+        paragraph_strategy().prop_map(|p| (
+            ReaderBlockKind::Paragraph,
+            SessionContent::Element(ContentElement::Paragraph(p)),
+        )),
+        list_strategy().prop_map(|l| (
+            ReaderBlockKind::List,
+            SessionContent::Element(ContentElement::List(l)),
+        )),
+        numbered_list_strategy().prop_map(|l| (
+            ReaderBlockKind::List,
+            SessionContent::Element(ContentElement::List(l)),
+        )),
+        nested_list_strategy().prop_map(|l| (
+            ReaderBlockKind::List,
+            SessionContent::Element(ContentElement::List(l)),
+        )),
+        session_strategy().prop_map(|s| (ReaderBlockKind::Session, SessionContent::Session(s),)),
+        definition_strategy().prop_map(|d| (
+            ReaderBlockKind::Definition,
+            SessionContent::Element(ContentElement::Definition(d)),
+        )),
+        verbatim_strategy().prop_map(|v| (
+            ReaderBlockKind::Verbatim,
+            SessionContent::Element(ContentElement::VerbatimBlock(Box::new(v))),
+        )),
+    ]
+}
+
+/// A two-line lead paragraph. The document-title steal (ADR-0002 / #783) promotes
+/// only a *single-line* first paragraph, so a two-line lead is never stolen and
+/// neutralizes the title boundary — the generated blocks are then measured as
+/// plain siblings. Mirrors `matrix.rs::lead`.
+fn reader_lead() -> SessionContent {
+    SessionContent::Element(ContentElement::Paragraph(Paragraph::new(vec![
+        ContentItem::TextLine(TextLine::new(TextContent::from_string(
+            "Lead line one".to_string(),
+            None,
+        ))),
+        ContentItem::TextLine(TextLine::new(TextContent::from_string(
+            "Lead line two".to_string(),
+            None,
+        ))),
+    ])))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// FAITHFULNESS over reader-shaped documents (lex#784): an arbitrary sequence
+    /// of sibling blocks built with NO pre-inserted `BlankLineGroup`s serializes to
+    /// Lex and re-parses to the same Skeleton (`canon`). This is the property-level
+    /// statement of the invariant the removed pre-insertion workaround used to hide.
+    ///
+    /// The only unfaithful adjacency the generator can produce — a Definition
+    /// immediately before a Verbatim (matrix.rs::is_known_hijack) — is rejected, so
+    /// the test exercises the real reader-shaped-separation failure mode without
+    /// asserting an adjacency the parser provably cannot round-trip yet.
+    #[test]
+    fn reader_shaped_document_is_faithful(
+        blocks in prop::collection::vec(reader_block_strategy(), 1..7),
+    ) {
+        // Reject the documented Definition → Verbatim hijack (the verbatim closer
+        // re-anchors the definition subject). Mirrors matrix.rs::is_known_hijack;
+        // the other two hijack partners (Table/Annotation) are never generated.
+        for pair in blocks.windows(2) {
+            if pair[0].0 == ReaderBlockKind::Definition
+                && pair[1].0 == ReaderBlockKind::Verbatim
+            {
+                return Ok(());
+            }
+        }
+
+        // A title-neutralizing lead, then the generated blocks — all reader-shaped,
+        // zero BlankLineGroups.
+        let mut children = vec![reader_lead()];
+        children.extend(blocks.into_iter().map(|(_, sc)| sc));
+
+        let mut doc = Document::new();
+        doc.root.children = SessionContainer::from_typed(children);
+
+        let serialized = export(&doc).expect("Serialization should not fail");
+        let reparsed = parse_document(&serialized)
+            .unwrap_or_else(|e| panic!("serialized Lex did not re-parse: {e}\n{serialized}"));
+
+        let want = canon(&doc);
+        let got = canon(&reparsed);
+        prop_assert_eq!(
+            want, got,
+            "reader-shaped document not faithful (canon mismatch)\n--- serialized Lex ---\n{}",
+            serialized
         );
     }
 }

--- a/crates/lex-babel/tests/round_trip_proptest/mod.rs
+++ b/crates/lex-babel/tests/round_trip_proptest/mod.rs
@@ -906,18 +906,8 @@ fn nested_list_strategy() -> impl Strategy<Value = List> {
                 parent_text,
                 vec![ContentElement::List(inner)],
             );
-            let sibling = ListItem {
-                marker: TextContent::from_string("-".to_string(), None),
-                text: vec![TextContent::from_string(format!("{sibling_text}\n"), None)],
-                children: GeneralContainer::empty(),
-                annotations: vec![],
-                location: Default::default(),
-            };
-            let mut container = ListContainer::empty();
-            container.push(ContentItem::ListItem(parent));
-            container.push(ContentItem::ListItem(sibling));
-            let mut list = List::new(vec![]);
-            list.items = container;
+            let sibling = ListItem::new("-".to_string(), format!("{sibling_text}\n"));
+            let mut list = List::new(vec![parent, sibling]);
             list.marker = Some(SequenceMarker {
                 raw_text: TextContent::from_string("-".to_string(), None),
                 style: DecorationStyle::Plain,
@@ -998,12 +988,13 @@ proptest! {
         // Reject the documented Definition → Verbatim hijack (the verbatim closer
         // re-anchors the definition subject). Mirrors matrix.rs::is_known_hijack;
         // the other two hijack partners (Table/Annotation) are never generated.
+        // `prop_assume!` discards the sample so proptest regenerates and still runs
+        // the full 256 accepted cases — rejected inputs are not counted as passes.
         for pair in blocks.windows(2) {
-            if pair[0].0 == ReaderBlockKind::Definition
-                && pair[1].0 == ReaderBlockKind::Verbatim
-            {
-                return Ok(());
-            }
+            prop_assume!(
+                !(pair[0].0 == ReaderBlockKind::Definition
+                    && pair[1].0 == ReaderBlockKind::Verbatim)
+            );
         }
 
         // A title-neutralizing lead, then the generated blocks — all reader-shaped,


### PR DESCRIPTION
Refs #785. Slice 5 (final implementation slice) of the Markdown↔Lex faithfulness epic.

## What this adds

`crates/lex-babel/tests/markdown/faithfulness_fixtures.rs` — drives the **real Markdown reader** (comrak, `MarkdownFormat::parse`) over the benchmark/reference markdown fixtures and asserts Faithfulness end-to-end (`canon(md_read(src)) == canon(reparse(serialize(md_read(src))))`) via the shared `crate::skeleton` harness, plus:
- the six required block-adjacency pairs (paragraph→paragraph, paragraph→list, list→paragraph, heading→body, paragraph→verbatim, paragraph→definition),
- H1-led and title-less document cases,
- the backtick-in-code-span **predictable-degrade** case.

## Context — READ THIS (major finding for the epic)

The empirical check the brief asked for found that **every real markdown fixture currently FAILS end-to-end Faithfulness through the real reader.** The headline "real documents round-trip" is **blocked on pre-existing tracked bugs** — the coordinator likely needs to pull the list-collapse fix (at least) into the epic before it can converge. All causes confirmed with minimal repros:

| Fixture | Round-trips today? | Blocked by |
|---|---|---|
| `010-kitchensink.md` | ✗ | **#798** (+ **#795**) |
| `comrak-readme.md` | ✗ | **#798** (+ **#790**) |
| commonmark reference | ✗ | **#798** |
| comrak reference | ✗ | **#798** (+ **#790**) |
| `20-ideas-naked.md` | ✗ | **#791** |

**#798 (filed by this slice) is the dominant blocker.** The Markdown reader builds every list item as `ListItem { text: "", children: [Paragraph] }` (comrak's block model — an item contains a paragraph). The Lex serializer emits that as the loose form `-\n    text`, which lex-core does **not** re-parse as a list — the whole list collapses into one Paragraph blob. So **no reader-built markdown list round-trips**, and since every real fixture contains lists, #798 alone sinks all of them. It shares #790's root *mechanism* (a nested block body under a marker collapses to a paragraph) but #790's title and repros name only verbatim/definition/table, so it is tracked separately (close as dup of #790 if that fix is scoped to cover lists).

**#790** additionally hits comrak-readme / comrak-reference: a colon-terminated paragraph before a code block is absorbed as the verbatim subject and the body de-indents.

**#795 is also new — filed by this slice.** `## 1\. Primary Session` (numbered heading in kitchensink) → the reader builds `Session { style: None }`; the serializer emits `1. Primary Session`, which re-parses with a Numerical session marker. A Faithfulness (serializer) violation on a valid AST, distinct from #790/#791/#792/#798.

## How this stays honest (what reviewers must NOT ask for)

- **Do not force green by weakening `canon`** and **do not skip** the blocked assertions. This suite uses the same **known-failure sweep** the formatter suite uses (`format_invariants`): each blocked fixture is listed against its tracked issue, and the sweep is **anti-rot** — the moment #798/#790/#791/#795 is fixed, the fixture flips to faithful and the list forces its removal, turning the acceptance criterion into a live end-to-end assertion. The blocked `paragraph→list` / `list→paragraph` adjacency pair is likewise asserted as a *currently-failing known gap*, not skipped.
- **Do not fix #798/#790/#791/#792/#795 in this PR** — out of scope for the test slice; they are the coordinator's convergence call.
- The four passing adjacency pairs, the H1/title-less cases, and the degrade case are asserted live and pass.
- The floor that *does* hold end-to-end today — the reader always emits well-formed, re-parseable Lex — is asserted directly (`every_fixture_reader_output_is_reparseable`).

### Degrade case behavior

Markdown `` `` a`b `` `` (double-backtick code span containing a literal backtick) is Declared Lossy — a Lex single-backtick code span can't hold a backtick. It degrades **predictably**: the produced Lex re-parses cleanly into exactly one well-formed Paragraph (`Use ` + literal `` `a`b` `` + ` here.`), never corrupt structure. Asserted explicitly (re-parse succeeds, single body block, text preserved).

## Verification

- `cargo nextest run --workspace --exclude lex-wasm` — 2652 passed, 1 skipped.
- `release-core gate` — green.