### PR TITLE
fix(babel): escape marker-like session titles so they round-trip style-less (lex#795)

### DIFF
--- a/CHANGELOG/unreleased-795-marker-title-guard.md
+++ b/CHANGELOG/unreleased-795-marker-title-guard.md
@@ -1,0 +1,1 @@
+- Serializer escapes style-less session titles that begin with a marker-like token (1., a), IV., (1), 1.2.3) so they no longer re-parse with a spurious sequence-marker style (lex#795)

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -11,6 +11,8 @@ use lex_core::lex::ast::{
 
 use lex_core::lex::assembling::stages::normalize_labels::source_spelling;
 use lex_core::lex::ast::elements::sequence_marker::DecorationStyle;
+use lex_core::lex::lexing::line_classification::escape_session_title_marker_guard;
+use std::borrow::Cow;
 
 mod numbering;
 mod tables;
@@ -256,10 +258,20 @@ impl LexSerializer {
 impl Visitor for LexSerializer {
     fn visit_session(&mut self, session: &Session) {
         self.separate_before(BlockKind::Session);
-        let title = session.title.as_string();
-        if !title.is_empty() {
+        let raw_title = session.title.as_string();
+        if !raw_title.is_empty() {
             self.ensure_blank_lines(self.rules.session_blank_lines_before);
-            self.write_line(title);
+            // lex#795: a style-less session whose title text begins with a
+            // marker-like token (`1. X`, `IV. X`, `(a) X`, …) must be escaped, or
+            // it re-parses as a session WITH that sequence-marker style. A
+            // genuinely marked session carries its marker in `session.marker` and
+            // must keep its real marker unescaped.
+            let title = if session.marker.is_none() {
+                escape_session_title_marker_guard(raw_title)
+            } else {
+                Cow::Borrowed(raw_title)
+            };
+            self.write_line(&title);
             self.ensure_blank_lines(self.rules.session_blank_lines_after);
             self.indent_level += 1;
         }

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -27,13 +27,24 @@
 //!     paragraph before a verbatim is absorbed as the verbatim subject / turned into
 //!     a Definition, and the body de-indents. This is what now blocks the CommonMark
 //!     reference, comrak-readme, and comrak-reference (each has such a colon-para →
-//!     fenced-code adjacency, some inside a list item).
-//!   - **lex#795 (session-marker inference)** — a heading whose text begins with a
-//!     marker-like token (`## 1\. Primary Session` in kitchensink) serializes to
-//!     `1. Primary Session`, which re-parses with a Numerical session marker where
-//!     the reader had `style: None`. What now blocks kitchensink.
+//!     fenced-code adjacency, some inside a list item). It also blocks kitchensink:
+//!     its empty ```` ``` image ```` fence becomes an empty-subject verbatim whose
+//!     colon line is re-anchored by the closer hijack and swallows the preceding
+//!     `:: todo ::` block-annotation body.
+//!   - **lex#795 (session-marker inference) — FIXED.** A style-less session whose
+//!     title text begins with a marker-like token (`## 1\. Primary Session` in
+//!     kitchensink) used to serialize to a bare `1. Primary Session`, which
+//!     re-parsed WITH a Numerical session marker where the reader had `style: None`.
+//!     The Lex serializer now escapes the marker's structural separator
+//!     (`1\. Primary Session`, escaping.lex §3.4) when — and only when — the session
+//!     carries no explicit marker, and lex-core strips that guard backslash on
+//!     re-parse, so the session round-trips with `style: None` and its title text
+//!     unchanged. Sessions are no longer a blocker for any fixture.
 //!   - **lex#791 (leading-annotation reorder)** — `20-ideas-naked.md`'s leading
-//!     document-level annotations reorder around the title on serialize.
+//!     document-level annotations reorder around the title on serialize. A related
+//!     annotation-attachment limitation (a floating block annotation attaches to
+//!     its neighbor rather than round-tripping as a sibling) is a second residual
+//!     blocker for kitchensink.
 //!
 //! ## How this suite stays honest (no forced green, no weakened canon)
 //!
@@ -103,14 +114,26 @@ const FIXTURES: &[(&str, &str)] = &[
 /// unlisted one starts failing (a new regression).
 const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     // #798 (reader-built loose lists) is FIXED — reader-built lists now round-trip.
-    // Each fixture below was verified (recursive Skeleton diff) to have no
-    // remaining list-structure divergence; the entry names the OTHER bug it still
-    // trips. kitchensink → #795 (its `## 1. Primary Session` numbered heading
-    // re-parses as a Numerical session marker). commonmark-reference /
-    // comrak-readme / comrak-reference → #790 (a colon-terminated paragraph before
-    // a fenced code block is absorbed as the verbatim subject / becomes a
-    // Definition, some inside a list item). See the module docs for the analysis.
-    ("kitchensink", "lex#795"),
+    // #795 (session-marker inference) is FIXED — a style-less marker-like heading
+    // (`## 1\. Primary Session`) now serializes with an escaped guard (`1\.`) and
+    // re-parses with `style: None`. Each fixture below was re-verified (recursive
+    // Skeleton diff) to have no remaining list- or session-marker divergence; the
+    // entry names the OTHER bug it still trips.
+    //
+    // commonmark-reference / comrak-readme / comrak-reference → #790 (a
+    // colon-terminated paragraph before a fenced code block is absorbed as the
+    // verbatim subject / becomes a Definition, some inside a list item).
+    //
+    // kitchensink → #790 as well: with #795 fixed, its residual divergence is the
+    // empty ```` ``` image ```` fence, which serializes to an empty-subject
+    // verbatim (`:` + `:: image ::`) whose colon line is re-anchored by the
+    // closer hijack (separation.rs "Closer re-anchoring") and swallows the
+    // preceding `:: todo ::` block-annotation body. It ALSO trips the standalone
+    // block-annotation limitation (a floating annotation attaches to its
+    // neighboring paragraph rather than round-tripping as a sibling — documented
+    // in separation.rs §"Annotations", the #791 class), so kitchensink stays
+    // blocked until both land. Tagged against #790, the first tracked cause.
+    ("kitchensink", "lex#790"),
     ("comrak-readme", "lex#790"),
     ("commonmark-reference", "lex#790"),
     ("comrak-reference", "lex#790"),
@@ -468,5 +491,107 @@ fn nested_single_item_degrades_but_outer_list_survives() {
             assert!(has_only, "nested single-item content lost:\n{lex}");
         }
         other => panic!("expected a ListItem, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// #795 — MARKER-LIKE SESSION TITLES
+//
+// A style-less session whose title text begins with a marker-like token
+// (`1.`, `a)`, `IV.`, `(1)`, `1.2.3`) must survive serialize→re-parse with
+// `style: None`. The serializer escapes the marker's structural separator
+// (escaping.lex §3.4) only when the session carries no explicit marker, and
+// lex-core strips that guard on re-parse. Genuine markers are untouched.
+// ============================================================================
+
+/// Every marker-like Markdown heading round-trips faithfully — the reader builds
+/// a `style: None` session, and the escaped Lex re-parses to the same skeleton
+/// (checked directly by `check_faithful`). Markdown headings carry no decoration
+/// style, so each of these reads as `style: None`.
+#[test]
+fn marker_like_headings_round_trip() {
+    for heading in [
+        "## 1\\. Numbered",
+        "## IV\\. Roman",
+        "## a\\. Alpha",
+        "## 1\\)  Paren",
+        "## \\(1) Double paren",
+        "## 1\\.2.3 Extended",
+        // A dash-leading heading is never a session marker (sessions reject dash
+        // markers), so it round-trips without needing a guard.
+        "## - Dash leading",
+        // A heading with no marker-like token must be unaffected.
+        "## Plain Heading",
+    ] {
+        let src = format!("# Doc\n\n{heading}\n\nBody text.\n");
+        check_faithful(&MarkdownFormat, &src)
+            .unwrap_or_else(|e| panic!("heading {heading:?} not faithful:\n{e}"));
+    }
+}
+
+/// The reader shape built directly: a `Session { marker: None, title: "1. X" }`
+/// (exactly what the Markdown reader produces for `## 1. X`). It must serialize
+/// to an escaped form and re-parse with `style: None` and its title text intact.
+#[test]
+fn reader_shaped_marker_title_reparses_style_none() {
+    use lex_core::lex::ast::elements::container::SessionContainer;
+    use lex_core::lex::ast::elements::typed_content::{ContentElement, SessionContent};
+    use lex_core::lex::ast::{Document, Paragraph, Session, TextContent};
+
+    let session = Session::new(
+        TextContent::from_string("1. Primary".to_string(), None),
+        vec![SessionContent::Element(ContentElement::Paragraph(
+            Paragraph::from_line("Body.".to_string()),
+        ))],
+    );
+    assert!(
+        session.marker.is_none(),
+        "reader builds a style-less session"
+    );
+
+    let mut doc = Document::new();
+    doc.root.children = SessionContainer::from_typed(vec![SessionContent::Session(session)]);
+
+    let lex = LexFormat::default();
+    let out = lex.serialize(&doc).expect("serialize");
+    assert!(
+        out.contains("1\\. Primary"),
+        "the style-less marker-like title must be escaped:\n{out}"
+    );
+
+    let reparsed = lex.parse(&out).expect("reparse");
+    let Some(ContentItem::Session(s)) = reparsed.root.children.iter().next() else {
+        panic!("expected a Session, got:\n{out}");
+    };
+    assert!(
+        s.marker.is_none(),
+        "re-parsed session must stay style-less, got {:?}\n{out}",
+        s.marker
+    );
+    assert_eq!(s.title.as_string(), "1. Primary", "title text preserved");
+
+    // And the whole document is Skeleton-faithful.
+    assert_eq!(canon(&doc), canon(&reparsed));
+}
+
+/// lex → lex byte-identity: a genuinely numbered session keeps its real marker
+/// (no spurious escape), and a hand-written escaped title round-trips verbatim.
+#[test]
+fn lex_sourced_sessions_are_byte_identical() {
+    let lex = LexFormat::default();
+    for source in [
+        // Genuine numbered session — the marker is real, must not be escaped.
+        "1. Real Session\n\n    Body.\n",
+        // Genuine alphabetical/roman/parenthetical.
+        "a. Alpha Session\n\n    Body.\n",
+        "IV. Roman Session\n\n    Body.\n",
+        // Style-less plain title — unaffected.
+        "Introduction\n\n    Body.\n",
+        // Hand-written escaped marker-like title — re-escaped identically.
+        "1\\. Primary\n\n    Body.\n",
+    ] {
+        let doc = lex.parse(source).expect("parse");
+        let out = lex.serialize(&doc).expect("serialize");
+        assert_eq!(out, source, "lex → lex must be byte-identical");
     }
 }

--- a/crates/lex-core/src/lex/building/extraction/session.rs
+++ b/crates/lex-core/src/lex/building/extraction/session.rs
@@ -4,7 +4,9 @@
 //! for building Session AST nodes.
 
 use crate::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
-use crate::lex::lexing::line_classification::parse_seq_marker;
+use crate::lex::lexing::line_classification::{
+    parse_seq_marker, unescape_session_title_marker_guard,
+};
 use crate::lex::token::normalization::utilities::{compute_bounding_box, extract_text};
 use crate::lex::token::Token;
 use std::ops::Range as ByteRange;
@@ -82,7 +84,17 @@ pub(in crate::lex::building) fn extract_session_data(
 
     // No valid marker found, treat everything as title
     let title_byte_range = compute_bounding_box(&tokens);
-    let title_text = extract_text(title_byte_range.clone(), source);
+    let mut title_text = extract_text(title_byte_range.clone(), source);
+
+    // escaping.lex §3.4: if the title is an *escaped* session marker (`1\.`,
+    // `\(1)`, `IV\.`, …) — the serializer guard that stops a style-less
+    // marker-like title from re-parsing WITH a sequence-marker style (lex#795) —
+    // strip the escaping backslash so the stored title text matches the
+    // original. The marker stays `None`; the source range keeps covering the
+    // backslash (the title spans it in source, it is just not part of the text).
+    if let Some(stripped) = unescape_session_title_marker_guard(&title_text) {
+        title_text = stripped;
+    }
 
     SessionData {
         title_text,

--- a/crates/lex-core/src/lex/lexing/line_classification.rs
+++ b/crates/lex-core/src/lex/lexing/line_classification.rs
@@ -309,9 +309,11 @@ pub fn escape_session_title_marker_guard(title: &str) -> Cow<'_, str> {
     if !leads_with_session_marker(title) {
         return Cow::Borrowed(title);
     }
-    // The leading marker segment is ASCII-alphanumeric (digits, a single ASCII
-    // letter, or ASCII Roman numerals), so the marker's first structural
-    // character is the first non-alphanumeric byte of the title.
+    // The marker's first structural character — the byte the guard backslash
+    // must precede — is the first non-alphanumeric byte of the title. For `1.`,
+    // `IV.`, or `a)` that byte follows an ASCII-alphanumeric run (digits, a
+    // single letter, or Roman numerals); for a parenthetical marker like `(1)`
+    // it is the leading `(` at position 0.
     match title.bytes().position(|b| !b.is_ascii_alphanumeric()) {
         Some(sep) => {
             let mut escaped = String::with_capacity(title.len() + 1);

--- a/crates/lex-core/src/lex/lexing/line_classification.rs
+++ b/crates/lex-core/src/lex/lexing/line_classification.rs
@@ -33,7 +33,9 @@
 use crate::lex::annotation::analyze_annotation_header_tokens;
 use crate::lex::ast::elements::sequence_marker::{DecorationStyle, Form, Separator};
 use crate::lex::escape::find_structural_lex_markers;
+use crate::lex::lexing::base_tokenization::tokenize;
 use crate::lex::token::{LineType, Token};
+use std::borrow::Cow;
 
 /// Parsed details about a list marker at the start of a line.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -278,6 +280,84 @@ pub fn parse_seq_marker(tokens: &[Token]) -> Option<ParsedListMarker> {
 /// Check if line starts with a list marker (after optional indentation)
 pub fn has_seq_marker(tokens: &[Token]) -> bool {
     parse_seq_marker(tokens).is_some()
+}
+
+/// Whether `title`, read as a would-be session-title line, leads with a token
+/// sequence that [`parse_seq_marker`] classifies as a *non-Plain* session
+/// sequence marker (Numerical / Alphabetical / Roman, in any separator or form).
+/// Sessions reject Plain (dash) markers, so a leading dash is never a session
+/// marker and reports `false`.
+fn leads_with_session_marker(title: &str) -> bool {
+    let tokens: Vec<Token> = tokenize(title).into_iter().map(|(t, _)| t).collect();
+    matches!(parse_seq_marker(&tokens), Some(pm) if pm.style != DecorationStyle::Plain)
+}
+
+/// Serializer guard (escaping.lex §3.4, lex#795): a style-less session whose
+/// title text begins with a marker-like token (`1.`, `a)`, `IV.`, `(1)`,
+/// `1.2.3`, …) would, if serialized verbatim, re-parse as a session *with* that
+/// sequence-marker style — a Faithfulness violation, since the source AST had no
+/// marker. Insert a single escaping backslash before the marker's first
+/// structural (non-alphanumeric) character so the leading token no longer reads
+/// as a marker. The backslash is stripped again on re-parse
+/// ([`unescape_session_title_marker_guard`]) and at render time (inline
+/// escaping, §1), so the title *text* is unchanged. Titles that do not lead with
+/// a session marker are returned untouched.
+///
+/// Callers must apply this only when the session carries no explicit marker: a
+/// genuinely numbered session keeps its real marker and must never be escaped.
+pub fn escape_session_title_marker_guard(title: &str) -> Cow<'_, str> {
+    if !leads_with_session_marker(title) {
+        return Cow::Borrowed(title);
+    }
+    // The leading marker segment is ASCII-alphanumeric (digits, a single ASCII
+    // letter, or ASCII Roman numerals), so the marker's first structural
+    // character is the first non-alphanumeric byte of the title.
+    match title.bytes().position(|b| !b.is_ascii_alphanumeric()) {
+        Some(sep) => {
+            let mut escaped = String::with_capacity(title.len() + 1);
+            escaped.push_str(&title[..sep]);
+            escaped.push('\\');
+            escaped.push_str(&title[sep..]);
+            Cow::Owned(escaped)
+        }
+        // Unreachable in practice: a matched marker always has a separator, so a
+        // non-alphanumeric byte exists. Fall back to the unescaped title.
+        None => Cow::Borrowed(title),
+    }
+}
+
+/// Parser counterpart to [`escape_session_title_marker_guard`] (escaping.lex
+/// §3.4: the structural layer that consumes a delimiter must strip its own
+/// escaping backslash). If `title` is an *escaped* session marker — a single
+/// backslash guarding the marker's first structural character whose removal
+/// yields a non-Plain session marker — return the title with that backslash
+/// removed (the marker stays suppressed, the text is restored). Returns `None`
+/// when `title` is not an escaped marker, so genuine content is left untouched,
+/// including `\<alnum>` sequences like `C:\Users` that §1 keeps literal.
+pub fn unescape_session_title_marker_guard(title: &str) -> Option<String> {
+    let bytes = title.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b' ' {
+            // The marker region ends at the first space; a guard backslash is
+            // always inside the marker, so stop looking.
+            break;
+        }
+        if b != b'\\' {
+            continue;
+        }
+        // §1: a backslash before an alphanumeric character is literal text, never
+        // a marker guard (the serializer only ever escapes the marker's
+        // non-alphanumeric separator). Anything else is not our escape.
+        match bytes.get(i + 1) {
+            Some(next) if !next.is_ascii_alphanumeric() => {}
+            _ => return None,
+        }
+        let mut candidate = String::with_capacity(title.len() - 1);
+        candidate.push_str(&title[..i]);
+        candidate.push_str(&title[i + 1..]);
+        return leads_with_session_marker(&candidate).then_some(candidate);
+    }
+    None
 }
 
 /// Check if a string is a single letter (a-z, A-Z)
@@ -581,5 +661,121 @@ mod tests {
             Token::BlankLine(Some("\n".to_string())),
         ];
         assert_eq!(classify_line_tokens(&tokens), LineType::ParagraphLine);
+    }
+
+    // ── lex#795: session-title marker-guard escaping (escaping.lex §3.4) ──────
+
+    #[test]
+    fn escape_guards_every_session_marker_form() {
+        // A style-less title whose text begins with a marker-like token gets a
+        // backslash before the marker's first structural character.
+        assert_eq!(
+            escape_session_title_marker_guard("1. Primary"),
+            "1\\. Primary"
+        );
+        assert_eq!(escape_session_title_marker_guard("a. Alpha"), "a\\. Alpha");
+        assert_eq!(
+            escape_session_title_marker_guard("IV. Roman"),
+            "IV\\. Roman"
+        );
+        assert_eq!(escape_session_title_marker_guard("1) Paren"), "1\\) Paren");
+        assert_eq!(
+            escape_session_title_marker_guard("(a) Double"),
+            "\\(a) Double"
+        );
+        assert_eq!(
+            escape_session_title_marker_guard("1.2.3 Extended"),
+            "1\\.2.3 Extended"
+        );
+    }
+
+    #[test]
+    fn escape_leaves_non_marker_titles_untouched() {
+        // No leading marker token → no guard. Plain (dash) markers are not valid
+        // session markers, so a leading dash is left alone too.
+        assert_eq!(
+            escape_session_title_marker_guard("Introduction"),
+            "Introduction"
+        );
+        assert_eq!(
+            escape_session_title_marker_guard("Version 2.0 notes"),
+            "Version 2.0 notes"
+        );
+        assert_eq!(
+            escape_session_title_marker_guard("- Not a session marker"),
+            "- Not a session marker"
+        );
+        // `1.Primary` (no space after the separator) is not a marker.
+        assert_eq!(escape_session_title_marker_guard("1.Primary"), "1.Primary");
+    }
+
+    #[test]
+    fn unescape_reverses_the_guard_for_every_form() {
+        assert_eq!(
+            unescape_session_title_marker_guard("1\\. Primary").as_deref(),
+            Some("1. Primary")
+        );
+        assert_eq!(
+            unescape_session_title_marker_guard("a\\. Alpha").as_deref(),
+            Some("a. Alpha")
+        );
+        assert_eq!(
+            unescape_session_title_marker_guard("IV\\. Roman").as_deref(),
+            Some("IV. Roman")
+        );
+        assert_eq!(
+            unescape_session_title_marker_guard("1\\) Paren").as_deref(),
+            Some("1) Paren")
+        );
+        assert_eq!(
+            unescape_session_title_marker_guard("\\(a) Double").as_deref(),
+            Some("(a) Double")
+        );
+        assert_eq!(
+            unescape_session_title_marker_guard("1\\.2.3 Extended").as_deref(),
+            Some("1.2.3 Extended")
+        );
+    }
+
+    #[test]
+    fn unescape_ignores_backslashes_that_are_not_marker_guards() {
+        // `\` before an alphanumeric is literal (escaping.lex §1, e.g. a path);
+        // removing it would not create a marker anyway.
+        assert_eq!(unescape_session_title_marker_guard("C:\\Users"), None);
+        assert_eq!(
+            unescape_session_title_marker_guard("\\1. literal-backslash-title"),
+            None
+        );
+        // A backslash before a non-marker separator is left alone.
+        assert_eq!(
+            unescape_session_title_marker_guard("Version 2\\.0 notes"),
+            None
+        );
+        // No backslash at all.
+        assert_eq!(unescape_session_title_marker_guard("1. Primary"), None);
+        assert_eq!(unescape_session_title_marker_guard("Introduction"), None);
+    }
+
+    #[test]
+    fn escape_then_unescape_is_identity() {
+        for title in [
+            "1. Primary",
+            "a) Second",
+            "IV. Historical",
+            "(1) Appendix",
+            "1.2.3 Deep",
+        ] {
+            let escaped = escape_session_title_marker_guard(title);
+            assert_ne!(
+                escaped.as_ref(),
+                title,
+                "guard must change a marker-like title"
+            );
+            assert_eq!(
+                unescape_session_title_marker_guard(&escaped).as_deref(),
+                Some(title),
+                "unescape must restore the original title text for {title:?}",
+            );
+        }
     }
 }

--- a/crates/lex-core/tests/integration/parser_regression.rs
+++ b/crates/lex-core/tests/integration/parser_regression.rs
@@ -299,3 +299,81 @@ fn regression_complex_session_with_all_elements() {
             });
     });
 }
+
+// ==================== #795: session-title marker-guard escaping ====================
+// A style-less session whose title text begins with a marker-like token is
+// serialized with an escaping backslash before the marker's structural separator
+// (`1\. Primary`), so it must NOT re-parse WITH a sequence-marker style, and the
+// escaping backslash must be stripped from the stored title text (escaping.lex
+// §3.4). A genuinely-marked session must keep its real marker.
+
+use lex_core::lex::ast::elements::sequence_marker::DecorationStyle;
+use lex_core::lex::ast::ContentItem;
+
+fn only_session(source: &str) -> lex_core::lex::ast::Session {
+    let doc = parse_document(source).unwrap();
+    match doc.root.children.iter().next().cloned() {
+        Some(ContentItem::Session(s)) => s,
+        other => panic!("expected a single Session, got {other:?}"),
+    }
+}
+
+#[test]
+fn regression_795_escaped_marker_title_has_no_marker_style() {
+    // `1\. Primary` — the serializer's guard form. Re-parses style-less with the
+    // backslash stripped from the title text.
+    let session = only_session("1\\. Primary\n\n    body\n");
+    assert!(
+        session.marker.is_none(),
+        "escaped marker-like title must not acquire a sequence-marker style, got {:?}",
+        session.marker
+    );
+    assert_eq!(
+        session.title.as_string(),
+        "1. Primary",
+        "the escaping backslash must be stripped from the stored title text"
+    );
+}
+
+#[test]
+fn regression_795_escaped_forms_roman_alpha_paren_extended() {
+    for (source, title) in [
+        ("IV\\. Historical\n\n    b\n", "IV. Historical"),
+        ("a\\) Second\n\n    b\n", "a) Second"),
+        ("\\(1) Appendix\n\n    b\n", "(1) Appendix"),
+        ("1\\.2.3 Deep\n\n    b\n", "1.2.3 Deep"),
+    ] {
+        let session = only_session(source);
+        assert!(
+            session.marker.is_none(),
+            "{source:?} must re-parse without a marker, got {:?}",
+            session.marker
+        );
+        assert_eq!(
+            session.title.as_string(),
+            title,
+            "title text for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn regression_795_genuine_numbered_session_keeps_its_marker() {
+    // A real, unescaped marker must still classify with its style.
+    let session = only_session("1. Primary\n\n    body\n");
+    let marker = session
+        .marker
+        .as_ref()
+        .expect("a genuine `1.` title must carry a sequence marker");
+    assert_eq!(marker.style, DecorationStyle::Numerical);
+    assert_eq!(session.title.as_string(), "1. Primary");
+}
+
+#[test]
+fn regression_795_backslash_before_alnum_is_literal_not_a_guard() {
+    // `\1. Primary` — a backslash before an alphanumeric is literal text (§1),
+    // never a marker guard, so it is left intact and stays style-less.
+    let session = only_session("\\1. Primary\n\n    body\n");
+    assert!(session.marker.is_none());
+    assert_eq!(session.title.as_string(), "\\1. Primary");
+}


### PR DESCRIPTION
Closes #795

## Context

**Root cause.** The Markdown reader builds a numbered heading like `## 1\. Primary` as `Session { style: None, title: "1. Primary" }` — Markdown headings carry no decoration-style concept. The Lex serializer emitted that title as a bare `1. Primary` line, and lex-core re-parses a leading `1.` as a **Numerical sequence marker**, so the re-parsed session acquired `style: Some(Numerical)` where the original had `None`. That is a Faithfulness (Skeleton) divergence on a valid AST — `style` is kept by `canon`, only marker *spelling* is quotiented.

**The escape mechanism (escaping.lex §3.4).** A marker's separator (`.`, `)`, `(`) is a *structural* character. §3.4 mandates that the layer treating a character structurally must honor `\<char>` as a literal (not-a-boundary) and **strip the escaping backslash from the resulting segment text**. So the fix is symmetric:

- **Serializer** (`crates/lex-babel/src/formats/lex/serializer.rs`, `visit_session`): when — and only when — `session.marker.is_none()` and the title text would parse as a non-Plain session marker, insert one backslash before the marker's first structural character (`1\.`, `IV\.`, `a\)`, `\(1)`, `1\.2.3`). A genuinely numbered session carries its marker in `session.marker` and is emitted verbatim.
- **Parser** (`crates/lex-core/src/lex/building/extraction/session.rs`): session-title extraction strips that guard backslash on re-parse, so the stored title is `1. Primary` (matching the reader) with `marker: None`.

Both directions share two helpers in `crates/lex-core/src/lex/lexing/line_classification.rs` (`escape_session_title_marker_guard` / `unescape_session_title_marker_guard`), the single source of truth. The guard fires on a backslash-before-*non-alphanumeric* only, so `\<alnum>` sequences that §1 keeps literal (e.g. `C:\Users`, or a hand-written `\1. Title`) are never touched.

**lex → lex byte-identity.** Verified by test: a plain title is untouched; a genuine `1.`/`a.`/`IV.` session keeps its real marker (no escape); a hand-written `1\. Primary` re-escapes to itself. The tier1/tier2 corpus sweep and all session/list fixtures stay green.

**Does kitchensink fully round-trip now?** **No — and it is correctly NOT promoted.** With #798 (merged) and this #795 fix, all three of kitchensink's marker-like headings (`1. Primary Session`, `1.1. Nested Session`, `2. Second Root Session`) now re-parse with `style: None`. But two residual, non-#795 divergences remain (confirmed by recursive Skeleton diff + minimal repros):
1. **#790** — its empty ```` ``` image ```` fence serializes to an empty-subject verbatim (`:` + `:: image ::`) whose colon line is re-anchored by the closer hijack and swallows the preceding `:: todo ::` block-annotation body. Same #790 family that blocks comrak-readme / commonmark-reference / comrak-reference.
2. The standalone block-annotation limitation (a floating `:: warning ::` annotation attaches to its neighboring paragraph rather than round-tripping as a sibling — documented in `separation.rs §"Annotations"`, the #791 class); not separation-fixable (confirmed: a leading blank does not make it a sibling).

So kitchensink's known-fail entry is **re-attributed from #795 to #790** (not removed), with a comment recording both residual causes. The `faithfulness_over_real_fixtures` anti-rot sweep stays green.

**Known-fails removed vs retained.** No `FIXTURE_KNOWN_FAIL` entry could be removed (kitchensink still fails for #790). There is no #795-tagged entry in `format_invariants` (that suite is lex→lex; the bug is reader-only). The kitchensink entry was re-tagged `lex#795` → `lex#790`.

## What reviewers must NOT ask for

- Don't escape genuine markers: a session with a real `session.marker` keeps its unescaped marker line — the guard is gated on `marker.is_none()`.
- Don't change lex-sourced session/list output: lex → lex is byte-identical (tested).
- Don't broaden the guard to paragraphs/definitions: #795 and the PRD scope this to session/heading titles; broadening is out of scope.
- Don't promote kitchensink to a live faithfulness assertion — it is still blocked by #790 (+ the annotation-sibling limitation), verified empirically.

## Tests

- **lex-core unit** (`line_classification.rs`): escape/unescape for every marker form (numeric, alpha, roman, parenthetical, extended), negatives (plain title, dash-leading, `C:\Users`, `\<alnum>`), and escape∘unescape identity.
- **lex-core parse regression** (`parser_regression.rs`): `1\.`/`IV\.`/`a\)`/`\(1)`/`1\.2.3` re-parse `style: None` with title text restored; genuine `1.` keeps Numerical; `\1.` stays literal.
- **lex-babel** (`faithfulness_fixtures.rs`): `check_faithful` over marker-like Markdown headings (numbered/roman/alpha/paren/extended/dash/plain); an in-code reader-shaped `Session { marker: None, title: "1. Primary" }` that serializes escaped and re-parses `style: None`; and a lex→lex byte-identity sweep.
- Full suite green: `cargo nextest run --workspace --exclude lex-wasm` → 2673 passed. `release-core gate` → OK.
