### PR TITLE
shipit: install/update the managed set

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,14 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/bin/install-release-core"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && pixi run ./bin/shipit hook sessionstart",
+            "type": "command"
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -27,6 +35,45 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/bin/delegate-guard"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && pixi run ./bin/shipit hook pretooluse",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && pixi run ./bin/shipit hook stop",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && pixi run ./bin/shipit hook subagent-stop",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && pixi run ./bin/shipit hook worktreecreate",
+            "type": "command"
           }
         ]
       }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -16,33 +16,3 @@
 # gates the source).
 skills/
 AGENTS.md
-
-# --- consumer-owned exclusions (lex) ---
-# OVERRIDE of the shipit-managed file (see header): there is no consumer-owned
-# markdownlint ignore seam separate from this managed file, so lex's own
-# non-prose reference markdown has to live here for now. Tracked as a shipit
-# model gap (arthur-debert/shipit#484) — a consumer with test-fixture/reference
-# markdown needs a sanctioned way to exclude it from the managed gate WITHOUT
-# editing this managed file.
-#
-#   - crates/lex-babel/tests/fixtures/*.md — verbatim upstream reference
-#     documents (comrak's README, the CommonMark/comrak markdown references)
-#     consumed byte-for-byte by lex-babel's interop tests. They are DELIBERATE
-#     reference inputs; reformatting them to satisfy prose rules would corrupt
-#     the fixtures and break the tests.
-crates/lex-babel/tests/fixtures/comrak-readme.md
-crates/lex-babel/tests/fixtures/markdown-reference-commonmark.md
-crates/lex-babel/tests/fixtures/markdown-reference-comrak.md
-#
-#   - CHANGELOG.md + CHANGELOG/*.md — the changelog surface. CHANGELOG.md is
-#     GENERATED from the CHANGELOG/*.md fragments by bin/changelog (release.toml
-#     pre-release-hook), so linting the generated aggregate is the generator's
-#     job, and hand-fixes to it are clobbered on the next release cut. The
-#     fragments and the aggregate also carry the normal changelog shape that the
-#     default prose ruleset misfires on — MD024 no-duplicate-heading fires on the
-#     repeated per-release `### Added` / `### Fixed` sub-headings, which is
-#     correct changelog structure, not debt. Excluding the surface rather than
-#     rewriting it to dedupe. (The managed ruleset lacks a changelog-genre
-#     accommodation — see the shipit model-gap issue.)
-CHANGELOG.md
-CHANGELOG/

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -21,7 +21,7 @@ AGY_REVIEW_APP_ID            = { doppler = "AGY_REVIEW_APP_ID" }
 copilot = {}
 
 [shipit]
-version = "585de97d983bc85c338865c0cc57784c277b9746"
+version = "8c46984320acee3f2202f8a76717323171037924"
 
 [managed]
 "skills/lex-primer/SKILL.md" = "sha256:ff616c1c447661298fb8e06a8a8a6ce60400d838c7c881b9e8bd526128e32901"

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -20,6 +20,34 @@ AGY_REVIEW_APP_ID            = { doppler = "AGY_REVIEW_APP_ID" }
 [reviewers]
 copilot = {}
 
+# [lint] — consumer-owned paths this repo excludes from the managed lint gate
+# (shipit#484). Gitignore-style globs, matched by shipit's own engine; they filter
+# the discovered file list BEFORE routing, so each entry drops a path from EVERY
+# leg (markdownlint, shfmt, …). This is the reconcile-safe home for these — install
+# never clobbers a consumer table — replacing the old OVERRIDE block in the
+# shipit-managed `.markdownlintignore` (now back to pristine).
+#   - crates/lex-babel/tests/fixtures/ — verbatim upstream reference documents
+#     (comrak's README, the CommonMark/comrak markdown references, kitchensink)
+#     consumed byte-for-byte by lex-babel's interop tests; reformatting them to
+#     satisfy prose rules would corrupt the fixtures and break the tests.
+#   - CHANGELOG.md + CHANGELOG/ — CHANGELOG.md is GENERATED from the CHANGELOG/*.md
+#     fragments by bin/changelog (release.toml pre-release-hook); the surface also
+#     carries the normal changelog shape MD024/no-duplicate-heading misfires on
+#     (repeated per-release `### Added` / `### Fixed`).
+#   - bin/install-release-core — VENDORED: release-core distributes and re-syncs
+#     this boot resolver (ADR-0003) on every release cut, and its upstream copy is
+#     not shfmt-clean to this repo's config, so a `chore: Release` sync reverts any
+#     local shfmt fix (it did — #799's fix was undone by v0.19.0). lex does not
+#     author this file; excluding it here keeps the gate green durably rather than
+#     re-fixing it every release. Real fix is upstream in release-core.
+[lint]
+ignore = [
+    "crates/lex-babel/tests/fixtures/",
+    "CHANGELOG.md",
+    "CHANGELOG/",
+    "bin/install-release-core",
+]
+
 [shipit]
 version = "8c46984320acee3f2202f8a76717323171037924"
 


### PR DESCRIPTION
`shipit install` reconciled the managed set.

Pinned to `8c46984320acee3f2202f8a76717323171037924` — the build that wrote this managed set and passed its self-certification (ADR-0033); the managed `bin/shipit` launcher execs exactly this build.

### Added
- `.claude/settings.json#shipit-pretooluse-hook`
- `.claude/settings.json#shipit-stop-hook`
- `.claude/settings.json#shipit-subagentstop-hook`
- `.claude/settings.json#shipit-sessionstart-hook`
- `.claude/settings.json#shipit-worktreecreate-hook`

### Overrides — consumer-edited, review before merging
These units were edited in the consumer since the last shipit install. This PR proposes restoring shipit's content (the diff below); **merging discards the consumer edit**. Review each diff and decide — closing the PR keeps the consumer's version.

<details><summary><code>.markdownlintignore</code></summary>

```diff
--- .markdownlintignore (consumer)
+++ .markdownlintignore (shipit)
@@ -16,33 +16,3 @@
 # gates the source).
 skills/
 AGENTS.md
-
-# --- consumer-owned exclusions (lex) ---
-# OVERRIDE of the shipit-managed file (see header): there is no consumer-owned
-# markdownlint ignore seam separate from this managed file, so lex's own
-# non-prose reference markdown has to live here for now. Tracked as a shipit
-# model gap (arthur-debert/shipit#484) — a consumer with test-fixture/reference
-# markdown needs a sanctioned way to exclude it from the managed gate WITHOUT
-# editing this managed file.
-#
-#   - crates/lex-babel/tests/fixtures/*.md — verbatim upstream reference
-#     documents (comrak's README, the CommonMark/comrak markdown references)
-#     consumed byte-for-byte by lex-babel's interop tests. They are DELIBERATE
-#     reference inputs; reformatting them to satisfy prose rules would corrupt
-#     the fixtures and break the tests.
-crates/lex-babel/tests/fixtures/comrak-readme.md
-crates/lex-babel/tests/fixtures/markdown-reference-commonmark.md
-crates/lex-babel/tests/fixtures/markdown-reference-comrak.md
-#
-#   - CHANGELOG.md + CHANGELOG/*.md — the changelog surface. CHANGELOG.md is
-#     GENERATED from the CHANGELOG/*.md fragments by bin/changelog (release.toml
-#     pre-release-hook), so linting the generated aggregate is the generator's
-#     job, and hand-fixes to it are clobbered on the next release cut. The
-#     fragments and the aggregate also carry the normal changelog shape that the
-#     default prose ruleset misfires on — MD024 no-duplicate-heading fires on the
-#     repeated per-release `### Added` / `### Fixed` sub-headings, which is
-#     correct changelog structure, not debt. Excluding the surface rather than
-#     rewriting it to dedupe. (The managed ruleset lacks a changelog-genre
-#     accommodation — see the shipit model-gap issue.)
-CHANGELOG.md
-CHANGELOG/
```
</details>

### Retired files kept — locally modified
shipit no longer distributes these files, but their content differs from every known pristine version, so they were NOT deleted. Remove them yourself once the local edits are no longer needed:
- `.github/workflows/copilot-review.yml`

### Checks activated locally
`lefthook install` ran where this install was invoked, so its `.git/hooks/{pre-commit,pre-push}` fire `pixi run lint` there now. Reviewers/mergers: run `lefthook install` on your own checkout (shipit-self: `pixi run -e lint install-hooks`) to make the checks live for you too. Activation is idempotent and leaves unrelated hooks intact.

### Consumer lint debt — reported, not blocking
whole-tree lint currently red: 2 failing check(s) — debt-clear pending. Install self-certified only the files it delivered (ADR-0033); the whole-tree gate is this repo's bar (the ADP01 checklist's lint step), cleared with the very env this PR delivers.
