### PR TITLE
Fix colon-subject absorption on re-parse (lex#814 §1/§3)

### DIFF
--- a/CHANGELOG/unreleased-colon-subject-absorption.md
+++ b/CHANGELOG/unreleased-colon-subject-absorption.md
@@ -1,0 +1,1 @@
+- Fix colon-terminated paragraph being absorbed as a following table/verbatim subject on re-parse (lex#814 §1/§3)

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -217,21 +217,19 @@ const TIER1_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 const TIER2_TARGETED_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #790 (residual) — a table nested inside definitions emits its closing
-    // `:: table ::` annotation one indent level too shallow, escaping the
-    // innermost container. The cell-block-content de-indent that used to list
-    // table-19/21/22/23 here is fixed (the serializer no longer re-walks cell
-    // children); this remaining case is the nested-closer indent.
+    // #790 (serializer residual) — a table nested inside definitions emits its
+    // closing `:: table ::` annotation one indent level too shallow (at the
+    // definition-body indent instead of the table-subject indent), escaping the
+    // innermost container. This is a SERIALIZER bug and remains open: the
+    // lex#814 §1/§3 parser fix repaired the semantic round-trip (Tier-2, below,
+    // no longer fails), but idempotence still breaks — re-formatting the
+    // shallow-closer output re-parses the table out of its container and drops
+    // it. The cell-block-content de-indent that used to list table-19/21/22/23
+    // here is a separate, already-fixed class.
     ("table.docs/table-08-nested-in-definition.lex", "lex#790"),
 ];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #790 (residual) — a table nested inside definitions emits its closing
-    // `:: table ::` annotation one indent level too shallow, so on re-parse the
-    // closer (and the table) detach from the innermost container. The cell-block-
-    // content class (table-19/20/21/22/23) is fixed; this nested-closer case
-    // remains.
-    ("table.docs/table-08-nested-in-definition.lex", "lex#790"),
     // #791 (deeper case) — leading/document-level annotations that in the source
     // are attached to the first *session* re-attach to the document *root* across
     // a round-trip: the annotations serialize at the document head and re-parse as

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -120,23 +120,28 @@ const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     // Skeleton diff) to have no remaining list- or session-marker divergence; the
     // entry names the OTHER bug it still trips.
     //
-    // commonmark-reference / comrak-readme / comrak-reference → #790 (a
-    // colon-terminated paragraph before a fenced code block is absorbed as the
-    // verbatim subject / becomes a Definition, some inside a list item).
+    // commonmark-reference / comrak-readme / comrak-reference → the colon-para-
+    // before-fenced-code *absorption* named in #790 is now FIXED at the parser
+    // (lex#814 §1/§3: a colon-terminated paragraph is no longer swallowed as the
+    // following verbatim's subject). These three big real-world READMEs, however,
+    // still diverge on OTHER residuals — nested block/standalone annotations that
+    // re-attach across the round-trip (the #791 class) and empty-image fences —
+    // so they stay blocked. Retagged to the lex#814 umbrella (§2/§4 + empty-fence
+    // residuals own what remains); do NOT re-attribute to the absorbed-subject
+    // cause, which no longer fires.
     //
-    // kitchensink → #790 as well: with #795 fixed, its residual divergence is the
-    // empty ```` ``` image ```` fence, which serializes to an empty-subject
-    // verbatim (`:` + `:: image ::`) whose colon line is re-anchored by the
-    // closer hijack (separation.rs "Closer re-anchoring") and swallows the
-    // preceding `:: todo ::` block-annotation body. It ALSO trips the standalone
-    // block-annotation limitation (a floating annotation attaches to its
-    // neighboring paragraph rather than round-tripping as a sibling — documented
-    // in separation.rs §"Annotations", the #791 class), so kitchensink stays
-    // blocked until both land. Tagged against #790, the first tracked cause.
-    ("kitchensink", "lex#790"),
-    ("comrak-readme", "lex#790"),
-    ("commonmark-reference", "lex#790"),
-    ("comrak-reference", "lex#790"),
+    // kitchensink → same story plus the empty ```` ``` image ```` fence, which
+    // serializes to an empty-subject verbatim (`:` + `:: image ::`) whose colon
+    // line is re-anchored by the closer hijack (separation.rs "Closer
+    // re-anchoring") and swallows the preceding `:: todo ::` block-annotation
+    // body. It ALSO trips the standalone block-annotation limitation (a floating
+    // annotation attaches to its neighboring paragraph rather than round-tripping
+    // as a sibling — separation.rs §"Annotations", the #791 class), so
+    // kitchensink stays blocked until those land.
+    ("kitchensink", "lex#814"),
+    ("comrak-readme", "lex#814"),
+    ("commonmark-reference", "lex#814"),
+    ("comrak-reference", "lex#814"),
     // #791 — leading document-level annotations reorder around the title.
     ("ideas-naked", "lex#791"),
 ];

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -502,6 +502,40 @@ impl GrammarMatcher {
             _ => return None,
         };
 
+        // Guard against absorbing a colon-terminated *paragraph* as this block's
+        // subject (lex#814 §1/§3). If the very first subject owns no content of its
+        // own — i.e. the next non-blank token is *another* subject — then the first
+        // subject is a colon-terminated paragraph, not a verbatim/table subject.
+        // Bail so the paragraph matcher claims it; the next `try_match` iteration
+        // re-anchors the verbatim/table on the REAL subject (the one that owns its
+        // container) and closes correctly.
+        //
+        // This must NOT fire for genuine verbatim shapes, whose first subject is
+        // directly followed by:
+        //   - a Container (inflow verbatim / multi-group verbatim), or
+        //   - a DataMarkerLine (marker-form empty verbatim, e.g. `An image:` /
+        //     `:: image ::`), or
+        //   - flat prose lines (fullwidth mode).
+        {
+            let mut peek = first_subject_idx + 1;
+            while peek < len {
+                if let LineContainer::Token(line) = &tokens[peek] {
+                    if line.line_type == BlankLine {
+                        peek += 1;
+                        continue;
+                    }
+                }
+                break;
+            }
+            if peek < len {
+                if let LineContainer::Token(line) = &tokens[peek] {
+                    if matches!(line.line_type, SubjectLine | SubjectOrListItemLine) {
+                        return None;
+                    }
+                }
+            }
+        }
+
         let mut cursor = first_subject_idx + 1;
 
         // Try to match one or more subject+content pairs followed by closing annotation
@@ -905,5 +939,72 @@ mod prose_continuation_tests {
             line(SubjectLine),
             container(vec![line(ParagraphLine)]),
         ]));
+    }
+}
+
+#[cfg(test)]
+mod verbatim_anchor_tests {
+    use super::*;
+    use crate::lex::token::LineToken;
+
+    fn line(line_type: LineType) -> LineContainer {
+        LineContainer::Token(LineToken {
+            source_tokens: vec![],
+            token_spans: vec![],
+            line_type,
+        })
+    }
+
+    fn container(children: Vec<LineContainer>) -> LineContainer {
+        LineContainer::Container { children }
+    }
+
+    // lex#814 §1/§3: a colon-terminated *paragraph* directly before a
+    // verbatim/table subject must NOT be absorbed as the block's subject. The
+    // matcher bails (returns None) so the paragraph matcher claims the colon
+    // line and the next `try_match` iteration re-anchors the verbatim on the
+    // REAL subject (the one that owns its container).
+    #[test]
+    fn colon_paragraph_before_verbatim_is_not_absorbed() {
+        use LineType::*;
+        // subject (colon-para) / blank / subject / container / closer
+        let tokens = vec![
+            line(SubjectLine),
+            line(BlankLine),
+            line(SubjectLine),
+            container(vec![line(ParagraphLine)]),
+            line(DataMarkerLine),
+        ];
+        assert!(
+            GrammarMatcher::match_verbatim_block(&tokens, 0).is_none(),
+            "first subject owns no container of its own — the block must not anchor on it"
+        );
+        // Re-anchored on the REAL subject at idx 2, it matches cleanly.
+        assert!(GrammarMatcher::match_verbatim_block(&tokens, 2).is_some());
+    }
+
+    // A genuine multi-group verbatim (every group subject is followed by its own
+    // container) must STILL match as one block — the guard must not fire here.
+    #[test]
+    fn multi_group_verbatim_still_matches() {
+        use LineType::*;
+        let tokens = vec![
+            line(SubjectLine),
+            container(vec![line(ParagraphLine)]),
+            line(SubjectLine),
+            container(vec![line(ParagraphLine)]),
+            line(DataMarkerLine),
+        ];
+        assert!(GrammarMatcher::match_verbatim_block(&tokens, 0).is_some());
+    }
+
+    // Marker-form empty verbatim (`An image:` / `:: image ::`) — the first
+    // subject is directly followed by the closing DataMarkerLine, not another
+    // subject, so the guard must not fire.
+    #[test]
+    fn marker_form_empty_verbatim_still_matches() {
+        use LineType::*;
+        let tokens = vec![line(SubjectLine), line(DataMarkerLine)];
+        assert!(GrammarMatcher::match_verbatim_block(&tokens, 0).is_some());
     }
 }

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -517,21 +517,12 @@ impl GrammarMatcher {
         //     `:: image ::`), or
         //   - flat prose lines (fullwidth mode).
         {
-            let mut peek = first_subject_idx + 1;
-            while peek < len {
-                if let LineContainer::Token(line) = &tokens[peek] {
-                    if line.line_type == BlankLine {
-                        peek += 1;
-                        continue;
-                    }
-                }
-                break;
-            }
-            if peek < len {
-                if let LineContainer::Token(line) = &tokens[peek] {
-                    if matches!(line.line_type, SubjectLine | SubjectOrListItemLine) {
-                        return None;
-                    }
+            if let Some(LineContainer::Token(line)) = tokens[first_subject_idx + 1..]
+                .iter()
+                .find(|tc| !matches!(tc, LineContainer::Token(l) if l.line_type == BlankLine))
+            {
+                if matches!(line.line_type, SubjectLine | SubjectOrListItemLine) {
+                    return None;
                 }
             }
         }


### PR DESCRIPTION
## Context

Handoff note for a stranger picking this up.

**What this fixes.** `GrammarMatcher::match_verbatim_block` (in `crates/lex-core/src/lex/parsing/parser.rs`) greedily anchored a verbatim/table block on the *first* subject line it found and spanned forward to the `:: label ::` closer. When that first subject was a colon-terminated **paragraph** with no content of its own, it was wrongly absorbed as the block's subject on re-parse. This is issue lex#814 §1 (a table nested inside a definition) and §3 (a colon-terminated paragraph before a fenced code block, via the Markdown reader).

**The fix (parser-only).** Right after the first subject index is located, peek forward skipping *only* blank lines. If the next non-blank token is another subject (`SubjectLine`/`SubjectOrListItemLine`), the first subject owns no container of its own, so return `None`. The paragraph matcher then claims the colon line, and the next `try_match` iteration re-anchors the verbatim/table on the *real* subject (the one that owns its container) and closes correctly.

The guard is deliberately narrow — it does NOT fire when the first subject is followed by:
- a `Container` (inflow verbatim and genuine multi-group verbatim like `verbatim-11`, `verbatim-13`, `benchmark/040-on-parsing` — every group subject owns its own container),
- a `DataMarkerLine` (marker-form empty verbatim, e.g. `An image:` / `:: image ::`), or
- flat prose lines (fullwidth-mode verbatim).

No serializer/babel code changed; no output bytes move. Regression tests added in a new `verbatim_anchor_tests` module in `parser.rs`.

**§4 is out of scope — do NOT "fix" it here.** Definition→Verbatim/Table/Annotation separation (§4) is token-ambiguous with genuine multi-group verbatim and touching it risks regressing grouping. The `is_known_hijack` tripwire in `crates/lex-babel/tests/lex_separation/matrix.rs` is left intact and RED on purpose. This PR does not change §4 behavior (full suite green confirms the tripwire did not flip).

## Known-fail list updates

- `format_invariants/mod.rs`: removed `table.docs/table-08-nested-in-definition.lex` from **TIER2** (semantic preservation now passes). **KEPT it in TIER1** (idempotence) — that residual is a separate **serializer** bug (#790): the nested closing `:: table ::` is emitted one indent level too shallow, so re-formatting drops the table. A parser-only fix cannot move it. Comment updated to spell this out.
- `markdown/faithfulness_fixtures.rs`: the colon-para-before-fenced-code *absorption* named in the old `#790` comment is now fixed, but the three big README fixtures (`commonmark-reference`, `comrak-readme`, `comrak-reference`) plus `kitchensink` still fail on **other** residuals (nested block/standalone annotation re-attachment — the #791 class — and empty-image fences). All four are **KEPT**, retagged from `lex#790` to the `lex#814` umbrella, with the comment rewritten to name the remaining causes. Do not re-attribute these to the absorbed-subject cause, which no longer fires.

## Not introduced by this PR (surprise, documented)

A synthetic *root-level* `colon-line:` immediately before a verbatim now falls through to a **pre-existing** separate bug where an orphan colon-terminated subject line at document root is dropped (reproducible with no verbatim at all: `Intro:\n\ntext` drops `Intro:` on the stale released `lexd` too). This is not touched here and does not affect the real §1/§3 nested cases, where the colon-para lives inside a container and is preserved (tier2 `table-08` passes).

## Tests

- `cargo nextest run -p lex-core` — 1416 pass, incl. new `verbatim_anchor_tests`; multi-group verbatims (`verbatim-11`, `verbatim-13`, `benchmark/040-on-parsing`) still parse grouped.
- `cargo nextest run -p lex-babel` — 484 pass (tier1/tier2 + markdown faithfulness anti-rot green).
- `cargo nextest run --workspace --exclude lex-wasm` — 2691 pass, 1 skipped.
- `release-core gate` — clean on the changeset (fmt/clippy/markdownlint on staged files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gKDjqd8GMKjTrDAWK59CM