### PR TITLE
Release cutover: author shipit [artifacts] (signed lexd + lex-wasm npm), add wasm32 std, seed changelog

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -67,6 +67,34 @@ local = true
 [toolchains]
 "." = "rust"
 
+# [artifacts] — the release surface this repo publishes (lex#832 cutover),
+# ported from the legacy `.github/workflows/release.yml` rust-cli.yml caller.
+# Two artifacts: the signed `lexd` binary matrix and the `lex-wasm` npm package.
+#
+#   - lexd: the `[[bin]] name = "lexd"` lives in crate `lex-cli` (its
+#     [package].name IS "lexd"), so `package = "lexd"`. Signed darwin + linux
+#     gnu (x86_64 + arm64) + linux musl x86_64, matching the legacy
+#     linux-musl-archs coverage. windows-x86_64 is OMITTED per the fleet
+#     pause (shipit#895), even though the legacy caller listed windows-archs.
+#     The `crates` endpoint triggers the workspace-wide crates.io publish in
+#     topological order — `lex-wasm` (publish = false) is auto-excluded via
+#     cargo metadata, so the legacy explicit `crates:` list is not restated.
+#   - lex-wasm: wasm-pack → @lex-fmt/lex-wasm on npm (legacy wasm-packages +
+#     wasm-npm-scope). Built on the linux-x86_64 host; the `web`-target wasm
+#     output is platform-independent, so one build platform suffices.
+[artifacts.lexd]
+build = [{ toolchain = "rust", package = "lexd" }]
+platforms = ["darwin-arm64", "linux-x86_64", "linux-arm64", "linux-x86_64-musl"]
+bundle = { composition = "archive" }
+sign = true
+endpoints = ["gh-release", "crates"]
+
+[artifacts.lex-wasm]
+build = [{ toolchain = "rust", package = "lex-wasm" }]
+platforms = ["linux-x86_64"]
+bundle = { composition = "wasm-pack", wasm-target = "web", scope = "lex-fmt" }
+endpoints = ["gh-release", "npm"]
+
 [shipit]
 version = "68747540c4a14771a03986ebd0e89ab951815fbf"
 

--- a/CHANGELOG/unreleased-shipit-release-cutover.md
+++ b/CHANGELOG/unreleased-shipit-release-cutover.md
@@ -1,0 +1,1 @@
+- Release: author the shipit `[artifacts]` cutover — signed `lexd` binary matrix (darwin + linux gnu/musl) to GitHub Releases + crates.io, and `lex-wasm` to `@lex-fmt/lex-wasm` on npm — plus the wasm32 std target for the wasm-pack build.

--- a/pixi.lock
+++ b/pixi.lock
@@ -46,6 +46,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.96.1-h2c6d0dc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -69,9 +70,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.96.1-hbe8e118_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.96.1-h38e4360_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-edit-0.13.11-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.138-h19f9e61_0.conda
@@ -81,6 +84,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wasm-pack-0.15.0-h19f9e61_0.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.96.1-hf6ec828_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-edit-0.13.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.138-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
@@ -144,6 +148,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.96.1-h2c6d0dc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -202,6 +207,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.96.1-hbe8e118_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
@@ -209,6 +215,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.96.1-h38e4360_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
@@ -256,6 +263,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.96.1-hf6ec828_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
@@ -1697,6 +1705,18 @@ packages:
   run_exports: {}
   size: 35384892
   timestamp: 1783676740091
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-wasm32-unknown-unknown-1.96.1-unix_2.conda
+  sha256: 2cab857e98ac15a9b05545121435ea02bbbef16d0e7e5a5c0718a44465e2b0f0
+  md5: 13d22769047ff225ff0646d5f7e7103a
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.96.1,<1.96.2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 25288008
+  timestamp: 1783677538736
 - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.96.1-h38e4360_1.conda
   sha256: 655a354a0ed44107848294c31caa95bd52a0e531afdc8a3d7fe334ed9bacf95b
   md5: f0e3cb7d6847c3973848cba304b184c4

--- a/pixi.toml
+++ b/pixi.toml
@@ -122,6 +122,14 @@ wasm-pack = "0.15.*"
 # <<< shipit-managed rust release deps <<<
 cargo-nextest = ">=0.9.138,<0.10"
 rust = "1.96.*"
+# The wasm32 std target for `wasm-pack build` (lex#832). lex OWNS its `rust`
+# pin here (consumer-owned, outside the managed rust-release-deps block), so
+# the managed rust-release-toolchain block that would carry the wasm32 std is
+# SKIPPED — same as phos-core#466. Without this, conda-forge's pinned `rust`
+# ships no wasm32-unknown-unknown sysroot std, and the lex-wasm artifact's
+# wasm-pack composition dies at "wasm32-unknown-unknown target not found in
+# sysroot" (proven live on phos-core). Same 1.96.* line as `rust`.
+rust-std-wasm32-unknown-unknown = "1.96.*"
 # uv backs the pinned bin/shipit launcher (ADR-0033: it provisions the repo's
 # pinned shipit via uv, PATH-independent). Both wf-checks lanes run
 # `pixi run --locked <task>` -> ./bin/shipit on a hosted runner where uv is not


### PR DESCRIPTION
## What

Authors lex's shipit release cutover so a staged rc can run (closes #832), porting the release surface from the legacy `.github/workflows/release.yml` (rust-cli.yml caller) into declarative `.shipit.toml` `[artifacts]`.

### Deliverables

1. **`.shipit.toml` `[artifacts]`**
   - `[artifacts.lexd]` — signed `lexd` binary. The `[[bin]] name = "lexd"` lives in crate `lex-cli` (its `[package].name` IS `"lexd"`), so `package = "lexd"`. Platforms: `darwin-arm64`, `linux-x86_64`, `linux-arm64`, `linux-x86_64-musl` (matching the legacy `linux-musl-archs`). **windows-x86_64 OMITTED** per the fleet pause (shipit#895). `archive` composition, `sign = true`, endpoints `gh-release` + `crates`. The `crates` endpoint drives the workspace-wide crates.io publish in topological order; `lex-wasm` (`publish = false`) is auto-excluded via `cargo metadata`, so the legacy explicit `crates:` list is not restated.
   - `[artifacts.lex-wasm]` — `wasm-pack` (web target, `scope = "lex-fmt"`) → `@lex-fmt/lex-wasm` on npm (legacy `wasm-packages` + `wasm-npm-scope`). Built on the `linux-x86_64` host; the web-target wasm output is platform-independent. Endpoints `gh-release` + `npm`.
2. **`pixi.toml`** — add `rust-std-wasm32-unknown-unknown = "1.96.*"` to the default `[dependencies]` beside the consumer-owned `rust` pin. lex owns its rust pin, so the managed rust-release-toolchain block that would carry the wasm32 std is skipped (same as phos-core#466); without it, `wasm-pack build` dies at "wasm32-unknown-unknown target not found in sysroot". Lockfile relocked via `pixi install`.
3. **Changelog** — seed `CHANGELOG/unreleased-shipit-release-cutover.md` (prepare refuses an empty release; the dir had zero `unreleased-*.md`).

## Verify

`./bin/shipit release preflight 0.19.4-release-rc --json --plan-only` emits a plan with:
- the `lexd` 4-platform matrix (`darwin-arm64` signed, 3 linux unsigned)
- a `sign` stage
- the `lex-wasm` artifact
- endpoints `gh-release` only — the `-release-rc` RC guard centrally drops `crates` + `npm`, exactly as intended (validates build+sign+wasm without the owner-gated fires).

Schema self-checked against the pinned shipit's `config.py` (closed `PLATFORMS` incl. `linux-x86_64-musl`; closed `ENDPOINTS`; wasm-pack `scope`/`wasm-target` keys) and `release/bundle.py` (`archive` + `wasm-pack` compositions). Lint green via commit/push hooks. No `.deb` in the legacy pipeline, so no `[artifacts.lexd-deb]`.

## Context / out of scope (coordinator after merge)

- **Pin reconcile** — the stale `68747540` pin -> current main is a separate `shipit install --pr` (a SessionStart reminder flagged it 10 commits behind). NOT touched here.
- **The rc proof** — the gh-only `-release-rc` fire and the one coordinated npm-live fire (`@lex-fmt/lex-wasm`); crates-live + npm-live stay OWNER-GATED.
- **Legacy workflow removal** — `release.yml` + `on-upstream-released.yml` are left untouched and running (cutover canon keeps legacy callers live until ADP02 re-points them).

This is the CUTOVER PR (declaration + config only) — do NOT dispatch a release from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)