### PR TITLE
Fix leading-annotation attachment consistency (lex#814 §2)

### DIFF
--- a/CHANGELOG/unreleased-leading-annotation-attachment.md
+++ b/CHANGELOG/unreleased-leading-annotation-attachment.md
@@ -1,0 +1,1 @@
+- Attach leading document-level annotations to the document root consistently across parse and re-parse (lex#814 §2)

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -199,11 +199,15 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 //          on serialize. The serializer used to emit the first-class title node
 //          before the body stream, hoisting it ahead of any annotation authored
 //          above it; it now emits the title at its own source position, so the two
-//          named repros (document-09, annotation-27) pass. A DEEPER case remains:
-//          annotations that in the source attach to the first *session* re-attach
-//          to the document *root* on round-trip (they serialize at the document
-//          head and re-parse as root-owned) — the inlines-spec fixtures and
-//          20-ideas-naked still fail Tier-2 on that attachment change.
+//          named repros (document-09, annotation-27) pass. The DEEPER case — a
+//          leading annotation that in the source attaches to the first *session*
+//          re-attaching to the document *root* on round-trip — is now FIXED by
+//          lex#814 §2 (`decide_attachment` routes a leading annotation to the root
+//          when the next content is a session, so parse(D) and parse(format(D))
+//          converge). The four inlines-spec fixtures round-trip again;
+//          20-ideas-naked still fails, but on a serializer residual (single-line→
+//          block annotation rewrite alters content), not attachment — see the
+//          TIER2_FIXTURE_KNOWN_FAIL note below.
 //   #792 — FIXED. Ragged/mismatched-row tables used to get padded + a separator
 //          row injected, adding cells to short rows (Tier-2). The serializer no
 //          longer pads short rows, so table-13 round-trips faithfully.
@@ -230,23 +234,24 @@ const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
 ];
 
 const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // #791 (deeper case) — leading/document-level annotations that in the source
-    // are attached to the first *session* re-attach to the document *root* across
-    // a round-trip: the annotations serialize at the document head and re-parse as
-    // root-owned rather than session-owned. #791's serializer-ordering fix keeps a
-    // leading annotation above the title (document-09, annotation-27 pass) but does
-    // not change this attachment target, so these fixtures still fail Tier-2.
-    ("benchmark/20-ideas-naked.lex", "lex#791"),
-    ("inlines.docs/specs/formatting/formatting.lex", "lex#791"),
-    (
-        "inlines.docs/specs/formatting/inlines-general.lex",
-        "lex#791",
-    ),
-    ("inlines.docs/specs/references/citations.lex", "lex#791"),
-    (
-        "inlines.docs/specs/references/references-general.lex",
-        "lex#791",
-    ),
+    // lex#814 §2 — FIXED the attachment inconsistency that this #791 "deeper case"
+    // described: leading document-level annotations authored above the first
+    // *session* used to bind to that session in parse(D) but re-attach to the
+    // document *root* in parse(format(D)) (the serializer emits them at the head
+    // in block form). `decide_attachment` now routes a leading annotation to the
+    // root whenever the next content is a session, so both directions converge on
+    // root. The four inlines-spec fixtures (formatting, inlines-general, citations,
+    // references-general) round-trip again and have been removed from this list.
+    //
+    // 20-ideas-naked STILL fails Tier-2, but on a SEPARATE serializer residual,
+    // not attachment: its leading annotations are single-line with trailing
+    // whitespace (`:: author :: Arthur Debert  `). The serializer rewrites them to
+    // block form, which trims the trailing spaces AND folds a trailing blank into
+    // the annotation as a `BlankLineGroup` child — so the annotation's *content*
+    // (not its target) differs across the round-trip. That is a serializer
+    // faithfulness bug for single-line→block annotation rewriting, tracked under
+    // the lex#814 umbrella; the §2 attachment fix does not address it.
+    ("benchmark/20-ideas-naked.lex", "lex#814"),
 ];
 
 #[cfg(test)]

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -40,11 +40,15 @@
 //!     carries no explicit marker, and lex-core strips that guard backslash on
 //!     re-parse, so the session round-trips with `style: None` and its title text
 //!     unchanged. Sessions are no longer a blocker for any fixture.
-//!   - **lex#791 (leading-annotation reorder)** — `20-ideas-naked.md`'s leading
-//!     document-level annotations reorder around the title on serialize. A related
-//!     annotation-attachment limitation (a floating block annotation attaches to
-//!     its neighbor rather than round-tripping as a sibling) is a second residual
-//!     blocker for kitchensink.
+//!   - **lex#814 §2 (leading-annotation attachment)** — `20-ideas-naked.md`'s
+//!     leading document-level annotations used to reorder around the title / bind
+//!     inconsistently across a round-trip; the attachment inconsistency is now
+//!     fixed (a leading annotation above the first session attaches to the root in
+//!     both parse directions). ideas-naked stays blocked on a serializer residual
+//!     (single-line→block annotation rewrite trims trailing whitespace and folds a
+//!     trailing blank into the body). A related annotation-attachment limitation (a
+//!     floating block annotation attaches to its neighbor rather than round-tripping
+//!     as a sibling) is a second residual blocker for kitchensink.
 //!
 //! ## How this suite stays honest (no forced green, no weakened canon)
 //!
@@ -142,8 +146,15 @@ const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     ("comrak-readme", "lex#814"),
     ("commonmark-reference", "lex#814"),
     ("comrak-reference", "lex#814"),
-    // #791 — leading document-level annotations reorder around the title.
-    ("ideas-naked", "lex#791"),
+    // #791 — leading document-level annotations reorder around the title. The
+    // attachment-inconsistency half of this (a leading annotation binding to the
+    // first session in parse(D) but to the root in parse(format(D))) is now FIXED
+    // by lex#814 §2. ideas-naked STILL fails faithfulness on a separate serializer
+    // residual: its single-line leading annotations (`:: author :: Arthur Debert  `)
+    // are rewritten to block form, which trims trailing whitespace and folds a
+    // trailing blank into the annotation body — altering content, not target.
+    // Retagged to the lex#814 umbrella for that serializer residual.
+    ("ideas-naked", "lex#814"),
 ];
 
 /// Drive the real reader over every fixture and grade Faithfulness against the

--- a/crates/lex-core/src/lex/assembling/stages/attach_annotations.rs
+++ b/crates/lex-core/src/lex/assembling/stages/attach_annotations.rs
@@ -167,6 +167,12 @@ fn attach_annotations_in_container(
         let next = distance::find_next_content(&entries, entry_idx, &container_span);
         let blank_after = distance::blank_gap_after(&entries, entry_idx, &container_span);
 
+        // Whether the next content element is a session. A leading document-level
+        // annotation above the first session is document metadata (lex#814 §2).
+        let next_is_session = next
+            .next
+            .is_some_and(|(_, idx)| matches!(children[idx], ContentItem::Session(_)));
+
         if let Some(target) = distance::decide_attachment(
             previous,
             next.next,
@@ -174,6 +180,7 @@ fn attach_annotations_in_container(
             blank_after,
             &kind,
             annotation_sink.allows_container(),
+            next_is_session,
         ) {
             attachments.push(PendingAttachment {
                 annotation_index: child_index,
@@ -714,6 +721,38 @@ mod tests {
         assert_eq!(paragraphs[1].annotations.len(), 1);
         assert_eq!(paragraphs[1].annotations[0].data.label.value, "test");
     }
+    #[test]
+    fn test_leading_annotation_above_session_attaches_to_root() {
+        // lex#814 §2: single-line leading annotations directly above the first
+        // session (no trailing blank) are document metadata and must attach to
+        // the document root — the same target the block form reaches after a
+        // format() round-trip (which adds a trailing blank). Before the fix
+        // these single-line annotations bound to the first session instead,
+        // making attachment inconsistent across parse/re-parse.
+        let source =
+            ":: author :: Arthur\n:: publishing-date :: today\nFirst Session\n\n    Body.\n";
+        let doc = parse_without_annotation_attachment(source).unwrap();
+
+        let result = AttachAnnotations::new().run(doc).unwrap();
+
+        // Both leading annotations land on the document root...
+        assert_eq!(result.annotations.len(), 2);
+        // ...and none linger as detached content items.
+        assert!(result
+            .root
+            .children
+            .iter()
+            .all(|item| !matches!(item, ContentItem::Annotation(_))));
+        // The first session carries no attached annotations.
+        let session = result
+            .root
+            .children
+            .iter()
+            .find_map(|item| item.as_session())
+            .expect("expected first session");
+        assert!(session.annotations.is_empty());
+    }
+
     #[test]
     fn test_benchmark_50_repro() {
         let source = ":: test.note severity=info :: Document preface.\n\n1. Intro\n";

--- a/crates/lex-core/src/lex/assembling/stages/attach_annotations.rs
+++ b/crates/lex-core/src/lex/assembling/stages/attach_annotations.rs
@@ -169,9 +169,13 @@ fn attach_annotations_in_container(
 
         // Whether the next content element is a session. A leading document-level
         // annotation above the first session is document metadata (lex#814 §2).
-        let next_is_session = next
-            .next
-            .is_some_and(|(_, idx)| matches!(children[idx], ContentItem::Session(_)));
+        // `decide_attachment` only consults this at the document root for a leading
+        // annotation, so gate the child lookup on those conditions (gemini, #816).
+        let next_is_session = kind.is_document()
+            && previous.is_none()
+            && next
+                .next
+                .is_some_and(|(_, idx)| matches!(children[idx], ContentItem::Session(_)));
 
         if let Some(target) = distance::decide_attachment(
             previous,

--- a/crates/lex-core/src/lex/assembling/stages/attach_annotations/distance.rs
+++ b/crates/lex-core/src/lex/assembling/stages/attach_annotations/distance.rs
@@ -114,6 +114,7 @@ pub fn blank_gap_after(
 /// - `blank_after`: Number of blank lines immediately after the annotation
 /// - `kind`: The kind of container (Document, Regular, or Detached)
 /// - `container_allowed`: Whether the container itself can receive annotations
+/// - `next_is_session`: Whether the next content element is a session
 ///
 /// # Returns
 /// The attachment target, or `None` if no valid target exists
@@ -124,9 +125,27 @@ pub fn decide_attachment(
     blank_after: usize,
     kind: &ContainerKind,
     container_allowed: bool,
+    next_is_session: bool,
 ) -> Option<AttachmentTarget> {
     // Rule 1: Document-level attachment
-    if kind.is_document() && previous.is_none() && blank_after > 0 {
+    //
+    // A leading document-level annotation (no previous content) is document
+    // metadata and must attach to the document root. In authored `parse(D)`
+    // form these leading annotations are single-line, so `blank_after == 0`;
+    // the serializer rewrites them to block form on `format(D)`, which adds a
+    // trailing blank (`blank_after > 0`). Keying attachment on `blank_after`
+    // alone therefore flips the target across a round-trip (lex#814 §2).
+    //
+    // To keep attachment consistent we also route a leading annotation to the
+    // root when the next content is a session: the annotations authored above
+    // the first session are document header metadata regardless of the trailing
+    // gap. (Annotations authored *above the document title* already route here
+    // via `blank_after > 0`, because title extraction leaves a line gap between
+    // the annotation and the first body element — so no separate title clause
+    // is needed, and adding one would mis-capture annotations authored *below*
+    // the title, which also present `previous.is_none()` once the title node is
+    // lifted out of the child list.)
+    if kind.is_document() && previous.is_none() && (blank_after > 0 || next_is_session) {
         return Some(AttachmentTarget::Container);
     }
 

--- a/crates/lex-core/src/lex/assembling/stages/attach_annotations/distance.rs
+++ b/crates/lex-core/src/lex/assembling/stages/attach_annotations/distance.rs
@@ -102,7 +102,8 @@ pub fn blank_gap_after(
 /// Decide where an annotation should attach based on proximity to surrounding content.
 ///
 /// # Attachment Rules
-/// 1. Document-start: Annotations at document start followed by a blank line attach to Document
+/// 1. Document-start: A leading annotation at document start attaches to Document when it is
+///    followed by a blank line or the next content element is a session (document metadata)
 /// 2. Closest wins: Otherwise, attach to the closest content element
 /// 3. Tie-breaker: If equidistant, the next element wins
 /// 4. Container-end: When no next content exists, may attach to container if allowed


### PR DESCRIPTION
## Context

Fixes lex#814 §2 (Family B). Document-level annotations authored above the first session (e.g. `:: author :: …`, `:: publishing-date :: …` at the top of `benchmark/20-ideas-naked.lex`) attached to the first **session** in `parse(D)` but re-attached to the document **root** in `parse(format(D))`. The serializer rewrites leading single-line annotations to block form (adding a trailing blank), which flipped the attachment target across a round-trip.

### What changed
`decide_attachment` (`crates/lex-core/src/lex/assembling/stages/attach_annotations/distance.rs`) Rule 1 now routes a leading document-level annotation (`previous.is_none()`) to the document root when **either** `blank_after > 0` **or** the next content element is a session. The caller (`attach_annotations.rs`) computes `next_is_session` from the next content child and threads it in. Both parse directions now converge on **root** — these annotations are document metadata.

- Grammar basis: `grammar-core.lex` §`<document> = <metadata>? <document-title>? <content>` — leading annotations are `<metadata>` (document header), and the "Note" at ~L315 confirms leading document-level annotations are the metadata region.

### Title clause considered and rejected
The original design also proposed a `document_has_title` clause. I dropped it:
- Annotations authored **above** the title already route to root via `blank_after > 0`, because title extraction lifts the title node out of `children` and leaves a line gap between the annotation and the first body element (verified).
- A blanket has-title clause **breaks** annotations authored **below** the title (e.g. `test_annotation_attaches_to_list`), because once the title is extracted, a below-title annotation also presents `previous.is_none()` — it would wrongly bind to root instead of the following content. So the clause is both redundant for the intended case and harmful.

### Known-fail updates
- `format_invariants/mod.rs` `TIER2_FIXTURE_KNOWN_FAIL`: **removed** the four `#791` inlines-spec fixtures (`formatting.lex`, `inlines-general.lex`, `citations.lex`, `references-general.lex`) — they round-trip again. **Kept** `benchmark/20-ideas-naked.lex` (retagged `lex#791`→`lex#814`) — it still fails Tier-2, but on a **separate serializer residual**, not attachment: its single-line leading annotations (`:: author :: Arthur Debert  `) are rewritten to block form, which trims trailing whitespace and folds a trailing blank into the annotation body (content differs, target does not).
- `markdown/faithfulness_fixtures.rs` `FIXTURE_KNOWN_FAIL`: **kept** `ideas-naked` (retagged to `lex#814`) — same serializer residual; still fails faithfulness.

### Tests
- Added `test_leading_annotation_above_session_attaches_to_root` in the attach_annotations unit tests.
- `test_example_e` (blank → root) and `test_example_f` (no title, immediate paragraph → paragraph, not root) still pass; document-09 / annotation-27 (#783 ordering) still pass.
- Full workspace green: `cargo nextest run --workspace --exclude lex-wasm` → 2692 passed. `release-core gate` → OK.

### Do NOT touch
The stray working-tree changes to `comms` (submodule pointer) and `skills/shipit-to-prd/SKILL.md` are from parallel work in this shared checkout and are intentionally excluded from this PR.