### PR TITLE
shipit: install/update the managed set

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -151,7 +151,7 @@ bundle = { composition = "wasm-pack", wasm-target = "web", scope = "lex-fmt" }
 endpoints = ["gh-release", "npm"]
 
 [shipit]
-version = "987ede012a3ac3be061e58abeb02e90f4fcbbf2d"
+version = "628d4381e92b7427c72e9a9144440bcea98e3f50"
 
 [managed]
 ".shipit-skills/coordinating/SKILL.md" = "sha256:065a793b117dcfbb1e97fea0a80b405c69995850af9a350061dbcc1f4ea4976a"


### PR DESCRIPTION
`shipit install` reconciled the managed set.

Pinned to `628d4381e92b7427c72e9a9144440bcea98e3f50` — the build that wrote this managed set and passed its self-certification (ADR-0033); the managed `bin/shipit` launcher execs exactly this build.

### Retired files kept — locally modified
shipit no longer distributes these files, but their content differs from every known pristine version, so they were NOT deleted. Remove them yourself once the local edits are no longer needed:
- `.github/workflows/copilot-review.yml`
