### PR TITLE
Converge lex#814: comms grammar bump + §4-as-intended

### DIFF
--- a/CHANGELOG/unreleased-814-convergence.md
+++ b/CHANGELOG/unreleased-814-convergence.md
@@ -1,1 +1,3 @@
-- Bump comms to the multi-group verbatim grammar; document the Definition→Verbatim separation as intended group semantics (lex#814 §4)
+- Bump comms to the multi-group verbatim grammar; document the Definition→Verbatim and Definition→Annotation separations as intended group semantics (lex#814 §4), with full positive-shape regression guards in the separation matrix
+- Characterize the Definition→Table adjacency as a known content-loss bug (lex#819, deferred): a single-group table cannot hold the definition as a group, so the merge drops the definition body and the table rows
+- Retag the `20-ideas-naked` known-failure to its own issue lex#817 (deferred): the single-line→block annotation rewrite alters annotation content across a round-trip

--- a/CHANGELOG/unreleased-814-convergence.md
+++ b/CHANGELOG/unreleased-814-convergence.md
@@ -1,0 +1,1 @@
+- Bump comms to the multi-group verbatim grammar; document the Definition→Verbatim separation as intended group semantics (lex#814 §4)

--- a/crates/lex-babel/src/formats/lex/separation.rs
+++ b/crates/lex-babel/src/formats/lex/separation.rs
@@ -43,22 +43,23 @@
 //!    a Table, and a block-form Verbatim all open with a construct the look-ahead
 //!    detects structurally, so they are NOT absorbed and need no blank.
 //!
-//! 2. **Closer re-anchoring (a parser hijack, NOT separation-fixable)** — the
-//!    verbatim/table matcher runs at the highest precedence and greedily pairs the
-//!    *first* `subject:` line it sees with the *next* `:: label ::` closer,
-//!    spanning blanks (multi-group verbatim) and dedents. A **Definition**
-//!    (`subject:` + indented body, no closer of its own) placed immediately before
-//!    any block that presents a `:: label ::` line — a Verbatim, a Table, or even
-//!    an Annotation (`:: label ::` is a valid verbatim closer) — is therefore
-//!    swallowed: its subject becomes the verbatim subject and everything down to
-//!    that closer is absorbed. No blank count prevents this — it is a grammar-level
-//!    ambiguity between Definition and `subject:`-plus-indent blocks. The three
-//!    cells (`Definition → Verbatim`, `Definition → Table`, `Definition →
-//!    Annotation`) are marked below; their value is the structural boundary
-//!    minimum (0, the definition's dedent), but the pair does not round-trip until
-//!    the parser bug is fixed. Tracked as a flagged finding in the PR; the
-//!    verification test characterizes the hijack rather than asserting faithfulness
-//!    for those cells.
+//! 2. **Multi-group verbatim absorption (intended group semantics, NOT a
+//!    separation gap)** — the verbatim/table matcher runs at the highest precedence
+//!    and pairs the *first* `subject:` line it sees with the *next* `:: label ::`
+//!    closer, spanning blanks and dedents. This is the multi-group verbatim
+//!    production (`comms/specs/grammar-core.lex` §4.5c): a verbatim block is
+//!    `<verbatim-group-with-content>+` sharing ONE closing annotation. A
+//!    **Definition** (`subject:` + indented body, no closer of its own) placed
+//!    immediately before any block that presents a `:: label ::` line — a Verbatim,
+//!    a Table, or even an Annotation (`:: label ::` is a valid verbatim closer) — is
+//!    structurally identical to a `<verbatim-group-with-content>`, and verbatim is
+//!    tried before definition (§4.7), so it becomes that block's FIRST group. No
+//!    blank count changes this: blank lines do not separate groups. The three cells
+//!    (`Definition → Verbatim`, `Definition → Table`, `Definition → Annotation`) are
+//!    marked below; their value is the structural boundary minimum (0, the
+//!    definition's dedent), and the merge is intended (lex#814 §4, resolved as
+//!    intended), not a bug. The verification test characterizes the merge as a
+//!    regression guard rather than asserting faithfulness for those cells.
 //!
 //! ## Spec/parser disagreements found
 //!
@@ -151,16 +152,18 @@ pub(super) fn min_blank_lines(prev: BlockKind, next: BlockKind) -> usize {
         (Verbatim, _) => 0,
 
         // ── Definition → * ───────────────────────────────────────────────────
-        // A Definition ends with a dedent (boundary minimum 0). BUT its bare
-        // `subject:` line is re-anchored by the next `:: label ::` closer (the
-        // hijack — see module docs), so Definition → Verbatim / Table / Annotation
-        // do NOT round-trip and no blank count fixes it. Value stays the boundary
-        // minimum; the hijack is a flagged parser bug, not a separation gap.
-        (Definition, Verbatim) => 0, // HIJACK: merges into a multi-group verbatim
-        (Definition, Table) => 0,    // HIJACK: merges into the table
+        // A Definition ends with a dedent (boundary minimum 0). Its `subject:` +
+        // indented body IS a `<verbatim-group-with-content>`, so when it sits
+        // immediately above a closer-terminated block the shared `:: label ::`
+        // closer makes it that verbatim's first group (see module docs). Per grammar
+        // §4.5c this is intended multi-group verbatim, not a separation gap —
+        // Definition → Verbatim / Table / Annotation merge by design and the value
+        // stays the boundary minimum.
+        (Definition, Verbatim) => 0, // merges as the verbatim's first group (multi-group verbatim)
+        (Definition, Table) => 0,    // merges into the table under the shared closer
         // Both annotation shapes present a `:: label ::` line (the marker *is* one;
-        // the block form opens with one), and either re-anchors as a verbatim closer.
-        (Definition, Annotation) | (Definition, AnnotationBody) => 0, // HIJACK: `:: label ::` re-anchors as a verbatim closer
+        // the block form opens with one), and either serves as the shared verbatim closer.
+        (Definition, Annotation) | (Definition, AnnotationBody) => 0, // merges: `:: label ::` is the shared verbatim closer
         (Definition, _) => 0,
 
         // ── Annotation (marker form) → * ─────────────────────────────────────

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -206,8 +206,8 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 //          when the next content is a session, so parse(D) and parse(format(D))
 //          converge). The four inlines-spec fixtures round-trip again;
 //          20-ideas-naked still fails, but on a serializer residual (single-line→
-//          block annotation rewrite alters content), not attachment — see the
-//          TIER2_FIXTURE_KNOWN_FAIL note below.
+//          block annotation rewrite alters content) tracked as lex#817 (deferred),
+//          not attachment — see the TIER2_FIXTURE_KNOWN_FAIL note below.
 //   #792 — FIXED. Ragged/mismatched-row tables used to get padded + a separator
 //          row injected, adding cells to short rows (Tier-2). The serializer no
 //          longer pads short rows, so table-13 round-trips faithfully.
@@ -249,9 +249,10 @@ const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     // block form, which trims the trailing spaces AND folds a trailing blank into
     // the annotation as a `BlankLineGroup` child — so the annotation's *content*
     // (not its target) differs across the round-trip. That is a serializer
-    // faithfulness bug for single-line→block annotation rewriting, tracked under
-    // the lex#814 umbrella; the §2 attachment fix does not address it.
-    ("benchmark/20-ideas-naked.lex", "lex#814"),
+    // faithfulness bug for single-line→block annotation rewriting, tracked as its
+    // own issue lex#817 (deferred, not fixed here); the lex#814 §2 attachment fix
+    // does not address it.
+    ("benchmark/20-ideas-naked.lex", "lex#817"),
 ];
 
 #[cfg(test)]

--- a/crates/lex-babel/tests/lex_separation/matrix.rs
+++ b/crates/lex-babel/tests/lex_separation/matrix.rs
@@ -12,9 +12,10 @@
 //! through the real matrix-driven serializer, re-parses, and asserts both blocks
 //! survive with the correct types.
 //!
-//! Group semantics are characterized rather than asserted faithful (see
-//! `separation.rs` module docs and `definition_before_closer_led_block_is_a_
-//! known_hijack`): per `comms/specs/grammar-core.lex` §4.5c, a Definition
+//! Group semantics are characterized rather than asserted faithful (see the
+//! `separation.rs` module docs and the
+//! `definition_before_closer_led_block_is_a_known_hijack` test): per
+//! `comms/specs/grammar-core.lex` §4.5c, a Definition
 //! immediately before a closer-terminated Verbatim (or before an Annotation whose
 //! `:: label ::` marker doubles as a verbatim closer) is that block's FIRST group.
 //! A definition's `subject:` + indented body is structurally identical to a

--- a/crates/lex-babel/tests/lex_separation/matrix.rs
+++ b/crates/lex-babel/tests/lex_separation/matrix.rs
@@ -12,20 +12,30 @@
 //! through the real matrix-driven serializer, re-parses, and asserts both blocks
 //! survive with the correct types.
 //!
-//! Intended group semantics are characterized rather than asserted faithful
-//! (see `separation.rs` module docs and `definition_before_closer_led_block_is_a_
+//! Group semantics are characterized rather than asserted faithful (see
+//! `separation.rs` module docs and `definition_before_closer_led_block_is_a_
 //! known_hijack`): per `comms/specs/grammar-core.lex` §4.5c, a Definition
-//! immediately before a closer-terminated Verbatim (or a Table/Annotation whose
+//! immediately before a closer-terminated Verbatim (or before an Annotation whose
 //! `:: label ::` marker doubles as a verbatim closer) is that block's FIRST group.
 //! A definition's `subject:` + indented body is structurally identical to a
 //! `<verbatim-group-with-content>`, and verbatim is tried before definition (§4.7),
 //! so the two cannot be authored as separate adjacent blocks — blank lines do not
-//! separate groups. This is the multi-group verbatim feature working as designed
-//! (lex#814 §4, resolved as intended), not a bug. Bare Annotation siblings are also not
-//! round-trippable as siblings (the parser attaches a floating annotation to a
-//! neighbor or the document head), so they are excluded from the sibling-sequence
-//! properties; the matrix still owns the lex#682 trailing-blank boundary, tested
-//! directly.
+//! separate groups. That is the multi-group verbatim feature working as designed
+//! (lex#814 §4, resolved as intended), not a bug: the definition's subject AND body
+//! survive as the verbatim's first group.
+//!
+//! Definition → Table is the ONE exception and is NOT intended: a table is
+//! single-group, so the definition cannot become a group. The merge instead
+//! collapses to a degenerate table that keeps only the definition's subject and
+//! DROPS the definition body and the table's own rows — a real, pre-existing
+//! content-loss bug tracked in lex#819 (deferred, not fixed here). Its tripwire
+//! CHARACTERIZES the known-bad shape; when #819 is fixed the pair should separate
+//! and Table drops out of `is_known_hijack`.
+//!
+//! Bare Annotation siblings are also not round-trippable as siblings (the parser
+//! attaches a floating annotation to a neighbor or the document head), so they are
+//! excluded from the sibling-sequence properties; the matrix still owns the lex#682
+//! trailing-blank boundary, tested directly.
 
 use lex_babel::formats::lex::export;
 use lex_core::lex::ast::elements::container::SessionContainer;
@@ -210,9 +220,20 @@ fn body_kinds(doc: &Document) -> Vec<Kind> {
     doc.root.children.iter().filter_map(kind_of).collect()
 }
 
+/// The non-blank block *items* directly under the document root (parallel to
+/// `body_kinds`, but keeping the nodes so a merged shape can be asserted).
+fn body_items(doc: &Document) -> Vec<&ContentItem> {
+    doc.root
+        .children
+        .iter()
+        .filter(|item| kind_of(item).is_some())
+        .collect()
+}
+
 // ─── The matrix, made executable ────────────────────────────────────────────
 
-/// The ordered pairs that merge by design, not by a separation gap. Per
+/// The ordered pairs where the Definition does not survive as a sibling but is
+/// absorbed into the following closer-terminated block. Per
 /// `comms/specs/grammar-core.lex` §4.5c, a verbatim block is
 /// `<verbatim-group-with-content>+` sharing ONE closing annotation (multi-group
 /// verbatim). A `<definition>` (`<subject-line> <indent> content`) authored as a
@@ -220,11 +241,17 @@ fn body_kinds(doc: &Document) -> Vec<Kind> {
 /// identical to a `<verbatim-group-with-content>` and is therefore that verbatim's
 /// FIRST group — verbatim is tried before definition (parse order §4.7), and blank
 /// lines do not separate groups, so the two cannot be authored as separate adjacent
-/// blocks. The same closer re-anchoring absorbs the Definition ahead of a Table or
-/// an Annotation closer (`:: label ::` is a valid verbatim closer), so all three
-/// `Definition → …` pairs merge. This is the multi-group verbatim feature working
-/// AS DESIGNED (lex#814 §4, resolved as intended), NOT a bug to fix. Documented in
-/// `separation.rs`.
+/// blocks. This holds for `Definition → Verbatim` and, because `:: label ::` also
+/// closes a verbatim, for `Definition → Annotation`; both are the multi-group
+/// verbatim feature working AS DESIGNED (lex#814 §4, resolved as intended) and lose
+/// no content.
+///
+/// `Definition → Table` is included too but for the OPPOSITE reason: it is a KNOWN
+/// CONTENT-LOSS BUG (lex#819, deferred), NOT intended. A table is single-group, so
+/// the definition cannot become a group; the merge collapses to a degenerate table
+/// that drops the definition body and the table rows. It stays in this set only
+/// because the pair does currently merge (not separate); when lex#819 is fixed the
+/// pair should separate and this arm must be removed. Documented in `separation.rs`.
 fn is_known_hijack(prev: Kind, next: Kind) -> bool {
     matches!(
         (prev, next),
@@ -232,6 +259,149 @@ fn is_known_hijack(prev: Kind, next: Kind) -> bool {
             | (Kind::Definition, Kind::Table)
             | (Kind::Definition, Kind::Annotation)
     )
+}
+
+/// Content strings of a verbatim group's `VerbatimLine` children, in order.
+fn verbatim_group_text<'a>(children: impl IntoIterator<Item = &'a ContentItem>) -> Vec<&'a str> {
+    children
+        .into_iter()
+        .filter_map(|c| match c {
+            ContentItem::VerbatimLine(line) => Some(line.content.as_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Assert the exact intended merged shape for a `Definition -> next` hijack.
+///
+/// The definition never survives as a sibling; per grammar §4.5c it is absorbed
+/// into the following closer-terminated block. Pinning the *positive* shape makes
+/// the guard fail not only when the pair SEPARATES into two siblings, but also
+/// when the parser drops content, produces the wrong merged kind, or absorbs the
+/// wrong neighbor — the weakness codex flagged in the old negative assertions.
+fn assert_definition_hijack_shape(next: Kind, reparsed: &Document, out: &str) {
+    let items = body_items(reparsed);
+    match next {
+        Kind::Verbatim => {
+            // The definition and the following marker-verbatim collapse into ONE
+            // two-group verbatim sharing the following verbatim's `:: verbatim ::`
+            // closer: group 0 IS the definition (subject "Term" / content
+            // "Def body."), group 1 is the following verbatim's subject ("Code2").
+            assert_eq!(
+                body_kinds(reparsed),
+                vec![Kind::Paragraph, Kind::Verbatim],
+                "(Definition -> Verbatim) must merge into lead + one verbatim; got {:?}\n{out}",
+                body_kinds(reparsed),
+            );
+            let v = match items[1] {
+                ContentItem::VerbatimBlock(v) => v.as_ref(),
+                other => panic!("expected a VerbatimBlock; got {other:?}\n{out}"),
+            };
+            let groups: Vec<_> = v.group().collect();
+            assert_eq!(
+                v.group_len(),
+                2,
+                "(Definition -> Verbatim) the definition must be the verbatim's FIRST of two \
+                 groups (§4.5c); got {} group(s)\n{out}",
+                v.group_len(),
+            );
+            assert_eq!(
+                groups[0].subject.as_string(),
+                "Term",
+                "(Definition -> Verbatim) group 0 subject must be the definition subject\n{out}",
+            );
+            assert_eq!(
+                verbatim_group_text(groups[0].children.iter()),
+                vec!["Def body."],
+                "(Definition -> Verbatim) group 0 content must be the definition body — a drop \
+                 here is exactly the content loss the positive assertion guards\n{out}",
+            );
+            assert_eq!(
+                groups[1].subject.as_string(),
+                "Code2",
+                "(Definition -> Verbatim) group 1 subject must be the following verbatim\n{out}",
+            );
+            assert_eq!(
+                v.closing_data.label.value, "verbatim",
+                "(Definition -> Verbatim) the shared closer must be the following verbatim's\n{out}",
+            );
+        }
+        Kind::Annotation => {
+            // The following annotation's `:: note ::` marker doubles as a verbatim
+            // closer, so the definition becomes a single-group verbatim closed by
+            // `:: note ::`; the annotation's own indented body is left behind as a
+            // trailing paragraph sibling. Nothing is lost — content is re-homed.
+            assert_eq!(
+                body_kinds(reparsed),
+                vec![Kind::Paragraph, Kind::Verbatim, Kind::Paragraph],
+                "(Definition -> Annotation) must merge into lead + verbatim (the definition, \
+                 closed by `:: note ::`) + the annotation body as a trailing paragraph; got \
+                 {:?}\n{out}",
+                body_kinds(reparsed),
+            );
+            let v = match items[1] {
+                ContentItem::VerbatimBlock(v) => v.as_ref(),
+                other => panic!("expected a VerbatimBlock; got {other:?}\n{out}"),
+            };
+            assert_eq!(
+                v.group_len(),
+                1,
+                "(Definition -> Annotation) the definition is the verbatim's only group\n{out}",
+            );
+            assert_eq!(
+                v.subject.as_string(),
+                "Term",
+                "(Definition -> Annotation) the verbatim subject must be the definition subject\n{out}",
+            );
+            assert_eq!(
+                verbatim_group_text(v.children.iter()),
+                vec!["Def body."],
+                "(Definition -> Annotation) the verbatim content must be the definition body\n{out}",
+            );
+            assert_eq!(
+                v.closing_data.label.value, "note",
+                "(Definition -> Annotation) the shared closer must be the annotation's `:: note ::`\n{out}",
+            );
+        }
+        Kind::Table => {
+            // KNOWN CONTENT-LOSS BUG (lex#819), NOT intended group semantics.
+            // Unlike verbatim, a table is single-group, so the definition cannot
+            // become a group; instead the merge collapses to a degenerate table
+            // that keeps ONLY the definition's subject and DROPS everything else —
+            // both the definition body AND the table's own rows. This is a real,
+            // pre-existing bug (deferred, tracked in lex#819), not faithful and not
+            // "intended." The assertion CHARACTERIZES the current known-bad shape so
+            // the loss is pinned and visible; when lex#819 is fixed the pair should
+            // SEPARATE (Table drops out of `is_known_hijack`) and this arm must be
+            // updated to expect two siblings.
+            assert_eq!(
+                body_kinds(reparsed),
+                vec![Kind::Paragraph, Kind::Table],
+                "(Definition -> Table) known bug lex#819: currently merges into lead + one \
+                 degenerate table; got {:?}\n{out}",
+                body_kinds(reparsed),
+            );
+            let table = match items[1] {
+                ContentItem::Table(t) => t.as_ref(),
+                other => panic!("expected a Table; got {other:?}\n{out}"),
+            };
+            assert_eq!(
+                table.subject.as_string(),
+                "Term",
+                "(Definition -> Table) known bug lex#819: the merged table keeps only the \
+                 definition subject\n{out}",
+            );
+            assert!(
+                table.header_rows.is_empty() && table.body_rows.is_empty(),
+                "(Definition -> Table) known bug lex#819: the merge DROPS all rows (content \
+                 loss); when #819 is fixed the pair should separate and this tripwire must be \
+                 updated; got {} header + {} body row(s)\n{out}",
+                table.header_rows.len(),
+                table.body_rows.len(),
+            );
+        }
+        other => panic!("assert_definition_hijack_shape called with non-hijack next {other:?}"),
+    }
 }
 
 #[test]
@@ -248,18 +418,15 @@ fn every_ordered_pair_reparses_as_two_blocks() {
             let kinds = body_kinds(&reparsed);
 
             if is_known_hijack(a, b) {
-                // Regression guard for the multi-group verbatim feature: the pair
-                // MUST still merge (the Definition is the verbatim's first group per
-                // grammar §4.5c). If it ever separates, multi-group verbatim has
-                // regressed — the opposite of a fix.
-                assert_ne!(
-                    kinds,
-                    vec![Kind::Paragraph, a, b],
-                    "({a:?} -> {b:?}) must still merge — a definition adjacent to a \
-                     closer-terminated verbatim is that verbatim's first group per the \
-                     multi-group grammar (§4.5c); if this separates, multi-group verbatim \
-                     has regressed.\n{out}"
-                );
+                // Regression guard for the Definition-absorbing adjacencies. Rather
+                // than the weak "does not equal the separated shape" check (which
+                // codex flagged — it would pass even if the parser dropped content
+                // or produced the wrong merged block), assert the POSITIVE merged
+                // shape. `assert_definition_hijack_shape` pins each pair: the
+                // lossless §4.5c merges (Verbatim/Annotation) AND the lex#819
+                // Table content-loss bug. If it separates OR the merged shape is
+                // wrong, the guard fails.
+                assert_definition_hijack_shape(b, &reparsed, &out);
                 continue;
             }
 
@@ -288,14 +455,17 @@ fn every_ordered_pair_reparses_as_two_blocks() {
 
 #[test]
 fn definition_before_closer_led_block_is_a_known_hijack() {
-    // Explicit regression guard for the intended group semantics (grammar §4.5c):
-    // a Definition immediately above a closer-terminated block is that block's
-    // first verbatim group. A Verbatim and a Table supply the shared `:: label ::`
-    // closer directly; an Annotation's `:: label ::` marker is *also* a valid
-    // verbatim closer, so it absorbs the definition too. This is multi-group
-    // verbatim working as designed — no blank count in the matrix changes it, and
-    // the pair MUST stay merged. If it ever separates, multi-group verbatim has
-    // regressed and the matrix docs must be revisited.
+    // Explicit regression guard that a Definition immediately above a
+    // closer-terminated block is absorbed rather than kept as a sibling. Two of
+    // these are the intended multi-group behavior (grammar §4.5c): Definition →
+    // Verbatim (the definition is the verbatim's first group under the shared
+    // closer) and Definition → Annotation (the `:: label ::` marker doubles as a
+    // verbatim closer, so the definition becomes a verbatim closed by it and the
+    // annotation body spills out as a trailing paragraph) — both lossless. The
+    // third, Definition → Table, is the lex#819 content-loss bug (deferred): a
+    // single-group table cannot hold the definition as a group, so the merge drops
+    // content. `assert_definition_hijack_shape` pins each shape positively — merge
+    // vs separate AND the exact merged block — so it fails on regression either way.
     for next in [Kind::Verbatim, Kind::Table, Kind::Annotation] {
         let doc = doc_with(vec![
             lead(),
@@ -304,15 +474,7 @@ fn definition_before_closer_led_block_is_a_known_hijack() {
         ]);
         let out = serialize(&doc);
         let reparsed = parse_document(&out).expect("reparse");
-        let kinds = body_kinds(&reparsed);
-        // The Definition never survives: its subject is consumed as the subject of
-        // the verbatim the matcher synthesizes around the re-anchored closer.
-        assert!(
-            !kinds.contains(&Kind::Definition),
-            "Definition -> {next:?} must stay merged — the definition subject is the \
-             verbatim's first group per grammar §4.5c; if it survives as a sibling, \
-             multi-group verbatim has regressed; got {kinds:?}\n{out}"
-        );
+        assert_definition_hijack_shape(next, &reparsed, &out);
     }
 }
 
@@ -583,9 +745,10 @@ proptest::proptest! {
     /// An arbitrary sequence of reader-shaped sibling blocks (NO BlankLineGroups)
     /// serializes and re-parses with the same block-type sequence. Drawn from the
     /// six kinds that round-trip as bare siblings (Annotation is excluded — bare
-    /// annotation siblings re-attach, an orthogonal parser behavior), and the
-    /// intended Definition→Verbatim / Definition→Table merge adjacencies (grammar
-    /// §4.5c) are skipped. #784 will grow this into the full reader-content proptest.
+    /// annotation siblings re-attach, an orthogonal parser behavior). The
+    /// `is_known_hijack` merge adjacencies are skipped: Definition→Verbatim (the
+    /// intended multi-group behavior, §4.5c) and Definition→Table (the lex#819
+    /// content-loss bug). #784 will grow this into the full reader-content proptest.
     #[test]
     fn reader_shaped_sibling_sequence_preserves_block_types(
         indices in proptest::collection::vec(0usize..6, 1..7),
@@ -602,11 +765,11 @@ proptest::proptest! {
             ][i])
             .collect();
 
-        // Skip the intended merge adjacencies (multi-group verbatim, grammar §4.5c).
+        // Skip the intended merge adjacencies (multi-group verbatim, grammar §4.5c)
+        // via prop_assume! rather than a silent early return, so a rejected draw is
+        // recorded as a proptest rejection instead of counting as a passing case.
         for pair in kinds.windows(2) {
-            if is_known_hijack(pair[0], pair[1]) {
-                return Ok(());
-            }
+            proptest::prop_assume!(!is_known_hijack(pair[0], pair[1]));
         }
 
         // Lead paragraph neutralizes the document-title boundary (slice #783).

--- a/crates/lex-babel/tests/lex_separation/matrix.rs
+++ b/crates/lex-babel/tests/lex_separation/matrix.rs
@@ -12,12 +12,16 @@
 //! through the real matrix-driven serializer, re-parses, and asserts both blocks
 //! survive with the correct types.
 //!
-//! Documented parser limitations are characterized rather than asserted faithful
+//! Intended group semantics are characterized rather than asserted faithful
 //! (see `separation.rs` module docs and `definition_before_closer_led_block_is_a_
-//! known_hijack`): a Definition immediately before a Verbatim, a Table, or an
-//! Annotation is swallowed by the verbatim/table matcher's greedy closer
-//! re-anchoring (any `:: label ::` closes the definition's subject as a verbatim),
-//! which no blank count fixes. Bare Annotation siblings are also not
+//! known_hijack`): per `comms/specs/grammar-core.lex` §4.5c, a Definition
+//! immediately before a closer-terminated Verbatim (or a Table/Annotation whose
+//! `:: label ::` marker doubles as a verbatim closer) is that block's FIRST group.
+//! A definition's `subject:` + indented body is structurally identical to a
+//! `<verbatim-group-with-content>`, and verbatim is tried before definition (§4.7),
+//! so the two cannot be authored as separate adjacent blocks — blank lines do not
+//! separate groups. This is the multi-group verbatim feature working as designed
+//! (lex#814 §4, resolved as intended), not a bug. Bare Annotation siblings are also not
 //! round-trippable as siblings (the parser attaches a floating annotation to a
 //! neighbor or the document head), so they are excluded from the sibling-sequence
 //! properties; the matrix still owns the lex#682 trailing-blank boundary, tested
@@ -208,12 +212,19 @@ fn body_kinds(doc: &Document) -> Vec<Kind> {
 
 // ─── The matrix, made executable ────────────────────────────────────────────
 
-/// The ordered pairs the parser cannot separate: a Definition's bare `subject:`
-/// line is re-anchored by the *next* `:: label ::` closer the verbatim/table
-/// matcher sees, merging the pair into one block. That closer can belong to a
-/// Verbatim, a Table, or an Annotation (`:: label ::` is a valid verbatim
-/// closer), so all three `Definition → …` pairs hijack. Documented in
-/// `separation.rs`; a flagged parser bug, not separation-fixable.
+/// The ordered pairs that merge by design, not by a separation gap. Per
+/// `comms/specs/grammar-core.lex` §4.5c, a verbatim block is
+/// `<verbatim-group-with-content>+` sharing ONE closing annotation (multi-group
+/// verbatim). A `<definition>` (`<subject-line> <indent> content`) authored as a
+/// peer immediately above a closer-terminated verbatim run is structurally
+/// identical to a `<verbatim-group-with-content>` and is therefore that verbatim's
+/// FIRST group — verbatim is tried before definition (parse order §4.7), and blank
+/// lines do not separate groups, so the two cannot be authored as separate adjacent
+/// blocks. The same closer re-anchoring absorbs the Definition ahead of a Table or
+/// an Annotation closer (`:: label ::` is a valid verbatim closer), so all three
+/// `Definition → …` pairs merge. This is the multi-group verbatim feature working
+/// AS DESIGNED (lex#814 §4, resolved as intended), NOT a bug to fix. Documented in
+/// `separation.rs`.
 fn is_known_hijack(prev: Kind, next: Kind) -> bool {
     matches!(
         (prev, next),
@@ -237,14 +248,17 @@ fn every_ordered_pair_reparses_as_two_blocks() {
             let kinds = body_kinds(&reparsed);
 
             if is_known_hijack(a, b) {
-                // Characterize the documented limitation: the pair merges. If the
-                // parser is fixed, this assertion flips and the cell can be
-                // asserted faithful — a deliberate tripwire.
+                // Regression guard for the multi-group verbatim feature: the pair
+                // MUST still merge (the Definition is the verbatim's first group per
+                // grammar §4.5c). If it ever separates, multi-group verbatim has
+                // regressed — the opposite of a fix.
                 assert_ne!(
                     kinds,
                     vec![Kind::Paragraph, a, b],
-                    "({a:?} -> {b:?}) is a documented parser hijack that should still merge; \
-                     if this now separates, update the matrix + separation.rs docs.\n{out}"
+                    "({a:?} -> {b:?}) must still merge — a definition adjacent to a \
+                     closer-terminated verbatim is that verbatim's first group per the \
+                     multi-group grammar (§4.5c); if this separates, multi-group verbatim \
+                     has regressed.\n{out}"
                 );
                 continue;
             }
@@ -274,13 +288,14 @@ fn every_ordered_pair_reparses_as_two_blocks() {
 
 #[test]
 fn definition_before_closer_led_block_is_a_known_hijack() {
-    // Explicit, documented characterization of the unfixable-by-separation cells:
-    // the verbatim/table matcher re-anchors the next `:: label ::` closer to the
-    // definition's `subject:` line and swallows the pair. A Verbatim and a Table
-    // supply that closer directly; an Annotation's `:: label ::` marker is *also*
-    // a valid verbatim closer, so it hijacks too. Tracked as a parser bug — no
-    // blank count in the matrix changes the outcome. If the parser is fixed, this
-    // test flips (a deliberate tripwire) and the matrix docs must be revisited.
+    // Explicit regression guard for the intended group semantics (grammar §4.5c):
+    // a Definition immediately above a closer-terminated block is that block's
+    // first verbatim group. A Verbatim and a Table supply the shared `:: label ::`
+    // closer directly; an Annotation's `:: label ::` marker is *also* a valid
+    // verbatim closer, so it absorbs the definition too. This is multi-group
+    // verbatim working as designed — no blank count in the matrix changes it, and
+    // the pair MUST stay merged. If it ever separates, multi-group verbatim has
+    // regressed and the matrix docs must be revisited.
     for next in [Kind::Verbatim, Kind::Table, Kind::Annotation] {
         let doc = doc_with(vec![
             lead(),
@@ -294,8 +309,9 @@ fn definition_before_closer_led_block_is_a_known_hijack() {
         // the verbatim the matcher synthesizes around the re-anchored closer.
         assert!(
             !kinds.contains(&Kind::Definition),
-            "Definition -> {next:?} is expected to be hijacked (definition subject \
-             absorbed into a verbatim); got {kinds:?}\n{out}"
+            "Definition -> {next:?} must stay merged — the definition subject is the \
+             verbatim's first group per grammar §4.5c; if it survives as a sibling, \
+             multi-group verbatim has regressed; got {kinds:?}\n{out}"
         );
     }
 }
@@ -568,8 +584,8 @@ proptest::proptest! {
     /// serializes and re-parses with the same block-type sequence. Drawn from the
     /// six kinds that round-trip as bare siblings (Annotation is excluded — bare
     /// annotation siblings re-attach, an orthogonal parser behavior), and the
-    /// documented Definition→Verbatim / Definition→Table hijack adjacencies are
-    /// rejected. #784 will grow this into the full reader-content proptest.
+    /// intended Definition→Verbatim / Definition→Table merge adjacencies (grammar
+    /// §4.5c) are skipped. #784 will grow this into the full reader-content proptest.
     #[test]
     fn reader_shaped_sibling_sequence_preserves_block_types(
         indices in proptest::collection::vec(0usize..6, 1..7),
@@ -586,7 +602,7 @@ proptest::proptest! {
             ][i])
             .collect();
 
-        // Reject the documented, unfixable hijack adjacencies.
+        // Skip the intended merge adjacencies (multi-group verbatim, grammar §4.5c).
         for pair in kinds.windows(2) {
             if is_known_hijack(pair[0], pair[1]) {
                 return Ok(());

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -45,8 +45,9 @@
 //!     inconsistently across a round-trip; the attachment inconsistency is now
 //!     fixed (a leading annotation above the first session attaches to the root in
 //!     both parse directions). ideas-naked stays blocked on a serializer residual
-//!     (single-line→block annotation rewrite trims trailing whitespace and folds a
-//!     trailing blank into the body). A related annotation-attachment limitation (a
+//!     tracked as its own issue lex#817 (deferred): single-line→block annotation
+//!     rewrite trims trailing whitespace and folds a trailing blank into the body.
+//!     A related annotation-attachment limitation (a
 //!     floating block annotation attaches to its neighbor rather than round-tripping
 //!     as a sibling) is a second residual blocker for kitchensink.
 //!
@@ -153,8 +154,9 @@ const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     // residual: its single-line leading annotations (`:: author :: Arthur Debert  `)
     // are rewritten to block form, which trims trailing whitespace and folds a
     // trailing blank into the annotation body — altering content, not target.
-    // Retagged to the lex#814 umbrella for that serializer residual.
-    ("ideas-naked", "lex#814"),
+    // Tracked as its own issue lex#817 (deferred, not fixed here) for that
+    // single-line→block serializer residual.
+    ("ideas-naked", "lex#817"),
 ];
 
 /// Drive the real reader over every fixture and grade Faithfulness against the


### PR DESCRIPTION
## Context

Convergence workstream for lex#814, on top of the epic (#815 §1/§3 + #816 §2). Base = `epic/814-formatter-faithfulness-parser-residuals`.

### 1. Bump comms to the merged multi-group verbatim grammar
Moves the `comms` submodule pointer `adeb49d → 422bcca` (comms#99). That commit adds ONLY the grammar reconciliation — the new `<verbatim-block> = (<verbatim-group-with-content> <blank-line>*)* <final-group> <blank-line>* <closing-annotation>` production plus §4.5c "Multi-Group Verbatim and the Definition-Adjacency Consequence". No fixtures change; it is a grammar DOC bump.

### 2. §4 reconciliation — reframe the intended merges + pin them with positive assertions
Per `comms/specs/grammar-core.lex` §4.5c, a verbatim block is `<verbatim-group-with-content>+` sharing ONE closing annotation (multi-group verbatim). A `<definition>` authored as a peer immediately above a closer-terminated verbatim run is structurally identical to a `<verbatim-group-with-content>` and is therefore that verbatim's FIRST group — verbatim is tried before definition (parse order §4.7), and blank lines do not separate groups.

- **Definition → Verbatim** and **Definition → Annotation** are the multi-group verbatim feature working **as designed** (lex#814 §4, INTENDED), and **lossless**. The `lex_separation` matrix now asserts the full **positive** merged shape for each (group subjects, content, and shared closer) via a shared `assert_definition_hijack_shape` helper — so the guard fails not only if the pair separates but also if the parser drops content, produces the wrong kind, or absorbs the wrong neighbor (codex's point). Annotation additionally re-homes the annotation body as a trailing paragraph.
- **Definition → Table** is the ONE exception and is **NOT** intended: a table is single-group, so the definition cannot become a group. The merge instead collapses to a degenerate table that keeps only the definition's subject and **drops** the definition body and the table's own rows — a real, pre-existing **content-loss bug tracked in lex#819 (deferred)**. Its arm characterizes the known-bad shape so the loss stays pinned and visible; when #819 is fixed the pair should separate and Table drops out of `is_known_hijack`. `is_known_hijack` behavior is unchanged in this PR.
- The proptest that skips these adjacencies now uses `prop_assume!` instead of a silent early return, so a skipped draw is recorded as a rejection rather than counting as a pass (gemini).

### 3. Retag the ideas-naked known-failure to lex#817
The `20-ideas-naked` / `ideas-naked` serializer residual (single-line→block annotation rewrite trims trailing whitespace and folds a trailing blank into the annotation body — altering content) is **deferred, not fixed**. Its known-fail entries in `format_invariants/mod.rs` and `markdown/faithfulness_fixtures.rs` are retagged from the lex#814 umbrella to its own issue **lex#817** (both entries kept — they legitimately still fail on #817).

## Verification
- `cargo nextest run -p lex-babel -p lex-core`: 1904 passed, 0 failed (incl. `lex_separation` 21/21, `format_invariants`, markdown `faithfulness`).
- `release-core gate`: OK.
