### PR TITLE
chore(lint): prettier-format web files flagged by the fleet sweep

### DIFF
--- a/crates/lex-babel/css/baseline.css
+++ b/crates/lex-babel/css/baseline.css
@@ -85,11 +85,11 @@ section.lex-session:first-child {
   margin-top: 0;
 }
 
-.lex-document>section.lex-session {
+.lex-document > section.lex-session {
   margin: var(--lex-space-200) 0;
 }
 
-.lex-document>section.lex-session:first-child {
+.lex-document > section.lex-session:first-child {
   margin-top: 0;
 }
 
@@ -168,12 +168,12 @@ h6 {
   font-weight: 600;
 }
 
-section.lex-session>h1:first-child,
-section.lex-session>h2:first-child,
-section.lex-session>h3:first-child,
-section.lex-session>h4:first-child,
-section.lex-session>h5:first-child,
-section.lex-session>h6:first-child {
+section.lex-session > h1:first-child,
+section.lex-session > h2:first-child,
+section.lex-session > h3:first-child,
+section.lex-session > h4:first-child,
+section.lex-session > h5:first-child,
+section.lex-session > h6:first-child {
   margin-top: 0;
 }
 
@@ -188,12 +188,12 @@ section.lex-session>h6:first-child {
   margin-top: 0;
 }
 
-h1+.lex-paragraph,
-h2+.lex-paragraph,
-h3+.lex-paragraph,
-h4+.lex-paragraph,
-h5+.lex-paragraph,
-h6+.lex-paragraph {
+h1 + .lex-paragraph,
+h2 + .lex-paragraph,
+h3 + .lex-paragraph,
+h4 + .lex-paragraph,
+h5 + .lex-paragraph,
+h6 + .lex-paragraph {
   margin-top: 0;
 }
 
@@ -478,13 +478,19 @@ img {
 
   /* Headings shouldn't appear at the bottom of a page orphaned from
    * their first content paragraph. */
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     break-after: avoid-page;
     page-break-after: avoid;
   }
 
   /* Figures and tables read poorly when split mid-element. */
-  figure, table {
+  figure,
+  table {
     break-inside: avoid-page;
     page-break-inside: avoid;
   }
@@ -494,7 +500,7 @@ img {
  * paged renderers (Chromium headless, weasyprint, etc.) honor it. */
 @page {
   @bottom-center {
-    content: counter(page) " / " counter(pages);
+    content: counter(page) ' / ' counter(pages);
     font-size: 9pt;
     color: #666;
   }

--- a/crates/lex-wasm/typescript/index.ts
+++ b/crates/lex-wasm/typescript/index.ts
@@ -23,24 +23,24 @@ import type {
   Location,
   Position,
   SemanticTokensData,
-  SemanticTokensLegend,
-} from './types';
+  SemanticTokensLegend
+} from './types'
 
 // Re-export types
-export * from './types';
+export * from './types'
 
 // The WASM module will be imported dynamically
-let wasmModule: typeof import('../pkg/lex_wasm') | null = null;
+let wasmModule: typeof import('../pkg/lex_wasm') | null = null
 
 /**
  * Initialize the WASM module.
  * Must be called before using any other functions.
  */
 export async function init(): Promise<void> {
-  if (wasmModule) return;
+  if (wasmModule) return
 
   // Dynamic import of the WASM module
-  wasmModule = await import('../pkg/lex_wasm');
+  wasmModule = await import('../pkg/lex_wasm')
 }
 
 /**
@@ -48,47 +48,43 @@ export async function init(): Promise<void> {
  */
 export interface LexDocument {
   /** Get the document source text. */
-  source(): string;
+  source(): string
 
   /** Get the document URI. */
-  uri(): string;
+  uri(): string
 
   /** Get semantic tokens for syntax highlighting. */
-  semanticTokens(): SemanticTokensData;
+  semanticTokens(): SemanticTokensData
 
   /** Get document symbols (outline). */
-  documentSymbols(): DocumentSymbol[];
+  documentSymbols(): DocumentSymbol[]
 
   /** Get hover information at a position. */
-  hover(line: number, character: number): Hover | null;
+  hover(line: number, character: number): Hover | null
 
   /** Get go-to-definition locations. */
-  gotoDefinition(line: number, character: number): Location[];
+  gotoDefinition(line: number, character: number): Location[]
 
   /** Find all references to the symbol at a position. */
-  references(
-    line: number,
-    character: number,
-    includeDeclaration: boolean
-  ): Location[];
+  references(line: number, character: number, includeDeclaration: boolean): Location[]
 
   /** Get folding ranges. */
-  foldingRanges(): FoldingRange[];
+  foldingRanges(): FoldingRange[]
 
   /** Get completion suggestions. */
-  completion(line: number, character: number): CompletionItem[];
+  completion(line: number, character: number): CompletionItem[]
 
   /** Get diagnostics (errors, warnings). */
-  diagnostics(): Diagnostic[];
+  diagnostics(): Diagnostic[]
 
   /** Get spellcheck diagnostics using the provided checker. */
-  spellcheckDiagnostics(checker: EmbeddedSpellchecker): Diagnostic[];
+  spellcheckDiagnostics(checker: EmbeddedSpellchecker): Diagnostic[]
 
   /** Format the document source. */
-  format(): string;
+  format(): string
 
   /** Export the document as HTML. */
-  toHtml(): string;
+  toHtml(): string
 }
 
 /**
@@ -96,19 +92,19 @@ export interface LexDocument {
  */
 export interface EmbeddedSpellchecker {
   /** Check if a word is spelled correctly. */
-  check(word: string): boolean;
+  check(word: string): boolean
 
   /** Get spelling suggestions for a word. */
-  suggest(word: string): string[];
+  suggest(word: string): string[]
 
   /** Add a word to the custom dictionary (session-only). */
-  addCustomWord(word: string): void;
+  addCustomWord(word: string): void
 
   /** Get all custom words. */
-  getCustomWords(): string[];
+  getCustomWords(): string[]
 
   /** Load custom words (e.g., from localStorage). */
-  loadCustomWords(words: string[]): void;
+  loadCustomWords(words: string[]): void
 }
 
 /**
@@ -116,19 +112,19 @@ export interface EmbeddedSpellchecker {
  */
 export interface LexAnalyzer {
   /** Parse source text into a LexDocument. */
-  parse(source: string): LexDocument;
+  parse(source: string): LexDocument
 
   /** Parse source text with a specific URI. */
-  parseWithUri(source: string, uri: string): LexDocument;
+  parseWithUri(source: string, uri: string): LexDocument
 
   /** Get the semantic token legend for Monaco. */
-  semanticTokenLegend(): SemanticTokensLegend;
+  semanticTokenLegend(): SemanticTokensLegend
 
   /** Create a new spellchecker with the embedded dictionary. */
-  createSpellchecker(): EmbeddedSpellchecker;
+  createSpellchecker(): EmbeddedSpellchecker
 
   /** Get the version of lex-wasm. */
-  version(): string;
+  version(): string
 }
 
 /**
@@ -138,33 +134,33 @@ export interface LexAnalyzer {
  * that can parse documents and provide LSP-like features.
  */
 export async function createLexAnalyzer(): Promise<LexAnalyzer> {
-  await init();
+  await init()
 
   if (!wasmModule) {
-    throw new Error('Failed to initialize WASM module');
+    throw new Error('Failed to initialize WASM module')
   }
 
-  const { LexDocument, EmbeddedSpellchecker, version } = wasmModule;
+  const { LexDocument, EmbeddedSpellchecker, version } = wasmModule
 
   return {
     parse(source: string): LexDocument {
-      return new LexDocument(source) as unknown as LexDocument;
+      return new LexDocument(source) as unknown as LexDocument
     },
 
     parseWithUri(source: string, uri: string): LexDocument {
-      return LexDocument.withUri(source, uri) as unknown as LexDocument;
+      return LexDocument.withUri(source, uri) as unknown as LexDocument
     },
 
     semanticTokenLegend(): SemanticTokensLegend {
-      return LexDocument.semanticTokenLegend() as SemanticTokensLegend;
+      return LexDocument.semanticTokenLegend() as SemanticTokensLegend
     },
 
     createSpellchecker(): EmbeddedSpellchecker {
-      return new EmbeddedSpellchecker() as unknown as EmbeddedSpellchecker;
+      return new EmbeddedSpellchecker() as unknown as EmbeddedSpellchecker
     },
 
     version(): string {
-      return version();
-    },
-  };
+      return version()
+    }
+  }
 }

--- a/crates/lex-wasm/typescript/providers/completion.ts
+++ b/crates/lex-wasm/typescript/providers/completion.ts
@@ -2,9 +2,9 @@
  * Monaco completion provider for Lex.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument, CompletionItemKind } from '../index';
-import type { DocumentProvider } from './semantic_tokens';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument, CompletionItemKind } from '../index'
+import type { DocumentProvider } from './semantic_tokens'
 
 /**
  * Register a completion provider for Lex in Monaco.
@@ -21,38 +21,36 @@ export function registerCompletionProvider(
       model: monaco.editor.ITextModel,
       position: monaco.Position
     ): monaco.languages.ProviderResult<monaco.languages.CompletionList> {
-      const doc = documentProvider.getDocument(model.uri.toString());
-      if (!doc) return { suggestions: [] };
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) return { suggestions: [] }
 
       // Monaco positions are 1-indexed, lex-wasm expects 0-indexed
-      const items = doc.completion(position.lineNumber - 1, position.column - 1);
+      const items = doc.completion(position.lineNumber - 1, position.column - 1)
 
-      const suggestions: monaco.languages.CompletionItem[] = items.map(
-        (item, index) => ({
-          label: item.label,
-          kind: convertCompletionKind(monacoInstance, item.kind),
-          detail: item.detail,
-          insertText: item.insertText || item.label,
-          range: new monacoInstance.Range(
-            position.lineNumber,
-            position.column,
-            position.lineNumber,
-            position.column
-          ),
-          sortText: String(index).padStart(5, '0'),
-        })
-      );
+      const suggestions: monaco.languages.CompletionItem[] = items.map((item, index) => ({
+        label: item.label,
+        kind: convertCompletionKind(monacoInstance, item.kind),
+        detail: item.detail,
+        insertText: item.insertText || item.label,
+        range: new monacoInstance.Range(
+          position.lineNumber,
+          position.column,
+          position.lineNumber,
+          position.column
+        ),
+        sortText: String(index).padStart(5, '0')
+      }))
 
-      return { suggestions };
-    },
-  });
+      return { suggestions }
+    }
+  })
 }
 
 function convertCompletionKind(
   monacoInstance: typeof monaco,
   kind?: CompletionItemKind
 ): monaco.languages.CompletionItemKind {
-  if (!kind) return monacoInstance.languages.CompletionItemKind.Text;
+  if (!kind) return monacoInstance.languages.CompletionItemKind.Text
 
   // Map LSP completion kinds to Monaco
   const map: Record<number, monaco.languages.CompletionItemKind> = {
@@ -64,8 +62,8 @@ function convertCompletionKind(
     15: monacoInstance.languages.CompletionItemKind.Snippet,
     17: monacoInstance.languages.CompletionItemKind.File,
     18: monacoInstance.languages.CompletionItemKind.Reference,
-    19: monacoInstance.languages.CompletionItemKind.Folder,
-  };
+    19: monacoInstance.languages.CompletionItemKind.Folder
+  }
 
-  return map[kind] || monacoInstance.languages.CompletionItemKind.Text;
+  return map[kind] || monacoInstance.languages.CompletionItemKind.Text
 }

--- a/crates/lex-wasm/typescript/providers/definition.ts
+++ b/crates/lex-wasm/typescript/providers/definition.ts
@@ -2,9 +2,9 @@
  * Monaco go-to-definition provider for Lex.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument } from '../index';
-import type { DocumentProvider } from './semantic_tokens';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument } from '../index'
+import type { DocumentProvider } from './semantic_tokens'
 
 /**
  * Register a definition provider for Lex in Monaco.
@@ -19,16 +19,13 @@ export function registerDefinitionProvider(
       model: monaco.editor.ITextModel,
       position: monaco.Position
     ): monaco.languages.ProviderResult<monaco.languages.Definition> {
-      const doc = documentProvider.getDocument(model.uri.toString());
-      if (!doc) return null;
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) return null
 
       // Monaco positions are 1-indexed, lex-wasm expects 0-indexed
-      const locations = doc.gotoDefinition(
-        position.lineNumber - 1,
-        position.column - 1
-      );
+      const locations = doc.gotoDefinition(position.lineNumber - 1, position.column - 1)
 
-      if (locations.length === 0) return null;
+      if (locations.length === 0) return null
 
       return locations.map((loc) => ({
         uri: monacoInstance.Uri.parse(loc.uri),
@@ -37,10 +34,10 @@ export function registerDefinitionProvider(
           loc.range.start.character + 1,
           loc.range.end.line + 1,
           loc.range.end.character + 1
-        ),
-      }));
-    },
-  });
+        )
+      }))
+    }
+  })
 }
 
 /**
@@ -57,15 +54,15 @@ export function registerReferencesProvider(
       position: monaco.Position,
       context: monaco.languages.ReferenceContext
     ): monaco.languages.ProviderResult<monaco.languages.Location[]> {
-      const doc = documentProvider.getDocument(model.uri.toString());
-      if (!doc) return null;
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) return null
 
       // Monaco positions are 1-indexed, lex-wasm expects 0-indexed
       const locations = doc.references(
         position.lineNumber - 1,
         position.column - 1,
         context.includeDeclaration
-      );
+      )
 
       return locations.map((loc) => ({
         uri: monacoInstance.Uri.parse(loc.uri),
@@ -74,8 +71,8 @@ export function registerReferencesProvider(
           loc.range.start.character + 1,
           loc.range.end.line + 1,
           loc.range.end.character + 1
-        ),
-      }));
-    },
-  });
+        )
+      }))
+    }
+  })
 }

--- a/crates/lex-wasm/typescript/providers/diagnostics.ts
+++ b/crates/lex-wasm/typescript/providers/diagnostics.ts
@@ -5,8 +5,8 @@
  * Instead, diagnostics are set via `monaco.editor.setModelMarkers`.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument, EmbeddedSpellchecker, DiagnosticSeverity } from '../index';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument, EmbeddedSpellchecker, DiagnosticSeverity } from '../index'
 
 /**
  * Update diagnostics for a model.
@@ -19,10 +19,10 @@ export function updateDiagnostics(
   doc: LexDocument,
   spellchecker?: EmbeddedSpellchecker
 ): void {
-  const markers: monaco.editor.IMarkerData[] = [];
+  const markers: monaco.editor.IMarkerData[] = []
 
   // Get structural diagnostics
-  const diagnostics = doc.diagnostics();
+  const diagnostics = doc.diagnostics()
   for (const diag of diagnostics) {
     markers.push({
       severity: convertSeverity(monacoInstance, diag.severity),
@@ -31,13 +31,13 @@ export function updateDiagnostics(
       startColumn: diag.range.start.character + 1,
       endLineNumber: diag.range.end.line + 1,
       endColumn: diag.range.end.character + 1,
-      source: diag.source || 'lex',
-    });
+      source: diag.source || 'lex'
+    })
   }
 
   // Get spellcheck diagnostics if checker is provided
   if (spellchecker) {
-    const spellDiags = doc.spellcheckDiagnostics(spellchecker);
+    const spellDiags = doc.spellcheckDiagnostics(spellchecker)
     for (const diag of spellDiags) {
       markers.push({
         severity: monacoInstance.MarkerSeverity.Info,
@@ -47,12 +47,12 @@ export function updateDiagnostics(
         endLineNumber: diag.range.end.line + 1,
         endColumn: diag.range.end.character + 1,
         source: 'lex-spell',
-        code: 'spelling',
-      });
+        code: 'spelling'
+      })
     }
   }
 
-  monacoInstance.editor.setModelMarkers(model, 'lex', markers);
+  monacoInstance.editor.setModelMarkers(model, 'lex', markers)
 }
 
 function convertSeverity(
@@ -61,14 +61,14 @@ function convertSeverity(
 ): monaco.MarkerSeverity {
   switch (severity) {
     case 1:
-      return monacoInstance.MarkerSeverity.Error;
+      return monacoInstance.MarkerSeverity.Error
     case 2:
-      return monacoInstance.MarkerSeverity.Warning;
+      return monacoInstance.MarkerSeverity.Warning
     case 3:
-      return monacoInstance.MarkerSeverity.Info;
+      return monacoInstance.MarkerSeverity.Info
     case 4:
-      return monacoInstance.MarkerSeverity.Hint;
+      return monacoInstance.MarkerSeverity.Hint
     default:
-      return monacoInstance.MarkerSeverity.Warning;
+      return monacoInstance.MarkerSeverity.Warning
   }
 }

--- a/crates/lex-wasm/typescript/providers/folding.ts
+++ b/crates/lex-wasm/typescript/providers/folding.ts
@@ -2,9 +2,9 @@
  * Monaco folding range provider for Lex.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument } from '../index';
-import type { DocumentProvider } from './semantic_tokens';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument } from '../index'
+import type { DocumentProvider } from './semantic_tokens'
 
 /**
  * Register a folding range provider for Lex in Monaco.
@@ -18,18 +18,18 @@ export function registerFoldingRangeProvider(
     provideFoldingRanges(
       model: monaco.editor.ITextModel
     ): monaco.languages.ProviderResult<monaco.languages.FoldingRange[]> {
-      const doc = documentProvider.getDocument(model.uri.toString());
-      if (!doc) return [];
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) return []
 
-      const ranges = doc.foldingRanges();
+      const ranges = doc.foldingRanges()
 
       return ranges.map((r) => ({
         start: r.startLine + 1, // Monaco is 1-indexed
         end: r.endLine + 1,
-        kind: convertFoldingKind(monacoInstance, r.kind),
-      }));
-    },
-  });
+        kind: convertFoldingKind(monacoInstance, r.kind)
+      }))
+    }
+  })
 }
 
 function convertFoldingKind(
@@ -38,12 +38,12 @@ function convertFoldingKind(
 ): monaco.languages.FoldingRangeKind | undefined {
   switch (kind) {
     case 'comment':
-      return monacoInstance.languages.FoldingRangeKind.Comment;
+      return monacoInstance.languages.FoldingRangeKind.Comment
     case 'imports':
-      return monacoInstance.languages.FoldingRangeKind.Imports;
+      return monacoInstance.languages.FoldingRangeKind.Imports
     case 'region':
-      return monacoInstance.languages.FoldingRangeKind.Region;
+      return monacoInstance.languages.FoldingRangeKind.Region
     default:
-      return undefined;
+      return undefined
   }
 }

--- a/crates/lex-wasm/typescript/providers/hover.ts
+++ b/crates/lex-wasm/typescript/providers/hover.ts
@@ -2,9 +2,9 @@
  * Monaco hover provider for Lex.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument } from '../index';
-import type { DocumentProvider } from './semantic_tokens';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument } from '../index'
+import type { DocumentProvider } from './semantic_tokens'
 
 /**
  * Register a hover provider for Lex in Monaco.
@@ -19,19 +19,19 @@ export function registerHoverProvider(
       model: monaco.editor.ITextModel,
       position: monaco.Position
     ): monaco.languages.ProviderResult<monaco.languages.Hover> {
-      const doc = documentProvider.getDocument(model.uri.toString());
-      if (!doc) return null;
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) return null
 
       // Monaco positions are 1-indexed, lex-wasm expects 0-indexed
-      const hover = doc.hover(position.lineNumber - 1, position.column - 1);
-      if (!hover) return null;
+      const hover = doc.hover(position.lineNumber - 1, position.column - 1)
+      if (!hover) return null
 
       return {
         contents: [
           {
             value: hover.contents.value,
-            isTrusted: true,
-          },
+            isTrusted: true
+          }
         ],
         range: hover.range
           ? new monacoInstance.Range(
@@ -40,8 +40,8 @@ export function registerHoverProvider(
               hover.range.end.line + 1,
               hover.range.end.character + 1
             )
-          : undefined,
-      };
-    },
-  });
+          : undefined
+      }
+    }
+  })
 }

--- a/crates/lex-wasm/typescript/providers/semantic_tokens.ts
+++ b/crates/lex-wasm/typescript/providers/semantic_tokens.ts
@@ -5,15 +5,15 @@
  * highlighting using lex-wasm.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument, LexAnalyzer, SemanticTokensLegend } from '../index';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument, LexAnalyzer, SemanticTokensLegend } from '../index'
 
 /**
  * A document provider that caches parsed documents.
  */
 export interface DocumentProvider {
   /** Get or create a parsed document for a URI. */
-  getDocument(uri: string): LexDocument | null;
+  getDocument(uri: string): LexDocument | null
 }
 
 /**
@@ -30,35 +30,32 @@ export function registerSemanticTokensProvider(
   documentProvider: DocumentProvider,
   analyzer: LexAnalyzer
 ): monaco.IDisposable {
-  const legend = analyzer.semanticTokenLegend();
+  const legend = analyzer.semanticTokenLegend()
 
-  return monacoInstance.languages.registerDocumentSemanticTokensProvider(
-    languageId,
-    {
-      getLegend(): monaco.languages.SemanticTokensLegend {
-        return {
-          tokenTypes: legend.tokenTypes,
-          tokenModifiers: legend.tokenModifiers,
-        };
-      },
+  return monacoInstance.languages.registerDocumentSemanticTokensProvider(languageId, {
+    getLegend(): monaco.languages.SemanticTokensLegend {
+      return {
+        tokenTypes: legend.tokenTypes,
+        tokenModifiers: legend.tokenModifiers
+      }
+    },
 
-      provideDocumentSemanticTokens(
-        model: monaco.editor.ITextModel
-      ): monaco.languages.ProviderResult<monaco.languages.SemanticTokens> {
-        const doc = documentProvider.getDocument(model.uri.toString());
-        if (!doc) {
-          return { data: new Uint32Array() };
-        }
+    provideDocumentSemanticTokens(
+      model: monaco.editor.ITextModel
+    ): monaco.languages.ProviderResult<monaco.languages.SemanticTokens> {
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) {
+        return { data: new Uint32Array() }
+      }
 
-        const tokens = doc.semanticTokens();
-        return {
-          data: new Uint32Array(tokens),
-        };
-      },
+      const tokens = doc.semanticTokens()
+      return {
+        data: new Uint32Array(tokens)
+      }
+    },
 
-      releaseDocumentSemanticTokens(): void {
-        // No-op: documents are managed by the provider
-      },
+    releaseDocumentSemanticTokens(): void {
+      // No-op: documents are managed by the provider
     }
-  );
+  })
 }

--- a/crates/lex-wasm/typescript/providers/symbols.ts
+++ b/crates/lex-wasm/typescript/providers/symbols.ts
@@ -2,9 +2,9 @@
  * Monaco document symbol provider for Lex.
  */
 
-import type * as monaco from 'monaco-editor';
-import type { LexDocument, DocumentSymbol, SymbolKind } from '../index';
-import type { DocumentProvider } from './semantic_tokens';
+import type * as monaco from 'monaco-editor'
+import type { LexDocument, DocumentSymbol, SymbolKind } from '../index'
+import type { DocumentProvider } from './semantic_tokens'
 
 /**
  * Register a document symbol provider for Lex in Monaco.
@@ -18,13 +18,13 @@ export function registerDocumentSymbolProvider(
     provideDocumentSymbols(
       model: monaco.editor.ITextModel
     ): monaco.languages.ProviderResult<monaco.languages.DocumentSymbol[]> {
-      const doc = documentProvider.getDocument(model.uri.toString());
-      if (!doc) return [];
+      const doc = documentProvider.getDocument(model.uri.toString())
+      if (!doc) return []
 
-      const symbols = doc.documentSymbols();
-      return symbols.map((s) => convertSymbol(monacoInstance, s));
-    },
-  });
+      const symbols = doc.documentSymbols()
+      return symbols.map((s) => convertSymbol(monacoInstance, s))
+    }
+  })
 }
 
 function convertSymbol(
@@ -48,8 +48,8 @@ function convertSymbol(
       sym.selectionRange.end.line + 1,
       sym.selectionRange.end.character + 1
     ),
-    children: sym.children?.map((c) => convertSymbol(monacoInstance, c)) || [],
-  };
+    children: sym.children?.map((c) => convertSymbol(monacoInstance, c)) || []
+  }
 }
 
 function convertSymbolKind(
@@ -57,5 +57,5 @@ function convertSymbolKind(
   kind: SymbolKind
 ): monaco.languages.SymbolKind {
   // Monaco and LSP symbol kinds mostly align
-  return kind as monaco.languages.SymbolKind;
+  return kind as monaco.languages.SymbolKind
 }

--- a/crates/lex-wasm/typescript/types.ts
+++ b/crates/lex-wasm/typescript/types.ts
@@ -7,6 +7,13 @@
 
 export interface Position {
   line: number
+  /**
+   * Column within the line as a UTF-8 *byte* offset — NOT a UTF-16 code unit
+   * or codepoint index. lex-core/lex-wasm treat LSP columns as byte offsets
+   * throughout (see lex-lsp-core `prepare_paste.rs`), so on non-ASCII text
+   * this differs from the standard LSP/Monaco UTF-16 convention. Callers must
+   * pass byte offsets to get correct ranges.
+   */
   character: number
 }
 

--- a/crates/lex-wasm/typescript/types.ts
+++ b/crates/lex-wasm/typescript/types.ts
@@ -6,42 +6,42 @@
  */
 
 export interface Position {
-  line: number;
-  character: number;
+  line: number
+  character: number
 }
 
 export interface Range {
-  start: Position;
-  end: Position;
+  start: Position
+  end: Position
 }
 
 export interface Location {
-  uri: string;
-  range: Range;
+  uri: string
+  range: Range
 }
 
 export interface Diagnostic {
-  range: Range;
-  severity?: DiagnosticSeverity;
-  code?: string | number;
-  source?: string;
-  message: string;
+  range: Range
+  severity?: DiagnosticSeverity
+  code?: string | number
+  source?: string
+  message: string
 }
 
 export enum DiagnosticSeverity {
   Error = 1,
   Warning = 2,
   Information = 3,
-  Hint = 4,
+  Hint = 4
 }
 
 export interface DocumentSymbol {
-  name: string;
-  detail?: string;
-  kind: SymbolKind;
-  range: Range;
-  selectionRange: Range;
-  children?: DocumentSymbol[];
+  name: string
+  detail?: string
+  kind: SymbolKind
+  range: Range
+  selectionRange: Range
+  children?: DocumentSymbol[]
 }
 
 export enum SymbolKind {
@@ -70,38 +70,38 @@ export enum SymbolKind {
   Struct = 23,
   Event = 24,
   Operator = 25,
-  TypeParameter = 26,
+  TypeParameter = 26
 }
 
 export interface Hover {
-  contents: MarkupContent;
-  range?: Range;
+  contents: MarkupContent
+  range?: Range
 }
 
 export interface MarkupContent {
-  kind: 'plaintext' | 'markdown';
-  value: string;
+  kind: 'plaintext' | 'markdown'
+  value: string
 }
 
 export interface FoldingRange {
-  startLine: number;
-  startCharacter?: number;
-  endLine: number;
-  endCharacter?: number;
-  kind?: FoldingRangeKind;
+  startLine: number
+  startCharacter?: number
+  endLine: number
+  endCharacter?: number
+  kind?: FoldingRangeKind
 }
 
 export enum FoldingRangeKind {
   Comment = 'comment',
   Imports = 'imports',
-  Region = 'region',
+  Region = 'region'
 }
 
 export interface CompletionItem {
-  label: string;
-  kind?: CompletionItemKind;
-  detail?: string;
-  insertText?: string;
+  label: string
+  kind?: CompletionItemKind
+  detail?: string
+  insertText?: string
 }
 
 export enum CompletionItemKind {
@@ -129,16 +129,16 @@ export enum CompletionItemKind {
   Struct = 22,
   Event = 23,
   Operator = 24,
-  TypeParameter = 25,
+  TypeParameter = 25
 }
 
 export interface SemanticTokensLegend {
-  tokenTypes: string[];
-  tokenModifiers: string[];
+  tokenTypes: string[]
+  tokenModifiers: string[]
 }
 
 /**
  * Semantic tokens data as a flat array.
  * Format: [deltaLine, deltaStartChar, length, tokenType, tokenModifiers, ...]
  */
-export type SemanticTokensData = number[];
+export type SemanticTokensData = number[]


### PR DESCRIPTION
## Context

shipit's TOL01 fleet verification sweep (round 0, candidate `7a6b542`) flagged `lex-fmt/lex` with `LINT=FAIL` — evidence in **arthur-debert/shipit#558**, red-cell **class C** ("genuine consumer lint violations… prettier drift"). This PR is the consumer-side code fix for that cell.

## What changed

Applied the shipit-managed prettier config (`shipit/data/prettierrc.yaml`: single quotes, no semicolons, `trailingComma: none`, printWidth 100) to the **10 web-toolchain files** it flagged:

- `crates/lex-babel/css/baseline.css`
- `crates/lex-wasm/typescript/index.ts`, `types.ts`
- `crates/lex-wasm/typescript/providers/{completion,definition,diagnostics,folding,hover,semantic_tokens,symbols}.ts`

Formatting only — combinator spacing (`>`→` > `), quote style, semicolon removal, one-selector-per-line. **No content, config, or `[lint].ignore` change.** `crates/lex-babel/tests/fixtures/kitchensink.html` is untouched (gate-excluded via `.shipit.toml [lint]`), and the two theme CSS files already conformed.

## Verification

- `prettier --check` over all web files (fixture dir excluded): **clean**.
- `./bin/shipit lint`: **LINT: OK (32 checks)**.
- `pixi run test` (`cargo nextest run --workspace`): the reformatted `baseline.css` is embedded via `include_str!` and asserted on by lex-babel html tests — all its asserted substrings (`@page`, `counter(page)`, `break-inside`, `dt {`, `.lex-document`, `--lex-`, `.lex-verbatim`) survive. 3 pre-existing `lex-analysis` diagnostics failures (a lexplore fixture-loader IO error, `loader.rs:137` "Failed to find Footnotes #1") reproduce identically on the pristine base — unrelated to this change.

for arthur-debert/shipit#558