### PR TITLE
feat(lex-wasm): declare conda endpoint (additive, npm stays)

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -154,7 +154,12 @@ endpoints = ["gh-release", "conda"]
 build = [{ toolchain = "rust", package = "lex-wasm" }]
 platforms = ["linux-x86_64"]
 bundle = { composition = "wasm-pack", wasm-target = "web", scope = "lex-fmt" }
-endpoints = ["gh-release", "npm"]
+# The `conda` DERIVED endpoint repackages the platform-independent wasm archive
+# (the `wasm-pack` composition — treated as noarch-eligible via shipit v1.4.1's
+# `platform_independent` flag, shipit#1068) into ONE `noarch: generic` `.conda`
+# in the channel's `noarch/` subdir (ADR-0076). Declaring it here only makes it
+# SELECTABLE at dispatch (ADR-0070); npm stays (all wasm through conda, keep npm).
+endpoints = ["gh-release", "npm", "conda"]
 
 [shipit]
 version = "8de0ac48c5c52b5e88ccd020c5f84f9bd803cf47"


### PR DESCRIPTION
## Context

**Summary.** Adds `conda` to `[artifacts.lex-wasm].endpoints` in `.shipit.toml`, alongside the existing `gh-release` and `npm`. One-line config change plus an explanatory comment. No version bump, no other artifact block touched.

**Why.** Per the owner directive "all wasm through conda, keep npm". The `conda` DERIVED endpoint repackages the platform-independent `wasm-pack` archive — treated as noarch-eligible via shipit v1.4.1's `platform_independent` flag (shipit#1068) — into ONE `noarch: generic` `.conda` in the channel's `noarch/` subdir (ADR-0076).

**Boundary (declares-only / no-dispatch / npm-stays).**
- This is **additive and declares-only**: it merely makes `conda` **SELECTABLE** at dispatch (ADR-0070). It does not dispatch, seed, or publish anything. The live seed is coordinator-owned and is NOT dispatched from this PR.
- **npm stays** — this is not a migration off npm; both endpoints coexist.
- Only the `lex-wasm` block changed. `lexd` / `lexd-lsp` are untouched. No version bump.

**Verification.** `./bin/shipit release preflight <ver> --plan-only` parses cleanly and lex-wasm now offers `conda`. Proven in isolation (a throwaway copy with only the `lex-wasm` artifact) so the endpoint is attributable solely to lex-wasm, not to lexd/lexd-lsp which already carry conda:
```
artifacts  lex-wasm
endpoints  gh-release, npm, conda
```
shipit pin confirmed at `8de0ac4…` (v1.4.1).

for arthur-debert/shipit#1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ9rGEQpXLrmeyFAEZbGnG