### PR TITLE
fix(babel): reader-built lists round-trip through Lex (lex#798)

### DIFF
--- a/CHANGELOG/unreleased-798-loose-list-roundtrip.md
+++ b/CHANGELOG/unreleased-798-loose-list-roundtrip.md
@@ -1,0 +1,1 @@
+- faithfulness: reader-built Markdown lists (unordered, ordered, nested, multi-block) round-trip through Lex — the serializer hoists a foreign-reader item's leading paragraph onto the tight `- text` marker line instead of the loose form that collapsed the list to a paragraph (lex#798)

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -5,7 +5,8 @@ use lex_core::lex::ast::{
         verbatim::VerbatimGroupItemRef, VerbatimLine,
     },
     traits::{AstNode, Visitor},
-    Annotation, Definition, Document, List, ListItem, Paragraph, Session, Table, Verbatim,
+    Annotation, ContentItem, Definition, Document, List, ListItem, Paragraph, Session, Table,
+    Verbatim,
 };
 
 use lex_core::lex::assembling::stages::normalize_labels::source_spelling;
@@ -47,6 +48,18 @@ pub struct LexSerializer {
     /// first. `separate_before` consults the separation matrix against it to emit
     /// the grammar-mandated blank lines between adjacent blocks.
     sibling_levels: Vec<Option<BlockKind>>,
+    /// The Paragraph whose first line was hoisted onto a list item's marker line
+    /// (lex#798). A foreign reader (comrak) builds every list item as
+    /// `{ text: "", children: [Paragraph, …] }`; that empty-text shape would
+    /// serialize to the loose `-\n    body` form, which lex-core does NOT
+    /// re-parse as a list (it reads the bare `-` as prose and collapses the whole
+    /// list to a paragraph). `visit_list_item` instead emits the leading
+    /// paragraph's first line as the tight `- text` item, records that paragraph
+    /// here, and `visit_paragraph` skips re-emitting its first line.
+    hoisted_paragraph: Option<*const Paragraph>,
+    /// Set when `visit_paragraph` recognizes the hoisted paragraph, consumed by
+    /// the next `visit_text_line` to drop the already-hoisted first line.
+    skip_paragraph_first_line: bool,
 }
 
 impl LexSerializer {
@@ -60,6 +73,8 @@ impl LexSerializer {
             emitted_footnote_lists: Vec::new(),
             suppress_output: 0,
             sibling_levels: Vec::new(),
+            hoisted_paragraph: None,
+            skip_paragraph_first_line: false,
         }
     }
 
@@ -205,6 +220,28 @@ impl LexSerializer {
             }
         }
     }
+
+    /// lex#798 helper: if the item's leading block is a Paragraph with a first
+    /// text line, record it as the hoisted paragraph and return that first line
+    /// (to become the tight `- text` marker-line text). Leading BlankLineGroups
+    /// (which a reader would not emit, but which are harmless) are skipped. The
+    /// recorded paragraph's first line is dropped by `visit_paragraph` /
+    /// `visit_text_line` so it is not emitted twice.
+    fn hoist_leading_paragraph_line(&mut self, list_item: &ListItem) -> Option<String> {
+        let first_block = list_item
+            .children
+            .iter()
+            .find(|c| !matches!(c, ContentItem::BlankLineGroup(_)))?;
+        let ContentItem::Paragraph(paragraph) = first_block else {
+            return None;
+        };
+        let first_line = paragraph.lines.iter().find_map(|line| match line {
+            ContentItem::TextLine(tl) => Some(tl.text().trim_end().to_string()),
+            _ => None,
+        })?;
+        self.hoisted_paragraph = Some(paragraph as *const Paragraph);
+        Some(first_line)
+    }
 }
 
 impl Visitor for LexSerializer {
@@ -229,7 +266,16 @@ impl Visitor for LexSerializer {
         }
     }
 
-    fn visit_paragraph(&mut self, _paragraph: &Paragraph) {
+    fn visit_paragraph(&mut self, paragraph: &Paragraph) {
+        // lex#798: this paragraph's first line was hoisted onto the enclosing
+        // list item's marker line. It is not a standalone sibling block, so skip
+        // the separation blank and mark its first line to be dropped. Any
+        // remaining lines still emit as the item's indented body.
+        if self.hoisted_paragraph == Some(paragraph as *const Paragraph) {
+            self.hoisted_paragraph = None;
+            self.skip_paragraph_first_line = true;
+            return;
+        }
         // Paragraphs are handled by visiting TextLines; this hook only registers
         // the paragraph as a sibling block so the separation matrix can emit the
         // grammar-mandated blank before it (a reader-built AST has no
@@ -240,6 +286,11 @@ impl Visitor for LexSerializer {
     }
 
     fn visit_text_line(&mut self, text_line: &TextLine) {
+        // lex#798: drop the line already hoisted onto the list item's marker line.
+        if self.skip_paragraph_first_line {
+            self.skip_paragraph_first_line = false;
+            return;
+        }
         let text = text_line.text().trim_end();
         self.write_line(text);
     }
@@ -340,10 +391,28 @@ impl Visitor for LexSerializer {
             ""
         };
 
-        let line = if text.is_empty() {
+        // lex#798: a foreign reader builds each item as `{ text: "", children:
+        // [Paragraph, …] }` (comrak's block model — the item's content lives in a
+        // child Paragraph, not in `text`). Serializing that empty-text shape as
+        // the loose `-\n    body` form does not re-parse as a list — lex-core
+        // reads the bare `-` as prose and the whole list collapses to a
+        // paragraph. When the item has no marker-line text but its leading block
+        // is a Paragraph, hoist that paragraph's first line onto the marker line
+        // (the tight `- text` form, which re-parses as a list item). The
+        // paragraph's remaining lines and every other child stay in the indented
+        // body, so genuinely multi-block items (paragraph + sublist, extra
+        // paragraphs) are untouched.
+        let hoisted = if text.is_empty() {
+            self.hoist_leading_paragraph_line(list_item)
+        } else {
+            None
+        };
+        let effective_text = hoisted.as_deref().unwrap_or(text);
+
+        let line = if effective_text.is_empty() {
             marker
         } else {
-            format!("{marker} {text}")
+            format!("{marker} {effective_text}")
         };
 
         self.write_line(&line);

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -221,12 +221,18 @@ impl LexSerializer {
         }
     }
 
-    /// lex#798 helper: if the item's leading block is a Paragraph with a first
-    /// text line, record it as the hoisted paragraph and return that first line
-    /// (to become the tight `- text` marker-line text). Leading BlankLineGroups
-    /// (which a reader would not emit, but which are harmless) are skipped. The
-    /// recorded paragraph's first line is dropped by `visit_paragraph` /
-    /// `visit_text_line` so it is not emitted twice.
+    /// lex#798 helper: if the item's leading block is a *plain* Paragraph with a
+    /// first text line, record it as the hoisted paragraph and return that first
+    /// line (to become the tight `- text` marker-line text). Leading
+    /// BlankLineGroups (which a reader would not emit, but which are harmless) are
+    /// skipped. The recorded paragraph's first line is dropped by `visit_paragraph`
+    /// / `visit_text_line` so it is not emitted twice.
+    ///
+    /// A paragraph carrying block annotations is NOT hoisted: hoisting bypasses
+    /// its `visit_paragraph` body, and the Skeleton fold (`canon`) likewise only
+    /// folds an unannotated leading paragraph — keeping the two decisions
+    /// symmetric. (A Markdown-reader item never carries annotations; this is a
+    /// defensive invariant, not a reachable path today.)
     fn hoist_leading_paragraph_line(&mut self, list_item: &ListItem) -> Option<String> {
         let first_block = list_item
             .children
@@ -235,6 +241,9 @@ impl LexSerializer {
         let ContentItem::Paragraph(paragraph) = first_block else {
             return None;
         };
+        if !paragraph.annotations.is_empty() {
+            return None;
+        }
         let first_line = paragraph.lines.iter().find_map(|line| match line {
             ContentItem::TextLine(tl) => Some(tl.text().trim_end().to_string()),
             _ => None,

--- a/crates/lex-babel/src/ir/to_lex.rs
+++ b/crates/lex-babel/src/ir/to_lex.rs
@@ -4,10 +4,11 @@
 //! back to Lex AST structures.
 
 use lex_core::lex::ast::elements::{
-    typed_content, verbatim::VerbatimBlockMode, Annotation as LexAnnotation, ContentElement,
-    ContentItem as LexContentItem, Definition as LexDefinition, Label, List as LexList,
-    ListItem as LexListItem, Paragraph as LexParagraph, Session as LexSession,
-    Verbatim as LexVerbatim, VerbatimContent, VerbatimLine as LexVerbatimLine,
+    sequence_marker::SequenceMarker, typed_content, verbatim::VerbatimBlockMode,
+    Annotation as LexAnnotation, ContentElement, ContentItem as LexContentItem,
+    Definition as LexDefinition, Label, List as LexList, ListItem as LexListItem,
+    Paragraph as LexParagraph, Session as LexSession, Verbatim as LexVerbatim, VerbatimContent,
+    VerbatimLine as LexVerbatimLine,
 };
 use lex_core::lex::ast::range::Position;
 use lex_core::lex::ast::{Data, Document as LexDocument, Parameter, Range, TextContent};
@@ -342,7 +343,16 @@ fn to_lex_list(list: &List) -> LexContentItem {
         .enumerate()
         .map(|(i, item)| to_lex_list_item_with_style(item, &list.style, i + 1))
         .collect();
-    LexContentItem::List(LexList::new(items))
+    let mut lex_list = LexList::new(items);
+    // Record the list's decoration style on the List node (lex#798). Leaving
+    // `marker: None` here made the Lex serializer fall back to the plain dash —
+    // numbered/alpha/roman lists lost their markers on serialize — and left the
+    // Skeleton's list-style `None` where a re-parsed list carries a concrete
+    // style, tripping Faithfulness. Deriving the marker from the first item's
+    // style mirrors how the Lex parser sets a list's style from its first item.
+    let first_marker = format_marker_for_style(&list.style, 1);
+    lex_list.marker = SequenceMarker::parse(&first_marker, None);
+    LexContentItem::List(lex_list)
 }
 
 /// Converts an IR ListItem to a Lex ListItem with a marker derived from style and position.

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -9,27 +9,29 @@
 //! ## MAJOR FINDING — real documents do NOT round-trip faithfully today
 //!
 //! Every real fixture (`010-kitchensink.md`, `comrak-readme.md`, the CommonMark
-//! reference, …) currently FAILS end-to-end Faithfulness through the real reader.
+//! reference, …) still FAILS end-to-end Faithfulness through the real reader.
 //! The empirical causes, all **pre-existing** and confirmed by minimal repros:
 //!
-//!   - **lex#798 (reader-built loose lists collapse on serialize)** — the dominant
-//!     blocker. The Markdown reader builds every list item as
+//!   - **lex#798 (reader-built loose lists collapse on serialize) — FIXED.** The
+//!     Markdown reader builds every list item as
 //!     `ListItem { text: "", children: [Paragraph] }` (comrak's block model — an
-//!     item contains a paragraph). The Lex serializer emits that as the loose form
-//!     `-\n    text`, which lex-core does **not** re-parse as a list — it collapses
-//!     the whole list into one Paragraph blob. So NO reader-built list round-trips;
-//!     since every real fixture contains lists, this alone sinks all of them. Same
-//!     root *mechanism* as #790 (a nested block body under a marker collapses to a
-//!     paragraph) but a distinct, separately-tracked manifestation — #790's title
-//!     and repros name only verbatim/definition/table.
-//!   - **lex#790 (verbatim/definition nested bodies de-indent)** — a definition
-//!     body carrying a paragraph+list, and a colon-terminated paragraph before a
-//!     verbatim (the paragraph is absorbed as the verbatim subject and the body
-//!     de-indents). Present in comrak-readme / comrak-reference on top of #798.
+//!     item contains a paragraph); the Lex serializer used to emit that as the
+//!     loose `-\n    text` form, which lex-core does not re-parse as a list (it
+//!     collapsed the whole list into one Paragraph). The serializer now hoists the
+//!     item's leading Paragraph onto the tight `- text` marker line (and the
+//!     reader records the list's decoration style on the List node), so
+//!     reader-built lists — unordered, ordered, nested, multi-block — round-trip.
+//!     Lists are no longer a blocker for any fixture; the entries below were
+//!     re-attributed to the OTHER bug each still trips once #798 was out of the way.
+//!   - **lex#790 (verbatim/definition nested bodies de-indent)** — a colon-terminated
+//!     paragraph before a verbatim is absorbed as the verbatim subject / turned into
+//!     a Definition, and the body de-indents. This is what now blocks the CommonMark
+//!     reference, comrak-readme, and comrak-reference (each has such a colon-para →
+//!     fenced-code adjacency, some inside a list item).
 //!   - **lex#795 (session-marker inference)** — a heading whose text begins with a
 //!     marker-like token (`## 1\. Primary Session` in kitchensink) serializes to
 //!     `1. Primary Session`, which re-parses with a Numerical session marker where
-//!     the reader had `style: None`. A distinct axis; filed by this slice.
+//!     the reader had `style: None`. What now blocks kitchensink.
 //!   - **lex#791 (leading-annotation reorder)** — `20-ideas-naked.md`'s leading
 //!     document-level annotations reorder around the title on serialize.
 //!
@@ -93,21 +95,25 @@ const FIXTURES: &[(&str, &str)] = &[
 ];
 
 /// Fixtures whose end-to-end Faithfulness is BLOCKED by a tracked pre-existing
-/// bug, mapped to the dominant tracked issue. See the module docs for the full
-/// per-fixture cause analysis (kitchensink is additionally blocked by #795).
+/// bug, mapped to the remaining tracked issue now that lex#798 (lists) is fixed.
+/// See the module docs for the full per-fixture cause analysis.
 ///
 /// DO NOT clear an entry by weakening `canon` — fix the referenced bug. The
 /// sweep fails loudly if a listed fixture starts passing (promote it) or an
 /// unlisted one starts failing (a new regression).
 const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #798 — reader-built loose lists collapse on serialize (every fixture has
-    // lists, so #798 blocks them all). kitchensink ALSO hits #795 (numbered
-    // heading); comrak-readme / comrak-reference ALSO hit #790 (colon-para →
-    // verbatim-subject absorption). See the module docs for the full analysis.
-    ("kitchensink", "lex#798 (+ lex#795)"),
-    ("comrak-readme", "lex#798 (+ lex#790)"),
-    ("commonmark-reference", "lex#798"),
-    ("comrak-reference", "lex#798 (+ lex#790)"),
+    // #798 (reader-built loose lists) is FIXED — reader-built lists now round-trip.
+    // Each fixture below was verified (recursive Skeleton diff) to have no
+    // remaining list-structure divergence; the entry names the OTHER bug it still
+    // trips. kitchensink → #795 (its `## 1. Primary Session` numbered heading
+    // re-parses as a Numerical session marker). commonmark-reference /
+    // comrak-readme / comrak-reference → #790 (a colon-terminated paragraph before
+    // a fenced code block is absorbed as the verbatim subject / becomes a
+    // Definition, some inside a list item). See the module docs for the analysis.
+    ("kitchensink", "lex#795"),
+    ("comrak-readme", "lex#790"),
+    ("commonmark-reference", "lex#790"),
+    ("comrak-reference", "lex#790"),
     // #791 — leading document-level annotations reorder around the title.
     ("ideas-naked", "lex#791"),
 ];
@@ -192,11 +198,8 @@ fn every_fixture_reader_output_is_reparseable() {
 // Inputs are wrapped in a `# T` H1 (the Document Title) so the first body block
 // is not title-promoted, isolating the pair from the title boundary.
 //
-// Empirically today: para→para, heading→body, para→verbatim, para→definition
-// round-trip faithfully; para→list and list→para do NOT (blocked by lex#798 —
-// reader-built loose lists collapse on serialize). The blocked pair is asserted
-// as a currently-failing known gap rather than skipped, with the same anti-rot
-// as the fixture sweep.
+// All adjacency pairs — para→para, heading→body, para→verbatim, para→definition,
+// and (since lex#798) para→list and list→para — round-trip faithfully.
 // ============================================================================
 
 const H1: &str = "# T\n\n";
@@ -233,26 +236,16 @@ fn adjacency_paragraph_to_definition() {
     .unwrap();
 }
 
-/// paragraph→list and list→paragraph are the two adjacency pairs blocked by
-/// lex#798. Asserted as currently-failing (not skipped): the Markdown reader
-/// builds loose list items (`ListItem { text: "", children: [Paragraph] }`)
-/// which the serializer emits as `-\n    text` — a form lex-core re-parses as a
-/// paragraph, collapsing the list. When #798 is fixed these round-trip and this
-/// test fails, prompting promotion to plain `check_faithful(...).unwrap()`.
+/// paragraph→list and list→paragraph now round-trip faithfully (lex#798 fixed):
+/// the Lex serializer hoists a reader-built item's leading Paragraph onto the
+/// `- text` marker line, which re-parses as a list instead of collapsing to a
+/// paragraph.
 #[test]
-fn adjacency_list_pairs_blocked_by_lex798() {
+fn adjacency_list_pairs() {
     let para_to_list = format!("{H1}Lead in.\n\n- one\n- two\n");
     let list_to_para = format!("{H1}- one\n- two\n\nTrailer.\n");
-    for (name, md) in [
-        ("paragraph->list", &para_to_list),
-        ("list->paragraph", &list_to_para),
-    ] {
-        assert!(
-            check_faithful(&MarkdownFormat, md).is_err(),
-            "{name} now round-trips faithfully — lex#798 appears fixed; \
-             promote this to a live `check_faithful(...).unwrap()` adjacency assertion"
-        );
-    }
+    check_faithful(&MarkdownFormat, &para_to_list).unwrap();
+    check_faithful(&MarkdownFormat, &list_to_para).unwrap();
 }
 
 // ============================================================================
@@ -345,4 +338,86 @@ fn backtick_in_code_span_degrades_predictably() {
     // happens to survive `canon` too (the guarantee is non-corruption, not
     // round-trip; here both hold).
     assert_eq!(canon(&doc), canon(&reparsed));
+}
+
+// ============================================================================
+// lex#798 — reader-built lists round-trip (unordered / ordered / nested /
+// multi-block), driven through the real Markdown reader. Each item comrak builds
+// is `ListItem { text: "", children: [Paragraph, …] }`; the serializer hoists the
+// leading paragraph onto the tight `- text` marker line so it re-parses as a
+// list. Inputs are minimal in-test Markdown literals (no new .lex fixtures).
+// ============================================================================
+
+#[test]
+fn unordered_list_round_trips() {
+    check_faithful(&MarkdownFormat, &format!("{H1}- one\n- two\n- three\n")).unwrap();
+}
+
+#[test]
+fn ordered_list_keeps_numbers_and_round_trips() {
+    let md = format!("{H1}1. first\n2. second\n3. third\n");
+    check_faithful(&MarkdownFormat, &md).unwrap();
+    // The numbers must survive: a reader-built ordered list used to lose them to
+    // the plain dash because the List node carried no decoration style.
+    let lex = LexFormat::default()
+        .serialize(&MarkdownFormat.parse(&md).unwrap())
+        .unwrap();
+    assert!(
+        lex.contains("1. first") && lex.contains("2. second"),
+        "ordered markers lost on serialize:\n{lex}"
+    );
+}
+
+#[test]
+fn nested_list_round_trips() {
+    // Two-plus levels of nesting; sub-items stay under their parents.
+    let md = format!("{H1}- a\n    - b\n        - c\n        - c2\n    - b2\n- d\n");
+    check_faithful(&MarkdownFormat, &md).unwrap();
+}
+
+#[test]
+fn ordered_outer_with_nested_bullets_round_trips() {
+    let md = format!("{H1}1. first\n    - bullet\n    - bullet2\n2. second\n");
+    check_faithful(&MarkdownFormat, &md).unwrap();
+}
+
+#[test]
+fn multi_block_list_item_round_trips() {
+    // A genuinely multi-block item: lead paragraph + a nested paragraph + a
+    // sublist + a trailing paragraph. These must stay in the indented body (only
+    // the single leading paragraph is hoisted to the marker line), and the whole
+    // thing must round-trip.
+    let md = format!(
+        "{H1}- First item\n\n    Nested paragraph.\n\n    - sub a\n    - sub b\n\n    Trailing paragraph.\n\n- Second item\n"
+    );
+    check_faithful(&MarkdownFormat, &md).unwrap();
+}
+
+#[test]
+fn single_item_list_degrades_to_paragraph() {
+    // Declared Lossy (per list.lex): a Lex list needs >= 2 items, so a single
+    // `- x` is prose, not a list. comrak builds a one-item list; the serializer
+    // emits the tight `- x`, which lex-core re-parses as a Paragraph. The degrade
+    // must be predictable — content preserved, well-formed, no corruption — not a
+    // faithful round-trip.
+    let md = format!("{H1}- only one\n");
+    let doc = MarkdownFormat.parse(&md).unwrap();
+    let lex = LexFormat::default().serialize(&doc).unwrap();
+    let reparsed = LexFormat::default()
+        .parse(&lex)
+        .unwrap_or_else(|e| panic!("degraded Lex did not re-parse: {e}\n{lex}"));
+    let body: Vec<&ContentItem> = reparsed
+        .root
+        .children
+        .iter()
+        .filter(|c| !matches!(c, ContentItem::BlankLineGroup(_)))
+        .collect();
+    assert_eq!(body.len(), 1, "expected a single body block, got:\n{lex}");
+    match body[0] {
+        ContentItem::Paragraph(p) => assert!(
+            p.text().contains("only one"),
+            "single-item content lost in degrade:\n{lex}"
+        ),
+        other => panic!("expected the one-item list to degrade to a Paragraph, got {other:?}"),
+    }
 }

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -421,3 +421,52 @@ fn single_item_list_degrades_to_paragraph() {
         other => panic!("expected the one-item list to degrade to a Paragraph, got {other:?}"),
     }
 }
+
+#[test]
+fn nested_single_item_degrades_but_outer_list_survives() {
+    // The >= 2-item rule (list.lex) applies at EVERY level: a one-item *nested*
+    // list is prose too. So `- a / <indent>- only / - b` keeps the two-item outer
+    // list, and item `a`'s single nested item degrades to a Paragraph in its body
+    // — a clean, non-corrupting degrade (the outer structure is preserved), not a
+    // #798 list-collapse. This pins the boundary between #798 (fixed) and the
+    // 2-item Declared-Lossy rule.
+    let md = format!("{H1}- a\n    - only\n- b\n");
+    let doc = MarkdownFormat.parse(&md).unwrap();
+    let lex = LexFormat::default().serialize(&doc).unwrap();
+    let reparsed = LexFormat::default()
+        .parse(&lex)
+        .unwrap_or_else(|e| panic!("degraded Lex did not re-parse: {e}\n{lex}"));
+
+    let outer = reparsed
+        .root
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ContentItem::List(l) => Some(l),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("outer list must survive, got:\n{lex}"));
+    assert_eq!(
+        outer.items.len(),
+        2,
+        "outer list should keep 2 items:\n{lex}"
+    );
+
+    let first = outer.items.iter().next().unwrap();
+    match first {
+        ContentItem::ListItem(li) => {
+            assert!(
+                li.children
+                    .iter()
+                    .all(|c| !matches!(c, ContentItem::List(_))),
+                "the one-item nested list should degrade to prose, not stay a List:\n{lex}"
+            );
+            let has_only = li.children.iter().any(|c| match c {
+                ContentItem::Paragraph(p) => p.text().contains("only"),
+                _ => false,
+            });
+            assert!(has_only, "nested single-item content lost:\n{lex}");
+        }
+        other => panic!("expected a ListItem, got {other:?}"),
+    }
+}

--- a/crates/lex-babel/tests/round_trip_proptest/mod.rs
+++ b/crates/lex-babel/tests/round_trip_proptest/mod.rs
@@ -1018,3 +1018,136 @@ proptest! {
         );
     }
 }
+
+// ============================================================================
+// lex#798 — the exact reader-built list shape, as in-code ASTs (no Markdown).
+//
+// A foreign reader (comrak) builds each item as `ListItem { text: "", children:
+// [Paragraph, …] }` — the item's lead text lives in a wrapping Paragraph, never
+// on the marker line. The Lex serializer must hoist that leading Paragraph onto
+// the tight `- text` form so it re-parses as a list instead of collapsing to a
+// Paragraph. These assert that directly on the built AST, and that genuinely
+// multi-block items keep their indented body.
+// ============================================================================
+
+/// A reader-built list item: empty marker-line text, content in child blocks.
+fn reader_item(children: Vec<ContentItem>) -> ListItem {
+    let mut c = GeneralContainer::empty();
+    for child in children {
+        c.push(child);
+    }
+    ListItem {
+        marker: TextContent::from_string("-".to_string(), None),
+        text: vec![TextContent::from_string(String::new(), None)],
+        children: c,
+        annotations: vec![],
+        location: Default::default(),
+    }
+}
+
+fn para(text: &str) -> ContentItem {
+    ContentItem::Paragraph(Paragraph {
+        lines: vec![ContentItem::TextLine(TextLine::new(
+            TextContent::from_string(text.to_string(), None),
+        ))],
+        annotations: vec![],
+        location: Default::default(),
+    })
+}
+
+fn plain_list(items: Vec<ListItem>) -> List {
+    let mut container = ListContainer::empty();
+    for item in items {
+        container.push(ContentItem::ListItem(item));
+    }
+    let mut list = List::new(vec![]);
+    list.items = container;
+    list.marker = Some(SequenceMarker {
+        raw_text: TextContent::from_string("-".to_string(), None),
+        style: DecorationStyle::Plain,
+        separator: Separator::Period,
+        form: Form::Short,
+        location: Default::default(),
+    });
+    list
+}
+
+fn doc_with_list(list: List) -> Document {
+    let mut doc = Document::new();
+    doc.root.children =
+        SessionContainer::from_typed(vec![SessionContent::Element(ContentElement::List(list))]);
+    doc
+}
+
+#[test]
+fn reader_shaped_list_serializes_to_reparseable_list() {
+    let list = plain_list(vec![
+        reader_item(vec![para("one")]),
+        reader_item(vec![para("two")]),
+    ]);
+    let doc = doc_with_list(list);
+
+    let serialized = export(&doc).expect("serialization should not fail");
+    // Tight form, not the loose `-\n    text` that collapses on reparse.
+    assert!(
+        serialized.contains("- one") && serialized.contains("- two"),
+        "expected tight `- text` items, got:\n{serialized}"
+    );
+
+    let parsed = parse_document(&serialized).expect("serialized Lex must re-parse");
+    let lists = parsed
+        .root
+        .children
+        .iter()
+        .filter(|c| matches!(c, ContentItem::List(_)))
+        .count();
+    assert_eq!(
+        lists, 1,
+        "reader-built list must re-parse as a List:\n{serialized}"
+    );
+    // Skeleton-faithful: the empty-text + leading-Paragraph shape folds to the
+    // same item text the tight form re-parses to.
+    assert_eq!(canon(&doc), canon(&parsed), "not faithful:\n{serialized}");
+}
+
+#[test]
+fn reader_shaped_multi_block_item_keeps_body() {
+    // First item is genuinely multi-block: a lead paragraph plus a sublist. Only
+    // the lead paragraph is hoisted; the sublist stays in the indented body.
+    let sublist = plain_list(vec![
+        reader_item(vec![para("sub a")]),
+        reader_item(vec![para("sub b")]),
+    ]);
+    let list = plain_list(vec![
+        reader_item(vec![para("first"), ContentItem::List(sublist)]),
+        reader_item(vec![para("second")]),
+    ]);
+    let doc = doc_with_list(list);
+
+    let serialized = export(&doc).expect("serialization should not fail");
+    let parsed = parse_document(&serialized).expect("serialized Lex must re-parse");
+    assert_eq!(canon(&doc), canon(&parsed), "not faithful:\n{serialized}");
+
+    // The sublist survived as a nested List under the first item.
+    let outer = parsed
+        .root
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ContentItem::List(l) => Some(l),
+            _ => None,
+        })
+        .expect("outer list");
+    let first = outer.items.iter().next().expect("first item");
+    let has_sublist = match first {
+        ContentItem::ListItem(li) => li
+            .children
+            .iter()
+            .any(|c| matches!(c, ContentItem::List(_))),
+        _ => false,
+    };
+    assert!(
+        has_sublist,
+        "multi-block item lost its sublist:\n{serialized}"
+    );
+}

--- a/crates/lex-babel/tests/skeleton/mod.rs
+++ b/crates/lex-babel/tests/skeleton/mod.rs
@@ -241,18 +241,48 @@ fn canon_item(item: &ContentItem) -> Option<Canon> {
         ContentItem::ListItem(li) => {
             // Project *all* text elements (not just the first) so multi-line
             // item content is covered; collect refs from each.
-            let text = li
+            let mut text = li
                 .text
                 .iter()
                 .map(|t| t.as_string().trim_end())
                 .collect::<Vec<_>>()
                 .join("\n");
-            let refs = li.text.iter().flat_map(refs_in).collect();
+            let mut refs: Vec<String> = li.text.iter().flat_map(refs_in).collect();
+            let mut children = canon_items(li.children.iter());
+
+            // A foreign reader (comrak) builds a list item as
+            // `{ text: "", children: [Paragraph, …] }` — the item's lead text
+            // lives in a wrapping Paragraph, not in `text`. lex has no such
+            // wrapper: its lead text sits on the marker line, so the serializer
+            // hoists that leading Paragraph onto the `- text` marker line
+            // (lex#798), and it re-parses as `{ text: "…", children: [] }`. Fold
+            // the two representations together here — when the item carries no
+            // marker-line text but leads with a Paragraph, treat that
+            // paragraph's text as the item text. This is the Faithfulness analog
+            // of the serializer's marker-line hoist, exactly as
+            // `canon_annotation` mirrors the serializer's `clean_annotation`. It
+            // only fires on the empty-text (reader-built) shape; a Lex-sourced
+            // item always has marker-line text, so its Skeleton is unchanged.
+            if text.is_empty() {
+                if let Some(Canon::Paragraph {
+                    text: lead,
+                    refs: lead_refs,
+                    annotations,
+                }) = children.first()
+                {
+                    if annotations.is_empty() {
+                        text = lead.clone();
+                        refs = lead_refs.clone();
+                        children.remove(0);
+                    }
+                }
+            }
+
             Canon::ListItem {
                 text,
                 refs,
                 annotations: canon_annotations(&li.annotations),
-                children: canon_items(li.children.iter()),
+                children,
             }
         }
         ContentItem::Definition(d) => Canon::Definition {


### PR DESCRIPTION
Closes #798

## Context

**Root cause.** The comrak Markdown reader builds every list item as
`ListItem { text: "", children: [Paragraph, …] }` — comrak's block model puts the
item's content in a child Paragraph, not on the marker line. The Lex serializer
emitted that empty-text shape as the loose `-\n    text` form, which lex-core does
**not** re-parse as a list: it reads the bare `-` as prose and collapses the whole
list into a single Paragraph. Because every real Markdown document contains lists,
*no* reader-built list round-tripped — this was the headline faithfulness blocker
(the `paragraph→list` / `list→paragraph` adjacency gap, and every corpus fixture).

**Where I fixed it, and why.** Grounded in `comms/specs/elements/list.lex`: a Lex
list item's lead text sits on the marker line (`- text`); further lines/blocks are
the indented body. lex has no "empty marker, body-only" item form, so the fix
reshapes the reader-built AST into the canonical tight form at serialize time.

- **Serializer** (`crates/lex-babel/src/formats/lex/serializer.rs`) — the shared
  choke point the PRD names (ADR-0001): when an item has no marker-line text but
  its leading block is a Paragraph, hoist that paragraph's first line onto the
  tight `- text` line. Remaining lines and every other child stay in the indented
  body. This is reader-agnostic — RFC-XML and any future reader benefit.
- **Reader** (`crates/lex-babel/src/ir/to_lex.rs`) — record the list's decoration
  style on the `List` node. Leaving `marker: None` dropped ordered/alpha/roman
  numbering on serialize (User Story 6) and left the Skeleton's list style `None`
  where a re-parsed list carries a concrete style. Mirrors how the Lex parser sets
  a list's style from its first item.
- **Skeleton** (`crates/lex-babel/tests/skeleton/mod.rs`) — fold an empty-text
  item's leading Paragraph into the compared item text. This is the Faithfulness
  analog of the serializer's hoist, exactly as the existing `canon_annotation`
  mirrors the serializer's `clean_annotation`. It fires *only* on the reader-built
  empty-text shape; a Lex-sourced item always carries marker-line text, so its
  Skeleton is unchanged.

I did **not** touch the lex-core parser: the spec does not sanction the loose
`-\n    text` surface as a list, so accepting it there would contradict list.lex.
The serializer is the correct locus.

**Multi-block items stay correct.** Only the *single leading* Paragraph is hoisted.
An item with a paragraph + sublist, extra paragraphs, or a trailing paragraph keeps
its indented body and round-trips (covered by `multi_block_list_item_round_trips`
and the in-code `reader_shaped_multi_block_item_keeps_body`).

**lex → lex is byte-identical.** Both code changes are inert for Lex-sourced ASTs
(their items always carry marker-line text; their lists already have a marker), so
the `format_invariants` corpus sweep stays green and every `list.docs` fixture
`lexd format`s byte-for-byte unchanged (spot-checked).

## Known-fails removed vs retained

- **Removed / promoted:** `adjacency_list_pairs_blocked_by_lex798` → live
  `adjacency_list_pairs` (para→list and list→para now round-trip).
- **Retained (relabeled):** all five corpus fixtures still fail, but *not* on lists
  — verified by a recursive Skeleton diff that no list-structure divergence remains.
  Re-attributed to the bug each still trips: `kitchensink → lex#795` (numbered
  session heading), `comrak-readme` / `commonmark-reference` / `comrak-reference →
  lex#790` (a colon-terminated paragraph before a fenced code block is absorbed as
  a verbatim subject / becomes a Definition, some inside a list item),
  `ideas-naked → lex#791`. These are multi-blocker fixtures; they stay listed until
  their remaining blocker is fixed. No `#798` entries existed in
  `format_invariants`.

**Single-item lists** are Declared Lossy per list.lex (a Lex list needs ≥2 items),
so a one-item Markdown list degrades to a Paragraph — asserted as a predictable,
non-corrupting degrade (`single_item_list_degrades_to_paragraph`), not a round-trip.

## What reviewers should NOT ask for

- Don't collapse genuinely multi-block items to the tight form — only the single
  leading paragraph is hoisted, by design.
- Don't perturb Lex-sourced list output — the changes are gated on the reader-built
  empty-text shape and keep `lex → lex` byte-identical.

## Tests

- `cargo nextest run --workspace --exclude lex-wasm`: 2660 passed.
- New markdown-driven cases (unordered, ordered-keeps-numbers, nested 3-level,
  ordered-outer + nested bullets, multi-block, single-item degrade) and in-code
  reader-shape ASTs (`reader_shaped_list_serializes_to_reparseable_list`,
  `reader_shaped_multi_block_item_keeps_body`). The #784 reader-shaped proptest and
  #785 fixture suite still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rMcjusYfDRo6L1c7RFK8j
