### PR TITLE
[codex] add changelog for definition table fix

### DIFF
--- a/CHANGELOG/unreleased-pr-822.md
+++ b/CHANGELOG/unreleased-pr-822.md
@@ -1,0 +1,2 @@
+- Fix Definition→Table adjacency parsing so a closer-led table immediately after a
+  definition keeps both the definition body and all table rows (lex#819)


### PR DESCRIPTION
## Summary
- add the missing unreleased changelog fragment for the Definition -> Table adjacency fix merged in #822

## Validation
- git diff --check
- env RUSTC_WRAPPER= release-core gate (fails only in pre-existing repository-wide yamllint/markdownlint files; Rust clippy/fmt, shell, JSON, and lexd checks pass)