### PR TITLE
chore: clear shfmt + rustfmt lint debt

### DIFF
--- a/app-bin/dev/sandbox-test-linux.sh
+++ b/app-bin/dev/sandbox-test-linux.sh
@@ -31,23 +31,23 @@ IMAGE="lex-sandbox-dev:latest"
 DOCKERFILE="$REPO_ROOT/app-bin/dev/Dockerfile.sandbox"
 PLATFORM_FLAG=()
 if [[ -n "${SANDBOX_PLATFORM:-}" ]]; then
-	PLATFORM_FLAG=(--platform "$SANDBOX_PLATFORM")
+  PLATFORM_FLAG=(--platform "$SANDBOX_PLATFORM")
 fi
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-	docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/app-bin/dev"
+  docker build "${PLATFORM_FLAG[@]}" -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT/app-bin/dev"
 fi
 
 if [[ $# -eq 0 ]]; then
-	set -- cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'
+  set -- cargo nextest run -p lex-extension-host -E 'test(/sandbox/)'
 fi
 
 exec docker run --rm \
-	"${PLATFORM_FLAG[@]}" \
-	-v "$REPO_ROOT:/work" \
-	-v lex-sandbox-target:/target \
-	-v lex-sandbox-cargo-registry:/usr/local/cargo/registry \
-	-e CARGO_TARGET_DIR=/target \
-	-w /work \
-	"$IMAGE" \
-	"$@"
+  "${PLATFORM_FLAG[@]}" \
+  -v "$REPO_ROOT:/work" \
+  -v lex-sandbox-target:/target \
+  -v lex-sandbox-cargo-registry:/usr/local/cargo/registry \
+  -e CARGO_TARGET_DIR=/target \
+  -w /work \
+  "$IMAGE" \
+  "$@"

--- a/bin/shipit
+++ b/bin/shipit
@@ -30,12 +30,12 @@ manifest="$repo_root/.shipit.toml"
 
 # The development override (ADR-0033): honored and announced, never silent.
 if [ -n "${SHIPIT_EXEC:-}" ]; then
-	if [ -e "$SHIPIT_EXEC" ] && [ "$SHIPIT_EXEC" -ef "$self" ]; then
-		echo "shipit: SHIPIT_EXEC points at this launcher itself ($SHIPIT_EXEC); refusing the exec loop." >&2
-		exit 127
-	fi
-	echo "shipit: SHIPIT_EXEC override — exec'ing $SHIPIT_EXEC (the repo's pin is bypassed)." >&2
-	exec "$SHIPIT_EXEC" "$@"
+  if [ -e "$SHIPIT_EXEC" ] && [ "$SHIPIT_EXEC" -ef "$self" ]; then
+    echo "shipit: SHIPIT_EXEC points at this launcher itself ($SHIPIT_EXEC); refusing the exec loop." >&2
+    exit 127
+  fi
+  echo "shipit: SHIPIT_EXEC override — exec'ing $SHIPIT_EXEC (the repo's pin is bypassed)." >&2
+  exec "$SHIPIT_EXEC" "$@"
 fi
 
 # Resolve the pin: the `version` key of .shipit.toml's [shipit] table (a full
@@ -44,17 +44,17 @@ fi
 # the real parser lives on the Python side.
 pin=""
 if [ -f "$manifest" ]; then
-	pin="$(awk -F'"' '
+  pin="$(awk -F'"' '
 		/^\[/ { in_shipit = ($0 == "[shipit]") ? 1 : 0; next }
 		in_shipit && $1 ~ /^[[:space:]]*version[[:space:]]*=[[:space:]]*$/ { print $2; exit }
 	' "$manifest")"
 fi
 
 if [ -z "$pin" ]; then
-	echo "shipit: $manifest has no [shipit].version pin — this repo is not bootstrapped (ADR-0033)." >&2
-	echo "Bootstrap it: install shipit once (uv tool install --from $SHIPIT_GIT_URL shipit)," >&2
-	echo "then run \`shipit install --pr\` in this repo — the install stamps the pin this launcher execs." >&2
-	exit 127
+  echo "shipit: $manifest has no [shipit].version pin — this repo is not bootstrapped (ADR-0033)." >&2
+  echo "Bootstrap it: install shipit once (uv tool install --from $SHIPIT_GIT_URL shipit)," >&2
+  echo "then run \`shipit install --pr\` in this repo — the install stamps the pin this launcher execs." >&2
+  exit 127
 fi
 
 # The pin must be a FULL git object sha (40 hex for SHA-1, 64 for SHA-256) — the
@@ -63,10 +63,10 @@ fi
 # sha) is NOT a resolvable build: refuse toward the bootstrap rather than hand uv
 # a ref it would fail on with a murkier error.
 if ! printf '%s' "$pin" | grep -Eq '^[0-9a-f]{40}([0-9a-f]{24})?$'; then
-	echo "shipit: $manifest [shipit].version is not a full git sha (40 or 64 hex chars) — this repo is not bootstrapped (ADR-0033)." >&2
-	echo "Re-bootstrap it: install shipit once (uv tool install --from $SHIPIT_GIT_URL shipit)," >&2
-	echo "then run \`shipit install --pr\` in this repo — the install stamps a valid pin this launcher execs." >&2
-	exit 127
+  echo "shipit: $manifest [shipit].version is not a full git sha (40 or 64 hex chars) — this repo is not bootstrapped (ADR-0033)." >&2
+  echo "Re-bootstrap it: install shipit once (uv tool install --from $SHIPIT_GIT_URL shipit)," >&2
+  echo "then run \`shipit install --pr\` in this repo — the install stamps a valid pin this launcher execs." >&2
+  exit 127
 fi
 
 # Self-certification probe (ADR-0033): `shipit install` asserts this launcher
@@ -74,14 +74,14 @@ fi
 # resolved pin and stop — the real parse over the real manifest, with no uv
 # requirement and no network resolve in the postcondition.
 if [ -n "${SHIPIT_PIN_CHECK:-}" ]; then
-	printf '%s\n' "$pin"
-	exit 0
+  printf '%s\n' "$pin"
+  exit 0
 fi
 
 command -v uv >/dev/null 2>&1 || {
-	echo "shipit: uv is not on PATH — the pinned launcher provisions the repo's shipit via uv (ADR-0033)." >&2
-	echo "Install uv (https://docs.astral.sh/uv/), then re-run." >&2
-	exit 127
+  echo "shipit: uv is not on PATH — the pinned launcher provisions the repo's shipit via uv (ADR-0033)." >&2
+  echo "Install uv (https://docs.astral.sh/uv/), then re-run." >&2
+  exit 127
 }
 
 # Exec the repo's pinned build via uv — cached after the first resolve; PATH

--- a/claude-start
+++ b/claude-start
@@ -18,8 +18,8 @@
 set -euo pipefail
 
 if ! command -v claude >/dev/null 2>&1; then
-	echo "claude-start: the claude CLI is not on PATH — install Claude Code first." >&2
-	exit 127
+  echo "claude-start: the claude CLI is not on PATH — install Claude Code first." >&2
+  exit 127
 fi
 
 # Session id: sortable UTC launch stamp + this launcher's PID — unique across

--- a/crates/lex-babel/src/formats/markdown/parser.rs
+++ b/crates/lex-babel/src/formats/markdown/parser.rs
@@ -845,10 +845,7 @@ mod tests {
         let md = "# My Title\n\nBody.\n";
         let doc = parse_from_markdown(md).unwrap();
 
-        assert_eq!(
-            doc.title.as_ref().map(|t| t.as_str()),
-            Some("My Title")
-        );
+        assert_eq!(doc.title.as_ref().map(|t| t.as_str()), Some("My Title"));
         // No `doc.untitled` marker when a real title was lifted.
         assert!(!doc
             .annotations

--- a/crates/lex-cli/completions/lex.bash
+++ b/crates/lex-cli/completions/lex.bash
@@ -1,66 +1,66 @@
 _lex() {
-	local i cur opts cmd transforms word
-	COMPREPLY=()
-	if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
-		cur="$2"
-	else
-		cur="${COMP_WORDS[COMP_CWORD]}"
-	fi
-	cmd=""
-	opts=""
+  local i cur opts cmd transforms word
+  COMPREPLY=()
+  if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+    cur="$2"
+  else
+    cur="${COMP_WORDS[COMP_CWORD]}"
+  fi
+  cmd=""
+  opts=""
 
-	for i in "${COMP_WORDS[@]:0:COMP_CWORD}"; do
-		case "${cmd},${i}" in
-		",$1")
-			cmd="lex"
-			;;
-		*)
-			;;
-		esac
-	done
+  for i in "${COMP_WORDS[@]:0:COMP_CWORD}"; do
+    case "${cmd},${i}" in
+    ",$1")
+      cmd="lex"
+      ;;
+    *)
+      ;;
+    esac
+  done
 
-	case "${cmd}" in
-	lex)
-		opts="-h -V --list-transforms --help --version"
-		transforms="token-core-json token-core-simple token-core-pprint token-simple token-pprint token-line-json token-line-simple token-line-pprint ir-json ast-json ast-tag ast-treeviz"
+  case "${cmd}" in
+  lex)
+    opts="-h -V --list-transforms --help --version"
+    transforms="token-core-json token-core-simple token-core-pprint token-simple token-pprint token-line-json token-line-simple token-line-pprint ir-json ast-json ast-tag ast-treeviz"
 
-		# Handle flags
-		if [[ ${cur} == -* ]]; then
-			# shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
-			COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-			return 0
-		fi
+    # Handle flags
+    if [[ ${cur} == -* ]]; then
+      # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
+      COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+      return 0
+    fi
 
-		# Count non-flag arguments
-		local arg_count=0
-		for word in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
-			if [[ ! ${word} == -* ]]; then
-				((arg_count++))
-			fi
-		done
+    # Count non-flag arguments
+    local arg_count=0
+    for word in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
+      if [[ ! ${word} == -* ]]; then
+        ((arg_count++))
+      fi
+    done
 
-		# First positional argument: file path
-		if [[ ${arg_count} -eq 0 ]]; then
-			# shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
-			COMPREPLY=($(compgen -f -- "${cur}"))
-			return 0
-		fi
+    # First positional argument: file path
+    if [[ ${arg_count} -eq 0 ]]; then
+      # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
+      COMPREPLY=($(compgen -f -- "${cur}"))
+      return 0
+    fi
 
-		# Second positional argument: transform format
-		if [[ ${arg_count} -eq 1 ]]; then
-			# shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
-			COMPREPLY=($(compgen -W "${transforms}" -- "${cur}"))
-			return 0
-		fi
+    # Second positional argument: transform format
+    if [[ ${arg_count} -eq 1 ]]; then
+      # shellcheck disable=SC2207  # intentional word-split of compgen output; mapfile is bash4+ only and this completion supports bash 3
+      COMPREPLY=($(compgen -W "${transforms}" -- "${cur}"))
+      return 0
+    fi
 
-		COMPREPLY=()
-		return 0
-		;;
-	esac
+    COMPREPLY=()
+    return 0
+    ;;
+  esac
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-	complete -F _lex -o nosort -o bashdefault -o default -o filenames lex
+  complete -F _lex -o nosort -o bashdefault -o default -o filenames lex
 else
-	complete -F _lex -o bashdefault -o default -o filenames lex
+  complete -F _lex -o bashdefault -o default -o filenames lex
 fi


### PR DESCRIPTION
## Summary

Brings `shipit lint` back to green (**LINT: OK, 32 checks**). Two sources of debt:

- **shfmt (4 shell files):** `app-bin/dev/sandbox-test-linux.sh`, `bin/shipit`, `claude-start`, and `crates/lex-cli/completions/lex.bash` were tab-indented, conflicting with the shipit-managed `.editorconfig` 2-space convention that shfmt honors (and that the sibling managed launcher `bin/install-release-core` already follows). Reformatted with `shipit lint --fix` (shfmt -w). **Whitespace-only** — `git diff -w` over these files is empty.
- **rustfmt (1 file):** `crates/lex-babel/src/formats/markdown/parser.rs` carried a stray rustfmt miss from #811 (which used `--no-verify`): after a review simplification to `t.as_str()` the assertion fit on one line. `cargo fmt` collapses it.

## Verification

- `shipit lint` → `LINT: OK (32 checks)`
- `cargo fmt --all -- --check` clean workspace-wide
- lex-babel tests green

## Note on managed files

`bin/shipit` and `claude-start` are shipit-managed launchers. `shipit install --dry-run` does **not** list them for reconcile at the current pin (their tab versions are pristine), so they can't be fixed by refreshing — `shipit lint --fix` (shipit's own sanctioned fixer) is the correct tool. If a future `shipit install` reverts them to tabs, that's an upstream shipit inconsistency (it ships tab-indented launchers that fail its own shfmt gate under its own 2-space `.editorconfig`) worth reporting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)