### PR TITLE
Drop linux-x86_64-musl from [artifacts.lexd] pending shipit musl provisioning

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -73,8 +73,10 @@ local = true
 #
 #   - lexd: the `[[bin]] name = "lexd"` lives in crate `lex-cli` (its
 #     [package].name IS "lexd"), so `package = "lexd"`. Signed darwin + linux
-#     gnu (x86_64 + arm64) + linux musl x86_64, matching the legacy
-#     linux-musl-archs coverage. windows-x86_64 is OMITTED per the fleet
+#     gnu (x86_64 + arm64). The legacy linux-musl-archs coverage
+#     (linux-x86_64-musl) is TEMPORARILY DROPPED pending shipit musl
+#     provisioning (see the platforms comment below); re-add when it lands.
+#     windows-x86_64 is OMITTED per the fleet
 #     pause (shipit#895), even though the legacy caller listed windows-archs.
 #     The `crates` endpoint triggers the workspace-wide crates.io publish in
 #     topological order — `lex-wasm` (publish = false) is auto-excluded via
@@ -84,7 +86,11 @@ local = true
 #     output is platform-independent, so one build platform suffices.
 [artifacts.lexd]
 build = [{ toolchain = "rust", package = "lexd" }]
-platforms = ["darwin-arm64", "linux-x86_64", "linux-arm64", "linux-x86_64-musl"]
+# musl (linux-x86_64-musl) deferred: shipit's conda-forge rust toolchain has no
+# musl rust-std target yet (E0463 can't find crate for core) — a shipit-side gap
+# (lex is the first repo to exercise musl through shipit). Re-add once shipit
+# provisions musl (shipit musl-provisioning feature issue).
+platforms = ["darwin-arm64", "linux-x86_64", "linux-arm64"]
 bundle = { composition = "archive" }
 sign = true
 endpoints = ["gh-release", "crates"]


### PR DESCRIPTION
closes #837

## What

Remove `"linux-x86_64-musl"` from `[artifacts.lexd].platforms` in `.shipit.toml`, leaving `["darwin-arm64", "linux-x86_64", "linux-arm64"]`. Add a deferral comment (inline + in the artifacts block comment) explaining why and pointing at re-adding once shipit provisions musl.

## Why

shipit's conda-forge rust toolchain has no musl `rust-std` target yet, so the musl leg fails to build (E0463 `can't find crate for core`). This is a shipit-side gap — lex is the first repo to exercise musl through shipit. The other 3 lexd platforms + `lex-wasm` build fine, so dropping the one broken leg unblocks the release surface without touching working coverage.

## Verify

`./bin/shipit release preflight 0.19.4-release-rc --json --plan-only` shows:
- lexd matrix = 3 platforms (`darwin-arm64`, `linux-x86_64`, `linux-arm64`) — no musl ✓
- `sign` stage present ✓
- `lex-wasm` artifact intact ✓

Lint gate passed via commit/push hooks (33 checks OK).

## Context (handoff note)

- **Approach:** the issue prescribes the exact edit; no behavioral code change, config-only. I also reconciled the artifacts-block prose comment that previously claimed musl was covered, so the comment no longer lies about the platform set — part of the same musl-deferral change, not a scope expansion.
- **Out of scope / do NOT "fix":** do not re-add musl, do not touch other artifacts, platforms, lanes, or the `windows-x86_64` omission. musl comes back only when shipit provisions the musl toolchain.
- **⚠️ Brief-gap flag:** the issue asked to "link the shipit feature issue" for musl provisioning, but no concrete shipit issue number was provided (the issue title carries the literal placeholder `shipit#<musl-feature>`). I referenced the gap descriptively rather than fabricate a number. If a real shipit tracking issue exists, a reviewer should drop the number into the `.shipit.toml` comment.
- The coordinator re-runs the rc after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)