### PR TITLE
Fix Markdown mirror parenthesized refs

### DIFF
--- a/crates/lex-babel/src/ir/anchoring.rs
+++ b/crates/lex-babel/src/ir/anchoring.rs
@@ -158,6 +158,13 @@ fn wrap_preceding_word(out: &mut Vec<InlineContent>, word: &str, href: &str) -> 
             // node might still match, so keep scanning rather than giving up.
             continue;
         }
+        if last_word.starts_with(|c: char| !c.is_alphanumeric()) {
+            // A leading delimiter means the resolved "word" is guide text
+            // inside punctuation, e.g. `(see [#6])`. Treat that as unsafe to
+            // split so the reference can render as its own self-link instead
+            // of absorbing the delimiter and guide word into the link text.
+            return false;
+        }
 
         let prefix = prefix.to_string();
         let last_word = last_word.to_string();
@@ -617,6 +624,72 @@ mod tests {
                 },
             ],
             "unfound preceding anchor must fall back to the original reference"
+        );
+    }
+
+    #[test]
+    fn preceding_word_with_leading_punctuation_falls_back_to_reference() {
+        let nodes = vec![
+            plain("(see "),
+            reference(
+                "#6",
+                ReferenceType::Session {
+                    target: "#6".into(),
+                },
+                Some(WordAnchor {
+                    word: "see".into(),
+                    direction: AnchorDirection::Preceding,
+                }),
+            ),
+        ];
+        let out = apply_word_anchors(&nodes, &convert);
+        assert_eq!(
+            out,
+            vec![
+                InlineContent::Text("(see ".into()),
+                InlineContent::Reference {
+                    raw: "#6".into(),
+                    kind: ReferenceType::Session {
+                        target: "#6".into(),
+                    },
+                },
+            ],
+            "guide text with leading punctuation must stay outside the link"
+        );
+    }
+
+    #[test]
+    fn unsafe_nearest_preceding_word_does_not_wrap_earlier_match() {
+        let nodes = vec![
+            plain("see"),
+            InlineNode::code(" gap ".into()),
+            plain("(see "),
+            reference(
+                "#6",
+                ReferenceType::Session {
+                    target: "#6".into(),
+                },
+                Some(WordAnchor {
+                    word: "see".into(),
+                    direction: AnchorDirection::Preceding,
+                }),
+            ),
+        ];
+        let out = apply_word_anchors(&nodes, &convert_full);
+        assert_eq!(
+            out,
+            vec![
+                InlineContent::Text("see".into()),
+                InlineContent::Code(" gap ".into()),
+                InlineContent::Text("(see ".into()),
+                InlineContent::Reference {
+                    raw: "#6".into(),
+                    kind: ReferenceType::Session {
+                        target: "#6".into(),
+                    },
+                },
+            ],
+            "unsafe nearest match must fall back instead of wrapping an earlier occurrence"
         );
     }
 

--- a/crates/lex-babel/tests/markdown/export.rs
+++ b/crates/lex-babel/tests/markdown/export.rs
@@ -679,6 +679,44 @@ fn test_list_with_multi_paragraph_items() {
     assert!(md.contains("Item two"));
 }
 
+#[test]
+fn test_wrapped_list_item_keeps_following_sibling_bullet() {
+    let lex_src = concat!(
+        "Title\n",
+        "\n",
+        "- Hook invocations -- every Claude Code hook fires as `pixi run shipit\n",
+        "    hook <name>` (a transient `pixi run` per firing).\n",
+        "- The write-Run agent session -- as of PR #197, does work.\n",
+    );
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    assert!(
+        md.contains("\n- The write-Run agent session"),
+        "following sibling must remain its own list item: {md}"
+    );
+    assert!(
+        !md.contains("per firing). - The write-Run"),
+        "wrapped item text must not merge with the following sibling: {md}"
+    );
+}
+
+#[test]
+fn test_parenthesized_session_refs_keep_guide_text_outside_links() {
+    let lex_src = "(see [#6], [#7])\n";
+    let lex_doc = STRING_TO_AST.run(lex_src.to_string()).unwrap();
+    let md = MarkdownFormat.serialize(&lex_doc).unwrap();
+
+    assert!(
+        md.contains("(see [\\#6](#6), [\\#7](#7))"),
+        "parenthesized refs should self-link references without linking guide text: {md}"
+    );
+    assert!(
+        !md.contains("[(see]"),
+        "opening parenthesis and guide text must not be absorbed into a link: {md}"
+    );
+}
+
 // ============================================================================
 // DEFINITION LIST TESTS (#605)
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix Markdown export for parenthesized session references like `(see [#6], [#7])`
- Keep guide text with leading punctuation outside the implicit word anchor, falling back to reference self-links
- Add a wrapped-list regression guard for the sibling merge shape reported in #779

## Tests

- RED: `env RUSTC_WRAPPER= cargo test -p lex-babel preceding_word_with_leading_punctuation_falls_back_to_reference -- --nocapture`
- RED: `env RUSTC_WRAPPER= cargo test -p lex-babel test_parenthesized_session_refs_keep_guide_text_outside_links -- --nocapture`
- GREEN: `env RUSTC_WRAPPER= cargo test -p lex-babel ir::anchoring::tests -- --nocapture`
- GREEN: `env RUSTC_WRAPPER= cargo test -p lex-babel markdown::export -- --nocapture`
- GREEN: `env RUSTC_WRAPPER= cargo test -p lex-babel`

Closes #779
