### PR TITLE
[codex] fix single-line annotation serialization

### DIFF
--- a/crates/lex-babel/src/formats/lex/serializer.rs
+++ b/crates/lex-babel/src/formats/lex/serializer.rs
@@ -24,6 +24,28 @@ use tables::emit_pipe_table;
 #[cfg(test)]
 mod tests;
 
+fn source_single_line_annotation_body(annotation: &Annotation) -> Option<&str> {
+    if annotation.children.len() != 1 {
+        return None;
+    }
+    let Some(ContentItem::Paragraph(paragraph)) = annotation.children.iter().next() else {
+        return None;
+    };
+    if !paragraph.annotations.is_empty() {
+        return None;
+    }
+    let [ContentItem::TextLine(line)] = paragraph.lines.as_slice() else {
+        return None;
+    };
+    if annotation.range().span.is_empty() || line.range().span.is_empty() {
+        return None;
+    }
+    if annotation.range().start.line != line.range().start.line {
+        return None;
+    }
+    Some(line.text())
+}
+
 struct ListContext {
     index: usize,
     style: DecorationStyle,
@@ -509,15 +531,17 @@ impl Visitor for LexSerializer {
     }
 
     fn visit_annotation(&mut self, annotation: &Annotation) {
+        let single_line_body = source_single_line_annotation_body(annotation);
+        let has_block_body = !annotation.children.is_empty() && single_line_body.is_none();
         // The trailing-blank requirement (lex#682) applies only to a block
         // annotation *with a body* — its indented body would otherwise pull the
         // next sibling in. A marker-form annotation ends with a closed
         // `:: label ::` and separates like a Verbatim closer. Distinguish the two
         // so the separation matrix picks the right row/column.
-        let kind = if annotation.children.is_empty() {
-            BlockKind::Annotation
-        } else {
+        let kind = if has_block_body {
             BlockKind::AnnotationBody
+        } else {
+            BlockKind::Annotation
         };
         self.separate_before(kind);
         let label = source_spelling(&annotation.data.label);
@@ -540,16 +564,24 @@ impl Visitor for LexSerializer {
         // (lex#682).
         header.push_str(" ::");
 
+        if let Some(body) = single_line_body {
+            header.push(' ');
+            header.push_str(body);
+        }
         self.write_line(&header);
 
-        if !annotation.children.is_empty() {
+        if single_line_body.is_some() {
+            self.suppress_output += 1;
+        } else if has_block_body {
             self.indent_level += 1;
             self.enter_sibling_scope();
         }
     }
 
     fn leave_annotation(&mut self, annotation: &Annotation) {
-        if !annotation.children.is_empty() {
+        if source_single_line_annotation_body(annotation).is_some() {
+            self.suppress_output -= 1;
+        } else if !annotation.children.is_empty() {
             self.leave_sibling_scope();
             self.indent_level -= 1;
         }

--- a/crates/lex-babel/src/formats/lex/serializer/tests.rs
+++ b/crates/lex-babel/src/formats/lex/serializer/tests.rs
@@ -318,6 +318,39 @@ fn test_annotation_05_block_paragraph() {
     );
 }
 
+#[test]
+fn single_line_annotation_body_preserves_trailing_spaces_lex817() {
+    let source = ":: author :: Arthur Debert  \n\nBody.\n";
+    let formatted = format_full(source);
+    assert_eq!(formatted, source);
+    assert_eq!(format_full(&formatted), formatted, "must be idempotent");
+}
+
+#[test]
+fn single_line_annotation_body_before_title_stays_single_line_lex817() {
+    let source = ":: author :: Arthur Debert  \n:: publishing-date :: 2025/10/12\nIdeas, Naked\n";
+    let formatted = format_full(source);
+    assert!(
+        formatted.starts_with(":: author :: Arthur Debert  \n:: publishing-date :: 2025/10/12\n"),
+        "single-line leading annotation bodies must not be rewritten to block form:\n{formatted}"
+    );
+    assert_eq!(format_full(&formatted), formatted, "must be idempotent");
+}
+
+#[test]
+fn authored_block_annotation_body_stays_block_form() {
+    let source = ":: note ::\n    Body.\n\nNext.\n";
+    let formatted = format_full(source);
+    assert!(
+        formatted.starts_with(":: note ::\n    Body.\n"),
+        "authored block annotation body must not collapse to single-line form:\n{formatted}"
+    );
+    assert!(
+        !formatted.starts_with(":: note :: Body."),
+        "block annotation form must be preserved:\n{formatted}"
+    );
+}
+
 // ==== Round-trip Tests ====
 // Format → parse → format should be idempotent
 

--- a/crates/lex-babel/tests/format_invariants/mod.rs
+++ b/crates/lex-babel/tests/format_invariants/mod.rs
@@ -106,6 +106,10 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
             "Doc\n===\n\nDraft here [TK] and [TK-budget]. Per [@smith2019 p. 5]. As noted [::caveat].\n\n:: caveat ::\n    A caveat.\n",
         ),
         (
+            "single_line_annotation_trailing_space",
+            ":: author :: Arthur Debert  \n\nBody.\n",
+        ),
+        (
             "table_basic_ragged",
             "Stats:\n    |A|B|\n    |1|2|\n:: table ::\n",
         ),
@@ -204,10 +208,11 @@ fn targeted_cases() -> Vec<(&'static str, &'static str)> {
 //          re-attaching to the document *root* on round-trip — is now FIXED by
 //          lex#814 §2 (`decide_attachment` routes a leading annotation to the root
 //          when the next content is a session, so parse(D) and parse(format(D))
-//          converge). The four inlines-spec fixtures round-trip again;
-//          20-ideas-naked still fails, but on a serializer residual (single-line→
-//          block annotation rewrite alters content) tracked as lex#817 (deferred),
-//          not attachment — see the TIER2_FIXTURE_KNOWN_FAIL note below.
+//          converge). The four inlines-spec fixtures round-trip again.
+//   #817 — FIXED. Single-line annotation bodies with trailing whitespace used to
+//          rewrite to block form, trimming the body and changing the annotation
+//          boundary around following blanks. Source-authored single-line
+//          annotation bodies now stay single-line.
 //   #792 — FIXED. Ragged/mismatched-row tables used to get padded + a separator
 //          row injected, adding cells to short rows (Tier-2). The serializer no
 //          longer pads short rows, so table-13 round-trips faithfully.
@@ -233,27 +238,7 @@ const TIER1_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     ("table.docs/table-08-nested-in-definition.lex", "lex#790"),
 ];
 
-const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
-    // lex#814 §2 — FIXED the attachment inconsistency that this #791 "deeper case"
-    // described: leading document-level annotations authored above the first
-    // *session* used to bind to that session in parse(D) but re-attach to the
-    // document *root* in parse(format(D)) (the serializer emits them at the head
-    // in block form). `decide_attachment` now routes a leading annotation to the
-    // root whenever the next content is a session, so both directions converge on
-    // root. The four inlines-spec fixtures (formatting, inlines-general, citations,
-    // references-general) round-trip again and have been removed from this list.
-    //
-    // 20-ideas-naked STILL fails Tier-2, but on a SEPARATE serializer residual,
-    // not attachment: its leading annotations are single-line with trailing
-    // whitespace (`:: author :: Arthur Debert  `). The serializer rewrites them to
-    // block form, which trims the trailing spaces AND folds a trailing blank into
-    // the annotation as a `BlankLineGroup` child — so the annotation's *content*
-    // (not its target) differs across the round-trip. That is a serializer
-    // faithfulness bug for single-line→block annotation rewriting, tracked as its
-    // own issue lex#817 (deferred, not fixed here); the lex#814 §2 attachment fix
-    // does not address it.
-    ("benchmark/20-ideas-naked.lex", "lex#817"),
-];
+const TIER2_FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[];
 
 #[cfg(test)]
 mod tests {

--- a/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
+++ b/crates/lex-babel/tests/markdown/faithfulness_fixtures.rs
@@ -44,12 +44,12 @@
 //!     leading document-level annotations used to reorder around the title / bind
 //!     inconsistently across a round-trip; the attachment inconsistency is now
 //!     fixed (a leading annotation above the first session attaches to the root in
-//!     both parse directions). ideas-naked stays blocked on a serializer residual
-//!     tracked as its own issue lex#817 (deferred): single-line→block annotation
-//!     rewrite trims trailing whitespace and folds a trailing blank into the body.
-//!     A related annotation-attachment limitation (a
-//!     floating block annotation attaches to its neighbor rather than round-tripping
-//!     as a sibling) is a second residual blocker for kitchensink.
+//!     both parse directions). The lex#817 single-line annotation serializer
+//!     residual is also fixed. ideas-naked remains blocked on broader markdown
+//!     conversion residuals tracked under lex#814. A related annotation-attachment
+//!     limitation (a floating block annotation attaches to its neighbor rather
+//!     than round-tripping as a sibling) is a second residual blocker for
+//!     kitchensink.
 //!
 //! ## How this suite stays honest (no forced green, no weakened canon)
 //!
@@ -147,16 +147,7 @@ const FIXTURE_KNOWN_FAIL: &[(&str, &str)] = &[
     ("comrak-readme", "lex#814"),
     ("commonmark-reference", "lex#814"),
     ("comrak-reference", "lex#814"),
-    // #791 — leading document-level annotations reorder around the title. The
-    // attachment-inconsistency half of this (a leading annotation binding to the
-    // first session in parse(D) but to the root in parse(format(D))) is now FIXED
-    // by lex#814 §2. ideas-naked STILL fails faithfulness on a separate serializer
-    // residual: its single-line leading annotations (`:: author :: Arthur Debert  `)
-    // are rewritten to block form, which trims trailing whitespace and folds a
-    // trailing blank into the annotation body — altering content, not target.
-    // Tracked as its own issue lex#817 (deferred, not fixed here) for that
-    // single-line→block serializer residual.
-    ("ideas-naked", "lex#817"),
+    ("ideas-naked", "lex#814"),
 ];
 
 /// Drive the real reader over every fixture and grade Faithfulness against the


### PR DESCRIPTION
## Summary
- preserve source-authored single-line annotation bodies instead of rewriting them to block form
- keep trailing body whitespace faithful and suppress duplicate child emission for that path
- add regression coverage and remove the Lex fixture Tier-2 quarantine for benchmark/20-ideas-naked.lex
- retag markdown ideas-naked away from lex#817 because broader markdown conversion residuals remain under lex#814

Fixes #817.

## Validation
- cargo fmt --check
- env RUSTC_WRAPPER= cargo clippy -p lex-babel --all-targets -- -D warnings
- cargo test -p lex-babel format_invariants -- --nocapture
- cargo test -p lex-babel markdown::faithfulness_fixtures -- --nocapture
- cargo test -p lex-babel
- env RUSTC_WRAPPER= release-core gate (fails on pre-existing yaml/markdown lint violations outside this change; Rust fmt/clippy portions pass)