### PR TITLE
shipit: install/update the managed set

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -157,7 +157,7 @@ bundle = { composition = "wasm-pack", wasm-target = "web", scope = "lex-fmt" }
 endpoints = ["gh-release", "npm"]
 
 [shipit]
-version = "57d9d16b1a8d374e1558912376c4f10d70beae1d"
+version = "8de0ac48c5c52b5e88ccd020c5f84f9bd803cf47"
 
 [managed]
 ".shipit-skills/coordinating/SKILL.md" = "sha256:065a793b117dcfbb1e97fea0a80b405c69995850af9a350061dbcc1f4ea4976a"
@@ -181,9 +181,10 @@ agent-start = "sha256:70a2f96788eecbd689412d428a3615193edcd1deaccc730e6976332c61
 ".markdownlintignore" = "sha256:05b151b2b20689c8c8e5e488ac8c5131f62b273101fb60395eb7be1c5d79d101"
 ".yamllint.yaml" = "sha256:d5c3b7b69d0bdd0ce25335e0db50cea2355b3c8ff62f4edbbf2a7d7909a2fd54"
 ".prettierrc" = "sha256:9d40f301aa8fdd684ebde7c1d7a7493d764e46b6f45585dbb5b99c821123a947"
-"pixi.toml#shipit-tasks" = "sha256:d02ea7ec3c772affa6d9510007e434115e1d75b5f7231567c38fb96c05d1a02b"
+"pixi.toml#shipit-tasks" = "sha256:8a550f5d5a8f09c1ab685b120353bb8922a8578c2918c5ed2d688e423fed7f2c"
 "pixi.toml#shipit-lint-deps" = "sha256:c75669f6e5fe369c0a6a2d5bbcceb59f0c8a0c9a1eba163f00d1081048067224"
-"pixi.toml#shipit-environments" = "sha256:c54b53e3bb55cd59aaabf9daea85c81cffe3cbae8978e41cbef5db0f16b3838b"
+"pixi.toml#shipit-environments" = "sha256:940c14da94788ca8581c1363752ee5ab42eb07b1d8a9bf89fdb086bb0ed0cbed"
+"pixi.toml#shipit-lexd" = "sha256:225d8f91e31b39ee8139ab32083af6282108cba75ebd767a8e229f1c773d4c2e"
 "pixi.toml#shipit-rust-lint-toolchain" = "sha256:e5105bbd8feb8a1d5bde16dd427028303d1f0b3b4c43d7b85689de95c1200285"
 "pixi.toml#shipit-rust-release-deps" = "sha256:e644207b819072fedeb26ab033ee695679b89df3403dedd190ed6f400e58fbc0"
 "pixi.toml#shipit-node-deps" = "sha256:c9f9ff77b997e755780bcf35094b4ef3c77fd31c99c269e12c1eb61d1646f1a9"

--- a/pixi.lock
+++ b/pixi.lock
@@ -164,6 +164,7 @@ environments:
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -228,6 +229,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
+      - conda: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/linux-64/lexd-0.19.10-hb0f4dca_0.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/actionlint-1.7.12-hddfeb4d_0.conda
@@ -291,6 +293,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
+      - conda: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/linux-aarch64/lexd-0.19.10-he8cfe8b_0.conda
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
@@ -389,6 +392,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wasm-pack-0.15.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - conda: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/osx-arm64/lexd-0.19.10-h60d57d3_0.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -3159,3 +3163,18 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433413
   timestamp: 1764777166076
+- conda: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/linux-64/lexd-0.19.10-hb0f4dca_0.conda
+  sha256: d4660ca9d76ab0a912204fabf77dc4d962a0f8fc3880f414c18f9441315c2849
+  md5: c9f034be349e20271ce9027e7ea09f62
+  size: 4342098
+  timestamp: 1784427291315
+- conda: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/linux-aarch64/lexd-0.19.10-he8cfe8b_0.conda
+  sha256: 72ea73507c70e302a3ef0e85000d811c26fe1b5dcb65d9522c59ef3d747f75b6
+  md5: 7716d19cac2d56526e2dac5334ba2624
+  size: 4264380
+  timestamp: 1784427293435
+- conda: https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex/osx-arm64/lexd-0.19.10-h60d57d3_0.conda
+  sha256: 8a42023d6ae9002ea15e7c1b3414cb91512a4171870ba7fc768d1dcb50aab1af
+  md5: 0488b6110c72bfcd73fee9543ec9a9cf
+  size: 3841706
+  timestamp: 1784427295015

--- a/pixi.toml
+++ b/pixi.toml
@@ -71,7 +71,7 @@ lefthook = "2.1.*"
 # idempotent. Defined ONLY in this feature, so it exists in EXACTLY ONE env
 # (lint) and bare `pixi run lint-full` resolves unambiguously — the wf-checks
 # matrix job's `pixi run --locked lint-full` and a laptop run are identical.
-lint-full = { cmd = "./bin/shipit provision lexd && ./bin/shipit lint" }
+lint-full = { cmd = "./bin/shipit lint" }
 
 [environments]
 # >>> shipit-managed environments (do not edit; regenerate via `shipit install`) >>>

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,6 @@ platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64"]
 changelog = "./bin/shipit changelog"
 lint = "./bin/shipit lint"
 logs = "./bin/shipit logs"
-provision-lexd = "./bin/shipit provision lexd"
 # <<< shipit-managed tasks <<<
 
 # Consumer-owned tasks (outside the shipit-managed block above).
@@ -76,7 +75,7 @@ lint-full = { cmd = "./bin/shipit provision lexd && ./bin/shipit lint" }
 
 [environments]
 # >>> shipit-managed environments (do not edit; regenerate via `shipit install`) >>>
-lint = ["lint"]
+lint = ["lint", "shipit-lexd"]
 # <<< shipit-managed environments <<<
 
 # Consumer-owned dependencies (outside the shipit-managed blocks above).
@@ -170,3 +169,47 @@ rust-std-wasm32-unknown-unknown = "1.96.*"
 # otherwise present, so the launcher's one prerequisite must ride the env too.
 # (Flagged upstream: the block/managed set should own this — lex#828/#829.)
 uv = ">=0.5"
+
+# >>> shipit-managed lexd feature (do not edit; regenerate via `shipit install`) >>>
+[feature.shipit-lexd]
+# lexd — the lex Lang's lint-gate tool — resolved as an ordinary conda package
+# from the public Artifact channel (ADR-0066: `provision lexd` retired). The
+# channel is scoped to THIS reserved feature (a sibling of conda-forge, added to
+# whatever env `shipit-lexd` is wired into — the lint env), so lexd rides
+# pixi.lock and pixi's sha256 like every other linter, and `shipit install`
+# keeps the whole fleet on ONE lexd version — uniformity moved from a compiled
+# binary constant to this managed block (ADR-0047: not consumer config).
+channels = ["https://storage.googleapis.com/shipit-artifacts-public/lex-fmt/lex"]
+
+# The fleet-pinned lexd, PLATFORM-SCOPED via pixi `[target]` tables to the
+# channel's CLOSED SERVED SET (#1068) — `SERVED_SUBDIRS`
+# (`src/shipit/channel/buckets.py`): osx-arm64/linux-64/linux-aarch64 AND win-64.
+# The one target table per served subdir below IS that set; keep the two in step
+# (drift-guarded by `test_load_units_includes_the_managed_lexd_feature_block`,
+# which asserts these targets == `SERVED_SUBDIRS`). A bump is one edit here,
+# rolled fleet-wide on each consumer's next `shipit install` reconcile;
+# exact-pinned (`==`) so uniformity is a single version, never a resolved range.
+#
+# Scoping is load-bearing AND fail-closed-preserving:
+#  - A BLANKET `[feature.shipit-lexd.dependencies]` applied lexd to EVERY platform
+#    a composing env declares, so a consumer declaring a platform OUTSIDE the
+#    served set (e.g. osx-64, Intel Mac) had no channel candidate and got an
+#    unsatisfiable lint-env solve — `shipit install` then failed closed with no
+#    commit and no reconcile (#1068). Platforms NOT in the served set now carry
+#    NO lexd dep, so their lint env SOLVES and install/reconcile no longer breaks.
+#  - win-64 IS in the served set (served, merely owner-PAUSED under the Windows
+#    build pause #895, ADR-0071), so it KEEPS a target dep. The channel serves no
+#    win-64 lexd while the pause holds, so a win-64 lint solve finds no candidate
+#    and FAILS CLOSED — ADR-0071's "Windows consumers fail closed, loudly." Drop
+#    the win-64 target and a win-64 consumer would instead solve WITHOUT lexd
+#    (fail-open), silently breaking that invariant. It re-resolves automatically
+#    when #895 lifts and the channel produces win-64 — no edit here.
+[feature.shipit-lexd.target.osx-arm64.dependencies]
+lexd = "==0.19.10"
+[feature.shipit-lexd.target.linux-64.dependencies]
+lexd = "==0.19.10"
+[feature.shipit-lexd.target.linux-aarch64.dependencies]
+lexd = "==0.19.10"
+[feature.shipit-lexd.target.win-64.dependencies]
+lexd = "==0.19.10"
+# <<< shipit-managed lexd feature <<<


### PR DESCRIPTION
`shipit install` reconciled the managed set.

Pinned to `8de0ac48c5c52b5e88ccd020c5f84f9bd803cf47` — the build that wrote this managed set and passed its self-certification (ADR-0033); the managed `bin/shipit` launcher execs exactly this build.

### Added
- `pixi.toml#shipit-environments`
- `pixi.toml#shipit-lexd`

### Updated
- `pixi.toml#shipit-tasks`

### Retired files kept — locally modified
shipit no longer distributes these files, but their content differs from every known pristine version, so they were NOT deleted. Remove them yourself once the local edits are no longer needed:
- `.github/workflows/copilot-review.yml`

### Checks activated locally
`lefthook install` ran where this install was invoked, so its `.git/hooks/{pre-commit,pre-push}` fire `pixi run lint` there now. Reviewers/mergers: run `./bin/shipit install` on your own checkout (shipit-self: `pixi run -e lint install-hooks`) to make the checks live for you too. Activation is idempotent and leaves unrelated hooks intact.
