### PR TITLE
config(lexd): declare conda as a selectable derived endpoint

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -124,7 +124,13 @@ bundle = { composition = "archive" }
 # are NOT signed (no linux signing rail). Do not read the matrix as "all legs
 # signed".
 sign = true
-endpoints = ["gh-release", "crates"]
+# gh-release is the base surface the `conda` DERIVED endpoint repackages from
+# (a conda endpoint REQUIRES gh-release in the plan). Declaring conda here only
+# makes it SELECTABLE at dispatch (ADR-0070); the live stable SEED is
+# coordinator-owned and NOT dispatched in this change. `crates` stays declared
+# but is deselected at the ARF02 stable dispatch (endpoints="gh-release,conda"),
+# keeping lexd OFF crates.io (ADR-0070).
+endpoints = ["gh-release", "crates", "conda"]
 
 [artifacts.lexd-lsp]
 build = [{ toolchain = "rust", package = "lexd-lsp" }]


### PR DESCRIPTION
## Context

**What:** Widens `[artifacts.lexd].endpoints` from `["gh-release", "crates"]` to `["gh-release", "crates", "conda"]` and adds a comment mirroring the one on `[artifacts.lexd-lsp]`. This is the sole change — no other block, no `platforms`/`bundle`/`sign` change, no version bump, no dispatch.

**Why (ADR-0070):** Publish fires a SELECTABLE subset of the DECLARED endpoints; which endpoints actually fire is chosen at dispatch time. This PR only widens lexd's DECLARED menu so a later owner-gated STABLE lexd dispatch can select `endpoints="gh-release,conda"` and land lexd in the Artifact channel while staying off crates.io. Prerequisite config change for ARF02 WS05.

**Decision boundaries (do not re-open):**
- **Declares-only / no-dispatch.** Declaration only makes conda SELECTABLE; this PR dispatches nothing. The live stable channel SEED is coordinator-owned and out of scope here.
- **`crates` stays declared.** It remains in the menu; it is *deselected at the ARF02 stable dispatch* (`endpoints="gh-release,conda"`), which keeps lexd off crates.io (ADR-0070). Not removed here.
- **conda REQUIRES gh-release** as its base surface (the derived endpoint repackages from the gh-release assets); gh-release stays in the menu.

**Governing-doc self-check:** `arthur-debert/shipit` `docs/adr/0070` (selectable endpoint subset — publish fires a selected subset of declared endpoints), `0064` (Artifact channel / conda subdir map), `0071` (readiness gate), `docs/spec/artifact-channel.md`. Consistent with `[artifacts.lexd-lsp]`, which already declares `["gh-release", "conda"]`.

**Verify (green before open):**
- `pixi run test-full` — 2701 passed, 1 skipped (submodule fixtures provisioned). A bare `pixi run test` shows 3 fixture-load failures purely from the uninitialized `comms` submodule — pre-existing, unrelated to this config-only change.
- `./bin/shipit release preflight 0.19.10-rc.99 --plan-only` — exit 0, plan well-formed; aggregate `endpoints` includes `conda`.
- Negative control: injecting a bogus endpoint on lexd makes preflight fail with `[artifacts].lexd.endpoints: unknown endpoint ...; known endpoints: ... conda ...`, proving per-artifact validation is live and that lexd's `conda` is an accepted, selectable endpoint.

for arthur-debert/shipit#1004 (ARF02 WS05 part a; does not close a standalone issue).
