### PR TITLE
ci(release): endpoint selector + conda channel secrets in the release caller (ARF02-WS03 prereq)

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -44,6 +44,13 @@ name: shipit-release
 #                             identity (repo secret keeps its legacy name).
 #   APPLE_CERTIFICATE_PASSWORD, ASC_API_KEY_BASE64/_ID, ASC_API_ISSUER_ID
 #                             the cert passphrase + the ASC notary trio.
+#   ARTIFACT_CHANNEL_KEY_ID, ARTIFACT_CHANNEL_SECRET_KEY
+#                             the conda Artifact-channel endpoint's GCS HMAC
+#                             write pair (ADR-0064/0065, ARF02-WS02) — carried
+#                             by `full`/`publish` (both blocks declare them),
+#                             consumed only when the plan keeps the `conda`
+#                             endpoint (lexd-lsp). The RC guard drops conda on
+#                             a -release-rc version centrally.
 # gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
 
 on:
@@ -94,6 +101,19 @@ on:
         required: false
         type: boolean
         default: false
+      endpoints:
+        description: >-
+          Per-invocation endpoint selector (ADR-0070, #1046), consumed by
+          `full`/`publish`: a comma- or space-separated endpoint-name list
+          the publish verb narrows the fire to — every other declared
+          endpoint is selector-skipped (`gh-release` cannot be deselected;
+          unknown names are refused, by the verb). Empty: the full
+          post-guard set fires (gh-release + crates + npm). Ignored by the
+          other stages. This is what makes lex's scoped ARF02 channel seed
+          (`gh-release,conda`) possible WITHOUT firing the owner-gated
+          crates/npm endpoints.
+        required: false
+        type: string
 
 # The standalone dispatch caller's grant (workflows.lex §8): `contents:
 # write` for prepare's push and publish's gh-release, `actions: read` for
@@ -111,6 +131,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       unsigned: ${{ inputs.unsigned }}
+      endpoints: ${{ inputs.endpoints }}
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -120,6 +141,8 @@ jobs:
       ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
       ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+      ARTIFACT_CHANNEL_KEY_ID: ${{ secrets.ARTIFACT_CHANNEL_KEY_ID }}
+      ARTIFACT_CHANNEL_SECRET_KEY: ${{ secrets.ARTIFACT_CHANNEL_SECRET_KEY }}
 
   prepare:
     if: inputs.stage == 'prepare'
@@ -163,6 +186,9 @@ jobs:
       tag: ${{ inputs.tag }}
       run-id: ${{ inputs.run-id }}
       unsigned: ${{ inputs.unsigned }}
+      endpoints: ${{ inputs.endpoints }}
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      ARTIFACT_CHANNEL_KEY_ID: ${{ secrets.ARTIFACT_CHANNEL_KEY_ID }}
+      ARTIFACT_CHANNEL_SECRET_KEY: ${{ secrets.ARTIFACT_CHANNEL_SECRET_KEY }}

--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -108,8 +108,9 @@ on:
           the publish verb narrows the fire to — every other declared
           endpoint is selector-skipped (`gh-release` cannot be deselected;
           unknown names are refused, by the verb). Empty: the full
-          post-guard set fires (gh-release + crates + npm). Ignored by the
-          other stages. This is what makes lex's scoped ARF02 channel seed
+          post-guard set fires (gh-release + crates + conda + npm — the
+          union across lexd, lexd-lsp and lex-wasm). Ignored by the other
+          stages. This is what makes lex's scoped ARF02 channel seed
           (`gh-release,conda`) possible WITHOUT firing the owner-gated
           crates/npm endpoints.
         required: false


### PR DESCRIPTION
## Context

Prerequisite for the ARF02 Artifact-channel seed (shipit#999 / #1002). shipit#1046 (merged, now on `v1`) added a per-invocation `endpoints` selector to the composed release workflow blocks (`wf-release`/`wf-publish`). This wires lex's own dispatch caller to expose and forward it, and to forward the `ARTIFACT_CHANNEL_*` GCS HMAC write pair the `conda` endpoint needs (provisioned in ARF02-WS02: SA `artifact-channel-writer` + Doppler + lex Actions secrets).

## What changed

`.github/workflows/shipit-release.yml` only:
- New `endpoints` `workflow_dispatch` input (comma/space list; empty = full post-guard set).
- Forwarded to the `full` (`release:`) and `publish:` jobs — the two stages that publish. Not to prepare/build/sign (they declare no such input).
- `ARTIFACT_CHANNEL_KEY_ID` / `ARTIFACT_CHANNEL_SECRET_KEY` added to the `full` and `publish` `secrets:` blocks (both reusable workflows declare them; per the per-stage intersection rule).
- Header secrets doc updated to enumerate the new pair.

## Why it matters

Without this, the only CI path that fires `conda` is a full release, which also fires `lexd→crates.io` and `@lex-fmt/lex-wasm→npm` (owner-gated, irreversible). With it, the coordinator's seed dispatch `endpoints: gh-release,conda` scopes the fire to exactly those two; crates/npm are recorded `SKIP_SELECTOR`.

## Verification

- YAML validates; `endpoints` present on the 6 inputs and forwarded to `full`+`publish` only; `ARTIFACT_CHANNEL_*` on both those secrets blocks (not the others).
- The reusable `wf-release.yml@v1` / `wf-publish.yml@v1` now declare the `endpoints` input (shipit v1.2.4), so the `with:` forward validates at dispatch — no startup_failure.
- No behavior change when `endpoints` is empty (today's full release).

Self-checked against ADR-0070 (selector is per-invocation only, never a config field) and ADR-0064/0065 (channel + tiers).