### PR TITLE
Formatter faithfulness: table cells with block content (lex#790, partial)

### DIFF
--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -299,7 +299,7 @@ impl Visitor for LexSerializer {
     // across pipe continuation rows by `emit_pipe_table`), so it must NOT also
     // walk the cells' structured `children` — doing so re-emitted that block
     // content as stranded document-level siblings after the table (lex#790).
-    fn descend_into_table_cells(&self) -> bool {
+    fn descend_into_table_cells(&mut self) -> bool {
         false
     }
 

--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -295,6 +295,14 @@ impl LexSerializer {
 }
 
 impl Visitor for LexSerializer {
+    // The serializer rebuilds each table cell from its flat `content` (stacked
+    // across pipe continuation rows by `emit_pipe_table`), so it must NOT also
+    // walk the cells' structured `children` — doing so re-emitted that block
+    // content as stranded document-level siblings after the table (lex#790).
+    fn descend_into_table_cells(&self) -> bool {
+        false
+    }
+
     fn visit_session(&mut self, session: &Session) {
         self.separate_before(BlockKind::Session);
         let raw_title = session.title.as_string();

--- a/crates/lex-babel/src/formats/lex/serializer/tests.rs
+++ b/crates/lex-babel/src/formats/lex/serializer/tests.rs
@@ -394,6 +394,35 @@ fn test_round_trip_list_07_nested() {
 }
 
 #[test]
+fn table_cell_with_block_content_does_not_strand_children() {
+    // lex#790: a table cell carrying block content (a list) stores it both as
+    // flat `content` and as structured `children`. The serializer renders the
+    // flat content stacked across pipe continuation rows; it must NOT also walk
+    // the cell's children, which used to leak out as a dedented stranded list
+    // after the table. The reformat must be idempotent and contain no bare list.
+    let source = "\
+Data:
+    | Name  | Skills   |
+
+    | Alice | - Python |
+    |       | - Rust   |
+
+    | Bob   | Text     |
+";
+    let formatted = format_source(source);
+    // The list markers must stay inside the pipe grid — no bare `- ` line
+    // (a stranded list re-parses as a sibling and breaks faithfulness).
+    for line in formatted.lines() {
+        assert!(
+            !line.trim_start().starts_with("- ") || line.contains('|'),
+            "stranded list line escaped the table:\n{formatted}"
+        );
+    }
+    let formatted_again = format_source(&formatted);
+    assert_text_eq(&formatted, &formatted_again);
+}
+
+#[test]
 fn test_round_trip_definition_01() {
     let source = Lexplore::load(ElementType::Definition, 1).source();
     let formatted = format_source(&source);

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -217,27 +217,21 @@ const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #790 — table cells that carry *block* content (a list, verbatim, annotation,
-    // or a table nested in a definition inside a cell) still de-indent that inner
-    // structure on serialize, so the reformat is not idempotent. The subject-colon
-    // de-indent and simple multi-line text cells are fixed.
+    // #790 (residual) — a table nested inside definitions emits its closing
+    // `:: table ::` annotation one indent level too shallow, escaping the
+    // innermost container. The cell-block-content de-indent that used to list
+    // table-19/21/22/23 here is fixed (the serializer no longer re-walks cell
+    // children); this remaining case is the nested-closer indent.
     ("table.docs/table-08-nested-in-definition.lex", "lex#790"),
-    ("table.docs/table-19-cell-with-list.lex", "lex#790"),
-    ("table.docs/table-21-cell-with-verbatim.lex", "lex#790"),
-    ("table.docs/table-22-cell-with-mixed-content.lex", "lex#790"),
-    ("table.docs/table-23-cell-with-annotation.lex", "lex#790"),
 ];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #790 — table cells carrying block content (a list, verbatim, annotation, or a
-    // definition — incl. a table nested inside a definition) still lose or de-indent
-    // that inner structure across a round-trip.
+    // #790 (residual) — a table nested inside definitions emits its closing
+    // `:: table ::` annotation one indent level too shallow, so on re-parse the
+    // closer (and the table) detach from the innermost container. The cell-block-
+    // content class (table-19/20/21/22/23) is fixed; this nested-closer case
+    // remains.
     ("table.docs/table-08-nested-in-definition.lex", "lex#790"),
-    ("table.docs/table-19-cell-with-list.lex", "lex#790"),
-    ("table.docs/table-20-cell-with-definition.lex", "lex#790"),
-    ("table.docs/table-21-cell-with-verbatim.lex", "lex#790"),
-    ("table.docs/table-22-cell-with-mixed-content.lex", "lex#790"),
-    ("table.docs/table-23-cell-with-annotation.lex", "lex#790"),
     // #791 (deeper case) — leading/document-level annotations that in the source
     // are attached to the first *session* re-attach to the document *root* across
     // a round-trip: the annotations serialize at the document head and re-parse as

--- a/crates/lex-core/src/lex/ast/elements/table.rs
+++ b/crates/lex-core/src/lex/ast/elements/table.rs
@@ -264,11 +264,17 @@ impl AstNode for Table {
 
     fn accept(&self, visitor: &mut dyn Visitor) {
         visitor.visit_table(self);
-        // Descend into cell children (block-level content inside cells)
-        for row in self.all_rows() {
-            for cell in &row.cells {
-                for child in cell.children.iter() {
-                    child.accept(visitor);
+        // Descend into cell children (block-level content inside cells). A cell
+        // carries block content redundantly as flat `content` and structured
+        // `children`; a visitor that rebuilds the cell from the pipe rows (the
+        // Lex serializer) opts out so the children are not emitted a second time
+        // as stranded document-level blocks (lex#790).
+        if visitor.descend_into_table_cells() {
+            for row in self.all_rows() {
+                for cell in &row.cells {
+                    for child in cell.children.iter() {
+                        child.accept(visitor);
+                    }
                 }
             }
         }

--- a/crates/lex-core/src/lex/ast/elements/table.rs
+++ b/crates/lex-core/src/lex/ast/elements/table.rs
@@ -270,12 +270,8 @@ impl AstNode for Table {
         // Lex serializer) opts out so the children are not emitted a second time
         // as stranded document-level blocks (lex#790).
         if visitor.descend_into_table_cells() {
-            for row in self.all_rows() {
-                for cell in &row.cells {
-                    for child in cell.children.iter() {
-                        child.accept(visitor);
-                    }
-                }
+            for child in self.cell_children_iter() {
+                child.accept(visitor);
             }
         }
         // Visit annotations

--- a/crates/lex-core/src/lex/ast/traits.rs
+++ b/crates/lex-core/src/lex/ast/traits.rs
@@ -72,6 +72,17 @@ pub trait Visitor {
         _blank_line_group: &super::elements::blank_line_group::BlankLineGroup,
     ) {
     }
+
+    /// Whether `Table::accept` should descend into the block-level `children` of
+    /// table cells after `visit_table`. A table cell carries its block content
+    /// both as flat `content` (the pipe-row text) and as structured `children`;
+    /// visitors that reconstruct a cell from the pipe rows (the Lex serializer)
+    /// override this to `false` so the redundant children are not walked a second
+    /// time and emitted as stranded document-level blocks (lex#790). Analysis
+    /// visitors keep the default `true` so they see the cells' inner structure.
+    fn descend_into_table_cells(&self) -> bool {
+        true
+    }
 }
 
 /// Helper function to visit all children in a ContentItem slice

--- a/crates/lex-core/src/lex/ast/traits.rs
+++ b/crates/lex-core/src/lex/ast/traits.rs
@@ -80,7 +80,7 @@ pub trait Visitor {
     /// override this to `false` so the redundant children are not walked a second
     /// time and emitted as stranded document-level blocks (lex#790). Analysis
     /// visitors keep the default `true` so they see the cells' inner structure.
-    fn descend_into_table_cells(&self) -> bool {
+    fn descend_into_table_cells(&mut self) -> bool {
         true
     }
 }


### PR DESCRIPTION
## Summary

Fixes the largest cluster of the deferred lex#790 formatter-faithfulness known-fails: table cells carrying **block content** (a list, verbatim, annotation, or nested definition). 5 of 6 lex#790 table fixtures now round-trip and are promoted from anti-rot known-fails to live assertions.

## Root cause

A `TableCell` stores block content **twice**: as flat `content` (the pipe-row text, stacked across continuation rows by `emit_pipe_table`) *and* as structured `children`. `Table::accept` walked each cell's `children` a second time after `visit_table`, and the serializer emitted them as **dedented, stranded document-level blocks** after the table:

```
| Alice | - Python |
|       | - Rust   |
| Bob   | Text     |
- Python          ← stranded duplicate
- Rust
```

## Fix

Add `Visitor::descend_into_table_cells()` (default `true`) and gate the cell-children walk in `Table::accept` on it. The Lex serializer overrides it to `false` — it reconstructs each cell from the pipe rows, so the structured children are redundant. Analysis visitors keep descending (default `true`), so semantic tokens / symbols / navigation still see cell inner structure.

Promotes from the known-fail lists: `table-19/20/21/22/23`. Adds a targeted no-stranded-list regression test.

## Deferred (still known-fails, deeper parser-level bugs)

Investigated but **not** fixed here — both need parser-level work, out of scope for this serializer fix:

- **lex#790 residual — `table-08-nested-in-definition`**: a table nested in definitions whose `:: table ::` closer sits at *body* indent. Canonicalizing the closer to subject level lets a preceding colon-terminated paragraph absorb the table as its subject; moving all closers to body level (the other direction) regresses blank-line idempotence when a table has a following sibling (the body-level closer's trailing blank is absorbed on reparse). Needs a parser fix to the colon-paragraph/closer ambiguity (related to the `Definition→Table` hijack).
- **lex#791 — leading annotation attachment**: document-level annotations (`:: author ::`, `:: publishing-date ::`) that attach to the first *session* re-attach to the document *root* across a round-trip. Parser-level ownership issue.

## Testing

- `cargo test --workspace --exclude lex-wasm` green.
- `format_invariants` Tier-1 + Tier-2 corpus sweeps green with the 5 fixtures promoted.
- `shipit lint` → LINT: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)