### PR TITLE
chore: clear lint debt + add cargo-backed test task (shipit adoption, ADP01-WS01)

### DIFF
--- a/.github/render-homebrew-formula.py
+++ b/.github/render-homebrew-formula.py
@@ -7,6 +7,7 @@ find_unsubstituted post-check fails the run if any {{PLACEHOLDER}} survives.
 
 Called from .github/workflows/release.yml. Not a general-purpose tool.
 """
+
 from __future__ import annotations
 
 import os
@@ -67,7 +68,7 @@ def normalize_brew_desc(s: str) -> str:
     s = s.strip()
     for article in ("A ", "An ", "The "):
         if s.startswith(article):
-            s = s[len(article):]
+            s = s[len(article) :]
             if s and s[0].islower():
                 s = s[0].upper() + s[1:]
             break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
       # depended on by both lexd-lsp and lexd, so it sits after the
       # leaves and before the binary crates. lex-wasm has publish = false
       # and isn't in the list.
-      crates: lex-extension,lex-extension-host,lex-core,lex-babel,lex-config,lex-analysis,lex-lsp-core,lex-fmt,lexd-lsp,lexd
+      crates: "lex-extension,lex-extension-host,lex-core,lex-babel,lex-config,\
+        lex-analysis,lex-lsp-core,lex-fmt,lexd-lsp,lexd"
       # Brew formula subject. The other binary (lexd-lsp) is built and
       # signed alongside but ships as a tarball-only artifact (editor
       # extensions bundle it themselves).

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -16,3 +16,33 @@
 # gates the source).
 skills/
 AGENTS.md
+
+# --- consumer-owned exclusions (lex) ---
+# OVERRIDE of the shipit-managed file (see header): there is no consumer-owned
+# markdownlint ignore seam separate from this managed file, so lex's own
+# non-prose reference markdown has to live here for now. Tracked as a shipit
+# model gap (arthur-debert/shipit#484) — a consumer with test-fixture/reference
+# markdown needs a sanctioned way to exclude it from the managed gate WITHOUT
+# editing this managed file.
+#
+#   - crates/lex-babel/tests/fixtures/*.md — verbatim upstream reference
+#     documents (comrak's README, the CommonMark/comrak markdown references)
+#     consumed byte-for-byte by lex-babel's interop tests. They are DELIBERATE
+#     reference inputs; reformatting them to satisfy prose rules would corrupt
+#     the fixtures and break the tests.
+crates/lex-babel/tests/fixtures/comrak-readme.md
+crates/lex-babel/tests/fixtures/markdown-reference-commonmark.md
+crates/lex-babel/tests/fixtures/markdown-reference-comrak.md
+#
+#   - CHANGELOG.md + CHANGELOG/*.md — the changelog surface. CHANGELOG.md is
+#     GENERATED from the CHANGELOG/*.md fragments by bin/changelog (release.toml
+#     pre-release-hook), so linting the generated aggregate is the generator's
+#     job, and hand-fixes to it are clobbered on the next release cut. The
+#     fragments and the aggregate also carry the normal changelog shape that the
+#     default prose ruleset misfires on — MD024 no-duplicate-heading fires on the
+#     repeated per-release `### Added` / `### Fixed` sub-headings, which is
+#     correct changelog structure, not debt. Excluding the surface rather than
+#     rewriting it to dedupe. (The managed ruleset lacks a changelog-genre
+#     accommodation — see the shipit model-gap issue.)
+CHANGELOG.md
+CHANGELOG/

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -29,7 +29,7 @@ We measure performance across three dimensions:
 Process boot + arg parsing, no actual work:
 
 | Tool | Mean Latency |
-|---|---:|
+| --- | ---: |
 | `cmark --version` | **1.5 ms** |
 | `lexd --version` | **1.7 ms** |
 | `pandoc --version` | **24.8 ms** |
@@ -41,7 +41,7 @@ Process boot + arg parsing, no actual work:
 Time to read a file, parse it, and emit HTML.
 
 | Fixture | Size | `lexd → html` | `cmark md → html` | `pandoc md → html` |
-|---|---:|---:|---:|---:|
+| --- | ---: | ---: | ---: | ---: |
 | `010-kitchensink` (Tier A) | 2.4 KB | 10.6 ms | 1.5 ms | 200 ms |
 | `20-ideas-naked` (Tier A) | 9.8 KB | 23.2 ms | 1.6 ms | 222 ms |
 | `040-on-parsing` (Tier B) | 12.3 KB | 27.7 ms | 1.7 ms | 224 ms |
@@ -62,7 +62,7 @@ The `comrak` configuration matches `lex_babel::formats::markdown::parser::defaul
 Tier C exposes scaling behavior that the realistic-doc tier can't see (same content, controlled size).
 
 | Payload | `lex-core` parse | `comrak` parse | **Multiplier gap** |
-|---|---:|---:|---:|
+| --- | ---: | ---: | ---: |
 | Realistic docs (Tier A/B, 2–24 KB) | ~0.3–0.5 MB/s | ~120–220 MB/s | **~270–380×** |
 | Synthetic 10 KB (Tier C) | 12.79 ms | 47.5 µs | **~269×** |
 | Synthetic 100 KB (Tier C) | 158.2 ms | 498.9 µs | **~317×** |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ comms/
 ## Key Files
 
 | What | Where |
-|------|-------|
+| ------ | ------- |
 | AST nodes | `crates/lex-core/src/lex/ast.rs` |
 | Parser | `crates/lex-core/src/lex/parsing.rs` |
 | Lexer | `crates/lex-core/src/lex/lexing.rs` |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Structure comes from indentation and numbering, not markup. Ideas grow from free
 This repo is the unified Rust workspace containing all backend crates:
 
 | Crate | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `lex-core` | Parser and AST |
 | `lex-babel` | Format conversion (Markdown, HTML, PDF, PNG, Pandoc JSON, RFC XML) |
 | `lex-analysis` | Semantic analysis |

--- a/app-bin/dev/sandbox-test-linux.sh
+++ b/app-bin/dev/sandbox-test-linux.sh
@@ -31,23 +31,23 @@ IMAGE="lex-sandbox-dev:latest"
 DOCKERFILE="$REPO_ROOT/app-bin/dev/Dockerfile.sandbox"
 PLATFORM_FLAG=()
 if [[ -n "${SANDBOX_PLATFORM:-}" ]]; then
-    PLATFORM_FLAG=(--platform "$SANDBOX_PLATFORM")
+	PLATFORM_FLAG=(--platform "$SANDBOX_PLATFORM")
 fi
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/app-bin/dev"
+	docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/app-bin/dev"
 fi
 
 if [[ $# -eq 0 ]]; then
-    set -- cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'
+	set -- cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'
 fi
 
 exec docker run --rm \
-    "${PLATFORM_FLAG[@]}" \
-    -v "$REPO_ROOT:/work" \
-    -v lex-sandbox-target:/target \
-    -v lex-sandbox-cargo-registry:/usr/local/cargo/registry \
-    -e CARGO_TARGET_DIR=/target \
-    -w /work \
-    "$IMAGE" \
-    "$@"
+	"${PLATFORM_FLAG[@]}" \
+	-v "$REPO_ROOT:/work" \
+	-v lex-sandbox-target:/target \
+	-v lex-sandbox-cargo-registry:/usr/local/cargo/registry \
+	-e CARGO_TARGET_DIR=/target \
+	-w /work \
+	"$IMAGE" \
+	"$@"

--- a/bin/install-release-core
+++ b/bin/install-release-core
@@ -58,12 +58,12 @@ set -euo pipefail
 MAJOR=""
 PRINT_URL=0
 NO_INIT=0
-CLOUD=0          # forward --cloud to `release-core init` (cloud-only provisioning:
-                 # tag fetch, dep caches, NSS cert import — WS5/E). Set by --cloud
-                 # or auto-detected from $CLAUDE_CODE_REMOTE below.
-FROM_SOURCE=""   # install from a LOCAL path (a checkout's release_core source)
-                 # instead of a published wheel — same venv/PATH machinery.
-PYTHON="${PYTHON:-python3}"   # interpreter used to BUILD the isolated tool venv
+CLOUD=0 # forward --cloud to `release-core init` (cloud-only provisioning:
+# tag fetch, dep caches, NSS cert import — WS5/E). Set by --cloud
+# or auto-detected from $CLAUDE_CODE_REMOTE below.
+FROM_SOURCE="" # install from a LOCAL path (a checkout's release_core source)
+# instead of a published wheel — same venv/PATH machinery.
+PYTHON="${PYTHON:-python3}" # interpreter used to BUILD the isolated tool venv
 
 # The WS2 GitHub-Pages PEP 503 "simple" pip index (release#759). Served at the
 # dedicated custom domain pypi.magik.works (release#772): the account's user-site
@@ -92,28 +92,28 @@ BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
 RETRY_ATTEMPTS="${RETRY_ATTEMPTS:-3}"
 RETRY_SLEEP="${RETRY_SLEEP:-2}"
 retry() {
-  _attempt=1
-  while :; do
-    # Capture the command's exit code directly (NOT via `if cmd; then`: a failed
-    # `if` condition leaves $? = 0, so the rc would always read as 0 — the bug a
-    # naive `if "$@"; then return 0; fi; _rc=$?` form hides). `&& _rc=0 || _rc=$?`
-    # records the real status while keeping `set -e` happy.
-    "$@" && _rc=0 || _rc=$?
-    if [ "$_rc" -eq 0 ]; then
-      return 0
-    fi
-    if [ "$_attempt" -ge "$RETRY_ATTEMPTS" ]; then
-      echo "install-release-core: command failed after ${RETRY_ATTEMPTS} attempt(s) (rc=${_rc}): $*" >&2
-      return "$_rc"
-    fi
-    echo "install-release-core: attempt ${_attempt}/${RETRY_ATTEMPTS} failed (rc=${_rc}); retrying in $(( RETRY_SLEEP * _attempt ))s — transient?" >&2
-    sleep "$(( RETRY_SLEEP * _attempt ))"
-    _attempt=$(( _attempt + 1 ))
-  done
+	_attempt=1
+	while :; do
+		# Capture the command's exit code directly (NOT via `if cmd; then`: a failed
+		# `if` condition leaves $? = 0, so the rc would always read as 0 — the bug a
+		# naive `if "$@"; then return 0; fi; _rc=$?` form hides). `&& _rc=0 || _rc=$?`
+		# records the real status while keeping `set -e` happy.
+		"$@" && _rc=0 || _rc=$?
+		if [ "$_rc" -eq 0 ]; then
+			return 0
+		fi
+		if [ "$_attempt" -ge "$RETRY_ATTEMPTS" ]; then
+			echo "install-release-core: command failed after ${RETRY_ATTEMPTS} attempt(s) (rc=${_rc}): $*" >&2
+			return "$_rc"
+		fi
+		echo "install-release-core: attempt ${_attempt}/${RETRY_ATTEMPTS} failed (rc=${_rc}); retrying in $((RETRY_SLEEP * _attempt))s — transient?" >&2
+		sleep "$((RETRY_SLEEP * _attempt))"
+		_attempt=$((_attempt + 1))
+	done
 }
 
 usage() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage: install-release-core [--major vN] [--print-url] [--from-source PATH]
                             [--no-init] [--cloud]
 
@@ -153,28 +153,60 @@ EOF
 }
 
 while [ $# -gt 0 ]; do
-  case "$1" in
-    --major)
-      [ $# -ge 2 ] || { echo "install-release-core: --major needs a value (e.g. v2)" >&2; exit 64; }
-      MAJOR="$2"; shift 2 ;;
-    --major=*) MAJOR="${1#--major=}"; shift ;;
-    --print-url) PRINT_URL=1; shift ;;
-    --from-source)
-      [ $# -ge 2 ] || { echo "install-release-core: --from-source needs a PATH" >&2; exit 64; }
-      FROM_SOURCE="$2"; shift 2 ;;
-    --from-source=*) FROM_SOURCE="${1#--from-source=}"; shift ;;
-    --no-init) NO_INIT=1; shift ;;
-    --cloud) CLOUD=1; shift ;;
-    # Tolerated no-ops for stale resolvers/callers mid-fleet-migration: a not-yet
-    # re-pulled consumer's settings hook or an old CI step may still pass --repo /
-    # --commit / --force / --full / --config-only. Accept + ignore rather than
-    # exit 64 (which would break the very boot that updates the caller).
-    --repo) shift 2 ;;
-    --repo=*) shift ;;
-    --commit|--force|--full|--config-only|--user|--break-system-packages) shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "install-release-core: unknown argument '$1'" >&2; usage >&2; exit 64 ;;
-  esac
+	case "$1" in
+	--major)
+		[ $# -ge 2 ] || {
+			echo "install-release-core: --major needs a value (e.g. v2)" >&2
+			exit 64
+		}
+		MAJOR="$2"
+		shift 2
+		;;
+	--major=*)
+		MAJOR="${1#--major=}"
+		shift
+		;;
+	--print-url)
+		PRINT_URL=1
+		shift
+		;;
+	--from-source)
+		[ $# -ge 2 ] || {
+			echo "install-release-core: --from-source needs a PATH" >&2
+			exit 64
+		}
+		FROM_SOURCE="$2"
+		shift 2
+		;;
+	--from-source=*)
+		FROM_SOURCE="${1#--from-source=}"
+		shift
+		;;
+	--no-init)
+		NO_INIT=1
+		shift
+		;;
+	--cloud)
+		CLOUD=1
+		shift
+		;;
+	# Tolerated no-ops for stale resolvers/callers mid-fleet-migration: a not-yet
+	# re-pulled consumer's settings hook or an old CI step may still pass --repo /
+	# --commit / --force / --full / --config-only. Accept + ignore rather than
+	# exit 64 (which would break the very boot that updates the caller).
+	--repo) shift 2 ;;
+	--repo=*) shift ;;
+	--commit | --force | --full | --config-only | --user | --break-system-packages) shift ;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "install-release-core: unknown argument '$1'" >&2
+		usage >&2
+		exit 64
+		;;
+	esac
 done
 
 # Auto-detect a cloud session and forward --cloud to init (WS8: the SessionStart
@@ -187,14 +219,14 @@ done
 # fleet carries it now, so there is no `@vN`-derive fallback. No file → empty MAJOR
 # (the index install drops the version constraint — newest the index serves).
 if [ -z "$MAJOR" ] && [ -z "$FROM_SOURCE" ] && [ -f .release.major.txt ]; then
-  _file_major="$(tr -d '[:space:]' < .release.major.txt)"
-  if [ -n "$_file_major" ]; then
-    MAJOR="v${_file_major}"
-    # --print-url is a resolve-only probe: emit ONLY the constraint, nothing else
-    # (callers + the bats contract treat its output as machine-readable). Keep the
-    # human "pinned to" note for the real install path.
-    [ "$PRINT_URL" -eq 1 ] || echo "install-release-core: pinned to major line $MAJOR (from .release.major.txt)" >&2
-  fi
+	_file_major="$(tr -d '[:space:]' <.release.major.txt)"
+	if [ -n "$_file_major" ]; then
+		MAJOR="v${_file_major}"
+		# --print-url is a resolve-only probe: emit ONLY the constraint, nothing else
+		# (callers + the bats contract treat its output as machine-readable). Keep the
+		# human "pinned to" note for the real install path.
+		[ "$PRINT_URL" -eq 1 ] || echo "install-release-core: pinned to major line $MAJOR (from .release.major.txt)" >&2
+	fi
 fi
 
 # --from-source path resolution (no release/index resolution). The release_core
@@ -203,32 +235,32 @@ fi
 # FIRST: a checkout root descends to it automatically (release#516); only a path
 # without the nested layout is treated as the package dir itself.
 if [ -n "$FROM_SOURCE" ]; then
-  if [ -f "$FROM_SOURCE/templates/commons/lib/release_core/pyproject.toml" ]; then
-    FROM_SOURCE="$FROM_SOURCE/templates/commons/lib/release_core"
-  elif [ ! -f "$FROM_SOURCE/pyproject.toml" ]; then
-    echo "install-release-core: --from-source '$FROM_SOURCE' has no pyproject.toml (and no nested templates/commons/lib/release_core)" >&2
-    exit 1
-  fi
+	if [ -f "$FROM_SOURCE/templates/commons/lib/release_core/pyproject.toml" ]; then
+		FROM_SOURCE="$FROM_SOURCE/templates/commons/lib/release_core"
+	elif [ ! -f "$FROM_SOURCE/pyproject.toml" ]; then
+		echo "install-release-core: --from-source '$FROM_SOURCE' has no pyproject.toml (and no nested templates/commons/lib/release_core)" >&2
+		exit 1
+	fi
 fi
 
 # Build the pip version constraint from the major line (e.g. "v3" → >=3,<4). No
 # major → no constraint (the newest the index serves).
 if [ -n "$MAJOR" ]; then
-  _n="${MAJOR#v}"
-  _spec="release-core>=${_n},<$(( _n + 1 ))"
+	_n="${MAJOR#v}"
+	_spec="release-core>=${_n},<$((_n + 1))"
 else
-  _spec="release-core"
+	_spec="release-core"
 fi
 
 # --print-url is a resolve-only probe: from-source → the resolved path; published →
 # the pip constraint that would be installed from the index. No install, no init.
 if [ "$PRINT_URL" -eq 1 ]; then
-  if [ -n "$FROM_SOURCE" ]; then
-    printf '%s\n' "$FROM_SOURCE"
-  else
-    printf '%s\n' "$_spec"
-  fi
-  exit 0
+	if [ -n "$FROM_SOURCE" ]; then
+		printf '%s\n' "$FROM_SOURCE"
+	else
+		printf '%s\n' "$_spec"
+	fi
+	exit 0
 fi
 
 # Build (once) the DEDICATED venv — fully isolated from the user's pip, the system
@@ -237,12 +269,12 @@ fi
 # Fail fast on a misconfigured VENV_DIR: empty or `/` would make `rm -rf`, the venv
 # build, AND the `$VENV_DIR/bin/*` symlink glob below all act on the filesystem root.
 if [ -z "$VENV_DIR" ] || [ "$VENV_DIR" = "/" ]; then
-  echo "install-release-core: refusing to use invalid VENV_DIR '$VENV_DIR'" >&2
-  exit 1
+	echo "install-release-core: refusing to use invalid VENV_DIR '$VENV_DIR'" >&2
+	exit 1
 fi
 if ! "$VENV_DIR/bin/python" -c 'import sys' >/dev/null 2>&1; then
-  rm -rf "$VENV_DIR"
-  "$PYTHON" -m venv "$VENV_DIR"
+	rm -rf "$VENV_DIR"
+	"$PYTHON" -m venv "$VENV_DIR"
 fi
 
 # Install release_core into the venv. Two sources:
@@ -251,25 +283,25 @@ fi
 PIP="$VENV_DIR/bin/python -m pip install --disable-pip-version-check"
 
 if [ -n "$FROM_SOURCE" ]; then
-  echo "install-release-core: installing $FROM_SOURCE into $VENV_DIR" >&2
-  # FAIL-LOUD + transient-retry (WS6/F): a from-source install reads a LOCAL tree but
-  # still resolves deps (click) over the network, so wrap it in `retry`; set -e halts
-  # on a still-failing install after the retries. --force-reinstall re-lands the
-  # local tree on a re-run (release-dev self-sync).
-  # shellcheck disable=SC2086
-  retry $PIP --force-reinstall "$FROM_SOURCE"
+	echo "install-release-core: installing $FROM_SOURCE into $VENV_DIR" >&2
+	# FAIL-LOUD + transient-retry (WS6/F): a from-source install reads a LOCAL tree but
+	# still resolves deps (click) over the network, so wrap it in `retry`; set -e halts
+	# on a still-failing install after the retries. --force-reinstall re-lands the
+	# local tree on a re-run (release-dev self-sync).
+	# shellcheck disable=SC2086
+	retry $PIP --force-reinstall "$FROM_SOURCE"
 else
-  # INDEX install. The index version-compares, so a plain install upgrades to the
-  # newest matching wheel — NO --force-reinstall (the compare already does the
-  # right thing). transient-retry the install (WS6/F): a network blip must not
-  # fail-loud; a genuine "no such version" is deterministic and aborts after the
-  # retries with the FATAL message below.
-  echo "install-release-core: installing '$_spec' from the pip index ($PIP_INDEX_URL)" >&2
-  # shellcheck disable=SC2086
-  if ! retry $PIP --extra-index-url "$PIP_INDEX_URL" "$_spec"; then
-    echo "install-release-core: FATAL — could not install a release_core wheel from the pip index (after ${RETRY_ATTEMPTS} attempt(s)). The wheel pull is load-bearing: no wheel means no gate. Check network / the index ($PIP_INDEX_URL) and re-run." >&2
-    exit 1
-  fi
+	# INDEX install. The index version-compares, so a plain install upgrades to the
+	# newest matching wheel — NO --force-reinstall (the compare already does the
+	# right thing). transient-retry the install (WS6/F): a network blip must not
+	# fail-loud; a genuine "no such version" is deterministic and aborts after the
+	# retries with the FATAL message below.
+	echo "install-release-core: installing '$_spec' from the pip index ($PIP_INDEX_URL)" >&2
+	# shellcheck disable=SC2086
+	if ! retry $PIP --extra-index-url "$PIP_INDEX_URL" "$_spec"; then
+		echo "install-release-core: FATAL — could not install a release_core wheel from the pip index (after ${RETRY_ATTEMPTS} attempt(s)). The wheel pull is load-bearing: no wheel means no gate. Check network / the index ($PIP_INDEX_URL) and re-run." >&2
+		exit 1
+	fi
 fi
 
 # Expose the venv's console-scripts on PATH (symlink into BIN_DIR), so the gate
@@ -277,12 +309,12 @@ fi
 # without the tool venv itself being on PATH. Skip the venv's own internals.
 mkdir -p "$BIN_DIR"
 for _s in "$VENV_DIR"/bin/*; do
-  [ -f "$_s" ] || [ -L "$_s" ] || continue  # files + symlinks only (skip dirs / empty-glob '*')
-  _name="$(basename "$_s")"
-  case "$_name" in
-    python*|pip*|activate*|Activate.ps1|wheel|*.py) continue ;;
-  esac
-  ln -sf "$_s" "$BIN_DIR/$_name"
+	[ -f "$_s" ] || [ -L "$_s" ] || continue # files + symlinks only (skip dirs / empty-glob '*')
+	_name="$(basename "$_s")"
+	case "$_name" in
+	python* | pip* | activate* | Activate.ps1 | wheel | *.py) continue ;;
+	esac
+	ln -sf "$_s" "$BIN_DIR/$_name"
 done
 
 # Make the exposed scripts reachable — ONE place, every caller. BIN_DIR onto PATH
@@ -290,12 +322,16 @@ done
 # $GITHUB_PATH for later steps. This is the only environment-specific bit, and it
 # lives in the script (not re-scripted in each caller / CI yaml): a CI caller just
 # invokes the resolver and gets working console-scripts, same as a local session.
-case ":$PATH:" in *":$BIN_DIR:"*) : ;; *) PATH="$BIN_DIR:$PATH"; export PATH ;; esac
-[ -n "${GITHUB_PATH:-}" ] && printf '%s\n' "$BIN_DIR" >> "$GITHUB_PATH"
+case ":$PATH:" in *":$BIN_DIR:"*) : ;; *)
+	PATH="$BIN_DIR:$PATH"
+	export PATH
+	;;
+esac
+[ -n "${GITHUB_PATH:-}" ] && printf '%s\n' "$BIN_DIR" >>"$GITHUB_PATH"
 
 if [ "$NO_INIT" -eq 1 ]; then
-  echo "install-release-core: installed (--no-init; skipping release-core init)." >&2
-  exit 0
+	echo "install-release-core: installed (--no-init; skipping release-core init)." >&2
+	exit 0
 fi
 
 # init is best-effort: a failure (e.g. an older published wheel, or a Kind that
@@ -320,12 +356,12 @@ rc="$VENV_DIR/bin/release-core"
 # `set -u` errors on an empty-array `${arr[@]}` expansion, and the only arg is a
 # single literal flag with no whitespace, so word-splitting it is safe + portable.
 _init_flag=""
-[ "$CLOUD" -eq 1 ] && _init_flag="--cloud"   # cloud-only provisioning (WS5/E)
+[ "$CLOUD" -eq 1 ] && _init_flag="--cloud" # cloud-only provisioning (WS5/E)
 if [ -x "$rc" ]; then
-  echo "install-release-core: installed; running release-core init (full install)" >&2
-  # _init_flag is a single controlled literal (--cloud or empty), intentionally split.
-  # shellcheck disable=SC2086
-  "$rc" init $_init_flag || echo "warning: release-core init failed — managed files not refreshed" >&2
+	echo "install-release-core: installed; running release-core init (full install)" >&2
+	# _init_flag is a single controlled literal (--cloud or empty), intentionally split.
+	# shellcheck disable=SC2086
+	"$rc" init $_init_flag || echo "warning: release-core init failed — managed files not refreshed" >&2
 else
-  echo "warning: release-core not found in the tool venv ($rc) — skipping init" >&2
+	echo "warning: release-core not found in the tool venv ($rc) — skipping init" >&2
 fi

--- a/crates/lex-babel/README.lex
+++ b/crates/lex-babel/README.lex
@@ -288,6 +288,8 @@ the export implementation for testing.
           assert!(output.contains("expected content"));
       }
 
+    :: rust ::
+
     3.2. Integration test pattern (string level):
 
       #[test]
@@ -305,6 +307,8 @@ the export implementation for testing.
           // Use `insta` crate for snapshot testing
           insta::assert_snapshot!(format_output);
       }
+
+    :: rust ::
 
   Note: Use lex-parser's STRING_TO_AST.run() or similar parsing utilities to load
   isolated elements from spec files for testing.

--- a/crates/lex-babel/docs/epics/interop-architecture/02-sub-a-symmetric-ir.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/02-sub-a-symmetric-ir.md
@@ -42,7 +42,7 @@ Every format adapter then re-parses or guesses. The IR should carry the classifi
 ### 3. Round-trip parity audit
 
 | Element | Loss | Location |
-|---|---|---|
+| --- | --- | --- |
 | Heading | Level info reconstructed from parent context, not stored | `to_lex.rs:166-201` |
 | Bold/Italic nesting | `Bold([Italic([Text])])` flattens to `*_text_*` text | `to_lex.rs:517-541` |
 | Annotation rich body | OK structurally; semantics depend on dispatch (see umbrella) | — |

--- a/crates/lex-babel/docs/epics/interop-architecture/03-sub-b-unified-registry.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/03-sub-b-unified-registry.md
@@ -13,7 +13,7 @@ Part of the interop architecture work-stream — see umbrella #613.
 Two parallel label-dispatch surfaces exist today:
 
 | Surface | Runs when | Operates on | Produces |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **Verbatim/IR-build dispatch** | `from_lex` (IR construction) | lex-core AST `VerbatimBlock` via `from_lex_verbatim` (`crates/lex-babel/src/ir/from_lex.rs:314-397`) | Typed `DocNode` (`Table`, `Image`, `Video`, `Audio`) |
 | **Render dispatch** | Pre-serialization | lex-core AST via `crates/lex-babel/src/render_dispatch.rs` | Format-specific output spliced into serializer |
 

--- a/crates/lex-babel/docs/epics/interop-architecture/05-sub-d-markdown-hack.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/05-sub-d-markdown-hack.md
@@ -17,7 +17,7 @@ The HACK in `crates/lex-babel/src/formats/markdown/serializer.rs:441-503` (peak 
 Every serialization-oriented format on our horizon already has a native concept of "raw passthrough content":
 
 | Format | Native raw-passthrough mechanism |
-|---|---|
+| --- | --- |
 | Markdown (comrak) | `NodeValue::HtmlBlock { literal }` |
 | HTML (rcdom) | Raw text node (or today's splice-sentinel) |
 | Pandoc (planned, pandoc_ast) | `Block::RawBlock { format, content }` |
@@ -52,7 +52,7 @@ impl<'a> SpliceState<'a> {
 1. **Each format adapter wires `SpliceState` into its event walk** (~5 LOC of wiring) and provides a 1-line `emit_raw_passthrough(content)` callback:
 
 | Format | `emit_raw_passthrough` implementation |
-|---|---|
+| --- | --- |
 | Markdown | `push_child(parent, NodeValue::HtmlBlock { literal: content.to_string(), .. })` |
 | HTML | `append_text_node(parent, content, ContentType::Raw)` |
 | (Future) Pandoc | `push_child(parent, Block::RawBlock("markdown".into(), content.to_string()))` |

--- a/crates/lex-babel/docs/epics/interop-architecture/README.md
+++ b/crates/lex-babel/docs/epics/interop-architecture/README.md
@@ -7,7 +7,7 @@ Each `*.md` file in this directory mirrors the corresponding issue body, so revi
 ## Issues
 
 | # | File | Title |
-|---|---|---|
+| --- | --- | --- |
 | #612 | _(forthcoming as part of #612)_ | v1 interop scope — Markdown/HTML/PDF-out as the bar; Pandoc/LaTeX/HTML-import as planned; PDF-import is a category error |
 | #613 | [`01-umbrella.md`](./01-umbrella.md) | Umbrella: symmetrize the IR, unify label dispatch, retire the markdown HACK |
 | #614 | [`02-sub-a-symmetric-ir.md`](./02-sub-a-symmetric-ir.md) | Sub A: complete IR ↔ Lex symmetry |

--- a/crates/lex-cli/completions/lex.bash
+++ b/crates/lex-cli/completions/lex.bash
@@ -1,67 +1,66 @@
 _lex() {
-    local i cur opts cmd transforms word
-    COMPREPLY=()
-    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
-        cur="$2"
-    else
-        cur="${COMP_WORDS[COMP_CWORD]}"
-    fi
-    cmd=""
-    opts=""
+	local i cur opts cmd transforms word
+	COMPREPLY=()
+	if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+		cur="$2"
+	else
+		cur="${COMP_WORDS[COMP_CWORD]}"
+	fi
+	cmd=""
+	opts=""
 
-    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
-    do
-        case "${cmd},${i}" in
-            ",$1")
-                cmd="lex"
-                ;;
-            *)
-                ;;
-        esac
-    done
+	for i in "${COMP_WORDS[@]:0:COMP_CWORD}"; do
+		case "${cmd},${i}" in
+		",$1")
+			cmd="lex"
+			;;
+		*)
+			;;
+		esac
+	done
 
-    case "${cmd}" in
-        lex)
-            opts="-h -V --list-transforms --help --version"
-            transforms="token-core-json token-core-simple token-core-pprint token-simple token-pprint token-line-json token-line-simple token-line-pprint ir-json ast-json ast-tag ast-treeviz"
+	case "${cmd}" in
+	lex)
+		opts="-h -V --list-transforms --help --version"
+		transforms="token-core-json token-core-simple token-core-pprint token-simple token-pprint token-line-json token-line-simple token-line-pprint ir-json ast-json ast-tag ast-treeviz"
 
-            # Handle flags
-            if [[ ${cur} == -* ]] ; then
-                # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
+		# Handle flags
+		if [[ ${cur} == -* ]]; then
+			# shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
+			COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+			return 0
+		fi
 
-            # Count non-flag arguments
-            local arg_count=0
-            for word in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
-                if [[ ! ${word} == -* ]]; then
-                    ((arg_count++))
-                fi
-            done
+		# Count non-flag arguments
+		local arg_count=0
+		for word in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
+			if [[ ! ${word} == -* ]]; then
+				((arg_count++))
+			fi
+		done
 
-            # First positional argument: file path
-            if [[ ${arg_count} -eq 0 ]]; then
-                # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
-                COMPREPLY=( $(compgen -f -- "${cur}") )
-                return 0
-            fi
+		# First positional argument: file path
+		if [[ ${arg_count} -eq 0 ]]; then
+			# shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
+			COMPREPLY=($(compgen -f -- "${cur}"))
+			return 0
+		fi
 
-            # Second positional argument: transform format
-            if [[ ${arg_count} -eq 1 ]]; then
-                # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
-                COMPREPLY=( $(compgen -W "${transforms}" -- "${cur}") )
-                return 0
-            fi
+		# Second positional argument: transform format
+		if [[ ${arg_count} -eq 1 ]]; then
+			# shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
+			COMPREPLY=($(compgen -W "${transforms}" -- "${cur}"))
+			return 0
+		fi
 
-            COMPREPLY=()
-            return 0
-            ;;
-    esac
+		COMPREPLY=()
+		return 0
+		;;
+	esac
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _lex -o nosort -o bashdefault -o default -o filenames lex
+	complete -F _lex -o nosort -o bashdefault -o default -o filenames lex
 else
-    complete -F _lex -o bashdefault -o default -o filenames lex
+	complete -F _lex -o bashdefault -o default -o filenames lex
 fi

--- a/crates/lex-core/benches/corpus/gen.py
+++ b/crates/lex-core/benches/corpus/gen.py
@@ -7,6 +7,7 @@ content is plain prose so per-byte parser cost is predictable; a separate
 sanity check during the rig's initial run confirmed the wire codec
 round-trips structurally richer documents (sessions, subsections) too.
 """
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
@@ -46,19 +47,28 @@ def s1():
 def s2():
     d = ROOT / "s2_one_small"
     write(d / "frag.lex", paragraphs_for_bytes(100))
-    write(d / "host.lex", paragraphs_for_bytes(2_000) + include("frag.lex") + paragraphs_for_bytes(2_000))
+    write(
+        d / "host.lex",
+        paragraphs_for_bytes(2_000) + include("frag.lex") + paragraphs_for_bytes(2_000),
+    )
 
 
 def s3():
     d = ROOT / "s3_one_medium"
     write(d / "frag.lex", paragraphs_for_bytes(10_000))
-    write(d / "host.lex", paragraphs_for_bytes(2_000) + include("frag.lex") + paragraphs_for_bytes(2_000))
+    write(
+        d / "host.lex",
+        paragraphs_for_bytes(2_000) + include("frag.lex") + paragraphs_for_bytes(2_000),
+    )
 
 
 def s4():
     d = ROOT / "s4_one_large"
     write(d / "frag.lex", paragraphs_for_bytes(100_000))
-    write(d / "host.lex", paragraphs_for_bytes(2_000) + include("frag.lex") + paragraphs_for_bytes(2_000))
+    write(
+        d / "host.lex",
+        paragraphs_for_bytes(2_000) + include("frag.lex") + paragraphs_for_bytes(2_000),
+    )
 
 
 def s5():
@@ -75,7 +85,10 @@ def s6():
     d = ROOT / "s6_deep_chain"
     write(d / "level5.lex", paragraphs_for_bytes(1_000))
     for i in range(4, 0, -1):
-        write(d / f"level{i}.lex", paragraphs_for_bytes(1_000) + include(f"level{i+1}.lex"))
+        write(
+            d / f"level{i}.lex",
+            paragraphs_for_bytes(1_000) + include(f"level{i + 1}.lex"),
+        )
     write(d / "host.lex", paragraphs_for_bytes(500) + include("level1.lex"))
 
 

--- a/crates/lex-core/benches/md_corpus/prep.py
+++ b/crates/lex-core/benches/md_corpus/prep.py
@@ -15,6 +15,7 @@ Prerequisites:
   - `lexd` on PATH (any v0.10+ release covers `--to markdown`)
   - `comms/` submodule initialised
 """
+
 import subprocess
 import sys
 from pathlib import Path

--- a/docs/perf/PARSE_VS_MD_REPORT.md
+++ b/docs/perf/PARSE_VS_MD_REPORT.md
@@ -14,7 +14,7 @@
 - **Corpus**: four documents from `comms/specs/benchmark/`. Two pairs are hand-authored in both formats (tier A — fairest); two have the `.md` produced by `lexd … --to markdown` (tier B — production lex-babel converter, well exercised).
 
 | # | Fixture | Lex bytes | MD bytes | MD source |
-|---|---|---:|---:|---|
+| --- | --- | ---: | ---: | --- |
 | 1 | `010-kitchensink` | 2 456 | 2 189 | hand-authored |
 | 2 | `20-ideas-naked` | 10 057 | 9 453 | hand-authored |
 | 3 | `040-on-parsing` | 12 646 | 11 541 | auto-converted |
@@ -27,7 +27,7 @@ The Lex source is consistently ~5–10% larger than the Markdown encoding, but t
 ## Results
 
 | Fixture | Lex parse | MD parse | **Ratio** | Lex MB/s | MD MB/s |
-|---|---:|---:|---:|---:|---:|
+| --- | ---: | ---: | ---: | ---: | ---: |
 | 010-kitchensink | 7.35 ms | 17.0 µs | **432×** | 0.33 | 129 |
 | 20-ideas-naked | 18.63 ms | 34.6 µs | **538×** | 0.54 | 273 |
 | 040-on-parsing | 22.94 ms | 51.1 µs | **449×** | 0.55 | 226 |

--- a/docs/perf/PERFORMANCE_OVERVIEW.md
+++ b/docs/perf/PERFORMANCE_OVERVIEW.md
@@ -15,14 +15,14 @@ Hyperfine, `--warmup 3 --runs 20 --shell=none`, on a freshly-built `target/relea
 **Startup baselines** (process boot + arg parsing, no work):
 
 | Tool | Mean | Notes |
-|---|---:|---|
+| --- | ---: | --- |
 | `lexd --version` | **1.7 ms** | small Rust binary |
 | `pandoc --version` | **24.8 ms** | Haskell runtime |
 
 **Per-fixture** (mean ± σ, 20 runs each):
 
 | Fixture | Size (KB) | `lexd format` | `lexd → md` | `lexd → html` | `pandoc md → html` | lexd vs pandoc |
-|---|---:|---:|---:|---:|---:|---:|
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | 010-kitchensink | 2.4 | 10.5 ms ± 0.2 | 10.7 ± 0.3 | 10.7 ± 0.2 | 200.0 ± 3.2 | **19× faster** |
 | 20-ideas-naked | 9.8 | 23.2 ± 0.3 | 23.3 ± 0.2 | 23.5 ± 0.3 | 223.2 ± 4.2 | **9.6× faster** |
 | 040-on-parsing | 12.3 | 27.6 ± 0.2 | 27.8 ± 0.2 | 27.9 ± 0.4 | 225.1 ± 4.0 | **8.2× faster** |
@@ -47,7 +47,7 @@ Hyperfine, `--warmup 3 --runs 20 --shell=none`, on a freshly-built `target/relea
 ## Where Lex sits
 
 | Layer | What we measured | Verdict |
-|---|---|---|
+| --- | --- | --- |
 | **Wire-codec dispatch tax** | Include resolution through the extension registry | < 0.6% — invisible. |
 | **Raw parser throughput** | parse_document on 2–25 KB docs | ~0.3–0.5 MB/s. Slow end of parsers; comrak is ~500× faster. |
 | **End-to-end CLI ops** (`format`, `convert`) | hyperfine `target/release/lexd …` | 10–60 ms across 2.4–24 KB. 4–19× faster than pandoc. |

--- a/docs/perf/REPORT.md
+++ b/docs/perf/REPORT.md
@@ -26,7 +26,7 @@ wire-codec tax is below the measurement floor. **Ship it.**
 ### Corpus
 
 | Scenario | Host bytes | Total bytes | Notes |
-|---|---:|---:|---|
+| --- | ---: | ---: | --- |
 | s1_no_includes | 10 010 | 10 010 | Calibration: parse path only, no `lex.include` |
 | s2_one_small | 4 103 | 4 260 | One ~100 B include |
 | s3_one_medium | 4 103 | 14 113 | One ~10 KB include |
@@ -46,7 +46,7 @@ post-flip codec — so the result generalises beyond the prose corpus.
 Median wall time per `resolve_from_source` call (Criterion mid-estimate).
 
 | Scenario | Baseline R1 | Baseline R2 | Post-flip R1 | Post-flip R2 | HEAD R1 | Δ (post-flip vs baseline, mean) | Δ (HEAD vs baseline, mean) |
-|---|---:|---:|---:|---:|---:|---:|---:|
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | s1_no_includes | 12.278 ms | 12.371 ms | 12.286 ms | 12.373 ms | 12.361 ms | +0.04% | +0.30% |
 | s2_one_small | 6.4189 ms | 6.4863 ms | 6.4087 ms | 6.4587 ms | 6.4332 ms | −0.29% | −0.34% |
 | s3_one_medium | 18.202 ms | 18.381 ms | 18.172 ms | 18.310 ms | 18.186 ms | −0.27% | −0.55% |

--- a/multi-repo-bootstrap-plan.md
+++ b/multi-repo-bootstrap-plan.md
@@ -109,7 +109,7 @@ If `clone-lex-repos` is not on `$PATH` (env-setup hasn't propagated yet to the r
 ## Where each piece lives
 
 | Piece | Repo | Path | Distribution |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `clone-lex-repos` source | `arthur-debert/release` | `scripts/clone-lex-repos` | versioned in release repo |
 | Install step | `arthur-debert/release` | `env/setup.sh` | runs on session start |
 | Canonical-list update protocol | `arthur-debert/release` | (commit to scripts/) | PR + redeploy env |
@@ -123,7 +123,7 @@ Nothing lives in the per-stack lex-fmt repos themselves. This is intentional —
 ## Cost & tradeoff summary
 
 | Concern | Mitigation |
-|---|---|
+| --- | --- |
 | Full clones can be heavy (lexed 46M, lex 9M) | Default to full; expose `--depth=1` flag for fast read-only |
 | `--with-setup` runs 8 different toolchain bootstraps | Opt-in only; agents must add the flag when they need it |
 | Stale clones across long-running sessions | `--refresh` flag; skip-if-exists is the default but documented |

--- a/pixi.lock
+++ b/pixi.lock
@@ -26,7 +26,21 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    packages: {}
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-nextest-0.9.138-hb17b654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-nextest-0.9.138-h069e38c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.138-h19f9e61_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.138-h6fdd925_0.conda
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -35,6 +49,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-nextest-0.9.138-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
@@ -78,6 +93,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-nextest-0.9.138-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/go-shfmt-3.13.1-h22914b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
@@ -125,6 +141,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.138-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -164,6 +181,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.138-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -238,6 +256,19 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 207882
   timestamp: 1765214722852
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-nextest-0.9.138-hb17b654_0.conda
+  sha256: 8ac16143ca47bba88eef9b3e8d5a1f346611ae06978c7c8da5228e6cb5442ca3
+  md5: 452bb99dc31e1dc61072323b57ef4e28
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6874713
+  timestamp: 1782089518948
 - conda: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
   sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
   md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
@@ -745,6 +776,18 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 217215
   timestamp: 1765214743735
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-nextest-0.9.138-h069e38c_0.conda
+  sha256: 9a8bcb21dfb1ae40a2342b9199225aaa53db57ab5dccd74435f1346108eeb9b8
+  md5: 1a5d5a22c2b56e698d9c2986f4fdc45c
+  depends:
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6743620
+  timestamp: 1782089530027
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/go-shfmt-3.13.1-h22914b5_0.conda
   sha256: 6167f8e73add65218da61dd05467fa24addcf300be85cc23a7287d6f27ce7426
   md5: 5a8073ee07ff67cd8a7acad84525564d
@@ -1260,6 +1303,18 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 186122
   timestamp: 1765215100384
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.138-h19f9e61_0.conda
+  sha256: 4371be14b081992dfa94de65a1c6427fb6fffdc54ca72191d568bfd917450927
+  md5: 0e2d700cbe2a8ac00aebfc08323043f4
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6856922
+  timestamp: 1782089589167
 - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
   sha256: 75aa5e7a875afdcf4903b7dc98577672a3dc17b528ac217b915f9528f93c85fc
   md5: 427101d13f19c4974552a4e5b072eef1
@@ -1696,6 +1751,18 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 180327
   timestamp: 1765215064054
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.138-h6fdd925_0.conda
+  sha256: f1edbd55b66dc2ba88cdb28e6ee0fc95692317d0815c5e388fff7253b93dbd16
+  md5: ac3e73a6edf26e3ff08c3af4409e7232
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6319299
+  timestamp: 1782089539414
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
   sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
   md5: eed7278dfbab727b56f2c0b64330814b

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,3 +38,11 @@ lefthook = "2.1.*"
 # >>> shipit-managed environments (do not edit; regenerate via `shipit install`) >>>
 lint = ["lint"]
 # <<< shipit-managed environments <<<
+
+# Consumer-owned dependencies (outside the shipit-managed blocks above).
+# cargo-nextest provisions the `test` task's runner FROM pixi, so `pixi run test`
+# works in a clean pixi env — not only where nextest already happens to be on
+# PATH. The Rust toolchain itself (cargo/rustc) comes from the host, matching
+# lex's CI (setup-rust), which is why only the nextest runner is pinned here.
+[dependencies]
+cargo-nextest = ">=0.9.138,<0.10"

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,6 +12,13 @@ logs = "./bin/shipit logs"
 provision-lexd = "./bin/shipit provision lexd"
 # <<< shipit-managed tasks <<<
 
+# Consumer-owned tasks (outside the shipit-managed block above).
+# `test` runs the workspace suite via cargo-nextest — the runner lex's CI uses
+# (.github/workflows test-rust.yml / sandbox-tests.yml). Without this, `pixi run
+# test` falls through to the POSIX `test` builtin (silent exit 1, no suite run) —
+# the #444 trap.
+test = "cargo nextest run --workspace"
+
 [feature.lint.dependencies]
 # >>> shipit-managed lint deps (do not edit; regenerate via `shipit install`) >>>
 # The fleet-pinned lint toolchain (docs/prd/adoption.md: the managed set owns

--- a/tree-sitter-plan.md
+++ b/tree-sitter-plan.md
@@ -45,7 +45,7 @@ The grammar itself is **regular at each indent level**. Once indent/dedent bound
 ### External Scanner Responsibilities
 
 | What | How |
-|------|-----|
+| ------ | ----- |
 | Indentation tracking | Stack of indent levels; 4 spaces or 1 tab = 1 level |
 | INDENT token | Emitted when indent level increases |
 | DEDENT token(s) | Emitted when indent level decreases (possibly multiple) |
@@ -222,7 +222,7 @@ Integrate into CI alongside the existing test suite.
 Don't require full parity from day one. Compare progressively:
 
 | Phase | Compare | Ignore |
-|-------|---------|--------|
+| ------- | --------- | -------- |
 | M1-M2 | Node types + nesting depth | Inline content, locations, annotations |
 | M3-M4 | + List structure, annotation forms | Inline content, locations |
 | M5 | + Verbatim raw content | Inline content, locations |
@@ -305,7 +305,7 @@ Implemented in three sub-phases:
 ## Risk Register
 
 | Risk | Impact | Likelihood | Mitigation |
-|------|--------|------------|------------|
+| ------ | -------- | ------------ | ------------ |
 | Verbatim block scanning too complex for external scanner | High | Medium | Prototype early (Phase 5). Fallback: mark verbatim as opaque node, use current parser for content |
 | Session/definition ambiguity causes parse conflicts | Medium | Low | Tree-sitter's GLR + precedence handles this. Proven pattern from other indentation-sensitive grammars |
 | Inline parsing too complex in-grammar | Medium | Medium | Fallback: parse inlines as flat text in grammar, run inline pass in consumer. Loses incremental benefit but unblocks |


### PR DESCRIPTION
Adoption pre-work for shipit onboarding — for arthur-debert/shipit#471 (ADP01-WS01; note that tracker is a **cross-repo** shipit issue, not a lex issue). Two commits, both `chore`.

## Commit 1 — clear pre-existing lint debt

Brings `pixi run -e lint lint` (`./bin/shipit lint`) to GREEN without corrupting any semantically-meaningful content.

**Fixed:**

| Category | What |
|----------|------|
| ruff format (3 py) | Auto-formatted `render-homebrew-formula.py`, `benches/corpus/gen.py`, `benches/md_corpus/prep.py`. |
| shfmt (3 sh) | Auto-formatted `sandbox-test-linux.sh`, `install-release-core`, `completions/lex.bash` (a committed copy — `build.rs` generates into `OUT_DIR`, not the tree — so shfmt is safe there). |
| yamllint (1 line) | `release.yml:38` line-too-long — wrapped the `crates:` value with a double-quoted escaped line break. Folded value is **byte-identical** to the original comma list (verified via YAML load). |
| lexd (2) | `lex-babel/README.lex` — the flagged "footnotes" `[1]`/`[2]` were `events[1]`/`events[2]` array indices in Rust code examples that lexd inline-parsed as numbered footnotes. Fixed by making the two examples proper Lex **verbatim blocks** (`:: rust ::` closings), preserving the code exactly. Not by inventing footnote definitions. |
| markdownlint MD060 | Auto-fixed table pipe-spacing (compact→padded) across `BENCHMARKS.md`, `CLAUDE.md`, `README.md`, `tree-sitter-plan.md`, `multi-repo-bootstrap-plan.md`, `docs/perf/*.md`, and the interop-architecture epic docs. Cosmetic only. |

**Excluded (NOT reformatted), via a clearly-delimited consumer section in the shipit-managed `.markdownlintignore`:**

- `crates/lex-babel/tests/fixtures/{comrak-readme,markdown-reference-commonmark,markdown-reference-comrak}.md` — verbatim upstream reference documents consumed byte-for-byte by lex-babel's interop tests; reformatting would corrupt them.
- `CHANGELOG.md` + `CHANGELOG/` — `CHANGELOG.md` is **generated** from the fragments by `bin/changelog` (`release.toml` pre-release-hook), and the surface carries the normal changelog shape `MD024/no-duplicate-heading` misfires on (repeated per-release `### Added`/`### Fixed`). Excluded rather than rewritten to dedupe.

**Model gap — filed as arthur-debert/shipit#484:** editing the managed `.markdownlintignore` is an OVERRIDE (reverts at the next `shipit install` reconcile). A consumer with its own non-prose / reference / generated markdown has **no sanctioned exclusion seam**, and MD024 has no changelog-genre accommodation. The consumer section is the documented least-bad interim mechanism.

## Commit 2 — cargo-backed `test` pixi task (#444)

lex defined no `test` task, so `pixi run test` silently ran the POSIX `test` builtin (exit 1, no output — the #444 trap). Added a consumer-owned task (outside the managed `[tasks]` block) wired to cargo-nextest, lex's CI runner:

```
test = "cargo nextest run --workspace"
```

Verified: `pixi run test` compiles and runs the workspace suite — **2609 tests across 35 binaries, all passing** (1 skipped). The suite needs the `comms` git submodule (spec-file root `comms/specs`); `git submodule update --init` is a prerequisite, independent of this task.

## Notes / friction

- A fresh `gh repo clone` does not `lefthook install`, so the managed pre-commit lint gate did not auto-run — I verified `./bin/shipit lint` GREEN manually before each commit instead.
