### PR TITLE
docs: faithfulness epic convergence (ADR statuses, CONTEXT status, changelog)

### DIFF
--- a/CHANGELOG/unreleased-faithfulness-docs.md
+++ b/CHANGELOG/unreleased-faithfulness-docs.md
@@ -1,0 +1,1 @@
+- Document title model, faithfulness status, and ADR implementation notes

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,6 +93,54 @@ faithfully. Replaces the rejected "leading-blank title escape" — it survives
 `lexd format` (it is real content, not strippable whitespace) and is
 discoverable. See ADR-0002.
 
+## Faithfulness status — what round-trips today
+
+The Markdown↔Lex faithfulness epic (#781–#785, #798, #795) is the current state
+of the world. This table is the durable "what survives the trip" summary; the
+live, per-fixture truth is the anti-rot known-fail lists in
+`crates/lex-babel/tests/markdown/faithfulness_fixtures.rs` and
+`crates/lex-babel/tests/format_invariants/mod.rs` — keep this in sync with them.
+
+**Round-trips faithfully today** (Markdown → Lex → re-parse, Skeleton-equal):
+
+- Paragraphs, and Block Separation between **every** ordered sibling pair (the
+  separation matrix, ADR-0001 / #782).
+- Document title: a leading `# H1` ↔ `Document.title`, and a heading-less source
+  via the `:: doc.untitled ::` no-title marker (ADR-0002 / #783).
+- Lists — unordered, ordered (markers preserved), nested, and multi-block items
+  (reader-built loose lists hoist to tight form, #798).
+- Definitions.
+- Verbatim / fenced code blocks (as blocks).
+- Inline emphasis and inline code.
+- Marker-like session titles (`## 1. X` → `1\. X` guard, re-parses `style: None`,
+  #795).
+
+**Deferred — tracked bugs that do not round-trip yet** (listed in the test
+known-fail sweeps; fixing the bug flips the fixture to faithful and forces its
+removal from the list):
+
+- Nested verbatim/definition **body de-indent**: a colon-terminated paragraph
+  before a fenced block is absorbed as a verbatim subject / becomes a Definition,
+  and multi-line or nested table-cell bodies de-indent — **#790** (blocks
+  kitchensink, comrak-readme, both CommonMark references).
+- Leading document-level **annotation reorder** around the title / subtitle —
+  **#791** (blocks `20-ideas-naked`; also `document-09`, `annotation-27`).
+- Ragged / mismatched-row **table normalization** — padding + a separator row are
+  injected, adding cells — **#792** (`table-13`).
+
+**Declared Lossy** — knowingly non-round-trippable by construction, degrades
+predictably (never a bug to "fix"):
+
+- A **backtick inside a code span** (Markdown's ``` `` a`b `` ```): a Lex code
+  span is single-backtick and literal, so it cannot hold its own delimiter. The
+  markup is dropped; the text degrades to well-formed prose (no corrupt re-parse).
+- **Blank-line counts**: a run of blanks collapses to the single structural
+  separator (Skeleton ignores blank _count_).
+- **Single-item lists**: Lex requires ≥ 2 items, so a one-item Markdown list
+  degrades to a Paragraph (content preserved, not a faithful list).
+- **Lex-only constructs** outside the Equivalence Set: annotations, citation /
+  reference syntax, and sessions deeper than Markdown's six heading levels.
+
 ## Flagged ambiguities
 
 **"Lossless"** — always scope it: lossless _for the Equivalence Set_. A bare

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,7 +96,7 @@ discoverable. See ADR-0002.
 ## Faithfulness status — what round-trips today
 
 The Markdown↔Lex faithfulness epic (#781–#785, #798, #795) is the current state
-of the world. This table is the durable "what survives the trip" summary; the
+of the world. This section is the durable "what survives the trip" summary; the
 live, per-fixture truth is the anti-rot known-fail lists in
 `crates/lex-babel/tests/markdown/faithfulness_fixtures.rs` and
 `crates/lex-babel/tests/format_invariants/mod.rs` — keep this in sync with them.
@@ -122,9 +122,12 @@ removal from the list):
 - Nested verbatim/definition **body de-indent**: a colon-terminated paragraph
   before a fenced block is absorbed as a verbatim subject / becomes a Definition,
   and multi-line or nested table-cell bodies de-indent — **#790** (blocks
-  kitchensink, comrak-readme, both CommonMark references).
+  kitchensink, comrak-readme, both reference fixtures).
 - Leading document-level **annotation reorder** around the title / subtitle —
-  **#791** (blocks `20-ideas-naked`; also `document-09`, `annotation-27`).
+  **#791** (blocks the Markdown fixture `20-ideas-naked.md` / key
+  `ideas-naked`; also the formatter fixtures `document-09`, `annotation-27`).
+  Note the formatter fixture `benchmark/20-ideas-naked.lex` is a separate
+  known-fail tagged **#790**, not #791.
 - Ragged / mismatched-row **table normalization** — padding + a separator row are
   injected, adding cells — **#792** (`table-13`).
 

--- a/docs/adr/0001-lex-serializer-structural-block-separation.md
+++ b/docs/adr/0001-lex-serializer-structural-block-separation.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-accepted
+accepted — implemented in the Markdown↔Lex faithfulness epic (#781 invariant
+harness, #782 separation matrix; the lex#505/lex#682 band-aids were removed as
+planned). The title-boundary handling this ADR sketched (the leading-blank
+"title-escape") was **superseded by ADR-0002** before it shipped — see the "As
+implemented" note under Decision.
 
 ## Context
 
@@ -48,6 +52,14 @@ blank suppresses Lex's title-steal rule — `<document-title>` requires the *fir
 line) are the same structural rule applied to the title boundary. **No grammar
 or lexer change:** the title-steal rule in `grammar-core.lex` is intentional and
 untouched; the serializer merely emits spec-valid output.
+
+> **As implemented (ADR-0002 supersedes the title-escape).** The title→first-block
+> structural blank shipped as described (the title→\* cell of the separation
+> matrix, #782). The *title-escape for title-less documents* — a leading blank to
+> suppress the title-steal rule — did **not** ship: ADR-0002 settled that leading
+> blanks carry no title semantics and that a title-less document declares itself
+> with an explicit `:: doc.untitled ::` marker the parser honors. Read this ADR
+> for block separation; read ADR-0002 for the title model.
 
 ## Considered alternatives
 

--- a/docs/adr/0002-document-title-model.md
+++ b/docs/adr/0002-document-title-model.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-accepted (supersedes the title-handling portions of ADR-0001)
+accepted (supersedes the title-handling portions of ADR-0001) — implemented in
+the Markdown↔Lex faithfulness epic (#783 title model: the parser drops
+leading-blank suppression, `doc.untitled` is a registered reserved marker, and
+the Markdown reader emits it for a heading-less source). See the "As implemented"
+note under Consequences for the fixture renames that landed differently from the
+sketch below.
 
 ## Context
 
@@ -70,6 +75,17 @@ because leading blanks no longer carry title semantics.
   leading blank). `document-06-title-empty` is renamed/repurposed to match the
   settled behavior; `document-05-title-session-hoist`'s hoisting question is
   tracked separately.
+
+> **As implemented.** `document-06-title-empty` shipped renamed to
+> `document-06-title-untitled.lex`, carrying an explicit `:: doc.untitled ::`
+> lead — the settled title-less form (not an "empty title"). `document-05` shipped
+> as `document-05-title-session-none.lex`, pinning decision (2): a document whose
+> first content element is a session has **no** title. `doc.untitled` is
+> registered as a *reserved-core-builtin marker* (`DOC_RESERVED_MARKERS` in
+> `crates/lex-core/src/lex/builtins/doc.rs`, comms `general.lex` §4) — honored by
+> the parser but deliberately kept out of the render-bearing `DOC_BUILTIN_LABELS`
+> set, so it carries no metadata render schema.
+
 - The Markdown Reader emits `:: doc.untitled ::` for a heading-less source; the
   Markdown Serializer maps a Lex title to `# H1`. A leading `# H1` maps to the
   title. This replaces the "leading-blank title escape" that an earlier plan


### PR DESCRIPTION
## Context

This is the epic's **convergence docs pass** (the docs slice) for the Markdown↔Lex faithfulness epic. Documentation only — **no production logic or test changes** (all 470 `lex-babel` tests still pass; `release-core gate` green).

What it updates:

- **ADR-0001** (structural block separation): Status → *accepted — implemented* (#781 harness, #782 matrix; lex#505/lex#682 band-aids removed). Added an "As implemented" note recording that the sketched leading-blank **title-escape did not ship** — it was superseded by ADR-0002's explicit `:: doc.untitled ::`.
- **ADR-0002** (document title model): Status → *accepted — implemented* (#783). Added an "As implemented" note reconciling the fixture renames that shipped differently from the sketch: `document-06-title-empty` → `document-06-title-untitled.lex` (carries `:: doc.untitled ::`), `document-05` → `document-05-title-session-none.lex`, and `doc.untitled` registered as a reserved-core marker (`DOC_RESERVED_MARKERS`, kept out of the render-bearing `DOC_BUILTIN_LABELS`). Verified against the shipped fixtures and `crates/lex-core/src/lex/builtins/doc.rs`.
- **CONTEXT.md**: new durable "**Faithfulness status — what round-trips today**" section — round-trips (paragraphs + full separation matrix, title + `doc.untitled`, lists, definitions, verbatim, inline, marker-like session titles) vs **Deferred** tracked bugs (#790 body de-indent, #791 leading-annotation reorder, #792 ragged-table normalization) vs **Declared Lossy** (backtick-in-code-span, blank counts, single-item lists, Lex-only constructs). Cross-checked line-for-line against the anti-rot known-fail lists in `crates/lex-babel/tests/markdown/faithfulness_fixtures.rs` and `tests/format_invariants/mod.rs`.
- **CHANGELOG**: `unreleased-faithfulness-docs` fragment (via `release-core changelog add`).

**Docstring check:** read the module-level docs on `separation.rs`, `serializer.rs`, `line_classification.rs`, and the `doc.untitled` builtin — all already accurate and current (they reference ADR-0001/#782, #798, #795, escaping.lex §3.4). Left them as-is; no genuine staleness found.

Does **not** fix #790/#791/#792 and does **not** close the epic issues — the umbrella PR does that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rMcjusYfDRo6L1c7RFK8j