### PR TITLE
shipit: install/update the managed set

### DIFF
--- a/.agents/agents/reviewer/agent.md
+++ b/.agents/agents/reviewer/agent.md
@@ -1,0 +1,16 @@
+---
+name: reviewer
+description: "Read-only, branch-pinned reviewer: reads a PR head in a shared read-only Tree and emits one structured review result for shipit to post, mutates nothing. Use to review a PR."
+---
+
+<!-- Generated from src/shipit/data/roles/ by `pixi run regen-roles` (shipit.harness.prompts). Do not hand edit — edit the .lex fragments and regenerate. -->
+
+You are a REVIEWER subagent: read-only and branch-pinned. You review ONE PR head — read the diff and the surrounding code, then emit the structured review result that shipit posts through the review service. You run in a SHARED read-only Tree (its working files are read-only); you never write to the checkout, never build or run the project, never push, never comment on GitHub yourself, and never merge.
+
+Your slice:
+
+- Read the PR's diff and the code it touches; judge it against the issue it closes and the repo's conventions.
+- Classify every finding on the 4-tier severity ladder — critical | major | minor | nit — and order the review's findings highest severity first (every critical, then major, then minor, then nit). The major/minor boundary is the MERGE-BLOCK TEST: major-or-worse means a competent reviewer would hold the merge for it. critical = merging would be actively harmful (security hole, data loss, crash, broken build); major = a concrete correctness or behavioral defect worth blocking on; minor = worth doing, not worth holding the merge; nit = wording, naming, or style with no correctness, behavioral, or security impact.
+- Emit exactly one structured review result; shipit captures it and posts the PR review through the review service. Do not run `gh pr review`, comment on the PR, or otherwise post to GitHub yourself.
+- If a change is needed, say so IN the review; you do not make it yourself, and you do not flip the PR's draft/ready state.
+- Style or convention a linter could mechanically express — formatting, import order, type-hint completeness, docstring shape, naming pattern — is NOT a finding: the lint gate owns style (ADR-0036). Either a configured rule enforces the standard, or the standard does not exist and you do not enforce it ad hoc. If you believe a style rule SHOULD exist, say so once in the review summary as a rule proposal, never as per-line findings.

--- a/.shipit-skills/to-tickets/SKILL.md
+++ b/.shipit-skills/to-tickets/SKILL.md
@@ -59,7 +59,7 @@ Iterate until the user approves the breakdown. Before publishing, confirm the hu
 
 Work one epic at a time. For each approved epic:
 
-**a. Create the epic umbrella issue first.** This is the **execution tracker**, not the spec — use the epic template below. Title: `<REPO>-<EPIC>: Epic: <Epic Name>`. It carries a summary of the Spec, pointers to the authoritative Spec (`docs/spec/<feature-slug>.md`) and the relevant ADRs, and the WS list/topology. Apply the correct triage label unless instructed otherwise. Once the umbrella issue exists, record it in the dev-cycle log (best-effort — ADR-0032; continue on error):
+**a. Create the epic umbrella issue first.** This is the **execution tracker**, not the spec — use the epic template below. Title: `<REPO>-<EPIC>: Epic: <Epic Name>`. It carries a summary of the Spec, pointers to the authoritative Spec (`docs/spec/<slug>.md`) and the relevant ADRs, and the WS list/topology. Apply the correct triage label unless instructed otherwise. Once the umbrella issue exists, record it in the dev-cycle log (best-effort — ADR-0032; continue on error):
 
 ```sh
 shipit log event planning.epic.minted --about "<EPIC>: <Epic Name> (#<issue>)"
@@ -82,7 +82,7 @@ A short summary of the Spec — the *what & why*, enough to orient without openi
 
 ## Spec
 
-- **Spec**: a reference to the authoritative feature Spec file read in step 1 (`docs/spec/<feature-slug>.md`). When one feature splits into several epics, every epic points at the same feature Spec.
+- **Spec**: a reference to the authoritative feature Spec file read in step 1 (`docs/spec/<slug>.md`). When one feature splits into several epics, every epic points at the same feature Spec.
 - **ADRs**: references to the relevant ADRs.
 
 ## Work Streams

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -151,7 +151,7 @@ bundle = { composition = "wasm-pack", wasm-target = "web", scope = "lex-fmt" }
 endpoints = ["gh-release", "npm"]
 
 [shipit]
-version = "e206575b6e891e5126bb77dc5b7373449d9dd809"
+version = "afedd13dfd9f27ed1c5d7d61294a01ba3446bf1d"
 
 [managed]
 ".shipit-skills/coordinating/SKILL.md" = "sha256:065a793b117dcfbb1e97fea0a80b405c69995850af9a350061dbcc1f4ea4976a"
@@ -164,7 +164,7 @@ version = "e206575b6e891e5126bb77dc5b7373449d9dd809"
 ".shipit-skills/shepherding-prs/SKILL.md" = "sha256:8f627079f3d9846069742dd77cf4987eb550ff9a6c5e575f751ea8edf958ee2b"
 ".shipit-skills/shipit-session-status/SKILL.md" = "sha256:4720ad9b381d57c32dfd2aca6cb2a4b338dfa69cac90eedd85a71f7f2f8db962"
 ".shipit-skills/to-spec/SKILL.md" = "sha256:eafedcd9b9797aa3d9e97ee466e40000cc74de2d86f86e855f6e1e36219d3cce"
-".shipit-skills/to-tickets/SKILL.md" = "sha256:d922c867458135ebf665233149268b25ba8ea3147a59e5b7ffcc9c3748fda3d5"
+".shipit-skills/to-tickets/SKILL.md" = "sha256:11419ddc56ed6a6b07cc780b1c38aa5cf20bcdfb89479bda2f4e032a4ea80b57"
 "AGENTS.md#shipit-block" = "sha256:570976e63c75768cd51114f0d3ac5b35757b11abd3405eac400aea034ca5ceb5"
 ".gitignore#shipit-release-outputs" = "sha256:4a9beb3dea542cd0f1426a298069a506c6ea1fdfb3e852a9d2032dd475dfe143"
 "bin/shipit" = "sha256:c1c8d6653ce37ada6b6dbad1866148bc1e54a8951384ebc07df01abd86d084a3"
@@ -176,7 +176,7 @@ agent-start = "sha256:3f8b7d1d6e1d51f9a714e4781f8be89a60e3da26f33f55715c3a67f4ae
 ".yamllint.yaml" = "sha256:d5c3b7b69d0bdd0ce25335e0db50cea2355b3c8ff62f4edbbf2a7d7909a2fd54"
 ".prettierrc" = "sha256:9d40f301aa8fdd684ebde7c1d7a7493d764e46b6f45585dbb5b99c821123a947"
 "pixi.toml#shipit-tasks" = "sha256:d02ea7ec3c772affa6d9510007e434115e1d75b5f7231567c38fb96c05d1a02b"
-"pixi.toml#shipit-lint-deps" = "sha256:1523474906defcd91f9edbba39a87d2003828a9bf2670fc48240b7ad1bb10e29"
+"pixi.toml#shipit-lint-deps" = "sha256:c75669f6e5fe369c0a6a2d5bbcceb59f0c8a0c9a1eba163f00d1081048067224"
 "pixi.toml#shipit-environments" = "sha256:c54b53e3bb55cd59aaabf9daea85c81cffe3cbae8978e41cbef5db0f16b3838b"
 "pixi.toml#shipit-rust-lint-toolchain" = "sha256:e5105bbd8feb8a1d5bde16dd427028303d1f0b3b4c43d7b85689de95c1200285"
 "pixi.toml#shipit-rust-release-deps" = "sha256:0f4fa11a3baa8d38a52db7649a938c8366b01fa60d3193aa17a1754bd72db2b1"
@@ -185,6 +185,7 @@ agent-start = "sha256:3f8b7d1d6e1d51f9a714e4781f8be89a60e3da26f33f55715c3a67f4ae
 ".claude/agents/implementer.md" = "sha256:29a0e850f6a50f9f0e74f4bbaf52932b27231f6f2ab489aebeba895f5afdcc6c"
 ".claude/agents/reviewer.md" = "sha256:1c1eeba06829be68c7190f61216bc8fe0a20c6413f71ca1b4898cd60eb2a060d"
 ".claude/agents/shepherd.md" = "sha256:59c5ab182a25c616f826af9dc9427e11cddf0b6698ba586e0286f778f172dff3"
+".agents/agents/reviewer/agent.md" = "sha256:38d3d1265d8cf912652570932d0e59f867c71ad80b7c7e0a9fbbb55316c6cca5"
 ".claude/settings.json#shipit-pretooluse-hook" = "sha256:329d1ef1631ac5217473702961c4213a36f6de10873e2a2500731ff003f58c9a"
 ".claude/settings.json#shipit-stop-hook" = "sha256:f01a445a58731cca9cfa67032780749aed3ece69afa0cec813c1a522cf25ce8f"
 ".claude/settings.json#shipit-subagentstop-hook" = "sha256:48cf4d9e66102fe17d1f5cdd93b0fccef89547e32eb737ad519d809f5cf2b644"

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,8 +40,8 @@ test-full = "git submodule update --init --recursive && cargo nextest run --work
 rust = "1.96.*"
 # <<< shipit-managed rust lint toolchain <<<
 # >>> shipit-managed lint deps (do not edit; regenerate via `shipit install`) >>>
-# The fleet-pinned lint toolchain (docs/legacy-prd/adoption.md in the
-# arthur-debert/shipit repo: the managed set owns the consumer environment).
+# The fleet-pinned lint toolchain (https://github.com/arthur-debert/shipit/blob/main/docs/legacy-prd/adoption.md:
+# the managed set owns the consumer environment).
 # Canonical versions live HERE — a bump is one data edit, rolled fleet-wide on
 # each consumer's next `shipit install` reconcile.
 ruff = "0.15.*"


### PR DESCRIPTION
`shipit install` reconciled the managed set.

Pinned to `afedd13dfd9f27ed1c5d7d61294a01ba3446bf1d` — the build that wrote this managed set and passed its self-certification (ADR-0033); the managed `bin/shipit` launcher execs exactly this build.

### Added
- `.agents/agents/reviewer/agent.md`

### Updated
- `.shipit-skills/to-tickets/SKILL.md`
- `pixi.toml#shipit-lint-deps`

### Retired files kept — locally modified
shipit no longer distributes these files, but their content differs from every known pristine version, so they were NOT deleted. Remove them yourself once the local edits are no longer needed:
- `.github/workflows/copilot-review.yml`

### Checks activated locally
`lefthook install` ran where this install was invoked, so its `.git/hooks/{pre-commit,pre-push}` fire `pixi run lint` there now. Reviewers/mergers: run `./bin/shipit install` on your own checkout (shipit-self: `pixi run -e lint install-hooks`) to make the checks live for you too. Activation is idempotent and leaves unrelated hooks intact.
