### PR TITLE
[codex] fix definition table adjacency parsing

### DIFF
--- a/crates/lex-babel/src/formats/lex/separation.rs
+++ b/crates/lex-babel/src/formats/lex/separation.rs
@@ -43,36 +43,27 @@
 //!    a Table, and a block-form Verbatim all open with a construct the look-ahead
 //!    detects structurally, so they are NOT absorbed and need no blank.
 //!
-//! 2. **Multi-group verbatim absorption** — the verbatim/table matcher runs at the
+//! 2. **Multi-group verbatim absorption** — the verbatim matcher runs at the
 //!    highest precedence and pairs the *first* `subject:` line it sees with the
 //!    *next* `:: label ::` closer, spanning blanks and dedents. This is the
 //!    multi-group verbatim production (`comms/specs/grammar-core.lex` §4.5c): a
 //!    verbatim block is `<verbatim-group-with-content>+` sharing ONE closing
 //!    annotation. A **Definition** (`subject:` + indented body, no closer of its
 //!    own) placed immediately before any block that presents a `:: label ::` line —
-//!    a Verbatim, a Table, or an Annotation (`:: label ::` is a valid verbatim
-//!    closer) — is structurally identical to a `<verbatim-group-with-content>`, and
-//!    verbatim is tried before definition (§4.7), so it becomes that block's FIRST
-//!    group. No blank count changes this: blank lines do not separate groups. The
-//!    three cells (`Definition → Verbatim`, `Definition → Table`,
-//!    `Definition → Annotation`) all take the structural boundary minimum (0, the
-//!    definition's dedent) below, but they split into TWO cases:
+//!    a Verbatim or an Annotation (`:: label ::` is a valid verbatim closer) — is
+//!    structurally identical to a `<verbatim-group-with-content>`, and verbatim is
+//!    tried before definition (§4.7), so it becomes that block's FIRST group. No
+//!    blank count changes this: blank lines do not separate groups. The
+//!    `Definition → Verbatim` and `Definition → Annotation` cells take the
+//!    structural boundary minimum (0, the definition's dedent) below.
 //!
-//!    - `Definition → Verbatim` and `Definition → Annotation` are **intended and
-//!      lossless**: the definition's subject AND body survive as the verbatim's
-//!      first group. This is the group feature working as designed (lex#814 §4,
-//!      resolved as intended), not a separation gap.
-//!    - `Definition → Table` is the ONE exception and is **NOT intended**: a table
-//!      is single-group, so the definition cannot become a group. The merge instead
-//!      collapses to a degenerate table that keeps only the definition's subject and
-//!      DROPS the definition body AND the table's own rows — a real, pre-existing
-//!      **content-loss bug tracked in lex#819** (deferred, not fixed here). It is
-//!      explicitly NOT sanctioned; it merges lossily today, and when #819 is fixed
-//!      the pair should SEPARATE and Table drops out of `is_known_hijack`.
+//!    `Definition → Table` used to be a lossy exception: tables are single-group,
+//!    so the definition could not become a group and the merge dropped content.
+//!    The parser now requires a `:: table ::` span to start with pipe-row content,
+//!    so this pair separates normally (lex#819).
 //!
-//!    The verification test characterizes each merge (regression guard for the
-//!    lossless pairs, known-bad-shape tripwire for Table) rather than asserting
-//!    faithfulness for those cells.
+//!    The verification test characterizes the two remaining lossless merges rather
+//!    than asserting faithfulness for those cells.
 //!
 //! ## Spec/parser disagreements found
 //!
@@ -168,18 +159,12 @@ pub(super) fn min_blank_lines(prev: BlockKind, next: BlockKind) -> usize {
         // A Definition ends with a dedent (boundary minimum 0). Its `subject:` +
         // indented body IS a `<verbatim-group-with-content>`, so when it sits
         // immediately above a closer-terminated block the shared `:: label ::`
-        // closer makes it that verbatim's first group (see module docs). All these
-        // cells take the boundary minimum, but they split by intent:
-        //   - Definition → Verbatim / Annotation: INTENDED and LOSSLESS (grammar
-        //     §4.5c multi-group verbatim). The definition becomes the verbatim's
-        //     first group; subject AND body survive. Not a separation gap.
-        //   - Definition → Table: a KNOWN CONTENT-LOSS BUG (lex#819, deferred), NOT
-        //     intended. A table is single-group, so the definition cannot become a
-        //     group; the merge collapses to a degenerate table that drops the
-        //     definition body AND the table rows. When #819 is fixed the pair should
-        //     SEPARATE (Table leaves `is_known_hijack`).
+        // closer makes it that verbatim's first group (see module docs). Table is
+        // single-group and now separates (lex#819), but it still needs no extra
+        // blank: the definition's dedent is enough once the parser rejects the
+        // lossy table grouping.
         (Definition, Verbatim) => 0, // INTENDED lossless: becomes the verbatim's first group (multi-group verbatim §4.5c)
-        (Definition, Table) => 0, // KNOWN CONTENT-LOSS BUG (lex#819), NOT intended: table is single-group, merge drops the definition body and the table rows
+        (Definition, Table) => 0,
         // Both annotation shapes present a `:: label ::` line (the marker *is* one;
         // the block form opens with one), and either serves as the shared verbatim closer.
         (Definition, Annotation) | (Definition, AnnotationBody) => 0, // INTENDED lossless: `:: label ::` is the shared verbatim closer (multi-group verbatim §4.5c)

--- a/crates/lex-babel/tests/lex_separation/matrix.rs
+++ b/crates/lex-babel/tests/lex_separation/matrix.rs
@@ -26,12 +26,10 @@
 //! survive as the verbatim's first group.
 //!
 //! Definition → Table is the ONE exception and is NOT intended: a table is
-//! single-group, so the definition cannot become a group. The merge instead
-//! collapses to a degenerate table that keeps only the definition's subject and
-//! DROPS the definition body and the table's own rows — a real, pre-existing
-//! content-loss bug tracked in lex#819 (deferred, not fixed here). Its tripwire
-//! CHARACTERIZES the known-bad shape; when #819 is fixed the pair should separate
-//! and Table drops out of `is_known_hijack`.
+//! single-group, so the definition cannot become a group. The parser now requires
+//! a `:: table ::` span to start with pipe-row table content, so this pair
+//! separates into Definition + Table instead of collapsing to a degenerate table
+//! that drops both the definition body and the table's rows (lex#819).
 //!
 //! Bare Annotation siblings are also not round-trippable as siblings (the parser
 //! attaches a floating annotation to a neighbor or the document head), so they are
@@ -247,18 +245,12 @@ fn body_items(doc: &Document) -> Vec<&ContentItem> {
 /// verbatim feature working AS DESIGNED (lex#814 §4, resolved as intended) and lose
 /// no content.
 ///
-/// `Definition → Table` is included too but for the OPPOSITE reason: it is a KNOWN
-/// CONTENT-LOSS BUG (lex#819, deferred), NOT intended. A table is single-group, so
-/// the definition cannot become a group; the merge collapses to a degenerate table
-/// that drops the definition body and the table rows. It stays in this set only
-/// because the pair does currently merge (not separate); when lex#819 is fixed the
-/// pair should separate and this arm must be removed. Documented in `separation.rs`.
+/// `Definition → Table` used to be the known lex#819 content-loss exception, but
+/// tables are single-group and now separate rather than merging lossily.
 fn is_known_hijack(prev: Kind, next: Kind) -> bool {
     matches!(
         (prev, next),
-        (Kind::Definition, Kind::Verbatim)
-            | (Kind::Definition, Kind::Table)
-            | (Kind::Definition, Kind::Annotation)
+        (Kind::Definition, Kind::Verbatim) | (Kind::Definition, Kind::Annotation)
     )
 }
 
@@ -365,40 +357,9 @@ fn assert_definition_hijack_shape(next: Kind, reparsed: &Document, out: &str) {
             );
         }
         Kind::Table => {
-            // KNOWN CONTENT-LOSS BUG (lex#819), NOT intended group semantics.
-            // Unlike verbatim, a table is single-group, so the definition cannot
-            // become a group; instead the merge collapses to a degenerate table
-            // that keeps ONLY the definition's subject and DROPS everything else —
-            // both the definition body AND the table's own rows. This is a real,
-            // pre-existing bug (deferred, tracked in lex#819), not faithful and not
-            // "intended." The assertion CHARACTERIZES the current known-bad shape so
-            // the loss is pinned and visible; when lex#819 is fixed the pair should
-            // SEPARATE (Table drops out of `is_known_hijack`) and this arm must be
-            // updated to expect two siblings.
-            assert_eq!(
+            panic!(
+                "Definition -> Table is no longer a known hijack after lex#819; got {:?}\n{out}",
                 body_kinds(reparsed),
-                vec![Kind::Paragraph, Kind::Table],
-                "(Definition -> Table) known bug lex#819: currently merges into lead + one \
-                 degenerate table; got {:?}\n{out}",
-                body_kinds(reparsed),
-            );
-            let table = match items[1] {
-                ContentItem::Table(t) => t.as_ref(),
-                other => panic!("expected a Table; got {other:?}\n{out}"),
-            };
-            assert_eq!(
-                table.subject.as_string(),
-                "Term",
-                "(Definition -> Table) known bug lex#819: the merged table keeps only the \
-                 definition subject\n{out}",
-            );
-            assert!(
-                table.header_rows.is_empty() && table.body_rows.is_empty(),
-                "(Definition -> Table) known bug lex#819: the merge DROPS all rows (content \
-                 loss); when #819 is fixed the pair should separate and this tripwire must be \
-                 updated; got {} header + {} body row(s)\n{out}",
-                table.header_rows.len(),
-                table.body_rows.len(),
             );
         }
         other => panic!("assert_definition_hijack_shape called with non-hijack next {other:?}"),
@@ -423,10 +384,9 @@ fn every_ordered_pair_reparses_as_two_blocks() {
                 // than the weak "does not equal the separated shape" check (which
                 // codex flagged — it would pass even if the parser dropped content
                 // or produced the wrong merged block), assert the POSITIVE merged
-                // shape. `assert_definition_hijack_shape` pins each pair: the
-                // lossless §4.5c merges (Verbatim/Annotation) AND the lex#819
-                // Table content-loss bug. If it separates OR the merged shape is
-                // wrong, the guard fails.
+                // shape. `assert_definition_hijack_shape` pins the lossless §4.5c
+                // merges (Verbatim/Annotation). If either separates OR the merged
+                // shape is wrong, the guard fails.
                 assert_definition_hijack_shape(b, &reparsed, &out);
                 continue;
             }
@@ -457,17 +417,15 @@ fn every_ordered_pair_reparses_as_two_blocks() {
 #[test]
 fn definition_before_closer_led_block_is_a_known_hijack() {
     // Explicit regression guard that a Definition immediately above a
-    // closer-terminated block is absorbed rather than kept as a sibling. Two of
-    // these are the intended multi-group behavior (grammar §4.5c): Definition →
-    // Verbatim (the definition is the verbatim's first group under the shared
-    // closer) and Definition → Annotation (the `:: label ::` marker doubles as a
-    // verbatim closer, so the definition becomes a verbatim closed by it and the
-    // annotation body spills out as a trailing paragraph) — both lossless. The
-    // third, Definition → Table, is the lex#819 content-loss bug (deferred): a
-    // single-group table cannot hold the definition as a group, so the merge drops
-    // content. `assert_definition_hijack_shape` pins each shape positively — merge
-    // vs separate AND the exact merged block — so it fails on regression either way.
-    for next in [Kind::Verbatim, Kind::Table, Kind::Annotation] {
+    // closer-terminated Verbatim/Annotation is absorbed rather than kept as a
+    // sibling. Both are intended multi-group behavior (grammar §4.5c):
+    // Definition → Verbatim makes the definition the verbatim's first group under
+    // the shared closer; Definition → Annotation uses the `:: label ::` marker as
+    // a verbatim closer, so the definition becomes a verbatim closed by it and the
+    // annotation body spills out as a trailing paragraph. Definition → Table used
+    // to live here as lex#819's known content-loss bug, but a table is
+    // single-group and now separates instead.
+    for next in [Kind::Verbatim, Kind::Annotation] {
         let doc = doc_with(vec![
             lead(),
             block(Kind::Definition, Role::Prev),
@@ -747,9 +705,10 @@ proptest::proptest! {
     /// serializes and re-parses with the same block-type sequence. Drawn from the
     /// six kinds that round-trip as bare siblings (Annotation is excluded — bare
     /// annotation siblings re-attach, an orthogonal parser behavior). The
-    /// `is_known_hijack` merge adjacencies are skipped: Definition→Verbatim (the
-    /// intended multi-group behavior, §4.5c) and Definition→Table (the lex#819
-    /// content-loss bug). #784 will grow this into the full reader-content proptest.
+    /// `is_known_hijack` merge adjacency is skipped: Definition→Verbatim, the
+    /// intended multi-group behavior (§4.5c). Definition→Table used to be a
+    /// lossy member of this family, but tables are single-group and now separate
+    /// normally (lex#819). #784 will grow this into the full reader-content proptest.
     #[test]
     fn reader_shaped_sibling_sequence_preserves_block_types(
         indices in proptest::collection::vec(0usize..6, 1..7),

--- a/crates/lex-babel/tests/round_trip_proptest/mod.rs
+++ b/crates/lex-babel/tests/round_trip_proptest/mod.rs
@@ -861,13 +861,14 @@ proptest! {
 // The generator draws only the block kinds that round-trip faithfully as bare
 // siblings and excludes the adjacencies the parser provably cannot separate yet
 // — mirrored exactly from `tests/lex_separation/matrix.rs`:
-//   - A Definition immediately before a closer-led block (Verbatim/Table/
-//     Annotation) is hijacked: the verbatim/table matcher re-anchors the next
-//     `:: label ::` closer onto the definition's `subject:` line, swallowing the
-//     pair. No blank count fixes it (matrix.rs::is_known_hijack). We generate
-//     Verbatim (not Table/Annotation) as a closer-led sibling, so the only such
-//     adjacency reachable here is Definition→Verbatim, which the generator
-//     rejects.
+//   - A Definition immediately before a closer-led Verbatim/Annotation is
+//     hijacked: the verbatim matcher re-anchors the next `:: label ::` closer
+//     onto the definition's `subject:` line, swallowing the pair. No blank count
+//     fixes it (matrix.rs::is_known_hijack). We generate Verbatim (not
+//     Annotation) as a closer-led sibling, so the only such adjacency reachable
+//     here is Definition→Verbatim, which the generator rejects. Definition→Table
+//     used to be a lossy member of this family, but tables are single-group and
+//     now separate (lex#819).
 //   - Bare Annotation siblings do not round-trip as siblings (the parser
 //     re-attaches or hoists a floating annotation), so Annotation is never
 //     generated as a top-level block.

--- a/crates/lex-core/src/lex/parsing/parser.rs
+++ b/crates/lex-core/src/lex/parsing/parser.rs
@@ -13,7 +13,7 @@
 //! - `builder.rs` - AST node construction from matched patterns
 
 use crate::lex::parsing::ir::{NodeType, ParseNode};
-use crate::lex::token::{LineContainer, LineType};
+use crate::lex::token::{LineContainer, LineType, Token};
 use regex::Regex;
 use std::ops::Range;
 
@@ -594,6 +594,22 @@ impl GrammarMatcher {
                 LineContainer::Token(line) => {
                     if matches!(line.line_type, DataMarkerLine) {
                         // Found closing annotation (:: label ::) - success!
+                        // A table is single-group: unlike verbatim, it cannot
+                        // absorb preceding subject+content groups. If a shared
+                        // `:: table ::` closer would build a table from a span
+                        // whose first group is not pipe-row content, or from a
+                        // multi-group span, back off so the normal
+                        // definition/table matchers can claim their own blocks
+                        // without dropping rows (lex#819).
+                        if line_is_table_marker(line)
+                            && !table_span_has_single_pipe_group(
+                                tokens,
+                                first_subject_idx + 1,
+                                cursor,
+                            )
+                        {
+                            return None;
+                        }
                         // But only if we haven't mixed containers with flat content in a problematic way
                         return Some((
                             PatternMatch::VerbatimBlock {
@@ -618,6 +634,72 @@ impl GrammarMatcher {
             }
         }
     }
+}
+
+fn line_is_table_marker(line: &crate::lex::token::LineToken) -> bool {
+    line.line_type == LineType::DataMarkerLine
+        && line.source_tokens.iter().find_map(|token| match token {
+            Token::Text(text) => Some(text.as_str()),
+            _ => None,
+        }) == Some("table")
+}
+
+fn table_span_has_single_pipe_group(
+    tokens: &[LineContainer],
+    content_start: usize,
+    closing_idx: usize,
+) -> bool {
+    let mut saw_table_content = false;
+
+    for token in &tokens[content_start..closing_idx] {
+        match token {
+            LineContainer::Token(line) if line.line_type == LineType::BlankLine => continue,
+            LineContainer::Container { .. } if !saw_table_content => {
+                if !container_starts_with_pipe_row(token) {
+                    return false;
+                }
+                saw_table_content = true;
+            }
+            LineContainer::Token(line)
+                if !saw_table_content
+                    && matches!(
+                        line.line_type,
+                        LineType::SubjectLine | LineType::SubjectOrListItemLine
+                    ) =>
+            {
+                return false;
+            }
+            LineContainer::Token(line) if !saw_table_content => {
+                if !line_starts_with_pipe_row(line) {
+                    return false;
+                }
+                saw_table_content = true;
+            }
+            LineContainer::Token(line)
+                if matches!(
+                    line.line_type,
+                    LineType::SubjectLine | LineType::SubjectOrListItemLine
+                ) =>
+            {
+                return false;
+            }
+            LineContainer::Container { .. } => return false,
+            LineContainer::Token(_) => {}
+        }
+    }
+
+    saw_table_content
+}
+
+fn line_starts_with_pipe_row(line: &crate::lex::token::LineToken) -> bool {
+    for token in &line.source_tokens {
+        match token {
+            Token::Whitespace(_) | Token::Indentation | Token::Indent(_) => continue,
+            Token::Text(text) => return text.starts_with('|'),
+            _ => return false,
+        }
+    }
+    false
 }
 
 /// Main recursive descent parser using the declarative grammar.

--- a/crates/lex-core/tests/integration/elements_table.rs
+++ b/crates/lex-core/tests/integration/elements_table.rs
@@ -209,6 +209,35 @@ fn test_table_multiline_from_string() {
     });
 }
 
+#[test]
+fn test_definition_adjacent_to_table_keeps_table_rows_lex819() {
+    use lex_core::lex::parsing::parse_document;
+
+    let source =
+        "Term:\n    Definition body.\nData table:\n    | A | B |\n    | 1 | 2 |\n:: table ::\n";
+    let doc = parse_document(source).unwrap();
+
+    assert_ast(&doc)
+        .item_count(2)
+        .item(0, |item| {
+            item.assert_definition()
+                .subject("Term")
+                .child_count(1)
+                .child(0, |child| {
+                    child.assert_paragraph().text("Definition body.");
+                });
+        })
+        .item(1, |item| {
+            item.assert_table()
+                .subject("Data table")
+                .header_row_count(1)
+                .body_row_count(1)
+                .column_count(2)
+                .header_cells(0, &["A", "B"])
+                .body_cells(0, &["1", "2"]);
+        });
+}
+
 // ============================================================================
 // Separator Lines
 // ============================================================================


### PR DESCRIPTION
## Summary
- prevent the verbatim matcher from building a table from a multi-group span whose first content group is not pipe-row table content
- add a parser regression for Definition immediately followed by a closed table, asserting the definition body and table rows survive
- update separation/property docs so Definition -> Table is no longer treated as a known hijack

Fixes #819

## Validation
- cargo fmt --check
- cargo test -p lex-core
- cargo test -p lex-babel
- env RUSTC_WRAPPER= cargo clippy -p lex-core --all-targets -- -D warnings
- env RUSTC_WRAPPER= cargo clippy -p lex-babel --all-targets -- -D warnings
- env RUSTC_WRAPPER= release-core gate (fails only in pre-existing repository-wide yamllint/markdownlint files; Rust clippy/fmt, shell, JSON, and lexd checks pass)